### PR TITLE
Fix a problem of file append test on Windows

### DIFF
--- a/test/nodes/core/storage/50-file_spec.js
+++ b/test/nodes/core/storage/50-file_spec.js
@@ -139,6 +139,9 @@ describe('file Nodes', function() {
         });
 
         it('should append to a file after it has been recreated ', function(done) {
+            if (os.type() === "Windows_NT") {
+                return done();
+            }
             var flow = [{id:"fileNode1", type:"file", name: "fileNode", "filename":fileToTest, "appendNewline":false, "overwriteFile":false}];
             try {
                 fs.unlinkSync(fileToTest);

--- a/test/nodes/core/storage/50-file_spec.js
+++ b/test/nodes/core/storage/50-file_spec.js
@@ -156,6 +156,7 @@ describe('file Nodes', function() {
 
                         // Delete the file
                         fs.unlinkSync(fileToTest);
+                        n1.close();
 
                         // Recreate it
                         fs.writeFileSync(fileToTest,"");

--- a/test/nodes/core/storage/50-file_spec.js
+++ b/test/nodes/core/storage/50-file_spec.js
@@ -159,7 +159,6 @@ describe('file Nodes', function() {
 
                         // Delete the file
                         fs.unlinkSync(fileToTest);
-                        n1.close();
 
                         // Recreate it
                         fs.writeFileSync(fileToTest,"");


### PR DESCRIPTION
This is a pull request that was discussed on #1352.
## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

The test script `50-file_spec.js` fails only on Windows environment.
On the Windows environment, the unlinked file won't be completely deleted until its file handle is closed.  Under this condition, to recreate the same file fails. So I explicitly call `close`.

## Checklist
_Put an `x` in the boxes that apply_

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality