### PR TITLE
Incorrect reference to routes

### DIFF
--- a/nodes/core/io/21-httpin.js
+++ b/nodes/core/io/21-httpin.js
@@ -94,7 +94,7 @@ module.exports = function(RED) {
                     }
                 }
                 if (RED.settings.httpNodeCors) {
-                    var route = RED.httpNode.route['options'];
+                    var route = RED.httpNode.routes['options'];
                     if (route) {
                         for (var j = 0; j<route.length; j++) {
                             if (route[j].path == this.url) {


### PR DESCRIPTION
During a JSHint cleanup:

https://github.com/node-red/node-red/commit/4770a06679b997575a0baea89aea6ec6c45b3060#diff-53e5d380639e123b98b5a5286f85104e

it looks like a bug was introduced.  The reference to 'routes' was changed to 'route' in an entire block of code but one of them causes an error to occur (TypeError: Cannot read property 'length' of undefined) when httpNodeCors is set.
