### PR TITLE
Added 'exec' to the command in the node-red-pi script

### DIFF
--- a/bin/node-red-pi
+++ b/bin/node-red-pi
@@ -40,4 +40,4 @@ SCRIPT_PATH="`pwd`";
 cd $CURRENT_PATH
 
 # Run Node-RED
-/usr/bin/env node $OPTIONS $SCRIPT_PATH/../red.js $ARGS
+exec /usr/bin/env node $OPTIONS $SCRIPT_PATH/../red.js $ARGS


### PR DESCRIPTION
Hello,

The benefits of this change are:

- it allows process supervisors (like daemontools) to get the PID of the actual node-red process
- it leaves fewer process hanging around

nick.
