### PR TITLE
Don't use abbreviation 'mins' and 'minutes' in the same sentence.

### DIFF
--- a/nodes/core/core/20-inject.html
+++ b/nodes/core/core/20-inject.html
@@ -116,8 +116,8 @@
     <p>If no payload is specified the payload is set to the current time in millisecs since 1970. This allows subsequent functions to perform time based actions.</p>
     <p>The repeat function does what it says on the tin and continuously sends the payload every x seconds.</p>
     <p>The Fire once at start option actually waits 50mS before firing to give other nodes a chance to instantiate properly.</p>
-    <p><b>Note: </b>"Interval between times" and "at a specific time" will use cron. This means that 20 mins will be at the next hour, 20 mins past and 40 mins past - not in 20 minutes time.
-    If you want every 20 mins from now - use the basic "interval" option.</p>
+    <p><b>Note: </b>"Interval between times" and "at a specific time" will use cron. This means that 20 minutes will be at the next hour, 20 minutes past and 40 minutes past - not in 20 minutes time.
+    If you want every 20 minutes from now - use the basic "interval" option.</p>
 </script>
 
 <script type="text/javascript">


### PR DESCRIPTION
I don't think saving three letters justifies the use of a non-standard
abbreviation.  If we really need to save letters, then the SI units would
be better and for most people to read.

I also fix the line endings of two lines to make them CRLF rather than just LF to make the file consistent.
