### PR TITLE
Trivial mqtt var cleanup

### DIFF
--- a/nodes/core/io/10-mqtt.js
+++ b/nodes/core/io/10-mqtt.js
@@ -116,7 +116,6 @@ module.exports = function(RED) {
         this.broker = n.broker;
 
         this.brokerConfig = RED.nodes.getNode(this.broker);
-        var node = this;
 
         if (this.brokerConfig) {
             this.status({fill:"red",shape:"ring",text:"disconnected"},true);
@@ -129,6 +128,7 @@ module.exports = function(RED) {
                     this.client.publish(msg);
                 }
             });
+            var node = this;
             this.client.on("connectionlost",function() {
                 node.status({fill:"red",shape:"ring",text:"disconnected"});
             });


### PR DESCRIPTION
I noticed a spurious node variable declaration while reading the MQTT In code so I removed it. Then I realized that this left the MQTT Out code rather inconsistent so I fixed that to reduce the scope of the variable and be more consistent.
-Mark
