### PR TITLE
Using nodesExcludes of settings to filter nodes of non-local module

### DIFF
--- a/red/runtime/nodes/registry/localfilesystem.js
+++ b/red/runtime/nodes/registry/localfilesystem.js
@@ -248,6 +248,9 @@ function getNodeFiles(disableNodePathScan) {
                 nodeList[moduleFile.package.name].redVersion = moduleFile.package['node-red'].version;
             }
             nodeModuleFiles.forEach(function(node) {
+                if (isExcluded(path.basename(node.file))) {
+                    return;
+                }
                 node.local = moduleFile.local||false;
                 nodeList[moduleFile.package.name].nodes[node.name] = node;
             });


### PR DESCRIPTION
Sometimes we have to override existed node type with `nodesExcludes` for specific purpose. This requirement is not only for local nodes but non-local nodes. 