### PR TITLE
Proposed fix for Issue #326

### DIFF
--- a/test/nodes/helper.js
+++ b/test/nodes/helper.js
@@ -62,6 +62,7 @@ module.exports = {
     unload: function() {
         // TODO: any other state to remove between tests?
         redNodes.clearRegistry();
+        flows.stopFlows();
     },
 
     getNode: function(id) {


### PR DESCRIPTION
Proposed fix for issue #326.

It turns out on Windows that the reason we were having problems deleting the files was that there were open filehandles to the files which are closed by adding flows.stopFlows() to the helper.unload() function as mentioned in Issue #328. With the proposed changes in this pull request there are no more file related problems with the test on windows. However, there are two remaining points (which I think should be looked at as separate pull requests):

(1) the tail tests now pass on windows which in itself we don't expect them to as tail has been written specifically for non-windows platforms

(2) the output from the test when run as part of the travis build used to be:

TailNode
4 Aug 10:29:21 - [red] Starting flows
  ✓ should be loaded 
4 Aug 10:29:21 - [warn] [tail:tailNode] tail: `/home/travis/build/hbeeken/node-red-dev/test/nodes/core/storage/.tmp/tailMe.txt' has become inaccessible
4 Aug 10:29:21 - [warn] [tail:tailNode] : No such file or directory
4 Aug 10:29:21 - [red] Starting flows
  ✓ should tail a file 
4 Aug 10:29:21 - [warn] [tail:tailNode] tail:`/home/travis/build/hbeeken/node-red-dev/test/nodes/core/storage/.tmp/tailMe.txt' has become inaccessible
4 Aug 10:29:21 - [warn] [tail:tailNode] : No such file or directory
4 Aug 10:29:21 - [red] Starting flows
  ✓ work in non-split mode 
4 Aug 10:29:21 - [warn] [tail:tailNode] tail: `/home/travis/build/hbeeken/node-red-dev/test/nodes/core/storage/.tmp/tailMe.txt' has become inaccessible: No such file or directory

and is now (with my changes):

  TailNode
7 Aug 11:09:38 - [red] Starting flows
  ✓ should be loaded 
7 Aug 11:09:38 - [warn] [tail:tailNode] tail: cannot open `/home/travis/build/hbeeken/node-red-dev/test/nodes/core/storage/.tmp/tailMe.txt' for reading: No such file or directory
tail:`/home/travis/build/hbeeken/node-red-dev/test/nodes/core/storage/.tmp/tailMe.txt' has become accessible
7 Aug 11:09:38 - [red] Stopping flows
7 Aug 11:09:38 - [red] Starting flows
  ✓ should tail a file 
7 Aug 11:09:38 - [warn] [tail:tailNode] tail: cannot open `/home/travis/build/hbeeken/node-red-dev/test/nodes/core/storage/.tmp/tailMe.txt' for reading: No such file or directory
tail:`/home/travis/build/hbeeken/node-red-dev/test/nodes/core/storage/.tmp/tailMe.txt' has become accessible
7 Aug 11:09:38 - [red] Stopping flows
7 Aug 11:09:38 - [red] Starting flows
  ✓ work in non-split mode 
7 Aug 11:09:38 - [warn] [tail:tailNode] tail: cannot open `/home/travis/build/hbeeken/node-red-dev/test/nodes/core/storage/.tmp/tailMe.txt' for reading: No such file or directory
7 Aug 11:09:38 - [red] Stopping flows
7 Aug 11:09:38 - [warn] [tail:tailNode] tail:`/home/travis/build/hbeeken/node-red-dev/test/nodes/core/storage/.tmp/tailMe.txt' has become accessible

So is the test actually doing what its supposed to do? I'm not entirely sure the done() methods are in the right place..@zobalogh can you confirm?
