### PR TITLE
Fix logic so defined msg.payload is not prereq for delete.

### DIFF
--- a/nodes/core/storage/50-file.js
+++ b/nodes/core/storage/50-file.js
@@ -28,34 +28,31 @@ module.exports = function(RED) {
             var filename = msg.filename || this.filename;
             if (filename === "") {
                 node.warn('No filename specified');
+            } else if (msg.hasOwnProperty('delete')) {
+                fs.unlink(filename, function (err) {
+                    if (err) { node.warn('Failed to delete file : '+err); }
+                    //console.log('Deleted file",filename);
+                });
             } else if (typeof msg.payload != "undefined") {
-                if (msg.hasOwnProperty('delete')) {
-                    fs.unlink(filename, function (err) {
-                        if (err) { node.warn('Failed to delete file : '+err); }
-                        //console.log('Deleted file",filename);
+                var data = msg.payload;
+                if (typeof data == "object") {
+                    if (!Buffer.isBuffer(data)) {
+                        data = JSON.stringify(data);
+                    }
+                }
+                if (typeof data == "boolean") { data = data.toString(); }
+                if ((this.appendNewline)&&(!Buffer.isBuffer(data))) { data += "\n"; }
+                if (this.overwriteFile) {
+                    fs.writeFile(filename, data, function (err) {
+                        if (err) { node.warn('Failed to write to file : '+err); }
+                        //console.log('Message written to file',filename);
                     });
                 }
                 else {
-                    var data = msg.payload;
-                    if (typeof data == "object") {
-                        if (!Buffer.isBuffer(data)) {
-                            data = JSON.stringify(data);
-                        }
-                    }
-                    if (typeof data == "boolean") { data = data.toString(); }
-                    if ((this.appendNewline)&&(!Buffer.isBuffer(data))) { data += "\n"; }
-                    if (this.overwriteFile) {
-                        fs.writeFile(filename, data, function (err) {
-                            if (err) { node.warn('Failed to write to file : '+err); }
-                            //console.log('Message written to file',filename);
-                        });
-                    }
-                    else {
-                        fs.appendFile(filename, data, function (err) {
-                            if (err) { node.warn('Failed to append to file : '+err); }
-                            //console.log('Message appended to file',filename);
-                        });
-                    }
+                    fs.appendFile(filename, data, function (err) {
+                        if (err) { node.warn('Failed to append to file : '+err); }
+                        //console.log('Message appended to file',filename);
+                    });
                 }
             }
         });


### PR DESCRIPTION
I've no idea why I missed this when fixing the issue yesterday but the delete should not depend on the payload being defined. Ignoring whitespace helps when understanding this change.
-Mark.
