### PR TITLE
Keep Active Workspace

### DIFF
--- a/public/red/nodes.js
+++ b/public/red/nodes.js
@@ -608,6 +608,8 @@ RED.nodes = (function() {
                 new_workspaces.push(defaultWorkspace);
             }
 
+            RED.view.showLastActiveWorkspace();
+
             var node_map = {};
             var new_nodes = [];
             var new_links = [];

--- a/public/red/ui/tabs.js
+++ b/public/red/ui/tabs.js
@@ -22,7 +22,7 @@ RED.tabs = (function() {
     function createTabs(options) {
         var tabs = {};
         
-        var ul = $("#"+options.id)
+        var ul = $("#"+options.id);
         ul.addClass("red-ui-tabs");
         ul.children().first().addClass("active");
         ul.children().addClass("red-ui-tab");
@@ -38,6 +38,16 @@ RED.tabs = (function() {
             }
             return false;
         }
+
+        function saveActiveTab(link) {
+            if (options.saveActiveTab && link.attr('href')) {
+                RED.settings.set("tab-" + options.id, link.attr("href").slice(1));
+            }
+        }
+
+        function getLastActiveTab() {
+           return RED.settings.get("tab-" + options.id);
+        }
         
         function activateTab(link) {
             if (typeof link === "string") {
@@ -46,7 +56,8 @@ RED.tabs = (function() {
             if (!link.parent().hasClass("active")) {
                 ul.children().removeClass("active");
                 link.parent().addClass("active");
-                if (options.onchange) {
+                saveActiveTab(link);
+                if (options.onchange && link.attr('href')) {
                     options.onchange(tabs[link.attr('href').slice(1)]);
                 }
             }
@@ -104,7 +115,7 @@ RED.tabs = (function() {
                     options.onadd(tab);
                 }
                 link.attr("title",tab.label);
-                if (ul.find("li.red-ui-tab").size() == 1) {
+                if (ul.find("li.red-ui-tab").size() == 1 && !getLastActiveTab()) {
                     activateTab(link);
                 }
             },
@@ -123,6 +134,23 @@ RED.tabs = (function() {
                 tab.attr("title",label);
                 tab.text(label);
                 updateTabWidths();
+            },
+            activateSavedTab: function () {
+                if (!options.saveActiveTab) {
+                    return;
+                }
+                var activeTab = getLastActiveTab();
+                if (activeTab === undefined) {
+                    return;
+                }
+                var link = ul.find("a[href='#" + activeTab + "']");
+                if (link.length !== 0) {
+                    activateTab($(link[0]));
+                } else {
+                    var found = ul.find("a")[0];
+                    activateTab($(found));
+                }
+
             }
 
         }

--- a/public/red/ui/view.js
+++ b/public/red/ui/view.js
@@ -248,6 +248,7 @@ RED.view = (function() {
     
     var workspace_tabs = RED.tabs.create({
         id: "workspace-tabs",
+        saveActiveTab: true,
         onchange: function(tab) {
             if (tab.type == "subflow") {
                 $("#workspace-toolbar").show();
@@ -2028,6 +2029,9 @@ RED.view = (function() {
         addWorkspace: function(ws) {
             workspace_tabs.addTab(ws);
             workspace_tabs.resize();
+        },
+        showLastActiveWorkspace: function() {
+          workspace_tabs.activateSavedTab();
         },
         removeWorkspace: function(ws) {
             if (workspace_tabs.contains(ws.id)) {


### PR DESCRIPTION
PR linked to #453 

This PR is to save the activated workspace.

@knolleary if the PR is good for you, I'll squash it.
I had to make some change in the tab to keep the change clear and consistent with the rest of the API.
It's now possible to make all the tab saving their active tab and restore it.