### PR TITLE
speed up debug window - only process required number of messages

### DIFF
--- a/nodes/core/core/lib/debug/debug-utils.js
+++ b/nodes/core/core/lib/debug/debug-utils.js
@@ -29,7 +29,7 @@ RED.debug = (function() {
     var messagesByNode = {};
     var sbc;
     var activeWorkspace;
-    var numMessages = 100;
+    var numMessages = 100;  // Hardcoded number of message to show in debug window scrollback
 
     var filterVisible = false;
 
@@ -377,19 +377,17 @@ RED.debug = (function() {
         if (o) { stack.push(o); }
         if (!busy && (stack.length > 0)) {
             busy = true;
-            reallyHandleDebugMessage(stack.shift(), function() {
-                setTimeout(function() {
-                    busy = false;
-                    handleDebugMessage();
-                }, 15);  // every 15mS = 66 times a second
-            });
+            processDebugMessage(stack.shift());
+            setTimeout(function() {
+                busy = false;
+                handleDebugMessage();
+            }, 15);  // every 15mS = 66 times a second
             if (stack.length > numMessages) { stack = stack.splice(-numMessages); }
         }
     }
 
-    function reallyHandleDebugMessage(o,cb) {
+    function processDebugMessage(o) {
         var msg = document.createElement("div");
-
         var sourceNode = o._source;
 
         msg.onmouseenter = function() {

--- a/nodes/core/core/lib/debug/debug-utils.js
+++ b/nodes/core/core/lib/debug/debug-utils.js
@@ -29,6 +29,7 @@ RED.debug = (function() {
     var messagesByNode = {};
     var sbc;
     var activeWorkspace;
+    var numMessages = 100;
 
     var filterVisible = false;
 
@@ -369,7 +370,25 @@ RED.debug = (function() {
         })
         menuOptionMenu.show();
     }
+
+    var stack = [];
+    var busy = false;
     function handleDebugMessage(o) {
+        if (o) { stack.push(o); }
+        if (!busy && (stack.length > 0)) {
+            busy = true;
+            if (stack.length > numMessages) { stack = stack.splice(-numMessages); }
+            var a = stack.shift();
+            reallyHandleDebugMessage(a, function() {
+                setTimeout(function() {
+                    busy = false;
+                    handleDebugMessage();
+                }, 20);  // every 20mS = 50 times a second
+            });
+        }
+    }
+
+    function reallyHandleDebugMessage(o,cb) {
         var msg = document.createElement("div");
 
         var sourceNode = o._source;
@@ -497,7 +516,7 @@ RED.debug = (function() {
             }
         }
 
-        if (messages.length === 100) {
+        if (messages.length === numMessages) {
             m = messages.shift();
             if (view === "list") {
                 m.el.remove();
@@ -506,12 +525,13 @@ RED.debug = (function() {
         if (atBottom) {
             messageList.scrollTop(sbc.scrollHeight);
         }
+
+        if (cb) { cb(); }
     }
 
     return {
         init: init,
         refreshMessageList:refreshMessageList,
-        handleDebugMessage: handleDebugMessage,
-
+        handleDebugMessage: handleDebugMessage
     }
 })();

--- a/nodes/core/core/lib/debug/debug-utils.js
+++ b/nodes/core/core/lib/debug/debug-utils.js
@@ -377,14 +377,13 @@ RED.debug = (function() {
         if (o) { stack.push(o); }
         if (!busy && (stack.length > 0)) {
             busy = true;
-            if (stack.length > numMessages) { stack = stack.splice(-numMessages); }
-            var a = stack.shift();
-            reallyHandleDebugMessage(a, function() {
+            reallyHandleDebugMessage(stack.shift(), function() {
                 setTimeout(function() {
                     busy = false;
                     handleDebugMessage();
-                }, 20);  // every 20mS = 50 times a second
+                }, 15);  // every 15mS = 66 times a second
             });
+            if (stack.length > numMessages) { stack = stack.splice(-numMessages); }
         }
     }
 


### PR DESCRIPTION
speed up debug sidebar window processing of messages by only handling up to the number of messages in the history depth (100) - dropping any older than that, as they won’t be in the scrollable window anyway.
This is part 1 of 2
(part 2 will batch up messages across the websocket)