### PR TITLE
dont match only part of the node type

### DIFF
--- a/editor/js/ui/tab-info.js
+++ b/editor/js/ui/tab-info.js
@@ -125,7 +125,7 @@ RED.sidebar.info = (function() {
         $(table).appendTo(content);
         $("<hr/>").appendTo(content);
         if (!subflowNode && node.type != "comment") {
-            var helpText = $("script[data-help-name$='"+node.type+"']").html()||"";
+            var helpText = $("script[data-help-name='"+node.type+"']").html()||"";
             addTargetToExternalLinks($('<div class="node-help"><span class="bidiAware" dir=\"'+RED.text.bidi.resolveBaseTextDir(helpText)+'">'+helpText+'</span></div>').appendTo(content));
         }
         if (subflowNode) {


### PR DESCRIPTION
I noticed while developing a node that I was seeing the wrong data-help-name. My node type was 'timer' and I was seeing the help text for 'bigtimer'. I figured it had to be a substring match someplace.  It seems it's in the editor itself.

There may be a good reason there is a partial attribute match done. I couldnt really think of it, and tested a bit and everything seems ok. So if anything, this might help you think of other solutions to the problem. 