### PR TITLE
Fix WebSockets not working when httpAdminRoot false

### DIFF
--- a/red/red.js
+++ b/red/red.js
@@ -69,13 +69,21 @@ module.exports = {
             runtime.init(userSettings,api);
             api.init(httpServer,runtime);
             apiEnabled = true;
+            server = runtime.adminApi.server;
+            runtime.server = runtime.adminApi.server;
         } else {
             runtime.init(userSettings);
             apiEnabled = false;
+            if (httpServer){
+                server = httpServer;
+                runtime.server = httpServer;
+            } else {
+                server = runtime.adminApi.server;
+                runtime.server = runtime.adminApi.server; // useless at this point, but at least harmless.
+            }
         }
         adminApp = runtime.adminApi.adminApp;
         nodeApp = runtime.nodeApp;
-        server = runtime.adminApi.server;
         return;
     },
     start: function() {

--- a/red/runtime/nodes/registry/loader.js
+++ b/red/runtime/nodes/registry/loader.js
@@ -84,7 +84,7 @@ function createNodeApi(node) {
         red.auth = runtime.adminApi.auth;
         red.httpAdmin = runtime.adminApi.adminApp;
         red.httpNode = runtime.nodeApp;
-        red.server = runtime.adminApi.server;
+        red.server = runtime.server;
     } else {
         //TODO: runtime.adminApi is always stubbed if not enabled, so this block
         // is unused - but may be needed for the unit tests


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Fixes Websockets not able to listen if httpAdminRoot is unset/false.

When creating 'red.server' for a node, use runtime.server rather than runtime.adminApi.server, and fill runtime.server at startup with the valid http server regardless of adminApi being available.

This resolves websockets not working when the adminApi (httpAdminRoot) is disabled in settings.
It MAY resolve similar issues with other nodes if any others rely on RED.server actuaklly being the http server.

The websockets node uses RED.server, which is only initialised to the http server object if the adminApi is enabled.

These changes add a new variable (runtime.server) which is valid when adminApi is enabled or disabled, then uses this reference to the http server to populate RED.server for nodes.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality

(tested in old 17.5 locally.  untested in master).