### PR TITLE
Fix split character in TCP Request node

### DIFF
--- a/nodes/core/io/31-tcpin.js
+++ b/nodes/core/io/31-tcpin.js
@@ -393,8 +393,11 @@ module.exports = function(RED) {
         this.splitc = n.splitc;
 
         if (this.out != "char") { this.splitc = Number(this.splitc); }
-        else { this.splitc = this.splitc.replace("\\n",0x0A).replace("\\r",0x0D).replace("\\t",0x09).replace("\\e",0x1B).replace("\\f",0x0C).replace("\\0",0x00); } // jshint ignore:line
-
+        else {
+            this.splitc = this.splitc.replace("\\n",0x0A).replace("\\r",0x0D).replace("\\t",0x09).replace("\\e",0x1B).replace("\\f",0x0C).replace("\\0",0x00);
+            if (typeof this.splitc == "string") { this.splitc = this.splitc.charCodeAt(0); }
+        } // jshint ignore:line
+        
         var buf;
         if (this.out == "count") {
             if (this.splitc === 0) { buf = new Buffer(1); }


### PR DESCRIPTION
In the TCP request node (TCPGet) if one uses a normal character (say A) as the the split character, it will currently fail because the chatacter is compared to the ascii value. This pull requests fixes this.