### PR TITLE
Fix missing icons for some nodes

### DIFF
--- a/red/runtime/nodes/registry/registry.js
+++ b/red/runtime/nodes/registry/registry.js
@@ -599,6 +599,9 @@ function getNodeIconPath(module,icon) {
                 }
             }
         }
+        if (module !== "node-red") {
+            return getNodeIconPath("node-red", icon);
+        }
 
         return defaultIcon;
     }

--- a/test/red/runtime/nodes/registry/registry_spec.js
+++ b/test/red/runtime/nodes/registry/registry_spec.js
@@ -497,6 +497,12 @@ describe("red/nodes/registry/registry",function() {
             var iconPath = typeRegistry.getNodeIconPath('test-module','test_icon.png');
             iconPath.should.eql(testIcon);
         });
+
+        it('returns the debug icon when getting an unknown module', function() {
+            var debugIcon = path.resolve(__dirname+'/../../../../../public/icons/debug.png');
+            var iconPath = typeRegistry.getNodeIconPath('unknown-module', 'debug.png');
+            iconPath.should.eql(debugIcon);
+        });
     });
 
 });


### PR DESCRIPTION
#1318
If icons are missing for some nodes such as email and twitter, tries to check under public/icons.