### PR TITLE
New credentials API not used correctly

### DIFF
--- a/nodes/core/storage/66-mongodb.js
+++ b/nodes/core/storage/66-mongodb.js
@@ -27,8 +27,8 @@ module.exports = function(RED) {
         this.name = n.name;
 
         var url = "mongodb://";
-        if (this.credentials && this.credentials.username && this.credentials.password) {
-            url += this.credentials.username+":"+this.credentials.password+"@";
+        if (this.credentials && this.credentials.user && this.credentials.password) {
+            url += this.credentials.user+":"+this.credentials.password+"@";
         }
         url += this.hostname+":"+this.port+"/"+this.db;
 


### PR DESCRIPTION
When the code was modified for the new credentials API, these lines were left unchanged. As there was never a username value (as it is user not username) the credentials were never added to the generated URL, resulting in "Unauthorized" errors when an operation was finally executed on the connection.
