### PR TITLE
fix bug where savesettings did not honor local settings variables

### DIFF
--- a/red/runtime/storage/localfilesystem.js
+++ b/red/runtime/storage/localfilesystem.js
@@ -302,11 +302,11 @@ var localfilesystem = {
             })
         })
     },
-    saveSettings: function(settings) {
+    saveSettings: function(newsettings) {
         if (settings.readOnly) {
             return when.resolve();
         }
-        return writeFile(globalSettingsFile,JSON.stringify(settings,null,1));
+        return writeFile(globalSettingsFile,JSON.stringify(newsettings,null,1));
     },
     getSessions: function() {
         return when.promise(function(resolve,reject) {


### PR DESCRIPTION
settings is both passed in, and part of the closure.  This pull request renames the passed in version to 'newsettings' so that it does not conflict with settings.  In fact, settings and config is being confused here, as the file being saved is .config.json, not settings.js.
seems i signed with the wrong email address..  now added to github so hopefully it will accept the signature soon...