### PR TITLE
Fix debug message format for Buffer

### DIFF
--- a/nodes/core/core/58-debug.js
+++ b/nodes/core/core/58-debug.js
@@ -138,7 +138,7 @@ module.exports = function(RED) {
                                 value = value.substring(0,debuglength)+"...";
                             }
                         } else if (value && value.constructor) {
-                            if (value.constructor.name === "Buffer") {
+                            if (value.type === "Buffer") {
                                 value.__encoded__ = true;
                                 value.length = value.data.length;
                                 if (value.length > debuglength) {

--- a/test/nodes/core/core/58-debug_spec.js
+++ b/test/nodes/core/core/58-debug_spec.js
@@ -449,6 +449,34 @@ describe('debug node', function() {
         });
     });
 
+    it('should truncate a large buffer in the object', function(done) {
+        var flow = [{id:"n1", type:"debug"}];
+        helper.load(debugNode, flow, function() {
+            var n1 = helper.getNode("n1");
+            websocket_test(function() {
+                n1.emit("input", {payload: {foo: Buffer(1001).fill("X")}});
+            }, function(msg) {
+                var a = JSON.parse(msg);
+                a.should.eql({
+                    topic:"debug",
+                    data:{
+                        id:"n1",
+                        msg:JSON.stringify({
+                            foo:{
+                                type: "Buffer",
+                                data: Array(1000).fill(88),
+                                __encoded__: true,
+                                length: 1001
+                            }
+                        },null," "),
+                        property:"payload",
+                        format:"Object"
+                    }
+                });
+            }, done);
+        });
+    });
+
     it('should convert Buffer to hex', function(done) {
         var flow = [{id:"n1", type:"debug" }];
         helper.load(debugNode, flow, function() {


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
When an array of buffers is sent to the debug tab, the buffer size is displayed as `undefined` .
![arrayofbuffers](https://user-images.githubusercontent.com/31908137/31696208-b32ba634-b3ea-11e7-994f-857cffb32006.png)


I fixed this and added a test case.
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
