### PR TITLE
Add setting to cause insecure redirect

### DIFF
--- a/red/api/index.js
+++ b/red/api/index.js
@@ -87,6 +87,16 @@ function init(_server,_runtime) {
         if (!settings.disableEditor) {
             ui.init(runtime);
             var editorApp = express();
+            if (settings.insecureRedirect) {
+                editorApp.enable('trust proxy');
+                editorApp.use(function (req, res, next) {
+                    if (req.secure) {
+                        next();
+                    } else {
+                        res.redirect('https://' + req.headers.host + req.url);
+                    }
+                });
+            }
             editorApp.get("/",ensureRuntimeStarted,ui.ensureSlash,ui.editor);
             editorApp.get("/icons/:icon",ui.icon);
             theme.init(runtime);

--- a/red/api/index.js
+++ b/red/api/index.js
@@ -93,7 +93,7 @@ function init(_server,_runtime) {
                     if (req.secure) {
                         next();
                     } else {
-                        res.redirect('https://' + req.headers.host + req.url);
+                        res.redirect('https://' + req.headers.host + req.originalUrl);
                     }
                 });
             }

--- a/settings.js
+++ b/settings.js
@@ -129,6 +129,10 @@ module.exports = {
     //    cert: fs.readFileSync('certificate.pem')
     //},
 
+    // The following property can be used to cause insecure HTTP connections to be redirected
+    // to HTTPS.
+    //insecureRedirect: false
+
     // The following property can be used to disable the editor. The admin API
     // is not affected by this option. To disable both the editor and the admin
     // API, use either the httpRoot or httpAdminRoot properties


### PR DESCRIPTION
Add a setting to cause the redirection of insecure HTTP connections to editor to secure HTTPS connections.  Possibly only ever useful behind a proxy, like Bluemix.