### PR TITLE
Keyboard shortcuts dialog update

### DIFF
--- a/editor/js/ui/keyboard.js
+++ b/editor/js/ui/keyboard.js
@@ -113,6 +113,12 @@ RED.keyboard = (function() {
                         '<tr><td>&nbsp;</td><td></td></tr>'+
                         '<tr><td><span class="help-key">Ctrl/&#8984;</span> + <span class="help-key">i</span></td><td>'+RED._("keyboard.importNode")+'</td></tr>'+
                         '<tr><td><span class="help-key">Ctrl/&#8984;</span> + <span class="help-key">e</span></td><td>'+RED._("keyboard.exportNode")+'</td></tr>'+
+                        '<tr><td>&nbsp;</td><td></td></tr>'+
+                        '<tr><td><span class="help-key"> &#x2190; </span> <span class="help-key"> &#x2191; </span> <span class="help-key"> &#x2192; </span> <span class="help-key"> &#x2193; </span></td><td>'+RED._("keyboard.nudgeNode")+'</td></tr>'+
+                        '<tr><td><span class="help-key">Shift</span> + <span class="help-key"> &#x2190; </span></td><td rowspan="4">'+RED._("keyboard.moveNode")+'</td></tr>'+
+                        '<tr><td><span class="help-key">Shift</span> + <span class="help-key"> &#x2191; </span></td></tr>'+
+                        '<tr><td><span class="help-key">Shift</span> + <span class="help-key"> &#x2192; </span></td></tr>'+
+                        '<tr><td><span class="help-key">Shift</span> + <span class="help-key"> &#x2193; </span></td></tr>'+
                     '</table>'+
                 '</div>'+
                 '<div style="vertical-align: top;display:inline-block; box-sizing: border-box; width:50%; padding: 10px;">'+

--- a/editor/js/ui/keyboard.js
+++ b/editor/js/ui/keyboard.js
@@ -125,7 +125,8 @@ RED.keyboard = (function() {
                     '<table class="keyboard-shortcuts">'+
                         '<tr><td><span class="help-key">Ctrl/&#8984;</span> + <span class="help-key">Space</span></td><td>'+RED._("keyboard.toggleSidebar")+'</td></tr>'+
                         '<tr><td></td><td></td></tr>'+
-                        '<tr><td><span class="help-key">Delete</span></td><td>'+RED._("keyboard.deleteNode")+'</td></tr>'+
+                        '<tr><td><span class="help-key">Delete</span></td><td rowspan="2">'+RED._("keyboard.deleteSelected")+'</td></tr>'+
+                        '<tr><td><span class="help-key">Backspace</span></td></tr>'+
                         '<tr><td></td><td></td></tr>'+
                         '<tr><td><span class="help-key">Ctrl/&#8984;</span> + <span class="help-key">c</span></td><td>'+RED._("keyboard.copyNode")+'</td></tr>'+
                         '<tr><td><span class="help-key">Ctrl/&#8984;</span> + <span class="help-key">x</span></td><td>'+RED._("keyboard.cutNode")+'</td></tr>'+

--- a/editor/js/ui/keyboard.js
+++ b/editor/js/ui/keyboard.js
@@ -124,6 +124,7 @@ RED.keyboard = (function() {
                         '<tr><td><span class="help-key">Ctrl/&#8984;</span> + <span class="help-key">c</span></td><td>'+RED._("keyboard.copyNode")+'</td></tr>'+
                         '<tr><td><span class="help-key">Ctrl/&#8984;</span> + <span class="help-key">x</span></td><td>'+RED._("keyboard.cutNode")+'</td></tr>'+
                         '<tr><td><span class="help-key">Ctrl/&#8984;</span> + <span class="help-key">v</span></td><td>'+RED._("keyboard.pasteNode")+'</td></tr>'+
+                        '<tr><td><span class="help-key">Ctrl/&#8984;</span> + <span class="help-key">z</span></td><td>'+RED._("keyboard.undoChange")+'</td></tr>'+
                     '</table>'+
                 '</div>'+
                 '</div>')

--- a/red/api/locales/en-US/editor.json
+++ b/red/api/locales/en-US/editor.json
@@ -151,7 +151,8 @@
         "deleteNode": "Delete selected nodes or link",
         "copyNode": "Copy selected nodes",
         "cutNode": "Cut selected nodes",
-        "pasteNode": "Paste nodes"
+        "pasteNode": "Paste nodes",
+        "undoChange": "Undo the last change performed"
     },
     "library": {
         "openLibrary": "Open Library...",

--- a/red/api/locales/en-US/editor.json
+++ b/red/api/locales/en-US/editor.json
@@ -147,6 +147,8 @@
         "deleteSelected": "Delete selected nodes or link",
         "importNode": "Import nodes",
         "exportNode": "Export selected nodes",
+        "nudgeNode": "Move selected node(s) by a small amount",
+        "moveNode": "Move selected node(s) by a large amount",
         "toggleSidebar": "Toggle sidebar",
         "deleteNode": "Delete selected nodes or link",
         "copyNode": "Copy selected nodes",


### PR DESCRIPTION
Updated the Keyboard Shortcuts dialog to include most of the keyboard shortcuts registered during initialization.

The only keyboard shortcuts _not_ added were `[Ctrl]`+`[=]`, `[Ctrl]`+`[-]`, and `[Ctrl]`+`[0]` since those are overridden/owned by some browsers (like Firefox), and, hence, they don't always work.

PS. May need an update (possible merge conflict) if PR #922 is accepted.