### PR TITLE
Fix migration of Delay Node

### DIFF
--- a/nodes/core/core/89-delay.html
+++ b/nodes/core/core/89-delay.html
@@ -99,7 +99,7 @@
             timeout: {value:"5", required:true, validate:RED.validators.number()},
             timeoutUnits: {value:"seconds"},
             rate: {value:"1", required:true, validate:RED.validators.number()},
-            nbRateUnits: {value:"1", required:true, validate:RED.validators.number()},
+            nbRateUnits: {value:"1", required:false, validate:RED.validators.regex(/\d+|/)},
             rateUnits: {value: "second"},
             randomFirst: {value:"1", required:true, validate:RED.validators.number()},
             randomLast: {value:"5", required:true, validate:RED.validators.number()},


### PR DESCRIPTION
With the added nbRateUnits and the normal rules of validation, the editor was complaining about the rules not being met and blocking the deployment.

This resolve the problem by accepting empty string and any number.

see #994 

Solution discussed with @dceejay 