### PR TITLE
Rewrite credentials API to work with save on deploy.

### DIFF
--- a/public/red/main.js
+++ b/public/red/main.js
@@ -92,6 +92,14 @@ var RED = function() {
                         node.dirty = true;
                         node.changed = false;
                     }
+                    if(node._creds) {
+                        delete node._creds;
+                    }
+                });
+                RED.nodes.eachConfig(function (confNode) {
+                    if (confNode._creds) {
+                        delete confNode._creds;
+                    }
                 });
                 // Once deployed, cannot undo back to a clean state
                 RED.history.markAllDirty();

--- a/public/red/nodes.js
+++ b/public/red/nodes.js
@@ -175,12 +175,16 @@ RED.nodes = function() {
     /**
      * Converts a node to an exportable JSON Object
      **/
-    function convertNode(n) {
+    function convertNode(n, exportCreds) {
+        exportCreds = exportCreds || false;
         var node = {};
         node.id = n.id;
         node.type = n.type;
         for (var d in n._def.defaults) {
             node[d] = n[d];
+        }
+        if(exportCreds && n._creds) {
+            node._creds = n._creds.send;
         }
         if (n._def.category != "config") {
             node.x = n.x;
@@ -235,11 +239,11 @@ RED.nodes = function() {
             nns.push(workspaces[i]);
         }
         for (var i in configNodes) {
-            nns.push(convertNode(configNodes[i]));
+            nns.push(convertNode(configNodes[i], true));
         }
         for (var i in nodes) {
             var node = nodes[i];
-            nns.push(convertNode(node));
+            nns.push(convertNode(node, true));
         }
         return nns;
     }


### PR DESCRIPTION
Hi,

This is my pull request for the "save on deploy" part of #93.
The credentials are now fetched automatically when editing a node (as before) and only send when the user click the deploy button (with the flow).

I use a new property of the node : node._creds to store all the value needed. When the flow has been successfully send and save, the credentials information are removed from the node.

The Credentials are send into the node. There is no division between the flow and the credentials. The credentials are filtered before saving the flow.
