### PR TITLE
Added NLS enablement to the sidebar and index

### DIFF
--- a/editor/js/ui/library.js
+++ b/editor/js/ui/library.js
@@ -304,8 +304,7 @@ RED.library = (function() {
                 //    }
                 //}
                 //if (exists) {
-                //    $("#node-dialog-library-save-type").html(options.type);
-                //    $("#node-dialog-library-save-name").html(fullpath);
+                //    $("#node-dialog-library-save-content").html(RED._("library.dialogSaveOverwrite",{libraryType:options.type,libraryName:fullpath}));
                 //    $("#node-dialog-library-save-confirm").dialog( "open" );
                 //    return;
                 //}

--- a/editor/js/ui/sidebar.js
+++ b/editor/js/ui/sidebar.js
@@ -30,7 +30,8 @@ RED.sidebar = (function() {
     function addTab(title,content,closeable) {
         $("#sidebar-content").append(content);
         $(content).hide();
-        sidebar_tabs.addTab({id:"tab-"+title,label:title,closeable:closeable});
+        var id = content.id || "tab-"+title.replace(/([;&,\.\+\*\~':"\!\^#$%@\[\]\(\)=>\|])/g, "\\$1" );
+        sidebar_tabs.addTab({id:id,label:title,closeable:closeable});
         //content.style.position = "absolute";
         //$('#sidebar').tabs("refresh");
     }

--- a/editor/js/ui/tab-config.js
+++ b/editor/js/ui/tab-config.js
@@ -25,7 +25,7 @@ RED.sidebar.config = (function() {
     
     function show() {
         if (!RED.sidebar.containsTab("config")) {
-            RED.sidebar.addTab("config",content,true);
+            RED.sidebar.addTab(RED._("sidebar.config"),content,true);
         }
         refresh();
         RED.sidebar.show("config");

--- a/editor/js/ui/tab-info.js
+++ b/editor/js/ui/tab-info.js
@@ -36,7 +36,7 @@ RED.sidebar.info = (function() {
     
     function show() {
         if (!RED.sidebar.containsTab("info")) {
-            RED.sidebar.addTab("info",content,false);
+            RED.sidebar.addTab(RED._("sidebar.info"),content,false);
         }
         RED.sidebar.show("info");
     }

--- a/editor/js/ui/workspaces.js
+++ b/editor/js/ui/workspaces.js
@@ -56,7 +56,7 @@ RED.workspaces = (function() {
             RED.nodes.dirty(true);
         } else {
             $( "#node-dialog-delete-workspace" ).dialog('option','workspace',ws);
-            $( "#node-dialog-delete-workspace-name" ).text(ws.label);
+            $( "#node-dialog-delete-workspace-content" ).text(RED._("workspaces.deleteDialog",{label:ws.label}));
             $( "#node-dialog-delete-workspace" ).dialog('open');
         }
     }  

--- a/editor/templates/index.mst
+++ b/editor/templates/index.mst
@@ -46,7 +46,7 @@
         <div id="palette-container" class="palette-scroll">
         </div>
         <div id="palette-search">
-            <i class="fa fa-search"></i><input id="palette-search-input" type="text" placeholder="filter"><a href="#" id="palette-search-clear"><i class="fa fa-times"></i></a></input>
+            <i class="fa fa-search"></i><input id="palette-search-input" type="text" data-i18n="[placeholder]palette.filter"><a href="#" id="palette-search-clear"><i class="fa fa-times"></i></a></input>
         </div>
     </div><!-- /palette -->
 
@@ -55,10 +55,10 @@
         <div id="workspace-add-tab"><a id="btn-workspace-add-tab" href="#"><i class="fa fa-plus"></i></a></div>
         <div id="chart"></div>
         <div id="workspace-toolbar">
-            <a class="button" id="workspace-subflow-edit" href="#"><i class="fa fa-pencil"></i> edit name</a>
-            <a class="button disabled" id="workspace-subflow-add-input" href="#"><i class="fa fa-plus"></i> input</a>
-            <a class="button" id="workspace-subflow-add-output" href="#"><i class="fa fa-plus"></i> output</a>
-            <a class="button" id="workspace-subflow-delete" href="#"><i class="fa fa-trash"></i> delete subflow</a>
+            <a class="button" id="workspace-subflow-edit" href="#" data-i18n="[append]workspaces.editSubflowName"><i class="fa fa-pencil"></i> </a>
+            <a class="button disabled" id="workspace-subflow-add-input" href="#" data-i18n="[append]workspaces.input"><i class="fa fa-plus"></i> </a>
+            <a class="button" id="workspace-subflow-add-output" href="#" data-i18n="[append]workspaces.output"><i class="fa fa-plus"></i> </a>
+            <a class="button" id="workspace-subflow-delete" href="#" data-i18n="[append]workspaces.deleteSubflow"><i class="fa fa-trash"></i> </a>
         </div>
     </div>
 
@@ -80,14 +80,14 @@
 </div>
 
 <div id="notifications"></div>
-<div id="dropTarget"><div>Drop the flow here<br/><i class="fa fa-download"></i></div></div>
+<div id="dropTarget"><div data-i18n="[append]workspaces.dropFlowHere"><br/><i class="fa fa-download"></i></div></div>
 
 <div id="dialog" class="hide"><form id="dialog-form" class="form-horizontal"></form></div>
 <div id="node-config-dialog" class="hide"><form id="dialog-config-form" class="form-horizontal"></form><div class="form-tips" id="node-config-dialog-user-count"></div></div>
 <div id="subflow-dialog" class="hide">
     <form class="form-horizontal">
         <div class="form-row">
-            <label>Name</label><input type="text" id="subflow-input-name">
+            <label data-i18n="workspaces.subflowName"></label><input type="text" id="subflow-input-name">
         </div>
     </form>
     <div class="form-tips" id="subflow-dialog-user-count"></div>
@@ -95,21 +95,17 @@
 
 <div id="node-dialog-confirm-deploy" class="hide">
     <form class="form-horizontal">
-        <div id="node-dialog-confirm-deploy-config" style="text-align: center; padding-top: 30px;">
-         Some of the nodes are not properly configured. Are you sure you want to deploy?
+        <div id="node-dialog-confirm-deploy-config" style="text-align: center; padding-top: 30px;" data-i18n="workspaces.confirmDeployImproperlyConfigured">
         </div>
-        <div id="node-dialog-confirm-deploy-unknown" style="text-align: center; padding-top: 10px;">
-         The workspace contains some unknown node types:
+        <div id="node-dialog-confirm-deploy-unknown" style="text-align: center; padding-top: 10px;" data-i18n="[prepend]workspaces.confirmDeployUnknown;[append]workspaces.confirmDeploy">
          <ul style="width: 300px; margin: auto; text-align: left;" id="node-dialog-confirm-deploy-unknown-list"></ul>
-         Are you sure you want to deploy?
         </div>
     </form>
 </div>
 
 <div id="node-dialog-library-save-confirm" class="hide">
     <form class="form-horizontal">
-        <div style="text-align: center; padding-top: 30px;">
-         A <span id="node-dialog-library-save-type"></span> called <span id="node-dialog-library-save-name"></span> already exists. Overwrite?
+        <div style="text-align: center; padding-top: 30px;" id="node-dialog-library-save-content">
         </div>
     </form>
 </div>
@@ -117,12 +113,12 @@
 <div id="node-dialog-library-save" class="hide">
     <form class="form-horizontal">
         <div class="form-row">
-            <label for="node-dialog-library-save-folder"><i class="fa fa-folder-open"></i> Folder</label>
-            <input type="text" id="node-dialog-library-save-folder" placeholder="Folder">
+            <label for="node-dialog-library-save-folder" data-i18n="[append]workspaces.folderLabel"><i class="fa fa-folder-open"></i> </label>
+            <input type="text" id="node-dialog-library-save-folder" data-i18n="[placeholder]workspaces.folderPlaceholder">
         </div>
         <div class="form-row">
-            <label for="node-dialog-library-save-filename"><i class="fa fa-file"></i> Filename</label>
-            <input type="text" id="node-dialog-library-save-filename" placeholder="Filename">
+            <label for="node-dialog-library-save-filename" data-i18n="[append]workspaces.filenameLabel"><i class="fa fa-file"></i> </label>
+            <input type="text" id="node-dialog-library-save-filename" data-i18n="[placeholder]workspaces.filenamePlaceholder">
         </div>
     </form>
 </div>
@@ -131,7 +127,7 @@
     <form class="form-horizontal">
         <div class="form-row">
             <ul id="node-dialog-library-breadcrumbs" class="breadcrumb">
-                <li class="active"><a href="#">Library</a></li>
+                <li class="active" data-i18n="[append]workspaces.libraryBreadcrumb"><a href="#"></a></li>
             </ul>
         </div>
         <div class="form-row">
@@ -147,30 +143,29 @@
 <div id="node-dialog-rename-workspace" class="hide">
     <form class="form-horizontal">
         <div class="form-row">
-            <label for="node-input-workspace-name" ><i class="fa fa-tag"></i> <span data-i18n="workspace.label.name"></span>:</label>
+            <label for="node-input-workspace-name" ><i class="fa fa-tag"></i> <span data-i18n="workspace.label.name"></span></label>
             <input type="text" id="node-input-workspace-name">
         </div>
     </form>
 </div>
 <div id="node-dialog-delete-workspace" class="hide">
     <form class="form-horizontal">
-        <div style="text-align: center; padding-top: 30px;">
-         Are you sure you want to delete '<span id="node-dialog-delete-workspace-name"></span>'?
+        <div style="text-align: center; padding-top: 30px;" id="node-dialog-delete-workspace-content">
         </div>
     </form>
 </div>
 
 <script type="text/x-red" data-template-name="export-library-dialog">
     <div class="form-row">
-        <label for="node-input-filename" ><i class="fa fa-file"></i> Filename:</label>
-        <input type="text" id="node-input-filename" placeholder="Filename">
+        <label for="node-input-filename" data-i18n="[append]workspaces.libraryFilenamePlaceholder"><i class="fa fa-file"></i> </label>
+        <input type="text" id="node-input-filename" data-i18n="[placeholder]libraryFilenameLabel">
     </div>
 </script>
 
 <script type="text/x-red" data-template-name="subflow">
     <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
-        <input type="text" id="node-input-name" placeholder="name">
+        <label for="node-input-name" data-i18n="[append]workspaces.libraryNameLabel"><i class="fa fa-tag"></i> </label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]workspaces.libraryNamePlaceholder">
     </div>
 </script>
 

--- a/locales/en-US/editor.json
+++ b/locales/en-US/editor.json
@@ -1,7 +1,7 @@
 {
     "workspace": {
         "label": {
-            "name": "Name"
+            "name": "Name:"
         }
     },
 	"menu": {
@@ -120,11 +120,13 @@
 		"typeLibrary": "__type__ library",
 		"unnamedType": "Unnamed __type__",
 		"saveToLibrary": "Save to Library",
-		"exportToLibrary": "Export nodes to library"
+		"exportToLibrary": "Export nodes to library",
+        "dialogSaveOverwrite": "A __libraryType__ called __libraryName__ already exists. Overwrite?"
 	},
 	"palette": {
 		"noInfo": "no information available",
-		"popOverError": "Error generating pop-over label for '__type__'."
+		"popOverError": "Error generating pop-over label for '__type__'.",
+        "filter": "filter"
 	},
 	"tabInfo": {
 		"node": "Node",
@@ -136,7 +138,30 @@
 		"properties": "Properties",
 		"blank": "blank"
 	},
+    "sidebar": {
+        "info": "info",
+        "config": "config"
+    },
 	"workspaces": {
-		"subflow": "Subflow: "
-	}
+		"subflow": "Subflow: ",
+        "editSubflowName": "edit name",
+        "input": "input",
+        "output": "output",
+        "deleteSubflow": "delete subflow",
+        "dropFlowHere": "Drop the flow here",
+        "subflowName": "Name",
+        "folderPlaceholder": "Folder",
+        "filenamePlaceholder": "Filename",
+        "folderLabel": "Folder",
+        "filenameLabel": "Filename",
+        "libraryBreadcrumb": "Library",
+        "libraryFilenamePlaceholder": "Filename",
+        "libraryFilenameLabel": "Filename:",
+        "libraryNamePlaceholder": "Name",
+        "libraryNameLabel": "Name",
+        "confirmDeployImproperlyConfigured": "Some of the nodes are not properly configured. Are you sure you want to deploy?",
+        "confirmDeployUnknown": "The workspace contains some unknown node types:",
+        "confirmDeploy": "Are you sure you want to deploy?",
+        "deleteDialog": "Are you sure you want to delete '__label__'?"
+    }
 }

--- a/nodes/core/core/58-debug.html
+++ b/nodes/core/core/58-debug.html
@@ -140,7 +140,7 @@
             messages.id = "debug-content";
             content.appendChild(messages);
 
-            RED.sidebar.addTab("debug",content);
+            RED.sidebar.addTab(this._("debug.sidebarTitle"),content);
 
             function getTimestamp() {
                 var d = new Date();

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -80,7 +80,8 @@
         "notification": {
             "activated": "Successfully activated: __label__",
             "deactivated": "Successfully deactivated: __label__"
-        }
+        },
+        "sidebarTitle": "debug"
     },
     "exec": {
         "spawnerr": "Spawn command must be just the command - no spaces or extra parameters",

--- a/red/api/locales.js
+++ b/red/api/locales.js
@@ -19,7 +19,7 @@ module.exports = {
     get: function(req,res) {
         var namespace = req.params[0];
         namespace = namespace.replace(/\.json$/,"");
-        var lang = i18n.determineLangFromHeaders(req.acceptedLanguages);
+        var lang = i18n.determineLangFromHeaders(req.acceptedLanguages || []);
         var prevLang = i18n.i.lng();
         i18n.i.setLng(lang, function(){
             var catalog = i18n.catalog(namespace,lang);

--- a/red/i18n.js
+++ b/red/i18n.js
@@ -125,7 +125,7 @@ function determineLangFromHeaders(acceptedLanguages){
             lang = acceptedLanguages[i];
             break;
         // check the language without the country code
-        } else if (supportedLangs.indexOf(acceptedLangs[i].split("-")[0]) !== -1) {
+        } else if (supportedLangs.indexOf(acceptedLanguages[i].split("-")[0]) !== -1) {
             lang = acceptedLanguages[i].split("-")[0];
             break;
         }


### PR DESCRIPTION
This PR converts the text in the sidebar titles and `index.mst` to use NLS. Also, it contains a fix for a typo that creates an error when the `Accept Language` header is not present or it contains a hyphenated locale that is not a supported language (in its hyphenated form or otherwise). 