### PR TITLE
Add possibility to set node-red port from env variable.

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -21,7 +21,7 @@
  
 module.exports = {
     // the tcp port that the Node-RED web server is listening on
-    uiPort: 1880,
+    uiPort: process.env.PORT || 1880,
 
     // By default, the Node-RED UI accepts connections on all IPv4 interfaces.
     // The following property can be used to listen on a specific interface. For


### PR DESCRIPTION
Hey, all.

Lately I was trying to deploy node-red to [Cloud Foundry](http://www.cloudfoundry.org/index.html). Cloud Foundry sets ports for the web apps dynamically, to be able to work within CF apps need to be run on  port number that is equal to $PORT env variable. 

This quick fix will allow to run node-red into CF without additional changes.
