### PR TITLE
Fix bug: Export Subflows

### DIFF
--- a/editor/js/nodes.js
+++ b/editor/js/nodes.js
@@ -508,9 +508,9 @@ RED.nodes = (function() {
     /**
      * Converts the current node selection to an exportable JSON Object
      **/
-    function createExportableNodeSet(set, exportedSubflows) {
+    function createExportableNodeSet(set, exportedSubflows, exportedConfigNodes) {
         var nns = [];
-        var exportedConfigNodes = {};
+        exportedConfigNodes = exportedConfigNodes || {};
         exportedSubflows = exportedSubflows || {};
         for (var n=0;n<set.length;n++) {
             var node = set[n];
@@ -525,7 +525,7 @@ RED.nodes = (function() {
                             subflowSet.push(n);
                         }
                     });
-                    var exportableSubflow = createExportableNodeSet(subflowSet, exportedSubflows);
+                    var exportableSubflow = createExportableNodeSet(subflowSet, exportedSubflows, exportedConfigNodes);
                     nns = exportableSubflow.concat(nns);
                 }
             }

--- a/editor/js/nodes.js
+++ b/editor/js/nodes.js
@@ -508,10 +508,10 @@ RED.nodes = (function() {
     /**
      * Converts the current node selection to an exportable JSON Object
      **/
-    function createExportableNodeSet(set) {
+    function createExportableNodeSet(set, exportedSubflows) {
         var nns = [];
         var exportedConfigNodes = {};
-        var exportedSubflows = {};
+        exportedSubflows = exportedSubflows || {};
         for (var n=0;n<set.length;n++) {
             var node = set[n];
             if (node.type.substring(0,8) == "subflow:") {
@@ -525,7 +525,7 @@ RED.nodes = (function() {
                             subflowSet.push(n);
                         }
                     });
-                    var exportableSubflow = createExportableNodeSet(subflowSet);
+                    var exportableSubflow = createExportableNodeSet(subflowSet, exportedSubflows);
                     nns = exportableSubflow.concat(nns);
                 }
             }


### PR DESCRIPTION
I have flow with two sub-flows, the first sub-flow contains the second one.

When I'm trying to export and import the flow:
* It creates the sub-flow twice.
* It leaves the sub-flow empty.
* It makes the last copy of the sub-flow contains manipulating copies of the node's sequence.

### The original flow:
> ![node red](https://user-images.githubusercontent.com/14214460/27134416-289cfd6c-511e-11e7-811c-56eff25ed1b6.png) </br>
![node red1](https://user-images.githubusercontent.com/14214460/27134431-32f9d08c-511e-11e7-9729-0459b1ddbf6c.png) </br>
![node red2](https://user-images.githubusercontent.com/14214460/27134437-39295cc0-511e-11e7-8aae-d02d5ff7040e.png) </br>

### The imported flow:
> ![node red2](https://user-images.githubusercontent.com/14214460/27135132-6a033e22-5120-11e7-8021-9f0686a3c764.png)
![node red1](https://user-images.githubusercontent.com/14214460/27135145-6d86933c-5120-11e7-9d73-2e257fe89082.png)
![node red](https://user-images.githubusercontent.com/14214460/27135152-72d1125e-5120-11e7-9775-2a3f7568031c.png)

This code change solved the problem.
