### PR TITLE
Close comms on stopServer in test helper

### DIFF
--- a/test/nodes/helper.js
+++ b/test/nodes/helper.js
@@ -143,6 +143,9 @@ module.exports = {
             comms.start();
             done();
         });
+        server.on('close', function() {
+            comms.stop();
+        });
     },
 
     //TODO consider saving TCP handshake/server reinit on start/stop/start sequences

--- a/test/nodes/helper.js
+++ b/test/nodes/helper.js
@@ -143,15 +143,15 @@ module.exports = {
             comms.start();
             done();
         });
-        server.on('close', function() {
-            comms.stop();
-        });
     },
 
     //TODO consider saving TCP handshake/server reinit on start/stop/start sequences
     stopServer: function(done) {
         if (server) {
             try {
+                server.on('close', function() {
+                    comms.stop();
+                });
                 server.close(done);
             } catch(e) {
                 done();


### PR DESCRIPTION
I am using this file in another project to test nodes.
When running a test suite with gulp and jasmine-node the gulp process never ends as comms are still open.
This resolves the problem.
