### PR TITLE
preserves msg variables when firing messages in batch with 'find'-action

### DIFF
--- a/nodes/core/storage/66-mongodb.js
+++ b/nodes/core/storage/66-mongodb.js
@@ -194,7 +194,10 @@ module.exports = function(RED) {
                                 skip = Number(skip);
                             }
 
+                            var reserved = {}; for( var k in msg ) reserved[k] = msg[k];
+
                             coll.find(selector,msg.projection).sort(msg.sort).limit(limit).skip(skip).toArray(function(err, items) {
+                                for( var k in reserved ) msg[k] = reserved[k]
                                 if (err) {
                                     node.error(err);
                                 } else {


### PR DESCRIPTION
usecase
=======
I use the mongodb-in node to check whether an document exist, and if not, add it to mongodb.
This takes up 2 mongodb nodes to do the job.
So lets assume this coffeescript node:

    msg.collection = "foo"
    msg.limit = 1
    msg.skip = 1
    msg.item       = { "foo": "bar1", "flop": true }
    msg.payload = { "foo": msg.item.foo }

Now Imagine 10 variations of this message (with msg.item values bar1...bar10) which are sent sequentially to the mongodb-in node, using a node-red-contrib-splitter node.
The reason to store msg.item, is because msg.payload will be deleted by the mongodb-node.
By doing so, we can use the msg.item as a payload for storing it into a mongodb later on.
This has always worked with <  node-red v0.10.6

## The issue
Now imagine firing 10 variations of this message to a mongodb-in node sequentially .
Now for some weird reason (which I could not discover in the coffeescript or splitter node), it seems that the coll.find() of mongodb-node will return 10 msg objects with msg.item set to the *last item* (so 10 times a msg with msg.item set to 'bar10').

## The fix

This seems to do it
