### PR TITLE
Provide a 'local' context, available to this node only

### DIFF
--- a/editor/js/ui/common/typedInput.js
+++ b/editor/js/ui/common/typedInput.js
@@ -16,6 +16,7 @@
 (function($) {
     var allOptions = {
         msg: {value:"msg",label:"msg.",validate:RED.utils.validatePropertyExpression},
+        local: {value:"local",label:"local.",validate:RED.utils.validatePropertyExpression},
         flow: {value:"flow",label:"flow.",validate:RED.utils.validatePropertyExpression},
         global: {value:"global",label:"global.",validate:RED.utils.validatePropertyExpression},
         str: {value:"str",label:"string",icon:"red/images/typedInput/az.png"},

--- a/editor/js/ui/editor.js
+++ b/editor/js/ui/editor.js
@@ -1991,6 +1991,10 @@ RED.editor = (function() {
                     $(".node-input-expression-legacy").toggle(legacyMode);
                     try {
                         expr = jsonata(currentExpression);
+                        expr.assign('localContext',function(val) {
+                            usesContext = true;
+                            return null;
+                        });
                         expr.assign('flowContext',function(val) {
                             usesContext = true;
                             return null;

--- a/nodes/core/logic/15-change.html
+++ b/nodes/core/logic/15-change.html
@@ -136,14 +136,14 @@
 
                     var propertyName = $('<input/>',{class:"node-input-rule-property-name",type:"text"})
                         .appendTo(row1)
-                        .typedInput({types:['msg','flow','global']});
+                        .typedInput({types:['msg','local','flow','global']});
 
                     $('<div/>',{style:"display:inline-block;text-align:right; width:120px; padding-right:10px; box-sizing:border-box;"})
                         .text(to)
                         .appendTo(row2);
                     var propertyValue = $('<input/>',{class:"node-input-rule-property-value",type:"text"})
                         .appendTo(row2)
-                        .typedInput({default:'str',types:['msg','flow','global','str','num','bool','json','bin','date','jsonata']});
+                        .typedInput({default:'str',types:['msg','local','flow','global','str','num','bool','json','bin','date','jsonata']});
 
                     var row3_1 = $('<div/>').appendTo(row3);
                     $('<div/>',{style:"display:inline-block;text-align:right; width:120px; padding-right:10px; box-sizing:border-box;"})
@@ -151,7 +151,7 @@
                         .appendTo(row3_1);
                     var fromValue = $('<input/>',{class:"node-input-rule-property-search-value",type:"text"})
                         .appendTo(row3_1)
-                        .typedInput({default:'str',types:['msg','flow','global','str','re','num','bool']});
+                        .typedInput({default:'str',types:['msg','local','flow','global','str','re','num','bool']});
 
                     var row3_2 = $('<div/>',{style:"margin-top:8px;"}).appendTo(row3);
                     $('<div/>',{style:"display:inline-block;text-align:right; width:120px; padding-right:10px; box-sizing:border-box;"})
@@ -159,14 +159,14 @@
                         .appendTo(row3_2);
                     var toValue = $('<input/>',{class:"node-input-rule-property-replace-value",type:"text"})
                         .appendTo(row3_2)
-                        .typedInput({default:'str',types:['msg','flow','global','str','num','bool','json','bin']});
+                        .typedInput({default:'str',types:['msg','local','flow','global','str','num','bool','json','bin']});
 
                     $('<div/>',{style:"display:inline-block;text-align:right; width:120px; padding-right:10px; box-sizing:border-box;"})
                         .text(to)
                         .appendTo(row4);
                     var moveValue = $('<input/>',{class:"node-input-rule-property-move-value",type:"text"})
                         .appendTo(row4)
-                        .typedInput({default:'msg',types:['msg','flow','global']});
+                        .typedInput({default:'msg',types:['msg','local','flow','global']});
 
                     selectField.change(function() {
                         var width = $("#node-input-rule-container").width();

--- a/nodes/core/logic/15-change.js
+++ b/nodes/core/logic/15-change.js
@@ -62,7 +62,7 @@ module.exports = function(RED) {
             if (!rule.fromt) {
                 rule.fromt = "str";
             }
-            if (rule.t === "change" && rule.fromt !== 'msg' && rule.fromt !== 'flow' && rule.fromt !== 'global') {
+            if (rule.t === "change" && rule.fromt !== 'msg' && rule.fromt !== 'local' && rule.fromt !== 'flow' && rule.fromt !== 'global') {
                 rule.fromRE = rule.from;
                 if (rule.fromt !== 're') {
                     rule.fromRE = rule.fromRE.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
@@ -111,6 +111,8 @@ module.exports = function(RED) {
                 var fromRE;
                 if (rule.tot === "msg") {
                     value = RED.util.getMessageProperty(msg,rule.to);
+                } else if (rule.tot === 'local') {
+                    value = node.context().get(rule.to);
                 } else if (rule.tot === 'flow') {
                     value = node.context().flow.get(rule.to);
                 } else if (rule.tot === 'global') {
@@ -126,9 +128,11 @@ module.exports = function(RED) {
                     }
                 }
                 if (rule.t === 'change') {
-                    if (rule.fromt === 'msg' || rule.fromt === 'flow' || rule.fromt === 'global') {
+                    if (rule.fromt === 'msg' || rule.fromt === 'local' || rule.fromt === 'flow' || rule.fromt === 'global') {
                         if (rule.fromt === "msg") {
                             fromValue = RED.util.getMessageProperty(msg,rule.from);
+                        } else if (rule.fromt === 'local') {
+                            fromValue = node.context().get(rule.from);
                         } else if (rule.fromt === 'flow') {
                             fromValue = node.context().flow.get(rule.from);
                         } else if (rule.fromt === 'global') {
@@ -190,7 +194,9 @@ module.exports = function(RED) {
                 }
                 else {
                     var target;
-                    if (rule.pt === 'flow') {
+                    if (rule.pt === 'local') {
+                        target = node.context();
+                    } else if (rule.pt === 'flow') {
                         target = node.context().flow;
                     } else if (rule.pt === 'global') {
                         target = node.context().global;

--- a/red/api/locales/en-US/editor.json
+++ b/red/api/locales/en-US/editor.json
@@ -442,7 +442,7 @@
         "errors": {
             "invalid-expr": "Invalid JSONata expression:\n  __message__",
             "invalid-msg": "Invalid example JSON message:\n  __message__",
-            "context-unsupported": "Cannot test context functions\n $flowContext or $globalContext",
+            "context-unsupported": "Cannot test context functions\n $localContext, $flowContext, or $globalContext",
             "eval": "Error evaluating expression:\n  __message__"
         }
     },

--- a/red/api/locales/en-US/jsonata.json
+++ b/red/api/locales/en-US/jsonata.json
@@ -188,6 +188,10 @@
         "args":"array, function [, init]",
         "desc":"Returns an aggregated value derived from applying the `function` parameter successively to each value in `array` in combination with the result of the previous application of the function.\n\nThe function must accept two arguments, and behaves like an infix operator between each value within the `array`.\n\nThe optional `init` parameter is used as the initial value in the aggregation."
     },
+    "$localContext": {
+        "args": "string",
+        "desc": "Retrieves a context property from this node."
+    },
     "$flowContext": {
         "args": "string",
         "desc": "Retrieves a flow context property."

--- a/red/api/locales/ja/jsonata.json
+++ b/red/api/locales/ja/jsonata.json
@@ -187,6 +187,10 @@
         "args": "array, function [, init]",
         "desc": "配列の各要素値に関数 `function` を連続的に適用して得られる集約値を返します。 `function` の適用の際には、直前の `function` の適用結果と要素値が引数として与えられます。\n\n関数 `function` は引数を2つ取り、配列の各要素の間に配置する中置演算子のように作用しなくてはなりません。\n\n任意の引数 `init` には、集約時の初期値を設定します。"
     },
+    "$localContext": {
+        "args": "string",
+        "desc": "このノードからコンテキストプロパティを取得します。"
+    },
     "$flowContext": {
         "args": "string",
         "desc": "フローコンテキストのプロパティを取得します。"

--- a/red/runtime/locales/en-US/runtime.json
+++ b/red/runtime/locales/en-US/runtime.json
@@ -29,7 +29,6 @@
             "installed": "Installed module: __name__",
             "install-failed": "Install failed",
             "install-failed-long": "Installation of module __name__ failed:",
-            "install-failed-not-found": "$t(install-failed-long) module not found",
             "upgrading": "Upgrading module: __name__ to version: __version__",
             "upgraded": "Upgraded module: __name__. Restart Node-RED to use the new version",
             "upgrade-failed-not-found": "$t(server.install.install-failed-long) version not found",

--- a/red/runtime/util.js
+++ b/red/runtime/util.js
@@ -319,6 +319,8 @@ function evaluateNodeProperty(value, type, node, msg) {
         return Buffer.from(data);
     } else if (type === 'msg' && msg) {
         return getMessageProperty(msg,value);
+    } else if (type === 'local' && node) {
+        return node.context().get(value);
     } else if (type === 'flow' && node) {
         return node.context().flow.get(value);
     } else if (type === 'global' && node) {
@@ -334,6 +336,9 @@ function evaluateNodeProperty(value, type, node, msg) {
 
 function prepareJSONataExpression(value,node) {
     var expr = jsonata(value);
+    expr.assign('localContext',function(val) {
+        return node.context().get(val);
+    });
     expr.assign('flowContext',function(val) {
         return node.context().flow.get(val);
     });

--- a/test/nodes/core/core/89-trigger_spec.js
+++ b/test/nodes/core/core/89-trigger_spec.js
@@ -282,7 +282,7 @@ describe('trigger node', function() {
             n1.emit("input", {payload:1,topic:"A"});
             n1.emit("input", {payload:2,topic:"B"});
             n1.emit("input", {payload:3,topic:"C"});
-            setTimeout( function() { n1.emit("input", {payload:2,topic:"B"})}, 25 );
+            setTimeout( function() { n1.emit("input", {payload:2,topic:"B"})}, 20 );
         });
     });
 

--- a/test/red/runtime/util_spec.js
+++ b/test/red/runtime/util_spec.js
@@ -407,18 +407,28 @@ describe("red/util", function() {
               var result = util.evaluateJSONataExpression(expr,{payload:"hello"});
               result.should.eql("hello");
           });
+          it('accesses local context from an expression', function() {
+              var expr = util.prepareJSONataExpression('$localContext("foo")',{context:function() { return {get: function(key) { return {'foo':'bar'}[key]}}}});
+              var result = util.evaluateJSONataExpression(expr,{payload:"hello"});
+              result.should.eql("bar");
+          });
+          it('handles non-existent local context variable', function() {
+              var expr = util.prepareJSONataExpression('$localContext("nonExistent")',{context:function() { return {get: function(key) { return {'foo':'bar'}[key]}}}});
+              var result = util.evaluateJSONataExpression(expr,{payload:"hello"});
+              should.not.exist(result);
+          });
           it('accesses flow context from an expression', function() {
               var expr = util.prepareJSONataExpression('$flowContext("foo")',{context:function() { return {flow:{get: function(key) { return {'foo':'bar'}[key]}}}}});
               var result = util.evaluateJSONataExpression(expr,{payload:"hello"});
               result.should.eql("bar");
           });
-          it('handles non-existant flow context variable', function() {
-              var expr = util.prepareJSONataExpression('$flowContext("nonExistant")',{context:function() { return {flow:{get: function(key) { return {'foo':'bar'}[key]}}}}});
+          it('handles non-existent flow context variable', function() {
+              var expr = util.prepareJSONataExpression('$flowContext("nonExistent")',{context:function() { return {flow:{get: function(key) { return {'foo':'bar'}[key]}}}}});
               var result = util.evaluateJSONataExpression(expr,{payload:"hello"});
               should.not.exist(result);
           });
-          it('handles non-existant global context variable', function() {
-              var expr = util.prepareJSONataExpression('$globalContext("nonExistant")',{context:function() { return {global:{get: function(key) { return {'foo':'bar'}[key]}}}}});
+          it('handles non-existent global context variable', function() {
+              var expr = util.prepareJSONataExpression('$globalContext("nonExistent")',{context:function() { return {global:{get: function(key) { return {'foo':'bar'}[key]}}}}});
               var result = util.evaluateJSONataExpression(expr,{payload:"hello"});
               should.not.exist(result);
           });

--- a/test/red/runtime/util_spec.js
+++ b/test/red/runtime/util_spec.js
@@ -279,6 +279,21 @@ describe("red/util", function() {
             var result = util.evaluateNodeProperty('foo.bar','msg',{},{foo:{bar:"123"}});
             result.should.eql("123");
         });
+        it('returns local property',function() {
+            var result = util.evaluateNodeProperty('foo.bar','local',{
+                context:function() { return {
+                    get: function(k) {
+                        var ctx = {foo: {bar: 123}};
+                        if (k === 'foo.bar') {
+                            return ctx.foo.bar;
+                        } else {
+                            return ctx.foo.baz;
+                        }
+                    }
+                }}
+            },{});
+            result.should.eql(123);
+        });
         it('returns flow property',function() {
             var result = util.evaluateNodeProperty('foo.bar','flow',{
                 context:function() { return {
@@ -306,6 +321,10 @@ describe("red/util", function() {
                 }}
             },{});
             result.should.eql("123");
+        });
+        it('evaluates jsonata expression',function() {
+            var result = util.evaluateNodeProperty('$number(payload)','jsonata',{},{payload:"123"});
+            result.should.eql(123);
         });
     });
 


### PR DESCRIPTION
Can now access the node's local context in:
* change node -- added 'local.' pulldown option to src/dest fields
* jsonata expression -- get variable using $localContext() function

## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.


## Proposed changes

In order to use the Change node as a toggle (for instance), the previous value received needs to be saved to local context (only available to this change node). This new feature provides a `local.` pulldown option (similar to `flow.` and `global.`) to set/get a named variable.

The local context variables also can be retrieved in JSONata expression, using a new `$flowContext(name)` function. Again, similar to the `$flowContext(name)` and `$globalContext(name)` functions, but without the potential for conflicting variable names.

## Checklist
_Put an `x` in the boxes that apply_

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
