### PR TITLE
Add support for word overrides feature in sentiment node

### DIFF
--- a/nodes/core/analysis/72-sentiment.html
+++ b/nodes/core/analysis/72-sentiment.html
@@ -27,6 +27,7 @@
     <p>Analyses the <b>msg.payload</b> and adds a <b>msg.sentiment</b> object that contains the resulting AFINN-111 sentiment score as <b>msg.sentiment.score</b>.</p>
     <p>A score greater than zero is positive and less than zero is negative.</p>
     <p>The score typically ranges from -5 to +5, but can go higher and lower.</p>
+    <p>An object of word score overrides can be supplied as <b>msg.overrides</b>.</p>
     <p>See <a href="https://github.com/thisandagain/sentiment/blob/master/README.md" target="_new">the Sentiment docs here</a>.</p>
 </script>
 

--- a/nodes/core/analysis/72-sentiment.js
+++ b/nodes/core/analysis/72-sentiment.js
@@ -22,7 +22,7 @@ function SentimentNode(n) {
     var node = this;
 
     this.on("input", function(msg) {
-        sentiment(msg.payload, function (err, result) {
+        sentiment(msg.payload, msg.overrides || null, function (err, result) {
             msg.sentiment = result;
             node.send(msg);
         });


### PR DESCRIPTION
The current sentiment node would be more useful if we could use its override words feature as described here:  https://github.com/thisandagain/sentiment/blob/master/README.md#adding--overwriting-words

All a user would have to do is add an overrides property on the msg before sending it.  I've also added a line in in the UI's notes for this.
