### PR TITLE
Fix for node import when imported node is missing required parameters

### DIFF
--- a/public/red/nodes.js
+++ b/public/red/nodes.js
@@ -469,7 +469,14 @@ RED.nodes = (function() {
 
                         for (var d2 in node._def.defaults) {
                             if (node._def.defaults.hasOwnProperty(d2)) {
-                                node[d2] = n[d2];
+                                //check if the imported property is already in the node to be imported
+                                if (n.hasOwnProperty(d2)) {
+                                    //copy the property
+                                    node[d2] = n[d2];
+                                } else {
+                                    //otherwise copy the default value
+                                    node[d2] = node._def.defaults[d2].value;
+                                }
                             }
                         }
 


### PR DESCRIPTION
This issue happens when imported node is missing some parameters which are required in the new node. In such case, existing parameters should be imported and missing parameters should be set to defaults.

The issue is caused, because the check for node._def.defaults.hasOwnProperty(d2) is pointless, as d2 is already a value from the defaults iteration and the code to copy the default values was missing.

This sorts out the import of nodes via local file system, clipboard and library.
