### PR TITLE
Support for Node 4.0.0 and Travis CI testing for same

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,23 @@
 sudo: false
 language: node_js
+env:
+  - CXX="g++-4.8"
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+    - gcc-4.8
+matrix:
+  allow_failures:
+  - node_js: "4.1.0"
 before_install:
   - npm install -g npm@~1.4.18
+# node_js 4.1.0 is brand new
 node_js:
+  - "4.1.0"
+  - "4.0.0"
   - "0.12"
   - "0.10"
 script:

--- a/nodes/core/core/89-trigger.js
+++ b/nodes/core/core/89-trigger.js
@@ -64,7 +64,7 @@ module.exports = function(RED) {
                     else if (node.op1Templated) { msg.payload = mustache.render(node.op1,msg); }
                     else { msg.payload = node.op1; }
                     if (node.op1type !== "nul") { node.send(msg); }
-                    if (node.duration === 0) { tout = "infinite"; }
+                    if (node.duration === 0) { tout = 0; }
                     else {
                         tout = setTimeout(function() {
                             msg.payload = m2;

--- a/test/nodes/core/storage/50-file_spec.js
+++ b/test/nodes/core/storage/50-file_spec.js
@@ -457,7 +457,7 @@ describe('file Nodes', function() {
                     logEvents.should.have.length(1);
                     logEvents[0][0].should.have.a.property('msg');
                     //logEvents[0][0].msg.toString().should.equal("Error: ENOENT, open 'badfile'");
-                    logEvents[0][0].msg.toString().should.startWith("Error: ENOENT, open");
+                    logEvents[0][0].msg.toString().should.startWith("Error: ENOENT");
                     done();
                 },wait);
                 n1.receive({payload:""});


### PR DESCRIPTION
This pull request has several patches suggested by @dceejay that correct the two errors that were causing Node-RED not to build on Node 4.0.0. One was a bad test that failed when it should have succeeded (now fixed), and the other was a case where code set a value to a string when it was expecting a number.

The request also patches .travis.yml to test against Node 4.0.0 which includes setting up the Travis environment to use the gcc 4.8 compiler.

As it stands, the .travis.yml files allow failures on the 4.0.0 builds to not show up as failures of the main build. At some point that should be switched over, but there's still all of `node-red/node-red-nodes` to get tested under 4.0.0.