### PR TITLE
Delete workspace menu button not enabled when adding workspaces dynamically.

### DIFF
--- a/public/red/ui/view.js
+++ b/public/red/ui/view.js
@@ -100,6 +100,7 @@ RED.view = function() {
         RED.nodes.addWorkspace(ws);
         workspace_tabs.addTab(ws);
         workspace_tabs.activateTab(tabId);
+        updateWorkspaceDeleteBtnState();
         
         RED.history.push({t:'add',workspaces:[ws],dirty:dirty});
         RED.view.dirty(true);
@@ -122,6 +123,14 @@ RED.view = function() {
         $( "#node-dialog-delete-workspace" ).dialog('option','workspace',ws);
         $( "#node-dialog-delete-workspace-name" ).text(ws.label);
         $( "#node-dialog-delete-workspace" ).dialog('open');
+    }
+
+    function updateWorkspaceDeleteBtnState() {
+        if (workspace_tabs.count() == 1) {
+            $('#btn-workspace-delete').parent().addClass("disabled");
+        } else {
+            $('#btn-workspace-delete').parent().removeClass("disabled");
+        }
     }
     
     //d3.select(window).on("keydown", keydown);
@@ -1144,11 +1153,7 @@ RED.view = function() {
         addWorkspace: function(ws) {
             workspace_tabs.addTab(ws);
             workspace_tabs.resize();
-            if (workspace_tabs.count() == 1) {
-                $('#btn-workspace-delete').parent().addClass("disabled");
-            } else {
-                $('#btn-workspace-delete').parent().removeClass("disabled");
-            }
+            updateWorkspaceDeleteBtnState();
         },
         removeWorkspace: function(ws) {
             workspace_tabs.removeTab(ws.id);


### PR DESCRIPTION
The 'Delete workspace' menu button's enabled state was only set when "loading" workspaces, it was not set to enabled when dynamically adding a new workspace via the menu or chart 'plus' button.
Abstracted the logic to add/remove the disabled class on the element - which is now called when adding workspaces from menu/buttons and when loading workspaces.
