### PR TITLE
Added parsed YAML support for template node

### DIFF
--- a/nodes/core/core/80-template.html
+++ b/nodes/core/core/80-template.html
@@ -42,6 +42,7 @@
         <select id="node-input-output" style="width:180px;">
             <option value="str" data-i18n="template.label.plain"></option>
             <option value="json" data-i18n="template.label.json"></option>
+            <option value="yaml" data-i18n="template.label.yaml"></option>
         </select>
     </div>
 

--- a/nodes/core/core/80-template.js
+++ b/nodes/core/core/80-template.js
@@ -17,6 +17,8 @@
 module.exports = function(RED) {
     "use strict";
     var mustache = require("mustache");
+    var yaml = require("js-yaml");
+
 
     /**
      * Custom Mustache Context capable to resolve message property and node
@@ -79,6 +81,9 @@ module.exports = function(RED) {
                 }
                 if (node.outputFormat === "json") {
                     value = JSON.parse(value);
+                }
+                if (node.outputFormat === "yaml") {
+                    value = yaml.load(value);
                 }
 
                 if (node.fieldType === 'msg') {

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -195,6 +195,7 @@
             "mustache": "Mustache template",
             "plain": "Plain text",
             "json": "Parsed JSON",
+            "yaml": "Parsed YAML",
             "none": "none"
         },
         "templatevalue": "This is the payload: {{payload}} !"


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes
Added a parsed YAML option to the template node to parse YAML as an object.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
