### PR TITLE
Ignore the test coverage directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ flows.backup
 *_cred*
 nodes/node-red-nodes/
 .npm
+/coverage


### PR DESCRIPTION
I probably should have added this when we started using code coverage in travis builds as people will inevitably run istanbul locally too, (I suspect some of the other ignore entries should probably start with /.)
-Mark.
