### PR TITLE
Resolve dir argument of getLocalNodeFiles function

### DIFF
--- a/red/runtime/nodes/registry/localfilesystem.js
+++ b/red/runtime/nodes/registry/localfilesystem.js
@@ -67,6 +67,8 @@ function getLocalFile(file) {
  * @return an array of fully-qualified paths to .js files
  */
 function getLocalNodeFiles(dir) {
+    dir = path.resolve(dir);
+
     var result = [];
     var files = [];
     try {
@@ -205,7 +207,7 @@ function getNodeFiles(disableNodePathScan) {
 
     if (settings.coreNodesDir) {
         nodeFiles = getLocalNodeFiles(path.resolve(settings.coreNodesDir));
-        var defaultLocalesPath = path.resolve(path.join(settings.coreNodesDir,"core","locales"));
+        var defaultLocalesPath = path.join(settings.coreNodesDir,"core","locales");
         i18n.registerMessageCatalog("node-red",defaultLocalesPath,"messages.json");
     }
 

--- a/test/red/runtime/nodes/registry/localfilesystem_spec.js
+++ b/test/red/runtime/nodes/registry/localfilesystem_spec.js
@@ -36,6 +36,7 @@ describe("red/nodes/registry/localfilesystem",function() {
         for (var i=0;i<shouldHaveNodes.length;i++) {
             nodes.should.have.a.property(shouldHaveNodes[i]);
             nodes[shouldHaveNodes[i]].should.have.a.property('file');
+	        nodes[shouldHaveNodes[i]].file.should.equal(path.resolve(nodes[shouldHaveNodes[i]].file));
             nodes[shouldHaveNodes[i]].should.have.a.property('module',module||'node-red');
             nodes[shouldHaveNodes[i]].should.have.a.property('name',shouldHaveNodes[i]);
         }
@@ -86,7 +87,18 @@ describe("red/nodes/registry/localfilesystem",function() {
             checkNodes(nm.nodes,['TestNode5'],['TestNode1']);
             done();
         });
-        it("Finds nodes in settings.nodesDir (array)",function(done) {
+	    it("Finds nodes in settings.nodesDir (string,relative path)",function(done) {
+		    var relativeUserDir = path.join("test","red","runtime","nodes","resources","userDir");
+		    localfilesystem.init({i18n:{registerMessageCatalog:function(){}},events:{emit:function(){}},settings:{nodesDir:relativeUserDir,coreNodesDir:__dirname}});
+		    var nodeList = localfilesystem.getNodeFiles(true);
+		    nodeList.should.have.a.property("node-red");
+		    var nm = nodeList['node-red'];
+		    nm.should.have.a.property('name','node-red');
+		    nm.should.have.a.property("nodes");
+		    checkNodes(nm.nodes,['TestNode5'],['TestNode1']);
+		    done();
+	    });
+	    it("Finds nodes in settings.nodesDir (array)",function(done) {
             localfilesystem.init({i18n:{registerMessageCatalog:function(){}},events:{emit:function(){}},settings:{nodesDir:[userDir],coreNodesDir:__dirname}});
             var nodeList = localfilesystem.getNodeFiles(true);
             nodeList.should.have.a.property("node-red");


### PR DESCRIPTION
The getLocalNodeFiles is called 3 times.  Each time it called, the callee needs to resolve the dir argument.
That was not done for several of calls, and local modules (specified in the "nodesDir" setting) were not returned to client because of that.

This fix will allow to make sure the dir is consistently resolved.