### PR TITLE
Allow saving credentials in a different directory

### DIFF
--- a/bin/node-red-pi
+++ b/bin/node-red-pi
@@ -22,7 +22,7 @@ ARGS=""
 for arg in "$@"
 do
    case $arg in
-      --userDir|--settings|--help) ARGS="$ARGS $arg";;
+      --userDir|--credDir|--settings|--help) ARGS="$ARGS $arg";;
             --*) OPTIONS="$OPTIONS $arg";;
               *) ARGS="$ARGS $arg";;
    esac

--- a/red.js
+++ b/red.js
@@ -38,6 +38,7 @@ var knownOpts = {
     "settings": [path],
     "title": String,
     "userDir": [path],
+    "credDir": [path],
     "verbose": Boolean
 };
 var shortHands = {
@@ -48,6 +49,7 @@ var shortHands = {
     // doesn't get treated as --title
     "t":["--help"],
     "u":["--userDir"],
+    "c":["--credDir"],
     "v":["--verbose"]
 };
 nopt.invalidHandler = function(k,v,t) {
@@ -66,6 +68,7 @@ if (parsedArgs.help) {
     console.log("  -s, --settings FILE  use specified settings file");
     console.log("      --title    TITLE process window title");
     console.log("  -u, --userDir  DIR   use specified user directory");
+    console.log("  -c  --credDir  DIR   use specified credentials directory");
     console.log("  -v, --verbose        enable verbose output");
     console.log("  -?, --help           show this help");
     console.log("");
@@ -172,6 +175,9 @@ if (flowFile) {
 }
 if (parsedArgs.userDir) {
     settings.userDir = parsedArgs.userDir;
+}
+if (parsedArgs.credDir) {
+    settings.credDir = parsedArgs.credDir;
 }
 
 try {

--- a/red/runtime/storage/localfilesystem.js
+++ b/red/runtime/storage/localfilesystem.js
@@ -32,7 +32,6 @@ var flowsFullPath;
 var flowsFileBackup;
 var credentialsFile;
 var credentialsFileBackup;
-var oldCredentialsFile;
 var sessionsFile;
 var libDir;
 var libFlowsDir;
@@ -215,11 +214,10 @@ var localfilesystem = {
         var ffName = fspath.basename(flowsFullPath);
         var ffBase = fspath.basename(flowsFullPath,ffExt);
         var ffDir = fspath.dirname(flowsFullPath);
-
-        credentialsFile = fspath.join(settings.userDir,ffBase+"_cred"+ffExt);
-        credentialsFileBackup = fspath.join(settings.userDir,"."+ffBase+"_cred"+ffExt+".backup");
-
-        oldCredentialsFile = fspath.join(settings.userDir,"credentials.json");
+        
+        var credDir = settings.credDir || settings.userDir;
+        credentialsFile = fspath.join(credDir,ffBase+"_cred"+ffExt);
+        credentialsFileBackup = fspath.join(credDir,"."+ffBase+"_cred"+ffExt+".backup");
 
         flowsFileBackup = fspath.join(ffDir,"."+ffName+".backup");
 


### PR DESCRIPTION
Currently credentials always reside in the same directory as the flows.

This disallows saving credentials on e.g. a docker volume or other mounted drives. When using docker it could prove useful to get an update of the flow by auto-updating the docker image, but still use the credential data on a volume (this is what I am doing).

With this commit a --credDir parameter can be specified to save/load credentials somewhere else. If omitted, userDir will be used as fallback (fully backwards compatible).

Originally I wanted to write a storage plugin, but as the changes are minor and in the plugin I would mostly copy code, I decided to issue a pull request.

If this is too exotic I can understand that. No offense taken.