### PR TITLE
Provide a process.title

### DIFF
--- a/red.js
+++ b/red.js
@@ -179,6 +179,7 @@ RED.start().then(function() {
             if (settings.httpAdminRoot === false) {
                 util.log('[red] Admin UI disabled');
             }
+            process.title = 'node-red';
             util.log('[red] Server now running at '+getListenPath());
         });
     } else {


### PR DESCRIPTION
Set the process.title to 'node-red'.
Helps identify node-red amongst a plethora of other nodejs processes
Aids monitoring systems in identifying running processes
