### PR TITLE
Remove redundant "can be required without errors" test

### DIFF
--- a/test/red/nodes/index_spec.js
+++ b/test/red/nodes/index_spec.js
@@ -47,9 +47,6 @@ var storage = {
  };
 
 describe("red/nodes/index", function() {
-    it('can be required without errors', function() {
-        require("../../../red/nodes/index");
-    });
     
    it('nodes are initialised with credentials',function(done) {      
         

--- a/test/red/storage/index_spec.js
+++ b/test/red/storage/index_spec.js
@@ -16,10 +16,6 @@
 var should = require("should");
 
 describe("red/storage/index", function() {
-    it('can be required without errors', function(done) {
-        var storage = require("../../../red/storage/index");
-        done();
-    });
     
     it('rejects the promise when settings suggest loading a bad module', function(done) {
         


### PR DESCRIPTION
These "can be required without errors" tests can be removed once actual tests have been written. This pull request removes it from nodes/index and storage/index.
