### PR TITLE
Changes "Welcome to node red" to log statement

### DIFF
--- a/red/server.js
+++ b/red/server.js
@@ -58,7 +58,7 @@ function start() {
                     reportMetrics();
                 }, settings.runtimeMetricInterval||15000);
             }
-            console.log("\n\n"+log._("runtime.welcome")+"\n===================\n");
+            log.info("\n\n"+log._("runtime.welcome")+"\n===================\n");
             if (settings.version) {
                 log.info(log._("runtime.version",{component:"Node-RED",version:"v"+settings.version}));
             }


### PR DESCRIPTION
The console message:

```
Welcome to Node-RED
===================
```

is currently the only (non error related) console output which is done directly with `console.log`. This changes this so that it's done with the `log.info` method instead. This way we can set our log level to a preferred value and _only_ show that in the console.

This makes it possible to spin up a Node-RED server in a unit test (e.g. for testing a specific node) and don't have it polluting the test output.
