### PR TITLE
https link (rather than git) in dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you want to run the latest code from git, here's how to get started:
 
 2. Clone the code:
 
-        git clone git@github.com:node-red/node-red.git
+        git clone https://github.com/node-red/node-red.git
         cd node-red
 
 3. Install the node-red dependencies


### PR DESCRIPTION
A git link requires an SSH key with access to the repo, whilst an HTTPS link can be used by anybody