### PR TITLE
Fix empty extra node help content issue

### DIFF
--- a/red/runtime/nodes/registry/loader.js
+++ b/red/runtime/nodes/registry/loader.js
@@ -381,8 +381,10 @@ function getNodeHelp(node,lang) {
         }
         if (help) {
             node.help[lang] = help;
+        } else if (lang === runtime.i18n.defaultLang) {
+            return null;
         } else {
-            node.help[lang] = node.help[runtime.i18n.defaultLang];
+            node.help[lang] = getNodeHelp(node, runtime.i18n.defaultLang);
         }
     }
     return node.help[lang];

--- a/test/red/runtime/nodes/registry/loader_spec.js
+++ b/test/red/runtime/nodes/registry/loader_spec.js
@@ -585,6 +585,24 @@ describe("red/nodes/registry/loader",function() {
             loader.getNodeHelp(node,"fr").should.eql("bar");
             fs.readFileSync.calledTwice.should.be.true();
         });
+        it("fails to load en-US help content", function() {
+            stubs.push(sinon.stub(fs,"readFileSync", function(path) {
+                throw new Error("not found");
+            }));
+            var node = {
+                template: "/tmp/node/directory/file.html",
+                help:{}
+            };
+            delete node.help['en-US'];
+
+            should.not.exist(loader.getNodeHelp(node,"en-US"));
+            should.not.exist(node.help['en-US']);
+            fs.readFileSync.calledTwice.should.be.true();
+            fs.readFileSync.firstCall.args[0].should.eql(path.normalize("/tmp/node/directory/locales/en-US/file.html"));
+            fs.readFileSync.lastCall.args[0].should.eql(path.normalize("/tmp/node/directory/locales/en/file.html"));
+            should.not.exist(loader.getNodeHelp(node,"en-US"));
+            fs.readFileSync.callCount.should.eql(4);
+        });
 
     });
 });

--- a/test/red/runtime/nodes/registry/loader_spec.js
+++ b/test/red/runtime/nodes/registry/loader_spec.js
@@ -564,6 +564,27 @@ describe("red/nodes/registry/loader",function() {
             loader.getNodeHelp(node,"fr").should.eql("foo");
             fs.readFileSync.calledOnce.should.be.true();
         });
+        it("loads help, defaulting to en-US content for extra nodes", function() {
+            stubs.push(sinon.stub(fs,"readFileSync", function(path) {
+                if (path.indexOf("en-US") >= 0) {
+                    return 'bar';
+                }
+                throw new Error("not found");
+            }));
+            var node = {
+                template: "/tmp/node/directory/file.html",
+                help:{}
+            };
+            delete node.help['en-US'];
+
+            loader.getNodeHelp(node,"fr").should.eql("bar");
+            node.help['fr'].should.eql("bar");
+            fs.readFileSync.calledTwice.should.be.true();
+            fs.readFileSync.firstCall.args[0].should.eql(path.normalize("/tmp/node/directory/locales/fr/file.html"));
+            fs.readFileSync.lastCall.args[0].should.eql(path.normalize("/tmp/node/directory/locales/en-US/file.html"));
+            loader.getNodeHelp(node,"fr").should.eql("bar");
+            fs.readFileSync.calledTwice.should.be.true();
+        });
 
     });
 });


### PR DESCRIPTION
The commit should fix #1121 

As shown in the added test case, the new code loads an en-US file when `node.help['en-US']` is missing.