### PR TITLE
MQTT node - enable use of ws:// and wss://

### DIFF
--- a/nodes/core/io/10-mqtt.html
+++ b/nodes/core/io/10-mqtt.html
@@ -173,7 +173,7 @@
                 <label for="node-config-input-broker"><i class="fa fa-globe"></i> <span data-i18n="mqtt.label.broker"></span></label>
                 <input class="input-append-left" type="text" id="node-config-input-broker" placeholder="e.g. localhost" style="width:40%;" >
                 <label for="node-config-input-port" style="margin-left:20px; width:35px; "> <span data-i18n="mqtt.label.port"></span></label>
-                <input type="text" id="node-config-input-port" data-i18n="[placeholder]mqtt.label.port" style="width:55px">
+                <input type="text" id="node-config-input-port" placeholder="1883" style="width:55px">
             </div>
             <div class="form-row">
                 <input type="checkbox" id="node-config-input-usetls" style="display: inline-block; width: auto; vertical-align: top;">
@@ -256,7 +256,8 @@
 
 <script type="text/x-red" data-help-name="mqtt-broker">
     <p>A minimum MQTT broker connection requires only a broker server address to be added to the default configuration.</p>
-    <p>To secure the connection with SSL/TLS, a TLS Configuration must also be configured and selected.</p>
+    <p>If the <b>Server</b> option is set to a full url (e.g. ws://example.com:8083/mqtt), then the <b>Port</b> setting will be disabled and ignored.  See <a href='https://github.com/mqttjs/MQTT.js' target="_blank">mqttjs</a> for applicable urls.</p>
+    <p>To secure the connection with SSL/TLS, a TLS Configuration must also be configured and selected. (not applicable to wss://)</p>
     <p>If you create a Client ID it must be unique to the broker you are connecting to.</p>
     <p>For more information about MQTT see the <a href="http://www.eclipse.org/paho/" target="_blank">Eclipse Paho</a> site.</p>
 </script>
@@ -266,7 +267,7 @@
         category: 'config',
         defaults: {
             broker: {value:"",required:true},
-            port: {value:1883,required:true,validate:RED.validators.number()},
+            port: {value:1883,required:false,validate:function(v){ return RED.validators.number() || (v === null) }},
             tls: {type:"tls-config",required: false},
             clientid: {value:"", validate: function(v) {
                     if ($("#node-config-input-clientid").length) {
@@ -297,7 +298,13 @@
         label: function() {
             var b = this.broker;
             if (b === "") { b = "undefined"; }
-            return (this.clientid?this.clientid+"@":"")+b+":"+this.port;
+            var lab = "";
+            lab = (this.clientid?this.clientid+"@":"")+b;
+            if (b.indexOf("://") === -1){
+                if (!this.port){ lab = lab + ":1883"; }
+                else { lab = lab + ":" + this.port; }
+            }
+            return lab;
         },
         oneditprepare: function () {
             var tabs = RED.tabs.create({
@@ -373,6 +380,28 @@
             $("#node-config-input-cleansession").on("click",function() {
                 updateClientId();
             });
+            
+            function updatePortEntry(){
+                var disabled = $("#node-config-input-port").prop("disabled");
+                if ($("#node-config-input-broker").val().indexOf("://") === -1){
+                    if (disabled){
+                        $("#node-config-input-port").prop("disabled", false);
+                    }
+                }
+                else {
+                    if (!disabled){
+                        $("#node-config-input-port").prop("disabled", true);
+                    }
+                }
+            }
+            $("#node-config-input-broker").change(function() {
+                updatePortEntry();
+            });
+            $("#node-config-input-broker").on( "keyup", function() {
+                updatePortEntry();
+            });
+            setTimeout(updatePortEntry());
+            
         },
         oneditsave: function() {
             if (!$("#node-config-input-usetls").is(':checked')) {

--- a/nodes/core/io/10-mqtt.js
+++ b/nodes/core/io/10-mqtt.js
@@ -86,15 +86,27 @@ module.exports = function(RED) {
 
         // Create the URL to pass in to the MQTT.js library
         if (this.brokerurl === "") {
-            if (this.usetls) {
-                this.brokerurl="mqtts://";
+            // if the broken may be ws:// or wss:// or even tcp://
+            if (this.broker.indexOf("://") > -1) {
+                this.brokerurl = this.broker;
             } else {
-                this.brokerurl="mqtt://";
-            }
-            if (this.broker !== "") {
-                this.brokerurl = this.brokerurl+this.broker+":"+this.port;
-            } else {
-                this.brokerurl = this.brokerurl+"localhost:1883";
+                // construct the std mqtt:// url
+                if (this.usetls) {
+                    this.brokerurl="mqtts://";
+                } else {
+                    this.brokerurl="mqtt://";
+                }
+                if (this.broker !== "") {
+                    this.brokerurl = this.brokerurl+this.broker+":";
+                    // port now defaults to 1883 if unset.
+                    if (!this.port){
+                        this.brokerurl = this.brokerurl+"1883";
+                    } else {
+                        this.brokerurl = this.brokerurl+this.port;
+                    }
+                } else {
+                    this.brokerurl = this.brokerurl+"localhost:1883";
+                }
             }
         }
 


### PR DESCRIPTION
so...  
this adds on top of 0.17 the ability to use ws:// and wss:// (and possibly tcp://; but I don't know what that means in mqttjs terms).

Main changes:
Port now has a default of 1883 - i.e. it can be empty, and the placeholder has been changed to 1883.

If in the 'Server' configuration, ws:// or wss:// (or indeed just ://) are present, the Port entry greys out and is ignored.  I tried REALLY hard to use the Port entry to adjust the url - but that has to be for another day.

If :// does exist in the Server entry, then the whole Server entry is used as the url passed to mqttjs, so enabling 'ws://example.com:5555/mywspath', for example.

The label for the mqtt broker node will be server:port for normal use and the full url for the case where there is a :// in the Server entry.

Concerns:
Please check the 'Port' validation.  It seems to work, but I expected required=false and validators.number() to work with an empty entry really....
It seems a little heavy to hook keyup to check the state of the input field.

I tested on 0.16.2