### PR TITLE
Fix wrong argument in change node

### DIFF
--- a/nodes/core/logic/15-change.js
+++ b/nodes/core/logic/15-change.js
@@ -201,7 +201,7 @@ module.exports = function(RED) {
                         } else if (rule.t === 'set') {
                             target.set(property,value);
                         } else if (rule.t === 'change') {
-                            current = target.get(msg,property);
+                            current = target.get(property);
                             if (typeof current === 'string') {
                                 if ((fromType === 'num' || fromType === 'bool' || fromType === 'str') && current === fromValue) {
                                     // str representation of exact from number/boolean

--- a/test/nodes/core/logic/15-change_spec.js
+++ b/test/nodes/core/logic/15-change_spec.js
@@ -612,6 +612,103 @@ describe('change Node', function() {
                 changeNode1.receive({payload:true});
             });
         });
+
+        it('changes the value of the global context', function(done) {
+            var flow = [{"id":"changeNode1","type":"change",rules:[{ "t": "change", "p": "payload", "pt": "global", "from": "Hello", "fromt": "str", "to": "Goodbye", "tot": "str" }],"reg":false,"name":"changeNode","wires":[["helperNode1"]],"z":"flow"},
+                        {id:"helperNode1", type:"helper", wires:[],"z":"flow"}];
+            helper.load(changeNode, flow, function() {
+                var changeNode1 = helper.getNode("changeNode1");
+                var helperNode1 = helper.getNode("helperNode1");
+                helperNode1.on("input", function(msg) {
+                    try {
+                        helperNode1.context().global.get("payload").should.equal("Goodbye World!");
+                        done();
+                    } catch(err) {
+                        done(err);
+                    }
+                });
+                changeNode1.context().global.set("payload","Hello World!");
+                changeNode1.receive({payload:""});
+            });
+        });
+
+        it('changes the value and doesnt change type of the flow context for partial match', function(done) {
+            var flow = [{"id":"changeNode1","type":"change",rules:[{ "t": "change", "p": "payload", "pt": "flow", "from": "123", "fromt": "str", "to": "456", "tot": "num" }],"reg":false,"name":"changeNode","wires":[["helperNode1"]],"z":"flow"},
+                        {id:"helperNode1", type:"helper", wires:[],"z":"flow"}];
+            helper.load(changeNode, flow, function() {
+                var changeNode1 = helper.getNode("changeNode1");
+                var helperNode1 = helper.getNode("helperNode1");
+                helperNode1.on("input", function(msg) {
+                    try {
+                        helperNode1.context().flow.get("payload").should.equal("Change456Me");
+                        helperNode1.context().flow.get("payload").should.be.a.String();
+                        done();
+                    } catch(err) {
+                        done(err);
+                    }
+                });
+                changeNode1.context().flow.set("payload","Change123Me");
+                changeNode1.receive({payload:""});
+            });
+        });
+
+        it('changes the value and type of the flow context if a complete match', function(done) {
+            var flow = [{"id":"changeNode1","type":"change",rules:[{ "t": "change", "p": "payload", "pt": "flow", "from": "123", "fromt": "str", "to": "456", "tot": "num" }],"reg":false,"name":"changeNode","wires":[["helperNode1"]],"z":"flow"},
+                        {id:"helperNode1", type:"helper", wires:[],"z":"flow"}];
+            helper.load(changeNode, flow, function() {
+                var changeNode1 = helper.getNode("changeNode1");
+                var helperNode1 = helper.getNode("helperNode1");
+                helperNode1.on("input", function(msg) {
+                    try {
+                        helperNode1.context().flow.get("payload").should.equal(456);
+                        helperNode1.context().flow.get("payload").should.be.a.Number();
+                        done();
+                    } catch(err) {
+                        done(err);
+                    }
+                });
+                changeNode1.context().flow.set("payload","123");
+                changeNode1.receive({payload:""});
+            });
+        });
+
+        it('changes the value using number - number flow context', function(done) {
+            var flow = [{"id":"changeNode1","type":"change",rules:[{ "t": "change", "p": "payload", "pt": "flow", "from": "123", "fromt": "num", "to": "abc", "tot": "str" }],"reg":false,"name":"changeNode","wires":[["helperNode1"]],"z":"flow"},
+                        {id:"helperNode1", type:"helper", wires:[],"z":"flow"}];
+            helper.load(changeNode, flow, function() {
+                var changeNode1 = helper.getNode("changeNode1");
+                var helperNode1 = helper.getNode("helperNode1");
+                helperNode1.on("input", function(msg) {
+                    try {
+                        helperNode1.context().flow.get("payload").should.equal("abc");
+                        done();
+                    } catch(err) {
+                        done(err);
+                    }
+                });
+                changeNode1.context().flow.set("payload",123);
+                changeNode1.receive({payload:""});
+            });
+        });
+
+        it('changes the value using boolean - boolean flow context', function(done) {
+            var flow = [{"id":"changeNode1","type":"change",rules:[{ "t": "change", "p": "payload", "pt": "flow", "from": "true", "fromt": "bool", "to": "abc", "tot": "str" }],"reg":false,"name":"changeNode","wires":[["helperNode1"]],"z":"flow"},
+                        {id:"helperNode1", type:"helper", wires:[],"z":"flow"}];
+            helper.load(changeNode, flow, function() {
+                var changeNode1 = helper.getNode("changeNode1");
+                var helperNode1 = helper.getNode("helperNode1");
+                helperNode1.on("input", function(msg) {
+                    try {
+                        helperNode1.context().flow.get("payload").should.equal("abc");
+                        done();
+                    } catch(err) {
+                        done(err);
+                    }
+                });
+                changeNode1.context().flow.set("payload",true);
+                changeNode1.receive({payload:""});
+            });
+        });
     });
 
     describe("#delete", function() {


### PR DESCRIPTION
The change node could not change a value of flow and global context, because it passed wrong argument to `get()` function.
I fix it and add test cases.