### PR TITLE
Fix --help so it doesn't crash.

### DIFF
--- a/red/red.js
+++ b/red/red.js
@@ -33,15 +33,8 @@ var RED = {
 
     init: function(httpServer,userSettings) {
         settings = userSettings;
-        
-        var p = require(path.join(process.env.NODE_RED_HOME,"package.json"));
-        if (fs.existsSync(path.join(process.env.NODE_RED_HOME,".git"))) {
-            settings.version = p.version+".git";
-        } else {
-            settings.version = p.version;
-        }
-        
-        
+        settings.version = this.version();
+
         server.init(httpServer,settings);
         library.init();
         return server.app;
@@ -54,7 +47,15 @@ var RED = {
     credentials: credentials,
     events: events,
     log: log,
-    comms:comms
+    comms: comms,
+    version: function () {
+        var p = require(path.join(process.env.NODE_RED_HOME,"package.json"));
+        if (fs.existsSync(path.join(process.env.NODE_RED_HOME,".git"))) {
+            return p.version+".git";
+        } else {
+            return p.version;
+        }
+    }
 };
 
 RED.__defineGetter__("app", function() { console.log("Deprecated use of RED.app - use RED.httpAdmin instead"); return server.app });


### PR DESCRIPTION
Currently '''node red.js --help''' crashes with:

```
node-red/red.js:47
    console.log("Node-RED v"+RED.version());
                                 ^
TypeError: Object #<Object> has no method 'version'
```

This should fix it.
