### PR TITLE
Fix jquery selector, selecting more than one help pane/popover

### DIFF
--- a/editor/js/ui/palette.js
+++ b/editor/js/ui/palette.js
@@ -101,7 +101,7 @@ RED.palette = (function() {
             if (label != type) {
                 l = "<p><b>"+label+"</b><br/><i>"+type+"</i></p>";
             }
-            popOverContent = $(l+(info?info:$("script[data-help-name|='"+type+"']").html()||"<p>"+RED._("palette.noInfo")+"</p>").trim())
+            popOverContent = $(l+(info?info:$("script[data-help-name$='"+type+"']").html()||"<p>"+RED._("palette.noInfo")+"</p>").trim())
                                 .filter(function(n) {
                                     return (this.nodeType == 1 && this.nodeName == "P") || (this.nodeType == 3 && this.textContent.trim().length > 0)
                                 }).slice(0,2);
@@ -210,7 +210,7 @@ RED.palette = (function() {
                 if (nt.indexOf("subflow:") === 0) {
                     helpText = marked(RED.nodes.subflow(nt.substring(8)).info||"");
                 } else {
-                    helpText = $("script[data-help-name|='"+d.type+"']").html()||"";
+                    helpText = $("script[data-help-name$='"+d.type+"']").html()||"";
                 }
                 var help = '<div class="node-help">'+helpText+"</div>";
                 RED.sidebar.info.set(help);

--- a/editor/js/ui/tab-info.js
+++ b/editor/js/ui/tab-info.js
@@ -139,7 +139,7 @@ RED.sidebar.info = (function() {
         }
         table += "</tbody></table><hr/>";
         if (!subflowNode && node.type != "comment") {
-            var helpText = $("script[data-help-name|='"+node.type+"']").html()||"";
+            var helpText = $("script[data-help-name$='"+node.type+"']").html()||"";
             table  += '<div class="node-help">'+helpText+"</div>";
         }
         if (subflowNode) {


### PR DESCRIPTION
Due to jquery selector type, it can match a condition where the node type followed by a hyphen can also be matched. This moves to a stricter selector removing the hyphen condition.

From:
[https://api.jquery.com/attribute-contains-prefix-selector/](https://api.jquery.com/attribute-contains-prefix-selector/)
To:
[https://api.jquery.com/attribute-ends-with-selector/](https://api.jquery.com/attribute-ends-with-selector/)

Fixes #969