### PR TITLE
fix HTML node not to reuse message object for multiple output messages

### DIFF
--- a/nodes/core/parsers/70-HTML.js
+++ b/nodes/core/parsers/70-HTML.js
@@ -45,15 +45,16 @@ module.exports = function(RED) {
                             //if (node.ret === "val")  { pay2 = $(this).val(); }
                             /* istanbul ignore else */
                             if (pay2) {
-                                msg.payload = pay2;
-                                msg.parts = {
+                                var new_msg = RED.util.cloneMessage(msg);
+                                new_msg.payload = pay2;
+                                new_msg.parts = {
                                     id: msg._msgid,
                                     index: index,
                                     count: count,
                                     type: "string",
                                     ch: ""
                                 };
-                                node.send(msg);
+                                node.send(new_msg);
                             }
                         }
                         if (node.as === "single") {

--- a/test/nodes/core/parsers/70-HTML_spec.js
+++ b/test/nodes/core/parsers/70-HTML_spec.js
@@ -328,6 +328,32 @@ describe('html node', function() {
             });
         });
 
+        it('should not reuse message', function(done) {
+            fs.readFile(file, 'utf8', function(err, data) {
+                var flow = [{id:"n1",type:"html",wires:[["n2"]],tag:"ul",ret:"text",as:"multi"},
+                            {id:"n2", type:"helper"}];
+
+                helper.load(htmlNode, flow, function() {
+                    var n1 = helper.getNode("n1");
+                    var n2 = helper.getNode("n2");
+                    var prev_msg = undefined;
+                    n2.on("input", function(msg) {
+                        cnt++;
+                        if (prev_msg == undefined) {
+                            prev_msg = msg;
+                        }
+                        else {
+                            msg.should.not.equal(prev_msg);
+                        }
+                        if (cnt == 2) {
+                            done();
+                        }
+                    });
+                    n1.receive({payload:data,topic: "bar"});
+                });
+            });
+        });
+
     });
 
 });


### PR DESCRIPTION
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.


## Proposed changes

Current HTML node reuses message object when "as multiple messages, one for each element" mode is selected.  This causes following nodes see unexpected message property value.
This fix creates different objects for each output messages.

## Checklist
_Put an `x` in the boxes that apply_

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
