### PR TITLE
Support category with more than one word

### DIFF
--- a/editor/js/ui/palette.js
+++ b/editor/js/ui/palette.js
@@ -22,7 +22,7 @@ RED.palette = (function() {
     var categoryContainers = {};
 
     function createCategoryContainer(category, label){
-        label = label || category.replace("_", " ");
+        label = (label || category).replace(/_/g, " ");
         var catDiv = $('<div id="palette-container-'+category+'" class="palette-category palette-close hide">'+
             '<div id="palette-header-'+category+'" class="palette-header"><i class="expanded fa fa-angle-down"></i><span>'+label+'</span></div>'+
             '<div class="palette-content" id="palette-base-category-'+category+'">'+
@@ -127,7 +127,7 @@ RED.palette = (function() {
         }
         if (exclusion.indexOf(def.category)===-1) {
 
-            var category = def.category.replace(" ","_");
+            var category = def.category.replace(/ /g,"_");
             var rootCategory = category.split("-")[0];
 
             var d = document.createElement("div");


### PR DESCRIPTION
Node-Red Version (last commit):
> commit e9c1216d5cde177428f73c1abd94fe97ce48d195
> 	Author: Nick O'Leary <nick.oleary@gmail.com>
> 	Date:   Mon Jun 26 10:49:06 2017 +0100
> 
> 	    Handle logging out and already logged-out editor
> 	    Fixes #1288


NodeJs Version:
> v6.10.2

* When I register a node which it's category has more that 1 word - I see it on the palette with `_` instead of ` 
 `.
* When I register a node which it's category has more than 2 words - I can not see the category with the node on the palette.

This code change solved me the problems.
