### PR TITLE
Handle escape characters in template node which uses Mustache format and JSON output mode

### DIFF
--- a/nodes/core/core/80-template.js
+++ b/nodes/core/core/80-template.js
@@ -73,7 +73,16 @@ module.exports = function(RED) {
             try {
                 var value;
                 if (node.syntax === "mustache") {
-                    value = mustache.render(node.template,new NodeContext(msg, node.context()));
+                    if (node.outputFormat === "json") {
+                        value = mustache.render(node.template, new NodeContext(JSON.parse(JSON.stringify(msg), function (key, value) {
+                            if (typeof value === "string") {
+                                value = value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/\t/g, "\\t").replace(/\r/g, "\\r").replace(/\f/g, "\\f").replace(/[\b]/g, "\\b");
+                            }
+                            return value;
+                        }), node.context()));
+                    } else {
+                        value = mustache.render(node.template, new NodeContext(msg, node.context()));
+                    }
                 } else {
                     value = node.template;
                 }

--- a/test/nodes/core/core/80-template_spec.js
+++ b/test/nodes/core/core/80-template_spec.js
@@ -88,7 +88,7 @@ describe('template node', function() {
         });
     });
 
-    it('should handle escape charactors in Mustache format and JSON output mode', function(done) {
+    it('should handle escape characters in Mustache format and JSON output mode', function(done) {
         var flow = [{id:"n1", type:"template", field:"payload", syntax:"mustache", template:"{\"data\":\"{{payload}}\"}", output:"json", wires:[["n2"]]},{id:"n2",type:"helper"}];
         helper.load(templateNode, flow, function() {
             var n1 = helper.getNode("n1");

--- a/test/nodes/core/core/80-template_spec.js
+++ b/test/nodes/core/core/80-template_spec.js
@@ -88,6 +88,18 @@ describe('template node', function() {
         });
     });
 
+    it('should handle escape charactors in Mustache format and JSON output mode', function(done) {
+        var flow = [{id:"n1", type:"template", field:"payload", syntax:"mustache", template:"{\"data\":\"{{payload}}\"}", output:"json", wires:[["n2"]]},{id:"n2",type:"helper"}];
+        helper.load(templateNode, flow, function() {
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n2.on("input", function(msg) {
+                msg.payload.should.have.property('data', 'line\t1\nline\\2\r\nline\b3\f');
+                done();
+            });
+            n1.receive({payload:"line\t1\nline\\2\r\nline\b3\f"});
+        });
+    });
 
     it('should modify payload in plain text mode', function(done) {
         var flow = [{id:"n1", type:"template", field:"payload", syntax:"plain", template:"payload={{payload}}",wires:[["n2"]]},{id:"n2",type:"helper"}];


### PR DESCRIPTION
I fixed #1376 .
This fix supports return code and other characters which need escape character.