### PR TITLE
Use textContent to avoid manual escaping

### DIFF
--- a/editor/js/ui/view.js
+++ b/editor/js/ui/view.js
@@ -1297,7 +1297,7 @@ RED.view = (function() {
         sp.className = className;
         sp.style.position = "absolute";
         sp.style.top = "-1000px";
-        sp.innerHTML = (str||"").replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+        sp.textContent = (str||"");
         document.body.appendChild(sp);
         var w = sp.offsetWidth;
         document.body.removeChild(sp);


### PR DESCRIPTION
`textContent` is supported all browsers expect for IE 8 and older. I couldn't find any documentation on supported browsers so apologies if IE 8 is to be supported.

Source: http://caniuse.com/#search=textContent