### PR TITLE
added functionality to enable custom registry

### DIFF
--- a/red/nodes/index.js
+++ b/red/nodes/index.js
@@ -130,7 +130,7 @@ var nodeInterface = {
         return registry.getNodeConfig(id)
     },
 
-    clearRegistry: function() {
+    clear: function() {
         return registry.clear()
     },
 

--- a/red/nodes/index.js
+++ b/red/nodes/index.js
@@ -130,7 +130,7 @@ var nodeInterface = {
         return registry.getNodeConfig(id)
     },
 
-    clear: function() {
+    clearRegistry: function() {
         return registry.clear()
     },
 


### PR DESCRIPTION
this pr allows a developer to create a custom node registry, much like the storage module. The custom registry must be in the same directory as registry.js (red/nodes) and have the same methods.

Following on from this, a custom registry may allow for the nodes to be loaded / saved to alternative sources, such as databases or rest services