### PR TITLE
mqtt: Add 'name' to mqtt-broker node, and label it by this if it is set.

### DIFF
--- a/nodes/core/io/10-mqtt.html
+++ b/nodes/core/io/10-mqtt.html
@@ -166,6 +166,10 @@
 
 <script type="text/x-red" data-template-name="mqtt-broker">
     <div class="form-row">
+        <label for="node-config-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
+        <input type="text" id="node-config-input-name" data-i18n="[placeholder]common.label.name">
+    </div>
+    <div class="form-row">
         <ul style="background: #fff; min-width: 600px; margin-bottom: 20px;" id="node-config-mqtt-broker-tabs"></ul>
     </div>
     <div id="node-config-mqtt-broker-tabs-content" style="min-height: 170px;">
@@ -266,6 +270,7 @@
     RED.nodes.registerType('mqtt-broker',{
         category: 'config',
         defaults: {
+            name: {value:""},
             broker: {value:"",required:true},
             port: {value:1883,required:true,validate:RED.validators.number()},
             tls: {type:"tls-config",required: false},
@@ -296,9 +301,15 @@
             password: {type: "password"}
         },
         label: function() {
-            var b = this.broker;
-            if (b === "") { b = "undefined"; }
-            return (this.clientid?this.clientid+"@":"")+b+":"+this.port;
+            var lab = this.name;
+            if ((lab === undefined) || (lab ==="")) {
+                var b = this.broker;
+                if (b === "") { b = "undefined"; }
+                lab = (this.clientid?this.clientid+"@":"")+b+":"+this.port;
+            }
+            return lab;
+            
+            
         },
         oneditprepare: function () {
             var tabs = RED.tabs.create({


### PR DESCRIPTION
This pull request add a name property to the mqtt broker node.
All the changes are only in the html file.
If the name property is set, the label for the broker node becomes the name... rather than as currently.

Rational:  
I have an unusual situation where I have multiple mqtt broker nodes which all have the same broker configured, but use different credentials.  Issue is that they all list by the same label... so i never know which one is actually in use.

Original label:
If ClientId is set: <clientid>@<broker server name> 
else <broker server name>

New label:
If Name is set: <name> 
else If ClientId is set: <clientid>@<broker server name>
else <broker server name>

The label is used in the general html to produce the lists used in the mqtt-in and mqtt-out nodes.  I did consider using name (client@broker), but visually this got complex (too little room in dropdowns, etc.), so I kept it simple.  For most users, if they don;t set a name, the label and so the selection criteria will remain as it is now.