### PR TITLE
Version check no meta

### DIFF
--- a/red/runtime/nodes/registry/loader.js
+++ b/red/runtime/nodes/registry/loader.js
@@ -116,7 +116,7 @@ function loadNodeFiles(nodeFiles) {
         /* istanbul ignore else */
         if (nodeFiles.hasOwnProperty(module)) {
             if (nodeFiles[module].redVersion &&
-                !semver.satisfies(runtime.version().replace(/(\-[1-9A-Za-z-][0-9A-Za-z-\.]*)?(\+[0-9A-Za-z-]+)?$/,""), nodeFiles[module].redVersion)) {
+                !semver.satisfies(runtime.version().replace(/(\-[1-9A-Za-z-][0-9A-Za-z-\.]*)?(\+[0-9A-Za-z-\.]+)?$/,""), nodeFiles[module].redVersion)) {
                 //TODO: log it
                 runtime.log.warn("["+module+"] "+runtime.log._("server.node-version-mismatch",{version:nodeFiles[module].redVersion}));
                 continue;

--- a/red/runtime/nodes/registry/loader.js
+++ b/red/runtime/nodes/registry/loader.js
@@ -116,7 +116,7 @@ function loadNodeFiles(nodeFiles) {
         /* istanbul ignore else */
         if (nodeFiles.hasOwnProperty(module)) {
             if (nodeFiles[module].redVersion &&
-                !semver.satisfies(runtime.version().replace("-git",""), nodeFiles[module].redVersion)) {
+                !semver.satisfies(runtime.version().replace(/(\-[1-9A-Za-z-][0-9A-Za-z-\.]*)?(\+[0-9A-Za-z-]+)?$/,""), nodeFiles[module].redVersion)) {
                 //TODO: log it
                 runtime.log.warn("["+module+"] "+runtime.log._("server.node-version-mismatch",{version:nodeFiles[module].redVersion}));
                 continue;


### PR DESCRIPTION
 Hi all,

i have some private modifications and suffixed the version semver compliant (§9 http://semver.org/) with -mw. This breaks the loading of the dashboard with

[node-red-dashboard] Node module cannot be loaded on this version. Requires: >=0.14.0 

so i would like to have the line

!semver.satisfies(runtime.version().replace("-git",""), nodeFiles[module].redVersion)) {

in file red/runtime/nodes/registry/loader.js changed to

!semver.satisfies(runtime.version().replace(/(\-[1-9A-Za-z-][0-9A-Za-z-\.]*)?(\+[0-9A-Za-z-\.]+)?$/,""), nodeFiles[module].redVersion)) {

which would remove all metadata information bevor comparing the versions.

Tested with:
1.2.3-mw
1.2.3+240417
1.2.3+240417-mw
1.2.3-mw+240417
1.2.3-mw
1.2.3-m.w
1.2.3+24.04.17
1.2.3+24.04.17-m.w
1.2.3-m.w+24.04.17

The third is also correct because the hyphen is a valid character for metadata.

Regards,
Mario