### PR TITLE
Removing orphaned function: localfilesystem.writeFile(root,path,meta,body,res)

### DIFF
--- a/red/storage/localfilesystem.js
+++ b/red/storage/localfilesystem.js
@@ -123,23 +123,6 @@ function getFileBody(root,path) {
     return body;
 }
 
-function writeFile(root,path,meta,body,res) {
-    var fn = fspath.join(root,path);
-    var headers = "";
-    for (var i in meta) {
-        if (meta.hasOwnProperty(i)) {
-            headers += "// "+i+": "+meta[i]+"\n";
-        }
-    }
-    mkdirp(fspath.dirname(fn), function (err) {
-        fs.writeFile(fn,headers+body,function(err) {
-            //TODO: handle error
-            res.writeHead(204, {'Content-Type': 'text/plain'});
-            res.end();
-        });
-    });
-}
-
 var localfilesystem = {
     init: function(_settings) {
         settings = _settings;


### PR DESCRIPTION
Nick/Dave! It looks like writeFile() is never exported. Additionally no local functions use it (they all call fs.writeFile()). Therefore I think it's safe to remove it. Thoughts? Thanks!
