### PR TITLE
Fix creating userDir other than system drive on Windows

### DIFF
--- a/red.js
+++ b/red.js
@@ -87,8 +87,11 @@ if (parsedArgs.settings) {
     if (fs.existsSync(path.join(process.env.NODE_RED_HOME,".config.json"))) {
         // NODE_RED_HOME contains user data - use its settings.js
         settingsFile = path.join(process.env.NODE_RED_HOME,"settings.js");
+    } else if (process.env.HOMEPATH && fs.existsSync(path.join(process.env.HOMEPATH,".node-red",".config.json"))) {
+        // Consider compatibility for older versions
+        settingsFile = path.join(process.env.HOMEPATH,".node-red","settings.js");
     } else {
-        var userDir = parsedArgs.userDir || path.join(process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE,".node-red");
+        var userDir = parsedArgs.userDir || path.join(process.env.HOME || process.env.USERPROFILE || process.env.HOMEPATH,".node-red");
         var userSettingsFile = path.join(userDir,"settings.js");
         if (fs.existsSync(userSettingsFile)) {
             // $HOME/.node-red/settings.js exists

--- a/red/runtime/storage/localfilesystem.js
+++ b/red/runtime/storage/localfilesystem.js
@@ -186,9 +186,19 @@ var localfilesystem = {
                 fs.statSync(fspath.join(process.env.NODE_RED_HOME,".config.json"));
                 settings.userDir = process.env.NODE_RED_HOME;
             } catch(err) {
-                settings.userDir = fspath.join(process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE || process.env.NODE_RED_HOME,".node-red");
-                if (!settings.readOnly) {
-                    promises.push(promiseDir(fspath.join(settings.userDir,"node_modules")));
+                try {
+                    // Consider compatibility for older versions
+                    if (process.env.HOMEPATH) {
+                        fs.statSync(fspath.join(process.env.HOMEPATH,".node-red",".config.json"));
+                        settings.userDir = fspath.join(process.env.HOMEPATH,".node-red");
+                    }
+                } catch(err) {
+                }
+                if (!settings.userDir) {
+                    settings.userDir = fspath.join(process.env.HOME || process.env.USERPROFILE || process.env.HOMEPATH || process.env.NODE_RED_HOME,".node-red");
+                    if (!settings.readOnly) {
+                        promises.push(promiseDir(fspath.join(settings.userDir,"node_modules")));
+                    }
                 }
             }
         }

--- a/test/red/runtime/storage/localfilesystem_spec.js
+++ b/test/red/runtime/storage/localfilesystem_spec.js
@@ -43,7 +43,7 @@ describe('LocalFileSystem', function() {
     });
 
 
-    it('should set userDir to NRH is .config.json present',function(done) {
+    it('should set userDir to NRH if .config.json presents',function(done) {
         var oldNRH = process.env.NODE_RED_HOME;
         process.env.NODE_RED_HOME = path.join(userDir,"NRH");
         fs.mkdirSync(process.env.NODE_RED_HOME);
@@ -65,11 +65,39 @@ describe('LocalFileSystem', function() {
         });
     });
 
+    it('should set userDir to HOMEPATH/.node-red if .config.json presents',function(done) {
+        var oldNRH = process.env.NODE_RED_HOME;
+        process.env.NODE_RED_HOME = path.join(userDir,"NRH");
+        var oldHOMEPATH = process.env.HOMEPATH;
+        process.env.HOMEPATH = path.join(userDir,"HOMEPATH");
+        fs.mkdirSync(process.env.HOMEPATH);
+        fs.mkdirSync(path.join(process.env.HOMEPATH,".node-red"));
+        fs.writeFileSync(path.join(process.env.HOMEPATH,".node-red",".config.json"),"{}","utf8");
+        var settings = {};
+        localfilesystem.init(settings).then(function() {
+            try {
+                fs.existsSync(path.join(process.env.HOMEPATH,".node-red","lib")).should.be.true();
+                fs.existsSync(path.join(process.env.HOMEPATH,".node-red","lib",'flows')).should.be.true();
+                settings.userDir.should.equal(path.join(process.env.HOMEPATH,".node-red"));
+                done();
+            } catch(err) {
+                done(err);
+            } finally {
+                process.env.NODE_RED_HOME = oldNRH;
+                process.env.NODE_HOMEPATH = oldHOMEPATH;
+            }
+        }).otherwise(function(err) {
+            done(err);
+        });
+    });
+
     it('should set userDir to HOME/.node-red',function(done) {
         var oldNRH = process.env.NODE_RED_HOME;
         process.env.NODE_RED_HOME = path.join(userDir,"NRH");
         var oldHOME = process.env.HOME;
         process.env.HOME = path.join(userDir,"HOME");
+        var oldHOMEPATH = process.env.HOMEPATH;
+        process.env.HOMEPATH = path.join(userDir,"HOMEPATH");
 
         fs.mkdirSync(process.env.HOME);
         var settings = {};
@@ -84,6 +112,38 @@ describe('LocalFileSystem', function() {
             } finally {
                 process.env.NODE_RED_HOME = oldNRH;
                 process.env.HOME = oldHOME;
+                process.env.HOMEPATH = oldHOMEPATH;
+            }
+        }).otherwise(function(err) {
+            done(err);
+        });
+    });
+
+    it('should set userDir to USERPROFILE/.node-red',function(done) {
+        var oldNRH = process.env.NODE_RED_HOME;
+        process.env.NODE_RED_HOME = "";
+        var oldHOME = process.env.HOME;
+        process.env.HOME = "";
+        var oldHOMEPATH = process.env.HOMEPATH;
+        process.env.HOMEPATH = path.join(userDir,"HOMEPATH");
+        var oldUSERPROFILE = process.env.USERPROFILE;
+        process.env.USERPROFILE = path.join(userDir,"USERPROFILE");
+
+        fs.mkdirSync(process.env.USERPROFILE);
+        var settings = {};
+        localfilesystem.init(settings).then(function() {
+            try {
+                fs.existsSync(path.join(process.env.USERPROFILE,".node-red","lib")).should.be.true();
+                fs.existsSync(path.join(process.env.USERPROFILE,".node-red","lib",'flows')).should.be.true();
+                settings.userDir.should.equal(path.join(process.env.USERPROFILE,".node-red"));
+                done();
+            } catch(err) {
+                done(err);
+            } finally {
+                process.env.NODE_RED_HOME = oldNRH;
+                process.env.HOME = oldHOME;
+                process.env.HOMEPATH = oldHOMEPATH;
+                process.env.USERPROFILE = oldUSERPROFILE;
             }
         }).otherwise(function(err) {
             done(err);


### PR DESCRIPTION
#1281
With this fix, process.env.USERPROFILE takes precedence over process.env.HOMEPATH.
For the users who upgrade from the older version to 0.17, if the file ".config.json" exists in process.env.HOMEPATH, Node-RED tries to keep using the folder.
I tested on Windows 7, Windows 10, Linux (Ubuntu), macOS (Sierra).  All worked fine.