### PR TITLE
Modify Japanese translation file for editor

### DIFF
--- a/red/api/locales/ja/editor.json
+++ b/red/api/locales/ja/editor.json
@@ -45,7 +45,7 @@
             "examples": "サンプル",
             "subflows": "サブフロー",
             "createSubflow": "サブフローを作成",
-            "selectionToSubflow": "サブフローの選択",
+            "selectionToSubflow": "選択部分をサブフロー化",
             "flows": "フロー",
             "add": "フローを新規追加",
             "rename": "フロー名を変更",


### PR DESCRIPTION
I modified Japanese translation mistake. Currently Japanese translation of "Selection to Subflow" is "サブフローの選択"("Select subflow"). "Selection to Subflow" should be "選択部分をサブフロー化"("Create subflow from selected flow").