### PR TITLE
Allow HTTP nodes to handle non-UTF8 content.

### DIFF
--- a/nodes/core/io/21-httpin.js
+++ b/nodes/core/io/21-httpin.js
@@ -27,17 +27,39 @@ module.exports = function(RED) {
     var jsonParser = express.json();
     var urlencParser = express.urlencoded();
     var onHeaders = require('on-headers');
+    var typer = require('media-typer');
+    var isUtf8 = require('is-utf8');
+
+    function isMIMETypeText(mimeType) {
+        var parsedType = typer.parse(mimeType)
+
+        if (parsedType.type === "text") {
+          return true;
+        }
+
+        if (parsedType.subtype === "xml" || parsedType.suffix === "xml") {
+          return true;
+        }
+
+        return false;
+    }
 
     function rawBodyParser(req, res, next) {
         if (req._body) { return next(); }
         req.body = "";
         req._body = true;
+
+       var textType = isMIMETypeText(req.headers['content-type'])
+
         getBody(req, {
-            limit: '1mb',
             length: req.headers['content-length'],
-            encoding: 'utf8'
+            encoding: textType ? "utf8" : null
         }, function (err, buf) {
             if (err) { return next(err); }
+            if (!textType && isUtf8(buf)) {
+              buf = buf.toString()
+            }
+
             req.body = buf;
             next();
         });

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "uglify-js":"2.4.24",
         "on-headers":"1.0.0",
         "is-utf8":"0.2.0",
+        "media-typer": "0.3.0",
         "fs.notify":"0.0.4",
         "passport":"0.2.2",
         "passport-http-bearer":"1.0.1",


### PR DESCRIPTION
Setting UTF-8 as the default body encoding stops us sending binary
content, e.g. audio, which can be decoded into a Buffer.

Use "Content-Type" header to decide whether to decode as UTF-8 or a Buffer. 
