### PR TITLE
Add uncaughtException handler

### DIFF
--- a/nodes/core/io/21-httprequest.js
+++ b/nodes/core/io/21-httprequest.js
@@ -41,6 +41,12 @@ module.exports = function(RED) {
         if (process.env.no_proxy != null) { noprox = process.env.no_proxy.split(","); }
         if (process.env.NO_PROXY != null) { noprox = process.env.NO_PROXY.split(","); }
 
+        process.setMaxListeners(0);
+        process.on('uncaughtException', function (err) {
+          node.error(err);
+        });
+
+
         this.on("input",function(msg) {
             var preRequestTimestamp = process.hrtime();
             node.status({fill:"blue",shape:"dot",text:"httpin.status.requesting"});

--- a/nodes/core/io/21-httprequest.js
+++ b/nodes/core/io/21-httprequest.js
@@ -41,11 +41,9 @@ module.exports = function(RED) {
         if (process.env.no_proxy != null) { noprox = process.env.no_proxy.split(","); }
         if (process.env.NO_PROXY != null) { noprox = process.env.NO_PROXY.split(","); }
 
-        process.setMaxListeners(0);
-        process.on('uncaughtException', function (err) {
-          node.error(err);
+       this.on('uncaughtException', function (err) {
+          node.error('http-request error' + err.name +  ':' + err.message);
         });
-
 
         this.on("input",function(msg) {
             var preRequestTimestamp = process.hrtime();


### PR DESCRIPTION
In the current version the whole nodered process dies if the request url cannot be reached and an EHOSTUNREACH occurs. The req.on('error',function(err) doesn't catch this error because of the asynchronous request handling.

process.setMaxListeners(0) is required to prevent the warning "possible EventEmitter memory leak detected. 11 uncaughtException listeners added" on startup.