### PR TITLE
Updated ws package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "sentiment":"1.0.6",
         "uglify-js":"2.7.3",
         "when": "3.7.7",
-        "ws": "0.8.1",
+        "ws": "1.1.1",
         "xml2js":"0.4.17",
         "node-red-node-feedparser":"0.1.*",
         "node-red-node-email":"0.1.*",


### PR DESCRIPTION
Updated websocket `ws` package version from 0.8.1 to 1.1.1 after stumbling upon a nasty application crash described here:
https://github.com/websockets/ws/issues/778

The Node Security Platform also reports a high severity and a medium severity security issues with version < 1.1.1:
https://nodesecurity.io/advisories/120
https://nodesecurity.io/advisories/67