### PR TITLE
Make more effort to stringify sensibly when storing in redis.

### DIFF
--- a/nodes/core/storage/65-redisout.js
+++ b/nodes/core/storage/65-redisout.js
@@ -83,6 +83,13 @@ module.exports = function(RED) {
                     var k = this.key || msg.topic;
                     if (k) {
                         if (this.structtype == "string") {
+                            if (Buffer.isBuffer(msg.payload)) {
+                                msg.payload = msg.payload.toString();
+                            } else if (typeof msg.payload === "object") {
+                                msg.payload = JSON.stringify(msg.payload);
+                            } else if (typeof msg.payload !== "string") {
+                                msg.payload = ""+msg.payload;
+                            }
                             this.client.set(k,msg.payload);
                         } else if (this.structtype == "hash") {
                             var r = hashFieldRE.exec(msg.payload);


### PR DESCRIPTION
If a user wants to put strings into redis they probably don't want to assign values like '[object Object]' to keys.
There probably should be helpers for this sort of thing to maintain some kind of consistency between nodes.
-Mark
