### PR TITLE
Defining storage interface

### DIFF
--- a/red/storage/index.js
+++ b/red/storage/index.js
@@ -13,22 +13,62 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
- 
- 
-var settings = require('../red').settings;
 
-var mod;
+var when = require('when');
 
-if (settings.storageModule) {
-    if (typeof settings.storageModule === "string") {
-        // TODO: allow storage modules to be specified by absolute path
-        mod = require("./"+settings.storageModule);
+var storageModule;
+
+function moduleSelector(aSettings) {
+    var toReturn;
+    if (aSettings.storageModule) {
+        if (typeof aSettings.storageModule === "string") {
+            // TODO: allow storage modules to be specified by absolute path
+            toReturn = require("./"+aSettings.storageModule);
+        } else {
+            toReturn = aSettings.storageModule;
+        }
     } else {
-        mod = settings.storageModule;
+        toReturn = require("./localfilesystem");
     }
-} else {
-    mod = require("./localfilesystem");
+    return toReturn;
 }
 
-module.exports = mod;
+var storageModuleInterface = {
+        init : function(settings) {
+            try {
+                storageModule = moduleSelector(settings);
+            } catch (e) {
+                return when.reject(e);
+            }
+            return storageModule.init(settings);
+        },
+        getFlows : function() {
+            return storageModule.getFlows();
+        },
+        saveFlows : function(flows) {
+            return storageModule.saveFlows(flows);
+        },
+        getCredentials : function() {
+            return storageModule.getCredentials();
+        },
+        saveCredentials : function(credentials) {
+            return storageModule.saveCredentials(credentials);
+        },
+        getAllFlows : function() {
+            return storageModule.getAllFlows();
+        },
+        getFlow : function(fn) {
+            return storageModule.getFlow(fn);
+        },
+        saveFlow : function(fn, data) {
+            return storageModule.saveFlow(fn, data);
+        },
+        getLibraryEntry : function(type, path) {
+            return storageModule.getLibraryEntry(type, path);
+        },
+        saveLibraryEntry : function(type, path, meta, body) {
+            return storageModule.saveLibraryEntry(type, path, meta, body);
+        }
+}
 
+module.exports = storageModuleInterface;

--- a/test/red/storage/index_spec.js
+++ b/test/red/storage/index_spec.js
@@ -16,9 +16,117 @@
 var should = require("should");
 
 describe("red/storage/index", function() {
-    it('can be required without errors', function() {
-        var RED = require('../../../red/red');
-        RED.init({},{});
-        require("../../../red/storage/index");
+    it('can be required without errors', function(done) {
+        var storage = require("../../../red/storage/index");
+        done();
     });
+    
+    it('rejects the promise when settings suggest loading a bad module', function(done) {
+        
+        var wrongModule = {
+                storageModule : "thisaintloading"
+        };
+        
+        var storage = require("../../../red/storage/index");
+       storage.init(wrongModule).then( function() {
+           var one = 1;
+           var zero = 0;
+           try {
+               zero.should.equal(one, "The initialization promise should never get resolved");   
+           } catch(err) {
+               done(err);
+           }
+       }).catch(function(e) {
+           done(); //successfully rejected promise
+       });
+    });
+    
+    it('non-string storage module', function(done) {
+        var initSetsMeToTrue = false;
+        
+        var moduleWithBooleanSettingInit = {
+                init : function() {
+                    initSetsMeToTrue = true;
+                }
+        };
+        
+        var setsBooleanModule = {
+                storageModule : moduleWithBooleanSettingInit
+        };
+        
+        var storage = require("../../../red/storage/index");
+        storage.init(setsBooleanModule);
+        initSetsMeToTrue.should.be.true;
+        done();
+    });
+    
+    it('respects storage interface', function(done) {
+        var calledFlagGetFlows = false;
+        var calledFlagGetCredentials = false;
+        var calledFlagGetAllFlows = false;
+        var calledInit = false;
+        
+        var interfaceCheckerModule = {
+                init : function (settings) {
+                    settings.should.be.an.Object;
+                    calledInit = true;
+                },
+                getFlows : function() {
+                    calledFlagGetFlows = true;
+                },
+                saveFlows : function (flows) {
+                    flows.should.be.true;
+                },
+                getCredentials : function() {
+                    calledFlagGetCredentials = true;
+                },
+                saveCredentials : function(credentials) {
+                    credentials.should.be.true;
+                },
+                getAllFlows : function() {
+                    calledFlagGetAllFlows = true;
+                },
+                getFlow : function(fn) {
+                    fn.should.be.true;
+                },
+                saveFlow : function(fn, data) {
+                    fn.should.be.true;
+                    data.should.be.true;
+                },
+                getLibraryEntry : function(type, path) {
+                    type.should.be.true;
+                    path.should.be.true;
+                },
+                saveLibraryEntry : function(type, path, meta, body) {
+                    type.should.be.true;
+                    path.should.be.true;
+                    meta.should.be.true;
+                    body.should.be.true;
+                }
+        };
+        
+        var moduleToLoad = {
+                storageModule : interfaceCheckerModule
+        };
+        var storage = require("../../../red/storage/index");
+        
+        storage.init(moduleToLoad);
+        storage.getFlows();
+        storage.saveFlows(true);
+        storage.getCredentials(); 
+        storage.saveCredentials(true);
+        storage.getAllFlows();
+        storage.getFlow(true);
+        storage.saveFlow(true, true);
+        storage.getLibraryEntry(true, true);
+        storage.saveLibraryEntry(true, true, true, true);
+        
+        calledInit.should.be.true;
+        calledFlagGetFlows.should.be.true;
+        calledFlagGetCredentials.should.be.true;
+        calledFlagGetAllFlows.should.be.true;
+        
+        done();
+    });
+    
 });


### PR DESCRIPTION
Hi Nick, this is a pull request to show you what I think is a possible way of re-wiring the storage/index.js so that it's more like an interface. I'm interested in your thoughts on it.

Please check if I'm going down on the right path. Also, where do I want to call <code>moduleSelector(settings);</code> from?

I'm not sure if I can call it from <code>storageModuleInterface</code> I defined unless I pre-define some kind of dummy object for <code>storageModule</code>.

Alternate ideas:

We could also possibly (although I don't know enough about JavaScript yet to see if this actually makes sense):

var storageModuleInterface = {
        init : function(_settings) {
            moduleSelector(settings);
            return storageModule.init(_settings);
        }
...........
}

storageModuleInterface.init();
module.exports = storageModuleInterface;

Or alternatively, a somewhat simpler model, but one that changes the existing external interface:

......
        init : function(_settings) {
            moduleSelector(_settings);
            return storageModule.init(_settings);
        }
......
Thanks!
