### PR TITLE
Fix the appearance of 'is between' rule on switch node edit dialog

### DIFF
--- a/nodes/core/logic/10-switch.html
+++ b/nodes/core/logic/10-switch.html
@@ -199,6 +199,7 @@
                         } else if (type === "btwn") {
                             row2.hide();
                             row3.show();
+                            btwnValue2Field.typedInput('show');
                         } else {
                             row2.hide();
                             row3.hide();


### PR DESCRIPTION
## Problem
Second input form of "is between" rule on switch node edit dialog is lacked.

<img src="https://raw.githubusercontent.com/wiki/Kazuki-Nakanishi/node-red/images/switch_between.png" width=70% height=70% alt="mqtt before">

## How to reproduce
1. Open edit dialog of switch node.
1. Change a rule to "is between".

