### PR TITLE
Change font family

### DIFF
--- a/editor/sass/editor.scss
+++ b/editor/sass/editor.scss
@@ -196,7 +196,7 @@
     border-radius:5px;
     overflow: hidden;
     font-size: 14px !important;
-    font-family: Menlo, Consolas, Courier, 'DejaVu Sans Mono', monospace !important;
+    font-family: Menlo, Consolas, 'DejaVu Sans Mono', Courier, monospace !important;
 }
 
 .editor-button {

--- a/editor/sass/editor.scss
+++ b/editor/sass/editor.scss
@@ -196,7 +196,7 @@
     border-radius:5px;
     overflow: hidden;
     font-size: 14px !important;
-    font-family: monospace !important;
+    font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace !important;
 }
 
 .editor-button {

--- a/editor/sass/editor.scss
+++ b/editor/sass/editor.scss
@@ -196,7 +196,7 @@
     border-radius:5px;
     overflow: hidden;
     font-size: 14px !important;
-    font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace !important;
+    font-family: Menlo, Consolas, Courier, 'DejaVu Sans Mono', monospace !important;
 }
 
 .editor-button {


### PR DESCRIPTION
Problem
-----

I am a Japanese programmer.When I used node-red, I found a bug about ace editor.

The next image is a screenshot of a bug.There are two parts I want you to pay attention to in this image.

1. Is not a monospaced font.
2. The cursor is out of position.

<img width="481" alt="2017-07-30 15 31 41" src="https://user-images.githubusercontent.com/7535743/28751195-4298a724-753c-11e7-9d27-5956b657deab.png">

This problem occurs on **Chrome** on the Mac.It does not occur in Safari.


Reproduction
-----

The environment I used is below.

- OS: macOS Sierra 10.12.5  (MacBook Pro (13-inch, 2017, Four Thunderbolt 3 Ports))
- Browser: Google Chrome version 60.0.3112.78 (Official Build) (64bit)
- npm version: 4.0.5
- node version: v7.4.0

To reproduce the bug, edit the setting "<img width="120" alt="2017-07-30 15 31 58" src="https://user-images.githubusercontent.com/7535743/28751196-440fdca8-753c-11e7-9202-d7efcf79bf8a.png">" on the flow editor.




Resolution
-----

By making a change like a pull request, it is now displayed as follows.

### Chrome
<img width="480" alt="2017-07-30 16 10 10" src="https://user-images.githubusercontent.com/7535743/28751407-9d67308a-7541-11e7-8a14-57e085753e4e.png">

### Safari
<img width="482" alt="2017-07-30 16 16 29" src="https://user-images.githubusercontent.com/7535743/28751435-79522d3e-7542-11e7-85da-2c2ba58a6fe7.png">

For "font-family", I referred to the style of the atom editor.

- reference: https://github.com/atom/atom/blob/master/static/text-editor.less#L7


Concern
-----

Perhaps, this problem occurs in non-English speaking countries.(There is no confirmation.)
So, there may be circumstances that can not be reproduced.


Finally
-----
English is not very good, so I'm glad if you give me a reply in a short sentence.