### PR TITLE
make selector of "joined using" filed shown correctly

### DIFF
--- a/nodes/core/logic/17-split.html
+++ b/nodes/core/logic/17-split.html
@@ -431,6 +431,9 @@
                 if (val === "auto") {
                     $("#node-input-accumulate").attr('checked', false);
                 }
+                else if (val === "custom") {
+                    $("#node-input-build").change();
+                }
                 else if (val === "merge") {
                     var topics = node.topics;
                     var container = $("#node-input-topics-container");
@@ -484,6 +487,7 @@
                 $(".node-row-trigger").toggle(val!=='auto');
                 if (val === 'string' || val==='buffer') {
                     $("#node-input-property").typedInput('types',['msg']);
+                    $("#node-input-joiner").typedInput("show");
                 } else {
                     $("#node-input-property").typedInput('types',['msg', {value:"full",label:"complete message",hasValue:false}]);
                 }


### PR DESCRIPTION
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.


## Proposed changes

In setting UI of JOIN node, selector field of *joined using* field is not shown correctly after mode change. 

![manual00](https://user-images.githubusercontent.com/30289092/35155179-35338a06-fd70-11e7-9bbd-a7098fec1279.png)

This fix redraw the field after mode change.

![manual01](https://user-images.githubusercontent.com/30289092/35155329-9c5a1272-fd70-11e7-9309-540137b070c7.png)
  

## Checklist
_Put an `x` in the boxes that apply_

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
