### PR TITLE
Add nock to node test helper.

### DIFF
--- a/test/nodes/helper.js
+++ b/test/nodes/helper.js
@@ -17,6 +17,11 @@
 var should = require("should");
 var when = require("when");
 var request = require('supertest');
+var nock;
+if (!process.version.match(/^v0\.[0-9]\./)) {
+    // only set nock for node >= 0.10
+    nock = require('nock');
+}
 var RED = require("../../red/red.js");
 var redNodes = require("../../red/nodes");
 var flows = require("../../red/nodes/flows");
@@ -62,8 +67,8 @@ module.exports = {
         };
         var settings = {
             available: function() { return false; }
-        }
-        
+        };
+
         redNodes.init(settings, storage);
         credentials.init(storage);
         RED.nodes.registerType("helper", helperNode);
@@ -112,5 +117,7 @@ module.exports = {
     },
 
     url: function() { return url; },
+
+    nock: nock,
 
 };


### PR DESCRIPTION
@knolleary,

I think a few node tests (web nodes in particular) will want to use nock which it turns out only works on node >= 0.10. Rather than have lots of tests doing the check against node.version. I thought it could be done here and node tests could just do:

```
var nock = helper.node;
...
if (nock) {
   it('test requiring nock', ...);
}
```

What do you think about doing this? Is there a more elegant way?

-Mark.
