### PR TITLE
Adding test for registry cheerio

### DIFF
--- a/red/nodes/registry.js
+++ b/red/nodes/registry.js
@@ -197,7 +197,7 @@ function loadTemplate(nodeInfo) {
 
     var content = fs.readFileSync(templateFilename,'utf8');
     
-    $ = cheerio.load(content);
+    var $ = cheerio.load(content);
     var template = "";
     var script = "";
     $("*").each(function(i,el) {


### PR DESCRIPTION
Adding a test that exercises <code>loadTemplate(nodeInfo)</code> . (Had to change the usual cheerio notation of $ = cheerio.load(content); and assign it to a local variable, otherwise Mocha detects a memory leak.)
