### PR TITLE
Use payload as request body for all http methods apart from TRACE

### DIFF
--- a/nodes/core/io/21-httprequest.js
+++ b/nodes/core/io/21-httprequest.js
@@ -85,7 +85,7 @@ module.exports = function(RED) {
             }
             var payload = null;
 
-            if (msg.payload && (method == "POST" || method == "PUT" || method == "PATCH" ) ) {
+            if (msg.payload && method != "TRACE") {
                 if (typeof msg.payload === "string" || Buffer.isBuffer(msg.payload)) {
                     payload = msg.payload;
                 } else if (typeof msg.payload == "number") {


### PR DESCRIPTION
Whilst the DELETE and GET methods do not have any defined semantics
they are not explicitly forbidden by the RFC. It only forbids a
request body for TRACE requests.

I'm mostly interested in request bodies for DELETE requests as an
api I need to interact with requires the ids of entities to be deleted
to be passed as a JSON array in the request body.

Ref: https://tools.ietf.org/html/rfc7231
