### PR TITLE
Allow port zero for Express

### DIFF
--- a/red.js
+++ b/red.js
@@ -168,6 +168,10 @@ if (settings.httpNodeRoot !== false) {
 }
 
 settings.uiPort = parsedArgs.port||settings.uiPort||1880;
+if (settings.uiPort === -1){
+    settings.uiPort = 0;
+}
+
 settings.uiHost = settings.uiHost||"0.0.0.0";
 
 if (flowFile) {
@@ -292,6 +296,8 @@ RED.start().then(function() {
             if (settings.httpAdminRoot === false) {
                 RED.log.info(RED.log._("server.admin-ui-disabled"));
             }
+            if (settings.uiPort === 0)
+                settings.uiPort = server.address().port;
             process.title = parsedArgs.title || 'node-red';
             RED.log.info(RED.log._("server.now-running", {listenpath:getListenPath()}));
         });

--- a/red.js
+++ b/red.js
@@ -167,9 +167,14 @@ if (settings.httpNodeRoot !== false) {
     settings.httpNodeAuth = settings.httpNodeAuth || settings.httpAuth;
 }
 
-settings.uiPort = parsedArgs.port||settings.uiPort||1880;
-if (settings.uiPort === -1){
-    settings.uiPort = 0;
+// if we got a port from command line, use it (even if 0)
+// replicate (settings.uiPort = parsedArgs.port||settings.uiPort||1880;) but allow zero
+if (parsedArgs.port !== undefined){
+    settings.uiPort = parsedArgs.port;
+} else {
+    if (settings.uiPort === undefined){
+        settings.uiPort = 1880;
+    }
 }
 
 settings.uiHost = settings.uiHost||"0.0.0.0";
@@ -265,9 +270,13 @@ if (settings.httpStatic) {
 }
 
 function getListenPath() {
+    var port = settings.serverPort;
+    if (port === undefined)
+        port = settings.uiPort;
+
     var listenPath = 'http'+(settings.https?'s':'')+'://'+
                     (settings.uiHost == '0.0.0.0'?'127.0.0.1':settings.uiHost)+
-                    ':'+settings.uiPort;
+                    ':'+port;
     if (settings.httpAdminRoot !== false) {
         listenPath += settings.httpAdminRoot;
     } else if (settings.httpStatic) {
@@ -296,8 +305,7 @@ RED.start().then(function() {
             if (settings.httpAdminRoot === false) {
                 RED.log.info(RED.log._("server.admin-ui-disabled"));
             }
-            if (settings.uiPort === 0)
-                settings.uiPort = server.address().port;
+            settings.serverPort = server.address().port;
             process.title = parsedArgs.title || 'node-red';
             RED.log.info(RED.log._("server.now-running", {listenpath:getListenPath()}));
         });

--- a/red.js
+++ b/red.js
@@ -271,8 +271,9 @@ if (settings.httpStatic) {
 
 function getListenPath() {
     var port = settings.serverPort;
-    if (port === undefined)
+    if (port === undefined){
         port = settings.uiPort;
+    }
 
     var listenPath = 'http'+(settings.https?'s':'')+'://'+
                     (settings.uiHost == '0.0.0.0'?'127.0.0.1':settings.uiHost)+


### PR DESCRIPTION
This pull request allows port zero to be set for the express port, so that the OS can auto-allocate a port number.
The allocated port number is written to settings.serverPort, from where it can be retrieved if required by the app.