### PR TITLE
Fix missing types logic.

### DIFF
--- a/red/nodes/flows.js
+++ b/red/nodes/flows.js
@@ -34,9 +34,9 @@ events.on('type-registered',function(type) {
             if (i != -1) {
                 missingTypes.splice(i,1);
                 util.log("[red] Missing type registered: "+type);
-            }
-            if (missingTypes.length === 0) {
-                parseConfig();
+                if (missingTypes.length === 0) {
+                    parseConfig();
+                }
             }
         }
 });


### PR DESCRIPTION
missingTypes.length was greater than zero so the only way it can be
zero immediately afterwards is if splice is called so move the zero
check after the splice.

Despite what istanbul reports this function is covered by the tests.
