### PR TITLE
Add support for rejectUnauthorized msg property

### DIFF
--- a/nodes/core/io/21-httprequest.html
+++ b/nodes/core/io/21-httprequest.html
@@ -79,7 +79,7 @@
         <li><code>headers</code>, if set, should be an object containing field/value
         pairs to be added as request headers</li>
         <li><code>payload</code> is sent as the body of the request</li>
-        <li><code>rejectUnauthorized</code> allows requests to be made </li>
+        <li><code>rejectUnauthorized</code> allows requests to be made to https sites that use self signed certificates</li>
     </ul>
     <p>When configured within the node, the URL property can contain <a href="http://mustache.github.io/mustache.5.html" target="_blank">mustache-style</a> tags. These allow the
     url to be constructed using values of the incoming message. For example, if the url is set to

--- a/nodes/core/io/21-httprequest.html
+++ b/nodes/core/io/21-httprequest.html
@@ -79,6 +79,7 @@
         <li><code>headers</code>, if set, should be an object containing field/value
         pairs to be added as request headers</li>
         <li><code>payload</code> is sent as the body of the request</li>
+        <li><code>rejectUnauthorized</code> allows requests to be made </li>
     </ul>
     <p>When configured within the node, the URL property can contain <a href="http://mustache.github.io/mustache.5.html" target="_blank">mustache-style</a> tags. These allow the
     url to be constructed using values of the incoming message. For example, if the url is set to

--- a/nodes/core/io/21-httprequest.js
+++ b/nodes/core/io/21-httprequest.js
@@ -154,6 +154,10 @@ module.exports = function(RED) {
             }
             if (tlsNode) {
                 tlsNode.addTLSOptions(opts);
+            } else {
+                if (msg.hasOwnProperty('rejectUnauthorized')) {
+                    opts.rejectUnauthorized = msg.rejectUnauthorized;
+                }
             }
             var req = ((/^https/.test(urltotest))?https:http).request(opts,function(res) {
                 (node.ret === "bin") ? res.setEncoding('binary') : res.setEncoding('utf8');


### PR DESCRIPTION
This update lets you pass msg.rejectUnauthorized=false to allow you to connect to https sites that don't have certs signed by recognised CAs

Based on http://stackoverflow.com/q/42983635/504554