### PR TITLE
use local grunt-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,24 +29,20 @@ For further help, or general discussion, please use the
 
 If you want to run the latest code from git, here's how to get started:
 
-1. Install grunt, the build tool
-
-        npm install -g grunt-cli
-
-2. Clone the code:
+1. Clone the code:
 
         git clone git@github.com:node-red/node-red.git
         cd node-red
 
-3. Install the node-red dependencies
+2. Install the node-red dependencies
 
         npm install
 
-4. Build the code
+3. Build the code
 
-        grunt build
+        npm run build
 
-5. Run
+4. Run
 
         node red.js
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     },
     "main"         : "red/red.js",
     "scripts"      : {
+        "build": "grunt build",
         "start": "node red.js",
-        "test": "./node_modules/.bin/grunt"
+        "test": "grunt"
     },
     "bin"          : {
         "node-red": "./red.js",


### PR DESCRIPTION
As discussed on the mailing list, npm scripts hoist the `node_modules/.bin` directory in to the path.  We can remove the step of installing grunt-cli globally.