### PR TITLE
Fix userDir test case when .config.json exists

### DIFF
--- a/test/red/runtime/storage/localfilesystem_spec.js
+++ b/test/red/runtime/storage/localfilesystem_spec.js
@@ -121,7 +121,7 @@ describe('LocalFileSystem', function() {
 
     it('should set userDir to USERPROFILE/.node-red',function(done) {
         var oldNRH = process.env.NODE_RED_HOME;
-        process.env.NODE_RED_HOME = "";
+        process.env.NODE_RED_HOME = path.join(userDir,"NRH");
         var oldHOME = process.env.HOME;
         process.env.HOME = "";
         var oldHOMEPATH = process.env.HOMEPATH;


### PR DESCRIPTION
#1317 
Fix a problem when ".config.json" exists on the directory that runs a grunt command.
