### PR TITLE
fix behavior of "a msg per line" mode of FILE IN node with empty line

### DIFF
--- a/nodes/core/storage/50-file.js
+++ b/nodes/core/storage/50-file.js
@@ -189,14 +189,9 @@ module.exports = function(RED) {
                                             parts:{index:count, ch:ch, type:type, id:msg._msgid}
                                         }
                                         count += 1;
-                                        if ((chunk.length < hwm) && (bits[i+1].length === 0)) {
-                                            m.parts.count = count;
-                                        }
                                         node.send(m);
                                     }
                                     spare = bits[i];
-                                    if (chunk.length !== hwm) { getout = false; }
-                                    //console.log("LEFT",bits[i].length,bits[i]);
                                 }
                                 if (node.format === "stream") {
                                     var m = {
@@ -232,6 +227,18 @@ module.exports = function(RED) {
                             if (node.format === "utf8") { msg.payload = lines.toString(); }
                             else { msg.payload = lines; }
                             node.send(msg);
+                        }
+                        else if (node.format === "lines") {
+                            var m = { payload: spare,
+                                      parts: {
+                                          index: count,
+                                          count: count+1,
+                                          ch: ch,
+                                          type: type,
+                                          id: msg._msgid
+                                      }
+                                    };
+                            node.send(m);
                         }
                         else if (getout) { // last chunk same size as high water mark - have to send empty extra packet.
                             var m = { parts:{index:count, count:count, ch:ch, type:type, id:msg._msgid} };


### PR DESCRIPTION
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.


## Proposed changes

Current *FILE IN* node with "a msg per line" mode produces unexpected *parts* property for a file with empty line.

For example, for following input file

```
--

--
```

we expect following messages:

```
{ payload:"--", parts: { id:..., index:0 }},
{ payload:"", parts: {id:..., index:1 }},
{ payload:"-", parts: {id:..., index:2, count:3 }}
```

but produces:

```
{ payload:"--", parts: { id:..., index:0, count:1 }},
{ payload:"", parts: {id:..., index:1 }},
{ payload:"-", parts: {id:..., index:2, count:3 }}
```

This PR fixes this behavior.

## Checklist
_Put an `x` in the boxes that apply_

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
