### PR TITLE
Added error logging for websocket node

### DIFF
--- a/nodes/core/io/22-websocket.js
+++ b/nodes/core/io/22-websocket.js
@@ -61,7 +61,7 @@ module.exports = function(RED) {
                 node.handleEvent(id,socket,'message',data,flags);
             });
             socket.on('error', function(err) {
-                node.warn(RED._("websocket.errors.socket-error")+inspect(err));
+                node.warn({message: RED._("websocket.errors.socket-error", {error: err.message}), stack: err.stack});
                 node.emit('erro');
                 if (!node.closing && !node.isServer) {
                     clearTimeout(node.tout);

--- a/nodes/core/io/22-websocket.js
+++ b/nodes/core/io/22-websocket.js
@@ -61,6 +61,7 @@ module.exports = function(RED) {
                 node.handleEvent(id,socket,'message',data,flags);
             });
             socket.on('error', function(err) {
+                node.warn(RED._("websocket.errors.socket-error")+inspect(err));
                 node.emit('erro');
                 if (!node.closing && !node.isServer) {
                     clearTimeout(node.tout);

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -357,7 +357,7 @@
             "url2": "By default, <code>payload</code> will contain the data to be sent over, or received from a websocket. The client can be configured to send or receive the entire message object as a JSON formatted string."
         },
         "errors": {
-            "connect-error": "An error occured on the ws connection: ",
+            "socket-error": "An error occurred on the ws connection: ",
             "send-error": "An error occurred while sending: ",
             "missing-conf": "Missing server configuration"
         }

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -357,7 +357,7 @@
             "url2": "By default, <code>payload</code> will contain the data to be sent over, or received from a websocket. The client can be configured to send or receive the entire message object as a JSON formatted string."
         },
         "errors": {
-            "socket-error": "An error occurred on the ws connection (__error__)",
+            "ws-error": "An error occurred on the ws connection (__error__)",
             "send-error": "An error occurred while sending: ",
             "missing-conf": "Missing server configuration"
         }

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -357,7 +357,7 @@
             "url2": "By default, <code>payload</code> will contain the data to be sent over, or received from a websocket. The client can be configured to send or receive the entire message object as a JSON formatted string."
         },
         "errors": {
-            "socket-error": "An error occurred on the ws connection: ",
+            "socket-error": "An error occurred on the ws connection (__error__)",
             "send-error": "An error occurred while sending: ",
             "missing-conf": "Missing server configuration"
         }


### PR DESCRIPTION
`websocket` node completely ignores errors here https://github.com/node-red/node-red/blob/0.16.2/nodes/core/io/22-websocket.js#L64. `ws` library responsibly sends error message as the first argument. You can specify domain which doesn't resolve, or your websocket server can pass some non-parsable bullshit, but everything `node-red` will show you is `disconnected` in UI. No messages in console/web interface.
That's not a mature node, w/o error handling it's just a raw draft. Fixed in PR.