### PR TITLE
exec: report PID to kill this exact process later

### DIFF
--- a/nodes/core/core/75-exec.js
+++ b/nodes/core/core/75-exec.js
@@ -157,6 +157,9 @@ module.exports = function(RED) {
                     }
                     node.activeProcesses[child.pid] = child;
                 }
+                // report pid so one could kill this exact process later
+                msg.payload = {pid:child.pid};
+                node.send([null,null,RED.util.cloneMessage(msg)]);
             }
         });
 


### PR DESCRIPTION
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.


## Proposed changes

Describe the nature of this change. What problem does it address?

EXEC node has got ability to kill running process by PID but the PID is unknown when the process is started.
Provided the patch which reports spawned process PID via third output in the form `{pid: PID}`. The subscriber may hold PID in, say, `context.flow` to later kill _this exact_ process.

## Checklist
_Put an `x` in the boxes that apply_

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
