### PR TITLE
Add node whitelist function

### DIFF
--- a/red/runtime/nodes/registry/localfilesystem.js
+++ b/red/runtime/nodes/registry/localfilesystem.js
@@ -32,6 +32,19 @@ function init(runtime) {
     i18n = runtime.i18n;
 }
 
+function isIncluded(name) {
+    if (settings.nodesIncludes) {
+        for (var i=0;i<settings.nodesIncludes.length;i++) {
+            if (settings.nodesIncludes[i] == name) {
+                return true;
+            }
+        }
+    } else {
+        return true;
+    }
+    return false;
+}
+
 function isExcluded(name) {
      if (settings.nodesExcludes) {
         for (var i=0;i<settings.nodesExcludes.length;i++) {
@@ -43,7 +56,7 @@ function isExcluded(name) {
     return false;
 }
 function getLocalFile(file) {
-    if (isExcluded(path.basename(file))) {
+    if (!isIncluded(path.basename(file)) || isExcluded(path.basename(file))) {
         return null;
     }
     try {
@@ -105,7 +118,7 @@ function scanDirForNodesModules(dir,moduleName) {
             if (/^@/.test(fn)) {
                 results = results.concat(scanDirForNodesModules(path.join(dir,fn),moduleName));
             } else {
-                if (!isExcluded(fn) && (!moduleName || fn == moduleName)) {
+                if (isIncluded(fn) && !isExcluded(fn) && (!moduleName || fn == moduleName)) {
                     var pkgfn = path.join(dir,fn,"package.json");
                     try {
                         var pkg = require(pkgfn);

--- a/test/red/runtime/nodes/registry/localfilesystem_spec.js
+++ b/test/red/runtime/nodes/registry/localfilesystem_spec.js
@@ -55,6 +55,16 @@ describe("red/nodes/registry/localfilesystem",function() {
             checkNodes(nm.nodes,['TestNode1','MultipleNodes1','NestedNode','TestNode2','TestNode3','TestNode4'],['TestNodeModule']);
             done();
         });
+        it("Includes node files from settings",function(done) {
+            localfilesystem.init({i18n:{registerMessageCatalog:function(){}},events:{emit:function(){}},settings:{nodesIncludes:['TestNode1.js'],coreNodesDir:resourcesDir}});
+            var nodeList = localfilesystem.getNodeFiles(true);
+            nodeList.should.have.a.property("node-red");
+            var nm = nodeList['node-red'];
+            nm.should.have.a.property('name','node-red');
+            nm.should.have.a.property("nodes");
+            checkNodes(nm.nodes,['TestNode1'],['MultipleNodes1','NestedNode','TestNode2','TestNode3','TestNode4','TestNodeModule']);
+            done();
+        });
         it("Excludes node files from settings",function(done) {
             localfilesystem.init({i18n:{registerMessageCatalog:function(){}},events:{emit:function(){}},settings:{nodesExcludes:['TestNode1.js'],coreNodesDir:resourcesDir}});
             var nodeList = localfilesystem.getNodeFiles(true);


### PR DESCRIPTION
I added whitelist function to constrain nodes which correspond with operation policy.
(Opposite of blacklist function, nodeExcludes in settings.js)
This function uses nodesIncludes in settings.js.

I have already discussed the design of this function with Dave and Nick. 