### PR TITLE
doc/tool: simplify instructions for dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,26 +29,22 @@ For further help, or general discussion, please use the
 
 If you want to run the latest code from git, here's how to get started:
 
-1. Install grunt, the build tool
-
-        npm install -g grunt-cli
-
-2. Clone the code:
+1. Clone the code:
 
         git clone https://github.com/node-red/node-red.git
         cd node-red
 
-3. Install the node-red dependencies
+2. Install the node-red dependencies
 
         npm install
 
-4. Build the code
+3. Build the code
 
-        grunt build
+        npm run build
 
-5. Run
+4. Run
 
-        node red.js
+        npm start
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "main"         : "red/red.js",
     "scripts"      : {
         "start": "node red.js",
-        "test": "./node_modules/.bin/grunt"
+        "test": "grunt",
+        "build": "grunt build"
     },
     "bin"          : {
         "node-red": "./red.js",


### PR DESCRIPTION
This approach no longer requires users to install grunt-cli globally.  It is already installed as a dev dependency and more reliable to use a pegged version internally.