### PR TITLE
Allow override of IP:port using environment veriables

### DIFF
--- a/red.js
+++ b/red.js
@@ -152,8 +152,8 @@ if (settings.httpNodeRoot !== false) {
     settings.httpNodeAuth = settings.httpNodeAuth || settings.httpAuth;
 }
 
-settings.uiPort = settings.uiPort||1880;
-settings.uiHost = settings.uiHost||"0.0.0.0";
+settings.uiPort = process.env.PORT||settings.uiPort||1880;
+settings.uiHost = process.env.IP||settings.uiHost||"0.0.0.0";
 
 if (flowFile) {
     settings.flowFile = flowFile;


### PR DESCRIPTION
This way you can easily override the IP:port combination from the commandline. For instance, c9 deploys applications this way.


Example deployed this way at:
 * https://ide.c9.io/gbraad/node-red/
 * https://node-red-gbraad-1.c9.io/