### PR TITLE
Enable the project open button when creating a first project

### DIFF
--- a/editor/js/ui/projects/projects.js
+++ b/editor/js/ui/projects/projects.js
@@ -545,6 +545,7 @@ RED.projects = (function() {
                                                     $( self ).dialog( "close" );
                                                 } else {
                                                     show('create-success');
+                                                    RED.menu.setDisabled('menu-item-projects-open',false);
                                                 }
                                             },
                                             400: {


### PR DESCRIPTION
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.


## Proposed changes

- Condition: There are no projects under $HOME/.node-red/projects.

Even if a user creates a new project, `Open...` button in projects menu does not become clickable until Node-RED will be restarted.
This behavior is kept even if the user creates multiple projects.

## Checklist
_Put an `x` in the boxes that apply_

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
