### PR TITLE
support for use_strict

### DIFF
--- a/red/server.js
+++ b/red/server.js
@@ -34,8 +34,6 @@ function createServer(_server,_settings) {
     app = createUI(settings);
     nodeApp = express();
     
-    flowfile = settings.flowFile || 'flows_'+require('os').hostname()+'.json';
-    
     app.get("/nodes",function(req,res) {
             res.writeHead(200, {'Content-Type': 'text/plain'});
             res.write(redNodes.getNodeConfigs());


### PR DESCRIPTION
variable appears unused but results in

ReferenceError: flowfile is not defined

when node is invoked with --use_strict

(For what I believe will provide improved security, I'm looking at the Node-RED changes that will allow it to run with --use_strict; there are just a few changes required.)
