### PR TITLE
Add number of units to the delay node (rate)

### DIFF
--- a/nodes/core/core/89-delay.html
+++ b/nodes/core/core/89-delay.html
@@ -44,10 +44,10 @@
         <label for="node-input-rateUnits"><span data-i18n="delay.msgper"></span></label>
         <input type="text" id="node-input-nbRateUnits" placeholder="1" style="text-align:end; width:30px !important">
         <select id="node-input-rateUnits" style="width:110px !important">
-          <option value="second" data-i18n="delay.label.units.second"></option>
-          <option value="minute" data-i18n="delay.label.units.minute"></option>
-          <option value="hour" data-i18n="delay.label.units.hour"></option>
-          <option value="day" data-i18n="delay.label.units.day"></option>
+          <option value="second" data-i18n="delay.label.units.second.singular"></option>
+          <option value="minute" data-i18n="delay.label.units.minute.singular"></option>
+          <option value="hour" data-i18n="delay.label.units.hour.singular"></option>
+          <option value="day" data-i18n="delay.label.units.day.singular"></option>
         </select>
         <br/>
         <div id="node-input-dr"><input style="margin: 20px 0 20px 100px; width: 30px;" type="checkbox" id="node-input-drop"><label style="width: 250px;" for="node-input-drop"><span data-i18n="delay.dropmsg"></span></label></div>
@@ -121,7 +121,13 @@
               return this.name || this._("delay.label.random");
             }
             else if (this.pauseType == "timed") {
-                return this.name || this.rate + " " + this._("delay.label.timed") + " " + (this.nbRateUnits > 1 ? this.nbRateUnits + ' ' : '') + this._("delay.label.units." + this.rateUnits);
+                var units = '';
+                if (this.nbRateUnits > 1) {
+                    units = this.nbRateUnits + ' ' + this._("delay.label.units." + this.rateUnits + ".plural");
+                } else {
+                    units = this._("delay.label.units." + this.rateUnits + ".singular");
+                }
+                return this.name || this.rate + " " + this._("delay.label.timed") + ' ' + units;
             }
             else {
                 var units = this.rateUnits ? (this.nbRateUnits > 1 ? this.nbRateUnits : '') + this.rateUnits.charAt(0) : "s";
@@ -132,12 +138,39 @@
             return this.name?"node_label_italic":"";
         },
         oneditprepare: function() {
+          var node = this;
           $( "#node-input-timeout" ).spinner({min:1});
           $( "#node-input-rate" ).spinner({min:1});
           $( "#node-input-nbRateUnits" ).spinner({min:1});
 
           $( "#node-input-randomFirst" ).spinner({min:0});
           $( "#node-input-randomLast" ).spinner({min:1});
+
+          $('.ui-spinner-button').click(function() {
+              $(this).siblings('input').change();
+          });
+
+          $( "#node-input-nbRateUnits" ).on('change keyup', function() {
+            var $this = $(this);
+            var val = parseInt($this.val());
+            var type = "singular";
+            if(val > 1) {
+                type = "plural";
+            }
+            if($this.attr("data-type") == type) {
+                return;
+            }
+            $this.attr("data-type", type);
+            console.log(type);
+            $("#node-input-rateUnits option").each(function () {
+                var $option = $(this);
+                var key = "delay.label.units." + $option.val() + "." + type;
+                $option.attr('data-i18n', 'node-red:' + key);
+                $option.html(node._(key));
+            })
+          });
+
+
 
           if (this.pauseType == "delay") {
             $("#delay-details").show();

--- a/nodes/core/core/89-delay.html
+++ b/nodes/core/core/89-delay.html
@@ -44,10 +44,10 @@
         <label for="node-input-rateUnits"><span data-i18n="delay.msgper"></span></label>
         <input type="text" id="node-input-nbRateUnits" placeholder="1" style="text-align:end; width:30px !important">
         <select id="node-input-rateUnits" style="width:110px !important">
-          <option value="second" data-i18n="delay.sec"></option>
-          <option value="minute" data-i18n="delay.min"></option>
-          <option value="hour" data-i18n="delay.hour"></option>
-          <option value="day" data-i18n="delay.day"></option>
+          <option value="second" data-i18n="delay.label.units.second"></option>
+          <option value="minute" data-i18n="delay.label.units.minute"></option>
+          <option value="hour" data-i18n="delay.label.units.hour"></option>
+          <option value="day" data-i18n="delay.label.units.day"></option>
         </select>
         <br/>
         <div id="node-input-dr"><input style="margin: 20px 0 20px 100px; width: 30px;" type="checkbox" id="node-input-drop"><label style="width: 250px;" for="node-input-drop"><span data-i18n="delay.dropmsg"></span></label></div>
@@ -121,7 +121,7 @@
               return this.name || this._("delay.label.random");
             }
             else if (this.pauseType == "timed") {
-                return this.name || this.rate+" "+this._("delay.label.timed")+" "+ (this.nbRateUnits > 1 ? this.nbRateUnits + ' ' : '') +this.rateUnits;
+                return this.name || this.rate + " " + this._("delay.label.timed") + " " + (this.nbRateUnits > 1 ? this.nbRateUnits + ' ' : '') + this._("delay.label.units." + this.rateUnits);
             }
             else {
                 var units = this.rateUnits ? (this.nbRateUnits > 1 ? this.nbRateUnits : '') + this.rateUnits.charAt(0) : "s";

--- a/nodes/core/core/89-delay.html
+++ b/nodes/core/core/89-delay.html
@@ -161,7 +161,6 @@
                 return;
             }
             $this.attr("data-type", type);
-            console.log(type);
             $("#node-input-rateUnits option").each(function () {
                 var $option = $(this);
                 var key = "delay.label.units." + $option.val() + "." + type;

--- a/nodes/core/core/89-delay.html
+++ b/nodes/core/core/89-delay.html
@@ -121,10 +121,10 @@
               return this.name || this._("delay.label.random");
             }
             else if (this.pauseType == "timed") {
-                return this.name || this.rate+" "+this._("delay.label.timed")+" "+this.rateUnits;
+                return this.name || this.rate+" "+this._("delay.label.timed")+" "+ (this.nbRateUnits > 1 ? this.nbRateUnits + ' ' : '') +this.rateUnits;
             }
             else {
-                var units = this.rateUnits ? this.rateUnits.charAt(0) : "s";
+                var units = this.rateUnits ? (this.nbRateUnits > 1 ? this.nbRateUnits : '') + this.rateUnits.charAt(0) : "s";
                 return this.name || this._("delay.label.queue")+" "+this.rate+" msg/"+units;
             }
         },

--- a/nodes/core/core/89-delay.html
+++ b/nodes/core/core/89-delay.html
@@ -42,6 +42,7 @@
         <label for="node-input-rate"><i class="fa fa-clock-o"></i> <span data-i18n="delay.rate"></span></label>
         <input type="text" id="node-input-rate" placeholder="1" style="text-align:end; width:30px !important">
         <label for="node-input-rateUnits"><span data-i18n="delay.msgper"></span></label>
+        <input type="text" id="node-input-nbRateUnits" placeholder="1" style="text-align:end; width:30px !important">
         <select id="node-input-rateUnits" style="width:140px !important">
           <option value="second" data-i18n="delay.sec"></option>
           <option value="minute" data-i18n="delay.min"></option>
@@ -98,6 +99,7 @@
             timeout: {value:"5", required:true, validate:RED.validators.number()},
             timeoutUnits: {value:"seconds"},
             rate: {value:"1", required:true, validate:RED.validators.number()},
+            nbRateUnits: {value:"1", required:true, validate:RED.validators.number()},
             rateUnits: {value: "second"},
             randomFirst: {value:"1", required:true, validate:RED.validators.number()},
             randomLast: {value:"5", required:true, validate:RED.validators.number()},
@@ -113,7 +115,7 @@
               if (this.timeoutUnits == "milliseconds") { units = "ms"; }
               return this.name||this._("delay.label.delay")+" "+this.timeout+" "+units;
             } else if (this.pauseType == "rate") {
-              var units = this.rateUnits ? this.rateUnits.charAt(0) : "s";
+              var units = this.rateUnits ? (this.nbRateUnits > 1 ? this.nbRateUnits : '') + this.rateUnits.charAt(0) : "s";
               return this.name||this._("delay.label.limit")+" "+this.rate+" msg/"+units;
             } else if (this.pauseType == "random") {
               return this.name || this._("delay.label.random");
@@ -132,6 +134,7 @@
         oneditprepare: function() {
           $( "#node-input-timeout" ).spinner({min:1});
           $( "#node-input-rate" ).spinner({min:1});
+          $( "#node-input-nbRateUnits" ).spinner({min:1});
 
           $( "#node-input-randomFirst" ).spinner({min:0});
           $( "#node-input-randomLast" ).spinner({min:1});

--- a/nodes/core/core/89-delay.html
+++ b/nodes/core/core/89-delay.html
@@ -43,7 +43,7 @@
         <input type="text" id="node-input-rate" placeholder="1" style="text-align:end; width:30px !important">
         <label for="node-input-rateUnits"><span data-i18n="delay.msgper"></span></label>
         <input type="text" id="node-input-nbRateUnits" placeholder="1" style="text-align:end; width:30px !important">
-        <select id="node-input-rateUnits" style="width:140px !important">
+        <select id="node-input-rateUnits" style="width:110px !important">
           <option value="second" data-i18n="delay.sec"></option>
           <option value="minute" data-i18n="delay.min"></option>
           <option value="hour" data-i18n="delay.hour"></option>

--- a/nodes/core/core/89-delay.js
+++ b/nodes/core/core/89-delay.js
@@ -51,6 +51,8 @@ module.exports = function(RED) {
             this.rate = 1000/n.rate;
         }
 
+        this.rate *= (n.nbRateUnits > 0 ? n.nbRateUnits : 1);
+
         if (n.randomUnits === "milliseconds") {
             this.randomFirst = n.randomFirst * 1;
             this.randomLast = n.randomLast * 1;

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -200,7 +200,13 @@
             "limit": "limit",
             "random": "random",
             "queue": "queue",
-            "timed": "releases per"
+            "timed": "releases per",
+            "units" : {
+                "second": "second(s)",
+                "minute": "minute(s)",
+                "hour": "hour(s)",
+                "day": "day(s)"
+            }
         },
         "error": {
             "buffer": "buffer exceeded 1000 messages",

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -202,10 +202,22 @@
             "queue": "queue",
             "timed": "releases per",
             "units" : {
-                "second": "second(s)",
-                "minute": "minute(s)",
-                "hour": "hour(s)",
-                "day": "day(s)"
+                "second": {
+                    "plural" : "Seconds",
+                    "singular": "Second"
+                },
+                "minute": {
+                    "plural" : "Minutes",
+                    "singular": "Minute"
+                },
+                "hour": {
+                    "plural" : "Hours",
+                    "singular": "Hour"
+                },
+                "day": {
+                    "plural" : "Days",
+                    "singular": "Day"
+                }
             }
         },
         "error": {

--- a/test/nodes/core/core/89-delay_spec.js
+++ b/test/nodes/core/core/89-delay_spec.js
@@ -173,10 +173,11 @@ describe('delay Node', function() {
     /**
      * Runs a rate limit test - only testing seconds!
      * @param aLimit - the message limit count
+     * @param nbUnit - the multiple of the unit, aLimit Message for nbUnit Seconds
      * @param runtimeInMillis - when to terminate run and count messages received
      */
-    function genericRateLimitSECONDSTest(aLimit, runtimeInMillis, done) {
-        var flow = [{"id":"delayNode1","type":"delay","nbRateUnits":"1","name":"delayNode","pauseType":"rate","timeout":5,"timeoutUnits":"seconds","rate":aLimit,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[["helperNode1"]]},
+    function genericRateLimitSECONDSTest(aLimit, nbUnit, runtimeInMillis, done) {
+        var flow = [{"id":"delayNode1","type":"delay","nbRateUnits":nbUnit,"name":"delayNode","pauseType":"rate","timeout":5,"timeoutUnits":"seconds","rate":aLimit,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[["helperNode1"]]},
                     {id:"helperNode1", type:"helper", wires:[]}];
         helper.load(delayNode, flow, function() {
             var delayNode1 = helper.getNode("delayNode1");
@@ -223,21 +224,27 @@ describe('delay Node', function() {
     }
 
     it('limits the message rate to 1 per second', function(done) {
-        genericRateLimitSECONDSTest(1, 1500, done);
+        genericRateLimitSECONDSTest(1, 1, 1500, done);
     });
 
-    it('limits the message rate to 2 per second, 2 seconds', function(done) {
+    it('limits the message rate to 1 per 2 second', function(done) {
         this.timeout(6000);
-        genericRateLimitSECONDSTest(2, 2100, done);
+        genericRateLimitSECONDSTest(1, 2, 3000, done);
+    });
+
+    it('limits the message rate to 2 per seconds, 2 seconds', function(done) {
+        this.timeout(6000);
+        genericRateLimitSECONDSTest(2, 1, 2100, done);
     });
 
     /**
      * Runs a rate limit test with drop support - only testing seconds!
      * @param aLimit - the message limit count
+     * @param nbUnit - the multiple of the unit, aLimit Message for nbUnit Seconds
      * @param runtimeInMillis - when to terminate run and count messages received
      */
-    function dropRateLimitSECONDSTest(aLimit, runtimeInMillis, done) {
-        var flow = [{"id":"delayNode1","type":"delay","name":"delayNode","pauseType":"rate","timeout":5,"nbRateUnits":"1","timeoutUnits":"seconds","rate":aLimit,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":true,"wires":[["helperNode1"]]},
+    function dropRateLimitSECONDSTest(aLimit, nbUnit, runtimeInMillis, done) {
+        var flow = [{"id":"delayNode1","type":"delay","name":"delayNode","pauseType":"rate","timeout":5,"nbRateUnits":nbUnit,"timeoutUnits":"seconds","rate":aLimit,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":true,"wires":[["helperNode1"]]},
                     {id:"helperNode1", type:"helper", wires:[]}];
         helper.load(delayNode, flow, function() {
             var delayNode1 = helper.getNode("delayNode1");
@@ -298,12 +305,17 @@ describe('delay Node', function() {
 
     it('limits the message rate to 1 per second, 4 seconds, with drop', function(done) {
         this.timeout(6000);
-        dropRateLimitSECONDSTest(1, 4000, done);
+        dropRateLimitSECONDSTest(1, 1, 4000, done);
+    });
+
+    it('limits the message rate to 1 per 2 seconds, 4 seconds, with drop', function(done) {
+        this.timeout(6000);
+        dropRateLimitSECONDSTest(1, 2, 4500, done);
     });
 
     it('limits the message rate to 2 per second, 5 seconds, with drop', function(done) {
         this.timeout(6000);
-        dropRateLimitSECONDSTest(2, 5000, done);
+        dropRateLimitSECONDSTest(2, 1, 5000, done);
     });
 
     /**

--- a/test/nodes/core/core/89-delay_spec.js
+++ b/test/nodes/core/core/89-delay_spec.js
@@ -227,7 +227,7 @@ describe('delay Node', function() {
         genericRateLimitSECONDSTest(1, 1, 1500, done);
     });
 
-    it('limits the message rate to 1 per 2 second', function(done) {
+    it('limits the message rate to 1 per 2 seconds', function(done) {
         this.timeout(6000);
         genericRateLimitSECONDSTest(1, 2, 3000, done);
     });

--- a/test/nodes/core/core/89-delay_spec.js
+++ b/test/nodes/core/core/89-delay_spec.js
@@ -40,7 +40,7 @@ describe('delay Node', function() {
     });
 
     it('should be loaded', function(done) {
-        var flow = [{"id":"delayNode1","type":"delay","name":"delayNode","pauseType":"delay","timeout":"5","timeoutUnits":"seconds","rate":"1","rateUnits":"day","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[[]]}];
+        var flow = [{"id":"delayNode1","type":"delay", "nbRateUnits":"1", "name":"delayNode","pauseType":"delay","timeout":"5","timeoutUnits":"seconds","rate":"1","rateUnits":"day","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[[]]}];
         helper.load(delayNode, flow, function() {
             var delayNode1 = helper.getNode("delayNode1");
             delayNode1.should.have.property('name', 'delayNode');
@@ -50,7 +50,7 @@ describe('delay Node', function() {
     });
 
     it('should be able to set rate to hour', function(done) {
-        var flow = [{"id":"delayNode1","type":"delay","name":"delayNode","pauseType":"delay","timeout":"5","timeoutUnits":"seconds","rate":"1","rateUnits":"hour","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[[]]}];
+        var flow = [{"id":"delayNode1","type":"delay", "nbRateUnits":"1", "name":"delayNode","pauseType":"delay","timeout":"5","timeoutUnits":"seconds","rate":"1","rateUnits":"hour","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[[]]}];
         helper.load(delayNode, flow, function() {
             var delayNode1 = helper.getNode("delayNode1");
             delayNode1.should.have.property('name', 'delayNode');
@@ -60,7 +60,7 @@ describe('delay Node', function() {
     });
 
     it('should be able to set rate to minute', function(done) {
-        var flow = [{"id":"delayNode1","type":"delay","name":"delayNode","pauseType":"delay","timeout":"5","timeoutUnits":"seconds","rate":"1","rateUnits":"minute","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[[]]}];
+        var flow = [{"id":"delayNode1","type":"delay", "nbRateUnits":"1", "name":"delayNode","pauseType":"delay","timeout":"5","timeoutUnits":"seconds","rate":"1","rateUnits":"minute","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[[]]}];
         helper.load(delayNode, flow, function() {
             var delayNode1 = helper.getNode("delayNode1");
             delayNode1.should.have.property('name', 'delayNode');
@@ -176,7 +176,7 @@ describe('delay Node', function() {
      * @param runtimeInMillis - when to terminate run and count messages received
      */
     function genericRateLimitSECONDSTest(aLimit, runtimeInMillis, done) {
-        var flow = [{"id":"delayNode1","type":"delay","name":"delayNode","pauseType":"rate","timeout":5,"timeoutUnits":"seconds","rate":aLimit,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[["helperNode1"]]},
+        var flow = [{"id":"delayNode1","type":"delay","nbRateUnits":"1","name":"delayNode","pauseType":"rate","timeout":5,"timeoutUnits":"seconds","rate":aLimit,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[["helperNode1"]]},
                     {id:"helperNode1", type:"helper", wires:[]}];
         helper.load(delayNode, flow, function() {
             var delayNode1 = helper.getNode("delayNode1");
@@ -237,7 +237,7 @@ describe('delay Node', function() {
      * @param runtimeInMillis - when to terminate run and count messages received
      */
     function dropRateLimitSECONDSTest(aLimit, runtimeInMillis, done) {
-        var flow = [{"id":"delayNode1","type":"delay","name":"delayNode","pauseType":"rate","timeout":5,"timeoutUnits":"seconds","rate":aLimit,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":true,"wires":[["helperNode1"]]},
+        var flow = [{"id":"delayNode1","type":"delay","name":"delayNode","pauseType":"rate","timeout":5,"nbRateUnits":"1","timeoutUnits":"seconds","rate":aLimit,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":true,"wires":[["helperNode1"]]},
                     {id:"helperNode1", type:"helper", wires:[]}];
         helper.load(delayNode, flow, function() {
             var delayNode1 = helper.getNode("delayNode1");
@@ -436,7 +436,7 @@ describe('delay Node', function() {
 
     it('handles delay queue', function(done) {
         this.timeout(2000);
-        var flow = [{id:"delayNode1", type :"delay","name":"delayNode","pauseType":"queue","timeout":1,"timeoutUnits":"seconds","rate":4,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[["helperNode1"]]},
+        var flow = [{id:"delayNode1", type :"delay","name":"delayNode","nbRateUnits":"1","pauseType":"queue","timeout":1,"timeoutUnits":"seconds","rate":4,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[["helperNode1"]]},
                     {id:"helperNode1", type:"helper", wires:[]}];
         helper.load(delayNode, flow, function() {
             var delayNode1 = helper.getNode("delayNode1");


### PR DESCRIPTION
Add possibility to set the value for the rate unit.
Backward compatible, if the new nbRateUnits is not set, default to 1. 

This way we can delay messages to 1 msg per X seconds/minutes/hours days instead of always 1. 

Useful when interacting with API that has an uncommon rate limiting like 1req per 2 seconds.