### PR TITLE
Feat/socks5 proxy simple

### DIFF
--- a/nodes/core/io/21-httprequest.html
+++ b/nodes/core/io/21-httprequest.html
@@ -107,7 +107,7 @@
     url to be constructed using values of the incoming message. For example, if the url is set to
     <code>example.com/{{{topic}}}</code>, it will have the value of <code>msg.topic</code> automatically inserted.
     Using {{{...}}} prevents mustache from escaping characters like / & etc.</p>
-    <p><b>Note</b>: If running behind a proxy, the standard <code>http_proxy=...</code> environment variable should be set and Node-RED restarted.</p>
+    <p><b>Note</b>: If running behind a proxy, the standard <code>http_proxy=...</code> environment variable should be set and Node-RED restarted. Node-RED also supports socks proxies via <code>socks_proxy=true</code> (defaults to localhost:1080) or <code>socks_proxy=socks5://your.proxy-address-or-ip.com:55234, the provided protocol is actually ignored but is required because url lib requires it.</code></p>
     <h4>Using multiple HTTP Request nodes</h4>
     <p>In order to use more than one of these nodes in the same flow, care must be taken with
     the <code>msg.headers</code> property. The first node will set this property with

--- a/nodes/core/io/21-httprequest.js
+++ b/nodes/core/io/21-httprequest.js
@@ -18,6 +18,8 @@ module.exports = function(RED) {
     "use strict";
     var http = require("follow-redirects").http;
     var https = require("follow-redirects").https;
+    var SocksHttpAgent = require('socks5-http-client/lib/Agent');
+    var SocksHttpsAgent = require('socks5-https-client/lib/Agent');
     var urllib = require("url");
     var mustache = require("mustache");
     var querystring = require("querystring");
@@ -37,11 +39,13 @@ module.exports = function(RED) {
         if (RED.settings.httpRequestTimeout) { this.reqTimeout = parseInt(RED.settings.httpRequestTimeout) || 120000; }
         else { this.reqTimeout = 120000; }
 
-        var prox, noprox;
+        var prox, noprox, socksProxy;
         if (process.env.http_proxy != null) { prox = process.env.http_proxy; }
         if (process.env.HTTP_PROXY != null) { prox = process.env.HTTP_PROXY; }
         if (process.env.no_proxy != null) { noprox = process.env.no_proxy.split(","); }
         if (process.env.NO_PROXY != null) { noprox = process.env.NO_PROXY.split(","); }
+        if (process.env.socks_proxy != null) { socksProxy = process.env.socks_proxy.toLowerCase(); }
+        if (process.env.SOCKS_PROXY != null) { socksProxy = process.env.SOCKS_PROXY.toLowerCase(); }
 
         this.on("input",function(msg) {
             var preRequestTimestamp = process.hrtime();
@@ -193,6 +197,18 @@ module.exports = function(RED) {
                     }
                 }
                 else { node.warn("Bad proxy url: "+process.env.http_proxy); }
+            } else if (socksProxy && !noproxy && socksProxy != "false") {
+                var uses_ssl = opts.protocol == "https:"
+                if (!opts.port) {
+                  opts.port = uses_ssl ? 443 : 80;
+                }
+                var agentOptions;
+                if (socksProxy != "true") {
+                    var socksOpts = urllib.parse(socksProxy)
+                    opts.socksHost = socksOpts.host;
+                    opts.socksPort = socksOpts.port;
+                }
+                opts.agent = new (uses_ssl ? SocksHttpsAgent : SocksHttpAgent)(opts);
             }
             if (tlsNode) {
                 tlsNode.addTLSOptions(opts);

--- a/nodes/core/io/21-httprequest.js
+++ b/nodes/core/io/21-httprequest.js
@@ -205,7 +205,7 @@ module.exports = function(RED) {
                 var agentOptions;
                 if (socksProxy != "true") {
                     var socksOpts = urllib.parse(socksProxy)
-                    opts.socksHost = socksOpts.host;
+                    opts.socksHost = socksOpts.hostname;
                     opts.socksPort = socksOpts.port;
                 }
                 opts.agent = new (uses_ssl ? SocksHttpsAgent : SocksHttpAgent)(opts);

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
         "raw-body":"2.2.0",
         "semver": "5.3.0",
         "sentiment":"2.1.0",
+        "socks5-http-client": "^1.0.2",
+        "socks5-https-client": "^1.2.1",
         "uglify-js":"3.0.20",
         "when": "3.7.8",
         "ws": "1.1.1",


### PR DESCRIPTION
This is a new feature which adds basic socks5 support to node-red. By basic I mean that it doesn't support authentication. I think adding support for that should be fairly simple if somebody wants that. Auth credentials can be passed in the passed in the socks_proxy env and then url lib parsing would already read that and the underlying https://github.com/mattcg/socks5-client should support setting socksPassword and socksUsername, but we don't need this so did not look into it.

Short description of the behaviour is described in: nodes/core/io/21-httprequest.html