### PR TITLE
Fix #1478 - Project files are not being flushed to disk after being written

### DIFF
--- a/red/runtime/locales/en-US/runtime.json
+++ b/red/runtime/locales/en-US/runtime.json
@@ -137,7 +137,8 @@
             "empty": "Existing __type__ file is empty",
             "invalid": "Existing __type__ file is not valid json",
             "restore": "Restoring __type__ file backup : __path__",
-            "restore-fail": "Restoring __type__ file backup failed : __message__"
+            "restore-fail": "Restoring __type__ file backup failed : __message__",
+            "fsync-fail": "Flushing file __path__ to disk failed : __message__"
         }
     }
 }

--- a/red/runtime/storage/localfilesystem.js
+++ b/red/runtime/storage/localfilesystem.js
@@ -114,8 +114,13 @@ function writeFile(path,content) {
     return when.promise(function(resolve,reject) {
         var stream = fs.createWriteStream(path);
         stream.on('open',function(fd) {
-            stream.end(content,'utf8',function() {
-                fs.fsync(fd,resolve);
+            stream.write(content,'utf8',function() {
+                fs.fsync(fd,function(err) {
+                    if (err) {
+                        log.warn(log._("storage.localfilesystem.fsync-fail",{path: path, message: err.toString()}));
+                    }
+                    stream.end(resolve);
+                });
             });
         });
         stream.on('error',function(err) {

--- a/test/red/runtime/nodes/index_spec.js
+++ b/test/red/runtime/nodes/index_spec.js
@@ -26,11 +26,11 @@ var registry = require("../../../../red/runtime/nodes/registry");
 
 describe("red/nodes/index", function() {
     before(function() {
-        sinon.stub(flows,"startFlows");
+        sinon.stub(index,"startFlows");
         process.env.NODE_RED_HOME = path.resolve(path.join(__dirname,"..","..","..",".."))
     });
     after(function() {
-        flows.startFlows.restore();
+        index.startFlows.restore();
         delete process.env.NODE_RED_HOME;
     });
 

--- a/test/red/runtime/nodes/index_spec.js
+++ b/test/red/runtime/nodes/index_spec.js
@@ -26,11 +26,11 @@ var registry = require("../../../../red/runtime/nodes/registry");
 
 describe("red/nodes/index", function() {
     before(function() {
-        sinon.stub(index,"startFlows");
+        sinon.stub(flows,"startFlows");
         process.env.NODE_RED_HOME = path.resolve(path.join(__dirname,"..","..","..",".."))
     });
     after(function() {
-        index.startFlows.restore();
+        flows.startFlows.restore();
         delete process.env.NODE_RED_HOME;
     });
 


### PR DESCRIPTION
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #1478.

The proposed fix calls `stream.write()` rather than `stream.end()` to write the file's contents. Then it calls `fs.fsync()` and finally `stream.end()` to close the file.

## Related changes due to timing differences when running tests

On my test system and Travis CI, this affected some timings and revealed a few race conditions in the existing unit tests for nodes.
 * The first was the Flows `startFlows()` function being incorrectly stubbed away in "test/red/runtime/nodes/index_spec.js". The wrong object was used in the stub, causing the `startFlows()` function to still be called, but there was no corresponding call to `stopFlows()`. 
   * I don't know if Travis CI would have caught this or not, but I saw it on two different desktops and it was very consistent.
 * The second was the Exec node. A test would pass if stderr only emitted one string, but it can sometimes emit two, as it's a stream. This failed twice on Travis CI for Node 4.
   * I would also see it fail about 25% on my desktop with Node 6. I'd also see these failures without any of my changes here. Race conditions in Node are fun.

I'd rather not include these timing fixes with this PR, but it was the only way I could get all the tests to reliably pass on both my systems and Travis CI.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [X] I have run `grunt` to verify the unit tests pass
- [X] I have added suitable unit tests to cover the new/changed functionality
