### PR TITLE
Add icons into property UI of JSON node

### DIFF
--- a/nodes/core/parsers/70-JSON.html
+++ b/nodes/core/parsers/70-JSON.html
@@ -1,7 +1,7 @@
 
 <script type="text/x-red" data-template-name="json">
     <div class="form-row">
-        <label for="node-input-action"><span data-i18n="json.label.action"></span></label>
+        <label for="node-input-action"><i class="fa fa-dot-circle-o"></i> <span data-i18n="json.label.action"></span></label>
         <select style="width:70%" id="node-input-action">
             <option value=""    data-i18n="json.label.actions.toggle"></option>
             <option value="str" data-i18n="json.label.actions.str"></option>
@@ -9,7 +9,7 @@
         </select>
     </div>
     <div class="form-row">
-        <label data-i18n="json.label.property"></label>
+        <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> <span data-i18n="json.label.property"></span></label>
         <input type="text" id="node-input-property" style="width:70%;"/>
     </div>
     <div class="form-row">


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

I added icons into property UI of JSON node because other nodes in the same group (CSV, HTML, XML and YAML node) have icons at the text input on their property UI.

![jsonnode_icons](https://user-images.githubusercontent.com/20310935/35429583-fd06bc32-02b7-11e8-9b27-686d9d322d46.png)

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
