### PR TITLE
Fix base64 udp send

### DIFF
--- a/nodes/core/io/32-udp.js
+++ b/nodes/core/io/32-udp.js
@@ -142,7 +142,7 @@ module.exports = function(RED) {
                 } else {
                     var message;
                     if (node.base64) {
-                        message = new Buffer(b64string, 'base64');
+                        message = new Buffer(msg.payload, 'base64');
                     } else if (msg.payload instanceof Buffer) {
                         message = msg.payload;
                     } else {


### PR DESCRIPTION
Looks like a copy and paste error for a base64 encoding example.
