### PR TITLE
Fixed name conflict of icon property for dashboard node

### DIFF
--- a/editor/js/nodes.js
+++ b/editor/js/nodes.js
@@ -492,7 +492,7 @@ RED.nodes = (function() {
             if (n.outputs > 0 && n.outputLabels && !/^\s*$/.test(n.outputLabels.join(""))) {
                 node.outputLabels = n.outputLabels.slice();
             }
-            if (n.icon) {
+            if (!n._def.defaults.hasOwnProperty("icon") && n.icon) {
                 var defIcon = RED.utils.getDefaultNodeIcon(n._def, n);
                 if (n.icon !== defIcon.module+"/"+defIcon.file) {
                     node.icon = n.icon;


### PR DESCRIPTION
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.


## Proposed changes

ui-tab, ui-link, and ui-button nodes use `icon` property.  This conflicted with dynamic icon change feature.
So I made this feature disable if a node defines `icon` property in defaults array.

By the way, the diff result looks like currentDefaultIcon is replaced with icon at line 1072 in editor/js/ui/editor.js.  But actually it isn't.  I just added `if` condition.

## Checklist
_Put an `x` in the boxes that apply_

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
