### PR TITLE
Bug fix in exec node. White spaces in arguments now works

### DIFF
--- a/nodes/core/core/75-exec.js
+++ b/nodes/core/core/75-exec.js
@@ -46,10 +46,11 @@ module.exports = function(RED) {
                 var arg = node.cmd;
                 if ((node.addpay === true) && msg.hasOwnProperty("payload")) { arg += " "+msg.payload; }
                 if (node.append.trim() !== "") { arg += " "+node.append; }
-                // slice whole line by spaces (trying to honour quotes);
-                arg = arg.match(/(?:[^\s"]+|"[^"]*")+/g);
+                // slice whole line by spaces and removes any quotes since spawn can't handle them
+                arg = arg.match(/(?:[^\s"]+|"[^"]*")+/g).map((a) => {
+                  if (/^".*"$/.test(a)) { return a.slice(1,-1)} else {return a};
+                });
                 var cmd = arg.shift();
-                if (/^".*"$/.test(cmd)) { cmd = cmd.slice(1,-1); }
                 /* istanbul ignore else  */
                 if (RED.settings.verbose) { node.log(cmd+" ["+arg+"]"); }
                 child = spawn(cmd,arg);


### PR DESCRIPTION
The exec node did not support white spaces in the arguments of the payload, say if you needed to provide a path with spaces in a certain arguments with quotes around the path, eg:

```java -cp "folder name/myjar.jar" MyClass```
 
It did work with having whitespaces in the command part of the payload, eg: 

```"folder name/exec" -someflag```

It worked in the command part since previously there was a line 52 (added by [dceejay](https://github.com/dceejay) in a previous [issue](https://github.com/node-red/node-red/issues/1100))
```if (/^"."$/.test(cmd)) { cmd = cmd.slice(1,-1); }``` 

that removed the quotes of the command part. This is needed since [spawn()](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) from node.js does not support quotes anywhere. 

I added the same functionality but for the whole line that gets passed from the exec node. It simply goes through the array of arguments and checks for any quotes and removes them if there are any, just as before but for the command, and the arguments. 