### PR TITLE
Removed duplicate [Delete] key entry in the Keyboard Shortcuts dialog.

### DIFF
--- a/editor/js/ui/keyboard.js
+++ b/editor/js/ui/keyboard.js
@@ -120,8 +120,6 @@ RED.keyboard = (function() {
                     '<table class="keyboard-shortcuts">'+
                         '<tr><td><span class="help-key">Ctrl/&#8984;</span> + <span class="help-key">Space</span></td><td>'+RED._("keyboard.toggleSidebar")+'</td></tr>'+
                         '<tr><td></td><td></td></tr>'+
-                        '<tr><td><span class="help-key">Delete</span></td><td>'+RED._("keyboard.deleteNode")+'</td></tr>'+
-                        '<tr><td></td><td></td></tr>'+
                         '<tr><td><span class="help-key">Ctrl/&#8984;</span> + <span class="help-key">c</span></td><td>'+RED._("keyboard.copyNode")+'</td></tr>'+
                         '<tr><td><span class="help-key">Ctrl/&#8984;</span> + <span class="help-key">x</span></td><td>'+RED._("keyboard.cutNode")+'</td></tr>'+
                         '<tr><td><span class="help-key">Ctrl/&#8984;</span> + <span class="help-key">v</span></td><td>'+RED._("keyboard.pasteNode")+'</td></tr>'+

--- a/red/api/locales/en-US/editor.json
+++ b/red/api/locales/en-US/editor.json
@@ -148,7 +148,6 @@
         "importNode": "Import nodes",
         "exportNode": "Export selected nodes",
         "toggleSidebar": "Toggle sidebar",
-        "deleteNode": "Delete selected nodes or link",
         "copyNode": "Copy selected nodes",
         "cutNode": "Cut selected nodes",
         "pasteNode": "Paste nodes"


### PR DESCRIPTION
This PR removes a duplicate entry for the `Delete` key in the Keyboard Shortcuts dialog. Please see screenshot below:

![Keyboard Shortcuts Screenshot](http://i.imgur.com/auu1n6T.png)

*PS. I'm working on the CLA - should have that e-mailed to Nick (@knolleary) soon.*