### PR TITLE
Fix settings.js by using webSocketNodeVerifyClient

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -174,7 +174,7 @@ module.exports = {
     // The following property can be used to verify websocket connection attempts.
     // This allows, for example, the HTTP request headers to be checked to ensure
     // they include valid authentication information.
-    //webSocketVerifyClient: function(info) {
+    //webSocketNodeVerifyClient: function(info) {
     //    // 'info' has three properties:
     //    //   - origin : the value in the Origin header
     //    //   - req : the HTTP request


### PR DESCRIPTION
The provided settings.js wrongly provide a commented function webSocketVerifyClient which doesn't have any effect.

The correct parameter is (according to the code of node websocket) webSocketNodeVerifyClient.