### PR TITLE
Credentials managed with the Flow

### DIFF
--- a/public/red/main.js
+++ b/public/red/main.js
@@ -92,6 +92,14 @@ var RED = function() {
                         node.dirty = true;
                         node.changed = false;
                     }
+                    if(node._creds) {
+                        delete node._creds;
+                    }
+                });
+                RED.nodes.eachConfig(function (confNode) {
+                    if (confNode._creds) {
+                        delete confNode._creds;
+                    }
                 });
                 // Once deployed, cannot undo back to a clean state
                 RED.history.markAllDirty();

--- a/public/red/nodes.js
+++ b/public/red/nodes.js
@@ -228,20 +228,42 @@ RED.nodes = function() {
         return nns;
     }
 
+    function convertNodeCreds(node) {
+        if (node._creds) {
+            if (jQuery.isEmptyObject(node._creds.send)) {
+                return null;
+            }
+            var credInfo = {'id': node.id, 'type': node.type, 'creds': node._creds.send};
+            return credInfo;
+        }
+        return null;
+    }
+
     //TODO: rename this (createCompleteNodeSet)
     function createCompleteNodeSet() {
+        var creds = [];
         var nns = [];
         for (var i in workspaces) {
             nns.push(workspaces[i]);
         }
         for (var i in configNodes) {
-            nns.push(convertNode(configNodes[i]));
+            var node = configNodes[i];
+            nns.push(convertNode(node));
+            var credInfo = convertNodeCreds(node);
+            if (credInfo != null) {
+                creds.push(credInfo);
+            }
+
         }
         for (var i in nodes) {
             var node = nodes[i];
             nns.push(convertNode(node));
+            var credInfo = convertNodeCreds(node);
+            if (credInfo != null) {
+                creds.push(credInfo);
+            }
         }
-        return nns;
+        return {'nodes': nns, 'creds': creds};
     }
 
     function importNodes(newNodesObj,createNewIds) {

--- a/red/nodes/index.js
+++ b/red/nodes/index.js
@@ -36,6 +36,8 @@ module.exports = {
     addCredentials: credentials.add,
     getCredentials: credentials.get,
     deleteCredentials: credentials.delete,
+    mergeCredentials: credentials.merge,
+
     createNode: createNode,
     registerType: registry.registerType,
     getType: registry.get,

--- a/red/server.js
+++ b/red/server.js
@@ -47,16 +47,25 @@ function createServer(_server,_settings) {
     app.post("/flows",
         express.json(),
         function(req,res) {
-            var flows = req.body;
-            redNodes.setFlows(flows).then(function() {
-                res.json(204);
-            }).otherwise(function(err) {
-                util.log("[red] Error saving flows : "+err);
-                res.send(500,err.message);
+            var flows = req.body.nodes;
+            var creds = req.body.creds;
+            redNodes.mergeCredentials(creds).then(function () {
+                redNodes.setFlows(flows).then(function () {
+                    res.json(204);
+                }).otherwise(function (err) {
+                    util.log("[red] Error saving flows : " + err);
+                    res.send(500, err.message);
+                });
+            }).otherwise(function (err) {
+                util.log("[red] Error saving credentials : " + err);
+                res.send(500, err.message);
             });
+
+
         },
         function(error,req,res,next) {
-            res.send(400,"Invalid Flow");
+            res.send(400,"Invalid Flow: "+ error);
+            console.error(error.stack);
         }
     );
 }


### PR DESCRIPTION
Hi,

This is my pull request for the "save on deploy" part of #93.
The credentials are now fetched automatically when editing a node (as before) and only send when the user click the deploy button (with the flow).

I use a new property of the node : node._creds to store all the value needed. When the flow has been successfully send and save, the credentials information are removed from the node.

If the PR is good for you, I'll squash it.
