### PR TITLE
Adding capability to the test helper to load more than one node at once

### DIFF
--- a/test/nodes/helper.js
+++ b/test/nodes/helper.js
@@ -77,7 +77,13 @@ module.exports = {
         redNodes.init(settings, storage);
         credentials.init(storage);
         RED.nodes.registerType("helper", helperNode);
-        testNode(RED);
+        if (Array.isArray(testNode)) {
+            for (var i = 0; i < testNode.length; i++) {
+                testNode[i](RED);
+            }
+        } else {
+            testNode(RED);            
+        }
         flows.load().then(function() {
             should.deepEqual(testFlows, flows.getFlows());
             cb();


### PR DESCRIPTION
When splitting the credentials for the swarm/foursquare web nodes (https://github.com/node-red/node-red-web-nodes/issues/41) I need to be able to test the swarm node by also loading the foursquare-credentials node. This requires an update to the test helper class in the main node-red stream to enable the loading of more than one node.
