### PR TITLE
Fixes removeItem not passing row data to callback.

### DIFF
--- a/editor/js/ui/editableList.js
+++ b/editor/js/ui/editableList.js
@@ -164,11 +164,12 @@
                 $('<i/>',{class:"fa fa-remove"}).appendTo(deleteButton);
                 li.addClass("red-ui-editableList-item-removable");
                 deleteButton.click(function() {
+                    var data = row.data('data');
                     li.addClass("red-ui-editableList-item-deleting")
                     li.fadeOut(300, function() {
                         $(this).remove();
                         if (that.options.removeItem) {
-                            that.options.removeItem(row.data('data'));
+                            that.options.removeItem(data);
                         }
                     });
                 });


### PR DESCRIPTION
Call to ```row.data('data')``` was happening after the ```.remove()``` call, which deletes the retained data. This was passing undefined back to the callback for removeItem.

I've changed the data retrieval to a temporary variable before the delete call.