### PR TITLE
Fix for custom userDir + custom flowFile name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 credentials.json
+settings.json
 flows*.json
 flows.backup
 *_cred*

--- a/red/storage/localfilesystem.js
+++ b/red/storage/localfilesystem.js
@@ -127,8 +127,7 @@ var localfilesystem = {
 
         if (settings.flowFile) {
             flowsFile = settings.flowFile;
-            //flowsFullPath = flowsFile; <-- in case of custom flow file, the userDir was ignored
-            flowsFullPath = fspath.join(userDir,flowsFile);
+            flowsFullPath = flowsFile;
         } else {
             flowsFile = 'flows_'+require('os').hostname()+'.json';
             flowsFullPath = fspath.join(userDir,flowsFile);

--- a/red/storage/localfilesystem.js
+++ b/red/storage/localfilesystem.js
@@ -127,7 +127,8 @@ var localfilesystem = {
 
         if (settings.flowFile) {
             flowsFile = settings.flowFile;
-            flowsFullPath = flowsFile;
+            //flowsFullPath = flowsFile; <-- in case of custom flow file, the userDir was ignored
+            flowsFullPath = fspath.join(userDir,flowsFile);
         } else {
             flowsFile = 'flows_'+require('os').hostname()+'.json';
             flowsFullPath = fspath.join(userDir,flowsFile);

--- a/settings.js
+++ b/settings.js
@@ -51,7 +51,7 @@ module.exports = {
 
     // Node-RED scans the `nodes` directory in the install directory to find nodes.
     // The following property can be used to specify an additional directory to scan.
-    //userDir: '/home/nol/.node-red/nodes/',
+    //nodesDir: '/home/nol/.node-red/nodes',
 
     // By default, the Node-RED UI is available at http://localhost:1880/
     // The following property can be used to specifiy a different root path.

--- a/settings.js
+++ b/settings.js
@@ -44,14 +44,14 @@ module.exports = {
     // To enabled pretty-printing of the flow within the flow file, set the following
     //  property to true:
     //flowFilePretty: true,
-
+    
     // By default, all user data is stored in the Node-RED install directory. To
     // use a different location, the following property can be used
-    //userDir: '/home/nol/.node-red/',		
-    
+    //userDir: '/home/nol/.node-red/',
+
     // Node-RED scans the `nodes` directory in the install directory to find nodes.
     // The following property can be used to specify an additional directory to scan.
-    //userDir: '/home/nol/.node-red/nodes/',		
+    //userDir: '/home/nol/.node-red/nodes/',
 
     // By default, the Node-RED UI is available at http://localhost:1880/
     // The following property can be used to specifiy a different root path.

--- a/settings.js
+++ b/settings.js
@@ -39,19 +39,19 @@ module.exports = {
     debugMaxLength: 1000,
 
     // The file containing the flows. If not set, it defaults to flows_<hostname>.json
-    flowFile: 'flows.json',
+    //flowFile: 'flows.json',
 
     // To enabled pretty-printing of the flow within the flow file, set the following
     //  property to true:
-    flowFilePretty: true,
+    //flowFilePretty: true,
 
     // By default, all user data is stored in the Node-RED install directory. To
     // use a different location, the following property can be used
-    userDir: '/Users/wdoganowski/git/node-red-projects/',
+    //userDir: '/home/nol/.node-red/',		
 
     // Node-RED scans the `nodes` directory in the install directory to find nodes.
     // The following property can be used to specify an additional directory to scan.
-    nodesDir: '/Users/wdoganowski/git/node-red-projects/',
+    //userDir: '/home/nol/.node-red/nodes/',		
 
     // By default, the Node-RED UI is available at http://localhost:1880/
     // The following property can be used to specifiy a different root path.

--- a/settings.js
+++ b/settings.js
@@ -39,19 +39,19 @@ module.exports = {
     debugMaxLength: 1000,
 
     // The file containing the flows. If not set, it defaults to flows_<hostname>.json
-    //flowFile: 'flows.json',
+    flowFile: '/Users/Wojtek/Git/node-red-projects/flows.json',
 
     // To enabled pretty-printing of the flow within the flow file, set the following
     //  property to true:
-    //flowFilePretty: true,
+    flowFilePretty: true,
     
     // By default, all user data is stored in the Node-RED install directory. To
     // use a different location, the following property can be used
-    //userDir: '/home/nol/.node-red/',
+    userDir: '/Users/Wojtek/Git/node-red-projects/',
 
     // Node-RED scans the `nodes` directory in the install directory to find nodes.
     // The following property can be used to specify an additional directory to scan.
-    //nodesDir: '/home/nol/.node-red/nodes',
+    nodesDir: '/Users/Wojtek/Git/node-red-nodes/',
 
     // By default, the Node-RED UI is available at http://localhost:1880/
     // The following property can be used to specifiy a different root path.

--- a/settings.js
+++ b/settings.js
@@ -39,19 +39,19 @@ module.exports = {
     debugMaxLength: 1000,
 
     // The file containing the flows. If not set, it defaults to flows_<hostname>.json
-    //flowFile: 'flows.json',
+    flowFile: 'flows.json',
 
     // To enabled pretty-printing of the flow within the flow file, set the following
     //  property to true:
-    //flowFilePretty: true,
-    
+    flowFilePretty: true,
+
     // By default, all user data is stored in the Node-RED install directory. To
     // use a different location, the following property can be used
-    //userDir: '/home/nol/.node-red/',
+    userDir: '/Users/wdoganowski/git/node-red-projects/',
 
     // Node-RED scans the `nodes` directory in the install directory to find nodes.
     // The following property can be used to specify an additional directory to scan.
-    //nodesDir: '/home/nol/.node-red/nodes',
+    nodesDir: '/Users/wdoganowski/git/node-red-projects/',
 
     // By default, the Node-RED UI is available at http://localhost:1880/
     // The following property can be used to specifiy a different root path.

--- a/settings.js
+++ b/settings.js
@@ -48,7 +48,7 @@ module.exports = {
     // By default, all user data is stored in the Node-RED install directory. To
     // use a different location, the following property can be used
     //userDir: '/home/nol/.node-red/',		
-
+    
     // Node-RED scans the `nodes` directory in the install directory to find nodes.
     // The following property can be used to specify an additional directory to scan.
     //userDir: '/home/nol/.node-red/nodes/',		


### PR DESCRIPTION
When using both custom userDir and flowFile, the userDir was ignored for the flows.json file. Also the settings.js was not ignored by github, but I believe it is user specific and should be ignored, no?
I was editing node-RED Version: 0.8.1.git