### PR TITLE
#sidebar-content retain a weird padding-top: 3px

### DIFF
--- a/editor/sass/sidebar.scss
+++ b/editor/sass/sidebar.scss
@@ -37,7 +37,6 @@
     right: 0;
     bottom: 25px;
     left: 0px;
-    padding-top: 3px;
     overflow-y: auto;
 }
 


### PR DESCRIPTION
workspace's content and tabs don't have retain the padding, but sidebar does.
it looks really weird:
![screenshot from 2015-08-14 11 14 41](https://cloud.githubusercontent.com/assets/2068895/9266657/c0333b5e-4276-11e5-9dd9-e23a71a7fb86.png)

it'll looks better if remove the "padding-top: 3px;".
![screenshot from 2015-08-14 11 24 38](https://cloud.githubusercontent.com/assets/2068895/9266681/19cbc988-4277-11e5-838b-6a00ccfac960.png)

