### PR TITLE
Inject node - bug in specific time mode spinner

### DIFF
--- a/nodes/core/core/20-inject.html
+++ b/nodes/core/core/20-inject.html
@@ -274,7 +274,7 @@
                         }
                         var p = value.split(":");
                         var offset = new Date().getTimezoneOffset();
-                        return (((Number(p[0])+1)*60)+Number(p[1])+offset)*60*1000;
+                        return ((Number(p[0])*60)+Number(p[1])+offset)*60*1000;
                     }
                     return value;
                 },


### PR DESCRIPTION
In the inject node, in "at specific time" mode, the time spinner doesn't work. On "up", the spinner adds one minute AND one hour. On "down", the spinner removes one minute and adds one hour.

Changes on my branch make the spinner only add/remove one minute and change hour when adding at HH:59 or removing at HH:00.