### PR TITLE
Update express.js response object method call.

### DIFF
--- a/red/api/ui.js
+++ b/red/api/ui.js
@@ -55,17 +55,17 @@ module.exports = {
     },
     icon: function(req,res) {
         if (iconCache[req.params.icon]) {
-            res.sendfile(iconCache[req.params.icon]); // if not found, express prints this to the console and serves 404
+            res.sendFile(iconCache[req.params.icon]); // if not found, express prints this to the console and serves 404
         } else { 
             for (var p=0;p<icon_paths.length;p++) {
                 var iconPath = path.join(icon_paths[p],req.params.icon);
                 if (fs.existsSync(iconPath)) {
-                    res.sendfile(iconPath);
+                    res.sendFile(iconPath);
                     iconCache[req.params.icon] = iconPath;
                     return;
                 }
             }
-            res.sendfile(defaultIcon);
+            res.sendFile(defaultIcon);
         }
     },
     editor: function(req,res) {


### PR DESCRIPTION
This will make Express stop logging deprecation warns 
to the console.