### PR TITLE
Node credentials

### DIFF
--- a/red/nodes/Node.js
+++ b/red/nodes/Node.js
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
- 
+
 var util = require("util");
 var EventEmitter = require("events").EventEmitter;
 var clone = require("clone");
 
 var flows = require("./flows");
-
+var credentials = require('./credentials')
 var comms = require("../comms");
 
 function Node(n) {
@@ -120,5 +120,4 @@ Node.prototype.error = function(msg) {
 Node.prototype.status = function(status,retain) {
     comms.publish("status/"+this.id,status,retain);
 }
-
 module.exports = Node;

--- a/red/nodes/credentials.js
+++ b/red/nodes/credentials.js
@@ -18,33 +18,114 @@ var util = require("util");
 
 var credentials = {};
 var storage = null;
+var credentialsDef = {};
+var redApp = null;
+var querystring = require('querystring');
+var Credentials;
+
+function getCredDef(type) {
+    var dashedType = type.replace(/\s+/g, '-');
+    return credentialsDef[dashedType];
+}
+
+function isRegistered(type) {
+    return getCredDef(type) != undefined;
+}
+
+function restPOST(type) {
+    redApp.post('/credentials/' + type + '/:id', function (req, res) {
+        var body = "";
+        req.on('data', function (chunk) {
+            body += chunk;
+        });
+        req.on('end', function () {
+            var nodeType = type;
+            var nodeID = req.params.id;
+
+            var newCreds = querystring.parse(body);
+            var credentials = Credentials.get(nodeID) || {};
+            var definition = getCredDef(nodeType);
+
+            for (var cred in definition) {
+                if (newCreds[cred] == undefined) {
+                    continue;
+                }
+                if (definition[cred].type == "password" && newCreds[cred] == '__PWRD__') {
+                    continue;
+                }
+                if (newCreds[cred] == '') {
+                    delete credentials[cred];
+                }
+                credentials[cred] = newCreds[cred];
+            }
+            Credentials.add(nodeID, credentials);
+            res.send(200);
+        });
+    });
+}
+
+function restGET(type) {
+    redApp.get('/credentials/' + type + '/:id', function (req, res) {
+        var nodeType = type;
+        var nodeID = req.params.id;
+
+        var credentials = Credentials.get(nodeID);
+        if (credentials == undefined) {
+            res.json({});
+            return;
+        }
+        var definition = getCredDef(nodeType);
+
+        var sendCredentials = {};
+        for (var cred in definition) {
+            if (definition[cred].type == "password") {
+                var key = 'has' + cred;
+                sendCredentials[key] = credentials[cred] != null && credentials[cred] != '';
+                continue;
+            }
+            sendCredentials[cred] = credentials[cred] || '';
+        }
+        res.json(sendCredentials);
+
+    });
+}
+function restDELETE(type) {
+    redApp.delete('/credentials/' + type + '/:id', function (req, res) {
+        var nodeID = req.params.id;
+
+        Credentials.delete(nodeID);
+        res.send(200);
+    });
+}
 
 module.exports = {
-    init: function(_storage) {
+    init: function (_storage) {
         storage = _storage;
+        redApp = require("../server").app;
+        Credentials = this;
     },
-    load: function() {
-        return storage.getCredentials().then(function(creds) {
+    load: function () {
+        return storage.getCredentials().then(function (creds) {
             credentials = creds;
-        }).otherwise(function(err) {
-            util.log("[red] Error loading credentials : "+err);
+        }).otherwise(function (err) {
+            util.log("[red] Error loading credentials : " + err);
         });
     },
-    add: function(id,creds) {
+    add: function (id, creds) {
         credentials[id] = creds;
         storage.saveCredentials(credentials);
     },
 
-    get: function(id) {
+    get: function (id) {
         return credentials[id];
     },
-    
-    delete: function(id) {
+
+    delete: function (id) {
         delete credentials[id];
         storage.saveCredentials(credentials);
     },
-    
-    clean: function(getNode) {
+
+    clean: function (getNode) {
         var deletedCredentials = false;
         for (var c in credentials) {
             var n = getNode(c);
@@ -56,6 +137,13 @@ module.exports = {
         if (deletedCredentials) {
             storage.saveCredentials(credentials);
         }
- 
+
+    },
+    register: function (type, definition) {
+        var dashedType = type.replace(/\s+/g, '-');
+        credentialsDef[dashedType] = definition;
+        restDELETE(dashedType);
+        restGET(dashedType);
+        restPOST(dashedType);
     }
 }

--- a/red/nodes/index.js
+++ b/red/nodes/index.js
@@ -36,6 +36,7 @@ module.exports = {
     addCredentials: credentials.add,
     getCredentials: credentials.get,
     deleteCredentials: credentials.delete,
+    registerCredentials: credentials.register,
     createNode: createNode,
     registerType: registry.registerType,
     getType: registry.get,


### PR DESCRIPTION
As discussed in the issue #93 here is the pull request following all your recommendation. 

I just thought that instead of creating a **RED.nodes.registerCredentials**, changing the **RED.nodes.registerType** to accept a third parameter that represent the definition of the credentials.

Also, I made the object Node load automatically its credentials into its attribute **this.credentials**

I took your sample node and created a new one with the support of credentials.
