### PR TITLE
Remove reference to undefined variable 'node'.

### DIFF
--- a/nodes/core/io/25-serial.js
+++ b/nodes/core/io/25-serial.js
@@ -269,7 +269,7 @@ module.exports = function(RED) {
                                 //}
                             });
                             obj.serial.on("disconnect",function() {
-                                node.warn("Serial Port gone away.");
+                                util.log("[serial] serial port "+port+" gone away");
                             });
                         }
                         setupSerial();


### PR DESCRIPTION
It would be nice to report node errors but simplest fix for now is to be consistent with the rest of the code which just uses util.log().
