### PR TITLE
adding skip to the mongodb input node

### DIFF
--- a/nodes/core/storage/66-mongodb.html
+++ b/nodes/core/storage/66-mongodb.html
@@ -197,7 +197,7 @@
 
 <script type="text/x-red" data-help-name="mongodb in">
     <p>Calls a MongoDB collection method based on the selected operator.</p>
-    <p>Find queries a collection using the <b>msg.payload</b> as the query statement as per the .find() function. Optionally, you may also (via a function) set a <b>msg.projection</b> object to constrain the returned fields, a <b>msg.sort</b> object and a <b>msg.limit</b> object.</p>
+        <p>Find queries a collection using the <b>msg.payload</b> as the query statement as per the .find() function. Optionally, you may also (via a function) set a <b>msg.projection</b> object to constrain the returned fields, a <b>msg.sort</b> object, a <b>msg.limit</b> number and a <b>msg.skip</b> number.</p>
     <p>Count returns a count of the number of documents in a collection or matching a query using the <b>msg.payload</b> as the query statement.</p>
     <p>Aggregate provides access to the aggregation pipeline using the <b>msg.payload</b> as the pipeline array.</p>
     <p>You can either set the collection method in the node config or on <b>msg.collection</b>. Setting it in the node will override <b>msg.collection</b>.</p>

--- a/nodes/core/storage/66-mongodb.js
+++ b/nodes/core/storage/66-mongodb.js
@@ -184,7 +184,7 @@ module.exports = function(RED) {
                         if (node.operation === "find") {
                             msg.projection = msg.projection || {};
                             var selector = ensureValidSelectorObject(msg.payload);
-                            coll.find(selector,msg.projection).sort(msg.sort).limit(msg.limit).toArray(function(err, items) {
+                            coll.find(selector,msg.projection).sort(msg.sort).limit(msg.limit).skip(msg.skip).toArray(function(err, items) {
                                 if (err) {
                                     node.error(err);
                                 } else {
@@ -192,6 +192,7 @@ module.exports = function(RED) {
                                     delete msg.projection;
                                     delete msg.sort;
                                     delete msg.limit;
+                                    delete msg.skip;
                                     node.send(msg);
                                 }
                             });


### PR DESCRIPTION
To get pagination out of the find query we need both limit and skip, and skip was missing. This pull request is adding it.