### PR TITLE
 Allow nodes to have translations not in core

### DIFF
--- a/red/api/locales.js
+++ b/red/api/locales.js
@@ -34,7 +34,7 @@ module.exports = {
         var namespace = req.params[0];
         namespace = namespace.replace(/\.json$/,"");
         var lang = determineLangFromHeaders(req.acceptsLanguages() || []);
-        var prevLang = i18n.i.lng();    
+        var prevLang = i18n.i.lng();
         i18n.i.setLng(lang, function(){
             var catalog = i18n.catalog(namespace,lang);
             res.json(catalog||{});

--- a/red/api/locales.js
+++ b/red/api/locales.js
@@ -16,30 +16,12 @@
 var fs = require('fs');
 var path = require('path');
 var i18n;
-var supportedLangs = [];
-
-var apiLocalDir = path.resolve(path.join(__dirname,"locales"));
-
-var initSupportedLangs = function() {
-    fs.readdir(apiLocalDir, function(err,files) {
-        if(!err) {
-            supportedLangs = files;
-        }
-    });
-}
 
 function determineLangFromHeaders(acceptedLanguages){
     var lang = i18n.defaultLang;
     acceptedLanguages = acceptedLanguages || [];
-    for (var i=0;i<acceptedLanguages.length;i++){
-        if (supportedLangs.indexOf(acceptedLanguages[i]) !== -1){
-            lang = acceptedLanguages[i];
-            break;
-        // check the language without the country code
-        } else if (supportedLangs.indexOf(acceptedLanguages[i].split("-")[0]) !== -1) {
-            lang = acceptedLanguages[i].split("-")[0];
-            break;
-        }
+    if (acceptedLanguages.length >= 1) {
+        lang = acceptedLanguages[0];
     }
     return lang;
 }
@@ -47,13 +29,12 @@ function determineLangFromHeaders(acceptedLanguages){
 module.exports = {
     init: function(runtime) {
         i18n = runtime.i18n;
-        initSupportedLangs();
     },
     get: function(req,res) {
         var namespace = req.params[0];
         namespace = namespace.replace(/\.json$/,"");
         var lang = determineLangFromHeaders(req.acceptsLanguages() || []);
-        var prevLang = i18n.i.lng();
+        var prevLang = i18n.i.lng();    
         i18n.i.setLng(lang, function(){
             var catalog = i18n.catalog(namespace,lang);
             res.json(catalog||{});


### PR DESCRIPTION
Currently only languages in the core are checked when
the editor requests a translation. This means that if
a node includes more translations they are not checked.

This change removes the check against that short list,
but it only checks the first language from the browser
supported list
