### PR TITLE
Package appmetrics-dash into NodeRED

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "editor", "messaging", "iot", "flow"
     ],
     "dependencies": {
+        "appmetrics": "^3.0.2",
         "basic-auth": "1.1.0",
         "bcryptjs": "2.4.3",
         "body-parser": "1.17.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "editor", "messaging", "iot", "flow"
     ],
     "dependencies": {
-        "appmetrics": "^3.0.2",
+        "appmetrics-dash": "^3.2.1",
         "basic-auth": "1.1.0",
         "bcryptjs": "2.4.3",
         "body-parser": "1.17.2",

--- a/red.js
+++ b/red.js
@@ -14,6 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+var dash;
+if (process.env.APPMETRICS) {
+    dash = require('appmetrics-dash');
+    dash.attach();
+}
 var http = require('http');
 var https = require('https');
 var util = require("util");


### PR DESCRIPTION
@knolleary Here's the code needed to put Appmetrics-dash into NodeRED. It can be enabled by setting the APPMETRICS environment variable. Appmetrics-dash will attach to NodeRED's web server instance, and the dashboard will be on <hostname:port>/appmetrics-dash. Happy to write docs!