### PR TITLE
Add note of removed flows in diffConfig

### DIFF
--- a/red/runtime/nodes/flows/util.js
+++ b/red/runtime/nodes/flows/util.js
@@ -203,6 +203,13 @@ module.exports = {
         var linkMap = {};
 
         var changedTabs = {};
+        
+        // Look for tabs that have been removed
+        for (id in oldConfig.flows) {
+            if (oldConfig.flows.hasOwnProperty(id) && (!newConfig.flows.hasOwnProperty(id))) {
+                removed[id] = oldConfig.allNodes[id];
+            }
+        }
 
         // Look for tabs that have been disabled
         for (id in oldConfig.flows) {


### PR DESCRIPTION
I've been using addFlow and removeFlow pragmatically.  Decided to update to latest-latest, and on removeFlow, NR went through the motions, and made the flow inaccessible, but in fact, re-started all the nodes in the flow (only seen because the flow was generating debug....).
I spent quite some time tracking down, and I believe that the new diffConfig does not mark flows themselves as being removed.  As such, all the nodes get 'removed', but they remain there in the underlying flow.  The flow itself then seems to disappear, but the modules are there running until another deploy-like action causes NR to realise it has nodes with no parent flow, and then removes them grumpily :).
Hope I found the right way of solving this...