### PR TITLE
node-red: parser/70-XML.js: Updated to enforce XML builder options

### DIFF
--- a/nodes/core/parsers/70-XML.js
+++ b/nodes/core/parsers/70-XML.js
@@ -31,6 +31,11 @@ module.exports = function(RED) {
                     var options = {};
                     if (msg.hasOwnProperty("options") && typeof msg.options === "object") { options = msg.options; }
                     options.async = false;
+
+		    //Explicitly create new builder object with options to enforce user specified options.
+		    // Ignoring "renderOpts" set initially, as user may choose to override.
+                    builder = new xml2js.Builder (options);
+
                     msg.payload = builder.buildObject(msg.payload, options);
                     node.send(msg);
                 }


### PR DESCRIPTION
I was not able to enforce XML options via XML node even though xml2js support. Found that, builder object is instantiated only once in the XML node, but if we create it using the options passed by user, then the options are enforced. 

Please see if this is acceptable.  I could test and validate the expected behaviour. Would like to know if it was deliberately kept out and there is another way to achieve the same ?