### PR TITLE
Add istanbul to Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,6 +41,16 @@ module.exports = function(grunt) {
             core: { src: ["test/_spec.js","test/red/**/*_spec.js"]},
             nodes: { src: ["test/nodes/**/*_spec.js"]}
         },
+        mocha_istanbul: {
+            options: {
+                globals: ['expect'],
+                timeout: 3000,
+                ignoreLeaks: false,
+                ui: 'bdd',
+                reporter: 'spec'
+            },
+            coverage: { src: ['test/**/*_spec.js'] }
+        },
         jshint: {
             options: {
                 jshintrc:true
@@ -396,6 +406,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-chmod');
     grunt.loadNpmTasks('grunt-jsonlint');
+    grunt.loadNpmTasks('grunt-mocha-istanbul');
 
     grunt.registerMultiTask('attachCopyright', function() {
         var files = this.data.src;

--- a/package.json
+++ b/package.json
@@ -84,10 +84,12 @@
         "grunt-nodemon":"~0.4.2",
         "grunt-sass":"~1.2.1",
         "grunt-simple-mocha": "~0.4.1",
+        "grunt-mocha-istanbul": "5.0.2",
         "mocha": "~3.2.0",
         "should": "^8.4.0",
         "sinon": "1.17.7",
-        "supertest": "2.0.1"
+        "supertest": "2.0.1",
+        "istanbul": "0.4.5"
     },
     "engines": {
         "node": ">=4"


### PR DESCRIPTION
Istanbul command can be run with grunt to output a coverage report.
When you run "grunt mocha_istanbul", you'll see the coverage report in coverage/lcov-report/index.html.