### PR TITLE
Fix hard crash during exception catch

### DIFF
--- a/red.js
+++ b/red.js
@@ -192,7 +192,7 @@ RED.start().then(function() {
 
 process.on('uncaughtException',function(err) {
     util.log('[red] Uncaught Exception:');
-    util.log(err.stack);
+    util.log(err && err.stack || err || "<undefined>");
     process.exit(1);
 });
 


### PR DESCRIPTION
When an uncaughtException is fired, sometimes there may be no error or no error.stack property, this causes a harder crash.
This patch fixes this in hope that if there is no stack, maybe err.toString() will be at least a little useful.

falls back to "<undefined>" if there is no error at all.
