### PR TITLE
fix 3 localfilesystem tests failing on Windows

### DIFF
--- a/red/storage/localfilesystem.js
+++ b/red/storage/localfilesystem.js
@@ -138,8 +138,8 @@ var localfilesystem = {
 
         if (settings.flowFile) {
             flowsFile = settings.flowFile;
-
-            if (flowsFile[0] == "/") {
+            // handle Unix and Windows "C:\"
+            if ((flowsFile[0] == "/") || (flowsFile[1] == ":")) {
                 // Absolute path
                 flowsFullPath = flowsFile;
             } else if (flowsFile.substring(0,2) === "./") {


### PR DESCRIPTION
Handle 3 core failures on Windows due to library paths that look like "'C:\Users\" instead of "/home" or "./", which caused localfilesystem to create a path with the runtime dir append to the home dir.