### PR TITLE
Upgrade JSONata to v1.3.0

### DIFF
--- a/editor/vendor/jsonata/formatter.js
+++ b/editor/vendor/jsonata/formatter.js
@@ -128,6 +128,8 @@
         '$map':{ args:[ 'array', 'function' ]},
         '$match':{ args:[ 'str', 'pattern', 'limit' ]},
         '$max':{ args:[ 'array' ]},
+        '$merge':{ args:[ 'array' ]},
+        '$millis':{ args:[  ]},
         '$min':{ args:[ 'array' ]},
         '$not':{ args:[ 'arg' ]},
         '$now':{ args:[  ]},

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "is-utf8":"0.2.1",
         "js-yaml": "3.8.4",
         "json-stringify-safe":"5.0.1",
-        "jsonata":"1.2.6",
+        "jsonata":"1.3.0",
         "media-typer": "0.3.0",
         "mqtt": "2.9.0",
         "multer": "1.3.0",

--- a/red/api/locales/en-US/jsonata.json
+++ b/red/api/locales/en-US/jsonata.json
@@ -95,6 +95,10 @@
         "args":"",
         "desc":"Returns a pseudo random number greater than or equal to zero and less than one."
     },
+    "$millis": {
+        "args":"",
+        "desc":"Returns the number of milliseconds since the Unix Epoch (1 January, 1970 UTC) as a number. All invocations of `$millis()` within an evaluation of an expression will all return the same value."
+    },
     "$sum": {
         "args": "array",
         "desc": "Returns the arithmetic sum of an `array` of numbers. It is an error if the input `array` contains an item which isn't a number."
@@ -159,6 +163,10 @@
     "$spread": {
         "args": "object",
         "desc": "Splits an object containing key/value pairs into an array of objects, each of which has a single key/value pair from the input object. If the parameter is an array of objects, then the resultant array contains an object for every key/value pair in every object in the supplied array."
+    },
+    "$merge": {
+        "args": "array&lt;object&gt;",
+        "desc": "Merges an array of `objects` into a single `object` containing all the key/value pairs from each of the objects in the input array. If any of the input objects contain the same key, then the returned `object` will contain the value of the last one in the array. It is an error if the input array contains an item that is not an object."
     },
     "$sift": {
         "args":"object, function",


### PR DESCRIPTION
[JSONata 1.3.0 was released on Sept. 4th.](https://github.com/jsonata-js/jsonata/releases/tag/v1.3)  This release includes three main additions: backticks can be used to preserve reserved tokens (in place of single– or double–quotes), two new functions have been added (including the highly useful `$merge`), and a new mode for more detailed error reporting has been added to the parser.

This merge request simply updates the npm dependency in package.json and defines additional help text for the two new functions added to JSONata 1.3.0