### PR TITLE
Extend timeout for the test case of installing non-existant path.

### DIFF
--- a/test/red/runtime/nodes/registry/installer_spec.js
+++ b/test/red/runtime/nodes/registry/installer_spec.js
@@ -124,6 +124,7 @@ describe('nodes/registry/installer', function() {
             });
         });
         it("rejects when non-existant path is provided", function(done) {
+            this.timeout(10000);
             var resourcesDir = path.resolve(path.join(__dirname,"..","resources","local","TestNodeModule","node_modules","NonExistant"));
             installer.installModule(resourcesDir).then(function() {
                 done(new Error("Unexpected success"));


### PR DESCRIPTION
In my laptop, one test case almost always failed due to timeout.
My laptop environment is:
OS: 32bits Windows 7
CPU: Intel Core i5-5200U @ 2.2GHz
Memory: 4GB

In this environment, it takes about 4 seconds. So I want to extend the timeout to 10 seconds for margin.