### PR TITLE
Fix jshint 'tests' definition.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,7 +71,7 @@ module.exports = function(grunt) {
                 },
                 tests: {
                     files: {
-                        src: ['test/*.js']
+                        src: ['test/**/*.js']
                     },
                     options: {
                         "expr": true


### PR DESCRIPTION
Oops. I hadn't noticed but jshint needs updating to search subdirectories for tests.
-Mark.
