### PR TITLE
Minor fixes to messages sent from "file in" nodes.

### DIFF
--- a/nodes/core/storage/50-file.js
+++ b/nodes/core/storage/50-file.js
@@ -76,13 +76,15 @@ module.exports = function(RED) {
             if (filename === "") {
                 node.warn('No filename specified');
             } else {
+                msg.filename = filename;
                 fs.readFile(filename,options,function(err,data) {
                     if (err) {
                         node.warn(err);
                         msg.error = err;
+                        delete msg.payload;
                     } else {
-                        msg.filename = filename;
                         msg.payload = data;
+                        delete msg.error;
                     }
                     node.send(msg);
                 });


### PR DESCRIPTION
@knolleary, @dceejay, I don't think there are any major compatibility issues with these changes but I'd be interested in your thoughts. I'm trying to write dropbox/s3/box.com nodes and I'd like to get the api clarified.
(Aside: I think it is probably worth reviewing all nodes with respect to this kind of well-definedness as it helps avoid unexpected flow behaviour and simplifies coding of subsequent nodes.)

Specifically:
- in the error case, set msg.filename to be the name of the file used (as
  is done in the non-error case),
- in the error case, delete msg.payload so that subsequent nodes only need
  check for a msg.payload to act upon if they don't care about error cases,
  and
- in the non-error case, delete msg.error to avoid passing through errors
  from earlier nodes to a subsequent node that does care about error cases

Messages sent will now always have well-defined behaviour with respect to
the payload, filename, and error in both error and non-error cases.
