### PR TITLE
[fix] github oauth strategy when Root is not /

### DIFF
--- a/red/api/auth/index.js
+++ b/red/api/auth/index.js
@@ -89,7 +89,7 @@ function login(req,res) {
         } else if (settings.adminAuth.type === "strategy") {
             response = {
                 "type":"strategy",
-                "prompts":[{type:"button",label:settings.adminAuth.strategy.label, url:"/auth/strategy"}]
+                "prompts":[{type:"button",label:settings.adminAuth.strategy.label, url: settings.httpAdminRoot + "auth/strategy"}]
             }
             if (settings.adminAuth.strategy.icon) {
                 response.prompts[0].icon = settings.adminAuth.strategy.icon;
@@ -186,12 +186,12 @@ module.exports = {
 
         adminApp.get('/auth/strategy', passport.authenticate(strategy.name));
         adminApp.get('/auth/strategy/callback',
-            passport.authenticate(strategy.name, {session:false, failureRedirect: '/' }),
+            passport.authenticate(strategy.name, {session:false, failureRedirect: settings.httpAdminRoot }),
             function(req, res) {
                 var tokens = req.user.tokens;
                 delete req.user.tokens;
                 // Successful authentication, redirect home.
-                res.redirect('/?access_token='+tokens.accessToken);
+                res.redirect(settings.httpAdminRoot + '?access_token='+tokens.accessToken);
             }
         );
 


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

#### Fix github oauth autentication strategy with node-red when the HttpAdminRoot is changed from the default value of '/'.

Node-red routes for oauth are hard-coded to '/auth/strategy' when they should use the settings.httpAdminRoot + `/auth/strategy`. Without this fix, github oauth only works if the httpAdminRoot is left to the default value.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
