### PR TITLE
Fail with error rather than silently on storage init problems.

### DIFF
--- a/red.js
+++ b/red.js
@@ -184,6 +184,9 @@ RED.start().then(function() {
     } else {
         util.log('[red] Running in headless mode');
     }
+}).otherwise(function(err) {
+    util.log("[red] Failed to start server:");
+    util.log(err.stack);
 });
 
 

--- a/red/server.js
+++ b/red/server.js
@@ -89,6 +89,8 @@ function start() {
             redNodes.loadFlows();
         });
         comms.start();
+    }).otherwise(function(err) {
+        defer.reject(err);
     });
     
     return defer.promise;


### PR DESCRIPTION
Storage initialization failures currently exit silently but they should at least output an error.
-Mark
