### PR TITLE
get port from environment by default

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -20,7 +20,7 @@
 
 module.exports = {
     // the tcp port that the Node-RED web server is listening on
-    uiPort: 1880,
+    uiPort: process.env.PORT || 1880,
 
     // By default, the Node-RED UI accepts connections on all IPv4 interfaces.
     // The following property can be used to listen on a specific interface. For


### PR DESCRIPTION
This allows the app to run on modern cloud platforms like [Cloud Foundry](https://www.cloudfoundry.org) without having any effect on other users. It might even be suitable to configure all the other variables through the environment by default and only taking the value from the `settings.js` file if there is no respective environment variable. This allows for a more modern and flexible way to deploy the application as described in this article: [http://12factor.net/config](http://12factor.net/config).