### PR TITLE
Fix global.keys() bug in function node

### DIFF
--- a/red/runtime/nodes/context.js
+++ b/red/runtime/nodes/context.js
@@ -20,7 +20,7 @@ var util = require("../util");
 
 function createContext(id,seed) {
     var data = seed || {};
-    var obj = seed || {};
+    var obj = {};
     obj.get = function get(key) {
         return util.getMessageProperty(data,key);
     };

--- a/red/runtime/nodes/context.js
+++ b/red/runtime/nodes/context.js
@@ -20,7 +20,7 @@ var util = require("../util");
 
 function createContext(id,seed) {
     var data = seed || {};
-    var obj = {};
+    var obj = seed || {};
     obj.get = function get(key) {
         return util.getMessageProperty(data,key);
     };
@@ -28,7 +28,14 @@ function createContext(id,seed) {
         util.setMessageProperty(data,key,value);
     }
     obj.keys = function() {
-        return Object.keys(data);
+        var keysData = Object.keys(data);
+        if (seed == null) {
+            return keysData;
+        } else {
+            return keysData.filter(function (key) {
+                return key !== "set" && key !== "get" && key !== "keys";
+            });
+        }
     }
     return obj;
 }

--- a/test/nodes/core/core/80-function_spec.js
+++ b/test/nodes/core/core/80-function_spec.js
@@ -160,6 +160,22 @@ describe('function node', function() {
         });
     });
 
+    it('should get keys in global context', function(done) {
+        var flow = [{id:"n1",type:"function",wires:[["n2"]],func:"msg.payload=global.keys();return msg;"},
+                    {id:"n2", type:"helper"}];
+        helper.load(functionNode, flow, function() {
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n1.context().global.set("count","0");
+            n2.on("input", function(msg) {
+                msg.should.have.property('topic', 'bar');
+                msg.should.have.property('payload', ['count']);
+                done();
+            });
+            n1.receive({payload:"foo",topic: "bar"});
+        });
+    });
+
     function testNonObjectMessage(functionText,done) {
         var flow = [{id:"n1",type:"function",wires:[["n2"]],func:functionText},
                 {id:"n2", type:"helper"}];


### PR DESCRIPTION
I fixed global.keys() bug which I found in pull request #1402.

Suggestion:
global.keys() method in my pull request doesn't support deprecated context.global in the function node document (https://nodered.org/docs/writing-functions). I think that it's better to change "deprecated" to "unsupported" in the document because global.keys() method needs to heavily handle both context.global and global.set()/get() if context.global is supported.