### PR TITLE
do not consider _msgid when merging objects

### DIFF
--- a/nodes/core/logic/17-split.js
+++ b/nodes/core/logic/17-split.js
@@ -441,7 +441,7 @@ module.exports = function(RED) {
                         }
                     } else {
                         for (propertyKey in property) {
-                            if (property.hasOwnProperty(propertyKey)) {
+                            if (property.hasOwnProperty(propertyKey) && propertyKey !== '_msgid') {
                                 group.payload[propertyKey] = property[propertyKey];
                             }
                         }


### PR DESCRIPTION
Hello. This one is fixing functionality of join node when merging complete objects. Currently it does not work as one might expect, because of `_msgid` property, which is not obvious.
But I'm not 100% sure this is a good solution.