### PR TITLE
Fix node.error() not printing when passed false

### DIFF
--- a/red/runtime/nodes/Node.js
+++ b/red/runtime/nodes/Node.js
@@ -236,7 +236,9 @@ Node.prototype.warn = function(msg) {
 };
 
 Node.prototype.error = function(logMessage,msg) {
-    logMessage = logMessage || "";
+    if (typeof logMessage != 'boolean') {
+        logMessage = logMessage || "";
+    }
     log_helper(this, Log.ERROR, logMessage);
     /* istanbul ignore else */
     if (msg) {


### PR DESCRIPTION
This should fix #1036