### PR TITLE
MQTT node - if Server/URL config contains '//' use it as a url

### DIFF
--- a/nodes/core/io/10-mqtt.html
+++ b/nodes/core/io/10-mqtt.html
@@ -233,7 +233,8 @@
 
 <script type="text/x-red" data-help-name="mqtt-broker">
     <p>A minimum MQTT broker connection requires only a broker server address to be added to the default configuration.</p>
-    <p>To secure the connection with SSL/TLS, a TLS Configuration must also be configured and selected.</p>
+    <p>If the <b>Server/URL</b> option is set to a full url (e.g. ws://example.com:8083/mqtt), then the <b>Port</b> setting will be ignored.  See <a href='https://github.com/mqttjs/MQTT.js' target="_blank">mqttjs</a> for applicable urls.</p>
+    <p>To secure the connection with SSL/TLS, a TLS Configuration must also be configured and selected. (not applicable to wss://)</p>
     <p>If you create a Client ID it must be unique to the broker you are connecting to.</p>
     <p>For more information about MQTT see the <a href="http://www.eclipse.org/paho/" target="_blank">Eclipse Paho</a> site.</p>
 </script>
@@ -274,7 +275,11 @@
         label: function() {
             var b = this.broker;
             if (b === "") { b = "undefined"; }
+            if (b.indexOf("//")){
+                return (this.clientid?this.clientid+"@":"")+b;
+            } else {
             return (this.clientid?this.clientid+"@":"")+b+":"+this.port;
+            }
         },
         oneditprepare: function () {
             var tabs = RED.tabs.create({

--- a/nodes/core/io/10-mqtt.js
+++ b/nodes/core/io/10-mqtt.js
@@ -86,6 +86,9 @@ module.exports = function(RED) {
 
         // Create the URL to pass in to the MQTT.js library
         if (this.brokerurl === "") {
+            if (this.broker.indexOf("//") > -1) {
+                this.brokerurl = this.broker;
+            } else {
             if (this.usetls) {
                 this.brokerurl="mqtts://";
             } else {
@@ -96,6 +99,7 @@ module.exports = function(RED) {
             } else {
                 this.brokerurl = this.brokerurl+"localhost:1883";
             }
+        }
         }
 
         if (!this.cleansession && !this.clientid) {

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -269,7 +269,7 @@
     },
     "mqtt": {
         "label": {
-            "broker": "Server",
+            "broker": "Server/URL",
             "qos": "QoS",
             "clientid": "Client ID",
             "port": "Port",


### PR DESCRIPTION
'Server' relabelled 'Server/URL'
If Server/URL config contains '//' use it as a complete url; enabled ws:// and wss://

Looks for '//' in 'broker', and if there, just uses this field as the url for the mqttjs connection.
Modifies the label for the mqtt broker node (i.e. does not append Port).

Tested in 'mqtt in' and 'mqtt out' in 15.2 against mosca running ws://ip:port/path

This enables ws://, wss:// (and other prefixes mqttjs accepts - tcp://; whatever that does :) ).

