### PR TITLE
Editor style can be changed to 'inverted' style by changing variables only

### DIFF
--- a/editor/js/ui/view.js
+++ b/editor/js/ui/view.js
@@ -199,8 +199,7 @@ RED.view = (function() {
 
     var outer_background = vis.append('svg:rect')
         .attr('width', space_width)
-        .attr('height', space_height)
-        .attr('fill','#fff');
+        .attr('height', space_height);
 
     var gridScale = d3.scale.linear().range([0,space_width]).domain([0,space_width]);
     var grid = vis.append('g');

--- a/editor/sass/colors.scss
+++ b/editor/sass/colors.scss
@@ -14,10 +14,23 @@
  * limitations under the License.
  **/
 
-$form-placeholder-color: #bbbbbb;
-$form-text-color: #444;
+$back: white;
+$back-dark: darken($back,2%);
+$back-light: lighten($back,2%);
+
+$inactive: darken($back,8%);
+$hover: darken($back,4%);
+$fore: black;
+$color-disabled: darken($fore,5%);
+
+$primary-border-color: darken($back,7.5%);
+$secondary-border-color: darken($back,15%);
+
+$button-active: darken($back,2%);
+$popover-back: lighten($back,10%);
+
+$form-placeholder-color: darken($fore,5%);
 $form-input-focus-color:  rgba(85,150,230,0.8);
-$form-input-border-color:  #ccc;
 
 
 $node-selected-color: #ff7f0e;
@@ -26,12 +39,9 @@ $link-color: #888;
 $link-subflow-color: #bbb;
 $link-unknown-color: #f00;
 
-$primary-border-color: #bbbbbb;
-$secondary-border-color: #dddddd;
-
-$tab-background-active: #fff;
-$tab-background-inactive: #f0f0f0;
-$tab-background-hover: #ddd;
+$tab-background-active: $back;
+$tab-background-inactive: $inactive;
+$tab-background-hover: $hover;
 
 $palette-header-background: #f3f3f3;
 

--- a/editor/sass/editor.scss
+++ b/editor/sass/editor.scss
@@ -29,7 +29,7 @@
 
 .form-row {
     clear: both;
-    color: $form-text-color;
+    color: $fore;
     margin-bottom:12px;
 }
 .form-row label {

--- a/editor/sass/forms.scss
+++ b/editor/sass/forms.scss
@@ -97,7 +97,7 @@ legend {
   margin-bottom: 20px;
   font-size: 21px;
   line-height: 40px;
-  color: #333333;
+  color: $fore;
   border: 0;
   border-bottom: 1px solid #e5e5e5;
 }
@@ -116,13 +116,18 @@ textarea {
   font-size: 14px;
   font-weight: normal;
   line-height: 20px;
+  background: $back-light;
+  color: $fore;
+}
+label {
+  background: $back;
 }
 
 input,
 button,
 select,
 textarea {
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-family: $font-family;
 }
 
 label {
@@ -153,7 +158,7 @@ input[type="color"],
   margin-bottom: 10px;
   font-size: 14px;
   line-height: 20px;
-  color: #555555;
+  color: $fore;
   vertical-align: middle;
   border-radius: 4px;
 }
@@ -184,8 +189,7 @@ input[type="search"],
 input[type="tel"],
 input[type="color"],
 .uneditable-input {
-  background-color: #ffffff;
-  border: 1px solid $form-input-border-color;
+  border: 1px solid $primary-border-color;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
      -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
           box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
@@ -208,6 +212,7 @@ input[type="tel"]:focus,
 input[type="color"]:focus,
 .uneditable-input:focus {
   border-color: $form-input-focus-color;
+  color: $fore;
   outline: 0;
   outline: thin dotted \9;
   /* IE6-9 */
@@ -248,8 +253,7 @@ input[type="file"] {
 
 select {
   width: 220px;
-  background-color: #ffffff;
-  border: 1px solid $form-input-border-color;
+  border: 1px solid $primary-border-color;
 }
 
 select[multiple],
@@ -495,7 +499,7 @@ input[readonly],
 select[readonly],
 textarea[readonly] {
   cursor: not-allowed;
-  background-color: #eeeeee;
+  background-color: $back-dark;
 }
 
 input[type="radio"][disabled],
@@ -772,8 +776,8 @@ select:focus:invalid:focus {
   font-weight: normal;
   line-height: 20px;
   text-align: center;
-  text-shadow: 0 1px 0 #ffffff;
-  background-color: #eeeeee;
+  text-shadow: 0 1px 0 $back;
+  background-color: $back-dark;
   border: 1px solid #ccc;
 }
 

--- a/editor/sass/globals.scss
+++ b/editor/sass/globals.scss
@@ -1,0 +1,1 @@
+$font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;

--- a/editor/sass/jquery.scss
+++ b/editor/sass/jquery.scss
@@ -16,11 +16,11 @@
 
 .ui-widget {
     font-size: 14px !important;
-    font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif !important;
+    font-family: $font-family;
 }
 .ui-widget input, .ui-widget select, .ui-widget textarea, .ui-widget button {
     font-size: 14px !important;
-    font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif !important;
+    font-family: $font-family;
 }
 .ui-widget input {
     box-shadow: none;
@@ -39,28 +39,36 @@
 
 .ui-dialog {
     border-radius: 1px;
-    background: #fff;
+    background: $back;
+    color: $fore;
     padding: 0;
     @include component-shadow;
+}
+.ui-dialog label {
+    color: $fore;
 }
 .ui-dialog .ui-dialog-content {
     padding: 25px 25px 10px 25px;
 }
 .ui-dialog .ui-dialog-title {
     width: auto;
+    color: $fore;
 }
 .ui-dialog .ui-dialog-titlebar {
     padding: 10px;
-    background: #f3f3f3;
+    background: $back-dark;
     border: none;
-    border-bottom: 1px solid #999;
+    border-bottom: 1px solid $primary-border-color;
     border-radius: 0;
 }
 .ui-corner-all {
     border-radius: 1px;
 }
 .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
-    background: #f3f3f3;
+    background: $back-dark;
+}
+.ui-widget-content {
+    border-top: 1px solid $primary-border-color;
 }
 .ui-dialog-no-close .ui-dialog-titlebar-close {
     display: none;
@@ -74,5 +82,10 @@
     float: none;
 }
 .ui-dialog .ui-dialog-buttonpane {
+    background: $back;
     padding: .3em 1em .5em 1em;
+}
+.ui-dialog .ui-dialog-buttonpane button {
+    border-color: $primary-border-color;
+    color: $fore;
 }

--- a/editor/sass/mixins.scss
+++ b/editor/sass/mixins.scss
@@ -30,10 +30,10 @@
 
 @mixin workspace-button {
     @include disable-selection;
-    color: $workspace-button-color;
+    color: $fore;
     box-sizing: border-box;
     display: inline-block;
-    background: $workspace-button-background;
+    background: $back;
     border: 1px solid $secondary-border-color;
     text-align: center;
     margin:0;
@@ -41,25 +41,25 @@
     cursor:pointer;
     &.disabled {
         cursor: default;
-        color: $workspace-button-color-disabled;
+        color: $color-disabled;
     }
     &:not(.disabled):hover {
         text-decoration: none;
-        color: $workspace-button-color-hover;
-        background: $workspace-button-background-hover;
+        color: $fore;
+        background: $hover;
     }
     &:not(.disabled):focus {
-        color: $workspace-button-color-focus;
+        color: $fore;
         text-decoration: none;
     }
     &:not(.disabled):active {
-        color: $workspace-button-color-active;
-        background: $workspace-button-background-active;
+        color: $fore;
+        background: $button-active;
         text-decoration: none;
     }
     &.selected:not(.disabled) {
-        color: $workspace-button-color-selected;
-        background: $workspace-button-background-active;
+        color: $fore;
+        background: $button-active;
         cursor: default;
     }
 
@@ -70,7 +70,7 @@
 
 @mixin component-footer {
     border-top: 1px solid $primary-border-color;
-    background: #f3f3f3;
+    background: $back;
     text-align: right;
     position: absolute;
     bottom: 0;

--- a/editor/sass/notifications.scss
+++ b/editor/sass/notifications.scss
@@ -28,8 +28,8 @@
     padding: 14px 18px;
     margin-bottom: 4px;
     box-shadow: 0 1px 1px 1px rgba(0,0,0, 0.15);
-    background-color: #fff;
-    color: #666;
+    background-color: $back;
+    color: $fore;
     border: 1px solid #325C80;
     border-left-width: 16px;
 }

--- a/editor/sass/palette.scss
+++ b/editor/sass/palette.scss
@@ -16,16 +16,16 @@
 
 
 #palette {
+    color: $fore;
     position: absolute;
     top: 0px;
     bottom: 0px;
     left:0px;
-    background: #f3f3f3;
+    background: $back-dark;
     width: 180px;
     text-align: center;
     @include disable-selection;
     @include component-border;
-
 }
 .palette-scroll {
     display: none;
@@ -48,27 +48,45 @@
     left:0;
     right:0;
     overflow: hidden;
-    background: #ffffff;
+    background: $back;
     text-align: center;
     height: 35px;
     padding: 3px;
     border-bottom: 1px solid $primary-border-color;
     box-sizing:border-box;
-}
-#palette-search i {
-    font-size: 10px;
-    color: #666;
-}
-#palette-search i.fa-search {
-    position: absolute;
-    pointer-events: none;
-    left: 12px;
-    top: 12px;
-}
-#palette-search i.fa-times {
-    position: absolute;
-    right: 7px;
-    top: 12px;
+    i {
+        font-size: 10px;
+        color: $fore;
+        &.fa-search {
+            position: absolute;
+            pointer-events: none;
+            left: 12px;
+            top: 12px;
+        }
+        &.fa-times {
+            position: absolute;
+            right: 7px;
+            top: 12px;
+        }
+    }
+    input {
+        background: $back;
+        color: $fore;
+        border-radius: 0;
+        border: none;
+        width: 100%;
+        box-shadow: none;
+        -webkit-box-shadow: none;
+        padding: 3px 17px 3px 22px;
+        margin: 0px;
+        height: 30px;
+        box-sizing:border-box;
+        &:focus {
+            border: none;
+            box-shadow: none;
+            -webkit-box-shadow: none;
+        }
+    }
 }
 
 #palette-search-clear {
@@ -80,23 +98,7 @@
     display: none;
 }
 
-#palette-search input {
-    border-radius: 0;
-    border: none;
-    width: 100%;
-    box-shadow: none;
-    -webkit-box-shadow: none;
-    padding: 3px 17px 3px 22px;
-    margin: 0px;
-    height: 30px;
-    box-sizing:border-box;
-}
 
-#palette-search input:focus {
-    border: none;
-    box-shadow: none;
-    -webkit-box-shadow: none;
-}
 #palette-footer {
     @include component-footer;
 }
@@ -106,16 +108,16 @@
 
 
 .palette-category {
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid $primary-border-color;
 }
 .palette-content {
-    background: #fff;
+    background: $back;
     padding: 3px;
 }
 
 .palette-header {
     position: relative;
-    background: $palette-header-background;
+    background: $back-dark;
     cursor: pointer;
     text-align: left;
     padding: 9px;

--- a/editor/sass/popover.scss
+++ b/editor/sass/popover.scss
@@ -21,8 +21,9 @@
      width: 300px;
      padding: 10px;
      height: auto;
-     background: #fff;
-     
+     background: $popover-back;
+     color: $fore;
+
      z-index: 1000;
      font-size: 14px;
      line-height: 1.4em;
@@ -41,7 +42,7 @@
 
  .red-ui-popover:after {
  	border-color: rgba(136, 183, 213, 0);
- 	border-right-color: #fff;
+ 	border-right-color: $popover-back;
  	border-width: 10px;
  	margin-top: -10px;
  }

--- a/editor/sass/sidebar.scss
+++ b/editor/sass/sidebar.scss
@@ -20,13 +20,13 @@
     right: 0px;
     bottom: 0px;
     width: 315px;
-    background: #fff;
+    background: $back;
     box-sizing: border-box;
     @include component-border;
 }
 
 #sidebar.closing {
-    background: #eee;
+    background: $back;
     border-color: #900;
     border-style: dashed;
 }
@@ -63,10 +63,10 @@
 }
 
 .sidebar-header {
-    color: #666;
+    color: $fore;
     text-align: right;
     padding: 8px 10px;
-    background: #f3f3f3;
+    background: $back-dark;
     border-bottom: 1px solid $secondary-border-color;
 }
 

--- a/editor/sass/style.scss
+++ b/editor/sass/style.scss
@@ -14,6 +14,7 @@
  * limitations under the License.
  **/
 
+@import "globals";
 @import "colors";
 @import "mixins";
 
@@ -50,9 +51,9 @@
 
 body {
     font-size: 14px;
-    font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    font-family: $font-family;
     padding-top: 100px;
-    background: #f3f3f3;
+    background: $back;
 }
 
 #main-container {

--- a/editor/sass/tabs.scss
+++ b/editor/sass/tabs.scss
@@ -15,6 +15,7 @@
  **/
 
 ul.red-ui-tabs {
+    background: $back;
     list-style-type: none;
     padding:0;
     margin: 0;
@@ -23,7 +24,6 @@ ul.red-ui-tabs {
     box-sizing:border-box;
     white-space: nowrap;
     border-bottom: 1px solid $primary-border-color;
-    background: #fff;
     @include disable-selection;
 }
 
@@ -45,12 +45,12 @@ ul.red-ui-tabs li {
 }
 
 ul.red-ui-tabs li a.red-ui-tab-label {
+    color: $fore;
     display: block;
     font-size: 14px;
     padding-left: 12px;
     width: 100%;
     height: 100%;
-    color: #666;
 }
 ul.red-ui-tabs li {
     position: relative;
@@ -68,7 +68,7 @@ ul.red-ui-tabs li {
     line-height: 28px;
     text-align: center;
     padding: 0px;
-    color: #aaa;
+    color: $fore;
     &:hover {
         background: $workspace-button-background-hover !important;
         opacity: 1;
@@ -79,7 +79,7 @@ ul.red-ui-tabs li:not(.active) a:hover+a.red-ui-tab-close {
 }
 
 ul.red-ui-tabs li.active a.red-ui-tab-close {
-    color: #aaa;
+    color: $fore;
     background: $tab-background-active;
     &:hover {
         background: $workspace-button-background-hover !important;
@@ -92,7 +92,7 @@ ul.red-ui-tabs li a:hover {
 }
 
 ul.red-ui-tabs li:not(.active) a:hover {
-    color: $workspace-button-color-hover;
+    color: $fore;
     background: $tab-background-hover;
 }
 
@@ -103,10 +103,10 @@ ul.red-ui-tabs li a:focus {
 ul.red-ui-tabs li.active {
     background: $tab-background-active;
     font-weight: bold;
-    border-bottom: 1px solid #fff;
+    border-bottom: 1px solid $back;
 }
 ul.red-ui-tabs li.active a {
-    color: #333;
+    color: $fore;
 }
 
 ul.red-ui-tabs li img {

--- a/editor/sass/typedInput.scss
+++ b/editor/sass/typedInput.scss
@@ -15,7 +15,7 @@
  **/
 
 .red-ui-typedInput-container {
-    border: 1px solid $form-input-border-color;
+    border: 1px solid $primary-border-color;
     border-radius: 4px;
     height: 34px;
     display: inline-block;

--- a/editor/sass/workspace.scss
+++ b/editor/sass/workspace.scss
@@ -17,7 +17,6 @@
 
 #chart {
    overflow: auto;
-   background: #e3e3e3;
    position: absolute;
    bottom:25px;
    top: 35px;
@@ -25,6 +24,7 @@
    right:0px;
    box-sizing:border-box;
    transition: right 0.2s ease;
+   fill: $back;
 }
 
 #chart svg:focus {
@@ -57,7 +57,7 @@
     right: 0;
     height: 35px;
     width: 35px;
-    background: #fff;
+    background: $back;
     border-bottom: 1px solid $primary-border-color;
 }
 


### PR DESCRIPTION
Refactoring of some styles to be able to easily change editor to a dark (or inverted) theme.

Only global changes have been made; to finish this refactoring completely these changes should also be applied to other components (eg. node links still have white background / not all of the dialog is completed / 'inverted' debug window need some TLC).

These changes should not interfere with the 'editorTheme' options.

Comments welcome
