### PR TITLE
Prevent RED.node.registerNode from overriding a constructor's prototype

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -8,6 +8,7 @@
     //"strict": true,   // commented out for now as it causes 100s of warnings, but want to get there eventually
     //"unused": true,   // Check for unused functions and variables
     "loopfunc": true,   // allow functions to be defined in loops
-    //"expr": true,       // allow ternery operator syntax...
-    "sub": true         // don't warn that foo['bar'] should be written as foo.bar
+    //"expr": true,     // allow ternery operator syntax...
+    "sub": true,        // don't warn that foo['bar'] should be written as foo.bar
+    "proto": true       // allow setting of __proto__ in node < v0.12
 }

--- a/red/runtime/nodes/registry/registry.js
+++ b/red/runtime/nodes/registry/registry.js
@@ -341,7 +341,11 @@ function registerNodeConstructor(type,constructor) {
             while(Object.getPrototypeOf(proto) !== Object.prototype) {
                 proto = Object.getPrototypeOf(proto);
             }
-            util.inherits(proto.constructor,Node);
+            //TODO: This is a partial implementation of util.inherits >= node v5.0.0
+            //      which should be changed when support for node < v5.0.0 is dropped
+            //      see: https://github.com/nodejs/node/pull/3455
+            proto.constructor.super_ = Node;
+            Object.setPrototypeOf(proto, Node.prototype);
         }
     }
 

--- a/red/runtime/nodes/registry/registry.js
+++ b/red/runtime/nodes/registry/registry.js
@@ -333,7 +333,18 @@ function registerNodeConstructor(type,constructor) {
     //TODO: Ensure type is known - but doing so will break some tests
     //      that don't have a way to register a node template ahead
     //      of registering the constructor
-    util.inherits(constructor,Node);
+    if(!(constructor.prototype instanceof Node)) {
+        if(Object.getPrototypeOf(constructor.prototype) === Object.prototype) {
+            util.inherits(constructor,Node);
+        } else {
+            var proto = constructor.prototype;
+            while(Object.getPrototypeOf(proto) !== Object.prototype) {
+                proto = Object.getPrototypeOf(proto);
+            }
+            util.inherits(proto.constructor,Node);
+        }
+    }
+
     nodeConstructors[type] = constructor;
     events.emit("type-registered",type);
 }

--- a/red/runtime/nodes/registry/registry.js
+++ b/red/runtime/nodes/registry/registry.js
@@ -345,7 +345,12 @@ function registerNodeConstructor(type,constructor) {
             //      which should be changed when support for node < v5.0.0 is dropped
             //      see: https://github.com/nodejs/node/pull/3455
             proto.constructor.super_ = Node;
-            Object.setPrototypeOf(proto, Node.prototype);
+            if(Object.setPrototypeOf) {
+                Object.setPrototypeOf(proto, Node.prototype);
+            } else {
+                // hack for node v0.10
+                proto.__proto__ = Node.prototype;
+            }
         }
     }
 

--- a/red/runtime/nodes/registry/registry.js
+++ b/red/runtime/nodes/registry/registry.js
@@ -326,6 +326,27 @@ function getCaller(){
     return stack[0].getFileName();
 }
 
+function inheritNode(constructor) {
+    if(Object.getPrototypeOf(constructor.prototype) === Object.prototype) {
+        util.inherits(constructor,Node);
+    } else {
+        var proto = constructor.prototype;
+        while(Object.getPrototypeOf(proto) !== Object.prototype) {
+            proto = Object.getPrototypeOf(proto);
+        }
+        //TODO: This is a partial implementation of util.inherits >= node v5.0.0
+        //      which should be changed when support for node < v5.0.0 is dropped
+        //      see: https://github.com/nodejs/node/pull/3455
+        proto.constructor.super_ = Node;
+        if(Object.setPrototypeOf) {
+            Object.setPrototypeOf(proto, Node.prototype);
+        } else {
+            // hack for node v0.10
+            proto.__proto__ = Node.prototype;
+        }
+    }
+}
+
 function registerNodeConstructor(type,constructor) {
     if (nodeConstructors[type]) {
         throw new Error(type+" already registered");
@@ -334,24 +355,7 @@ function registerNodeConstructor(type,constructor) {
     //      that don't have a way to register a node template ahead
     //      of registering the constructor
     if(!(constructor.prototype instanceof Node)) {
-        if(Object.getPrototypeOf(constructor.prototype) === Object.prototype) {
-            util.inherits(constructor,Node);
-        } else {
-            var proto = constructor.prototype;
-            while(Object.getPrototypeOf(proto) !== Object.prototype) {
-                proto = Object.getPrototypeOf(proto);
-            }
-            //TODO: This is a partial implementation of util.inherits >= node v5.0.0
-            //      which should be changed when support for node < v5.0.0 is dropped
-            //      see: https://github.com/nodejs/node/pull/3455
-            proto.constructor.super_ = Node;
-            if(Object.setPrototypeOf) {
-                Object.setPrototypeOf(proto, Node.prototype);
-            } else {
-                // hack for node v0.10
-                proto.__proto__ = Node.prototype;
-            }
-        }
+        inheritNode(constructor);
     }
 
     nodeConstructors[type] = constructor;

--- a/test/red/runtime/nodes/registry/registry_spec.js
+++ b/test/red/runtime/nodes/registry/registry_spec.js
@@ -20,7 +20,11 @@ var sinon = require("sinon");
 
 var typeRegistry = require("../../../../../red/runtime/nodes/registry/registry");
 
+var Node = require("../../../../../red/runtime/nodes/Node");
+
 var events = require("../../../../../red/runtime/events");
+
+var inherits = require("util").inherits;
 
 describe("red/nodes/registry/registry",function() {
 
@@ -428,9 +432,10 @@ describe("red/nodes/registry/registry",function() {
     });
 
     describe('#registerNodeConstructor', function() {
-        function TestNodeConstructor() {
-        }
+        var TestNodeConstructor;
         beforeEach(function() {
+            TestNodeConstructor = function TestNodeConstructor() {
+            };
             sinon.stub(events,'emit');
         });
         afterEach(function() {
@@ -452,7 +457,23 @@ describe("red/nodes/registry/registry",function() {
                 typeRegistry.registerNodeConstructor('node-type',TestNodeConstructor);
             }).should.throw("node-type already registered");
             events.emit.calledOnce.should.be.true;
-        })
+        });
+        it('extends a constructor with the Node constructor', function() {
+            TestNodeConstructor.prototype.should.not.be.an.instanceOf(Node);
+            typeRegistry.registerNodeConstructor('node-type',TestNodeConstructor);
+            TestNodeConstructor.prototype.should.be.an.instanceOf(Node);
+        });
+        it('does not override a constructor\'s prototype', function() {
+            function Foo(){};
+            inherits(TestNodeConstructor,Foo);
+            TestNodeConstructor.prototype.should.be.an.instanceOf(Foo);
+            TestNodeConstructor.prototype.should.not.be.an.instanceOf(Node);
+
+            typeRegistry.registerNodeConstructor('node-type',TestNodeConstructor);
+
+            TestNodeConstructor.prototype.should.be.an.instanceOf(Node);
+            TestNodeConstructor.prototype.should.be.an.instanceOf(Foo);
+        });
     });
 
 });

--- a/test/red/runtime/nodes/registry/registry_spec.js
+++ b/test/red/runtime/nodes/registry/registry_spec.js
@@ -473,6 +473,10 @@ describe("red/nodes/registry/registry",function() {
 
             TestNodeConstructor.prototype.should.be.an.instanceOf(Node);
             TestNodeConstructor.prototype.should.be.an.instanceOf(Foo);
+
+            typeRegistry.registerNodeConstructor('node-type2',TestNodeConstructor);
+            TestNodeConstructor.prototype.should.be.an.instanceOf(Node);
+            TestNodeConstructor.prototype.should.be.an.instanceOf(Foo);
         });
     });
 


### PR DESCRIPTION
Reopening https://github.com/node-red/node-red/pull/854 pointing to 0.14.0 branch