### PR TITLE
Allow at sign in module examples path

### DIFF
--- a/editor/js/ui/library.js
+++ b/editor/js/ui/library.js
@@ -38,7 +38,7 @@ RED.library = (function() {
                             li.className = "dropdown-submenu pull-left";
                             a = document.createElement("a");
                             a.href="#";
-                            var label = i.replace(/^node-red-contrib-/,"").replace(/^node-red-node-/,"").replace(/-/," ").replace(/_/," ");
+                            var label = i.replace(/^@.*\//,"").replace(/^node-red-contrib-/,"").replace(/^node-red-node-/,"").replace(/-/," ").replace(/_/," ");
                             a.innerHTML = label;
                             li.appendChild(a);
                             li.appendChild(buildMenu(data.d[i],root+(root!==""?"/":"")+i));

--- a/red/api/editor/library.js
+++ b/red/api/editor/library.js
@@ -95,7 +95,7 @@ module.exports = {
     },
     get: function(req,res) {
         if (req.params[0].indexOf("_examples_/") === 0) {
-            var m = /^_examples_\/([^\/]+)\/(.*)$/.exec(req.params[0]);
+            var m = /^_examples_\/(@.*?\/[^\/]+|[^\/]+)\/(.*)$/.exec(req.params[0]);
             if (m) {
                 var module = m[1];
                 var path = m[2];


### PR DESCRIPTION
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.


## Proposed changes

Describe the nature of this change. What problem does it address?

If nodes are installed from an npm package which has an [org-scoped name](https://www.npmjs.com/docs/orgs/publishing-an-org-scoped-package.html) &mdash; for example, `@myorg\node-red-contrib-mypackage` &mdash; the Node-RED UI does not currently allow examples in the package to be imported properly. I've seen a couple of issues with the org-scoped package name which this PR attempts to address:

1. The name is not abbreviated in the import menu on the UI as is done for non org-scoped packages.

For example, if a package named "node-red-contrib-mypackage" which contains examples were loaded, the "Import -> Examples" menu would have a "mypackage" entry in it. For a package named `@myorg\node-red-contrib-mypackage`, the name of the item under the "Import -> Examples" menu is `@myorg\node red-contrib-mypackage`. With the changes on this PR, the name would be "mypackage" for both the org-scoped and non org-scoped form of the package.

2. If the user selects an example from an org-scoped package to load via the "Import -> Examples" menu, the UI fails to load anything without showing an obvious error. With the console debug window loaded, a user would be able to at least see an error like this:

```
XML Parsing Error: no root element found
Location http://localhost:1880/library/flows/_examples_/@myorg/node-red-contrib-mypackage/myexample
Line Number 1, Column 1:
```
With the changes on this PR, the nodes from the example would be loaded into a flow without any error.

## Checklist
_Put an `x` in the boxes that apply_

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [X] I have run `grunt` to verify the unit tests pass
- [X] I have added suitable unit tests to cover the new/changed functionality

I added a unit test for the `red/api/editor/library.js` change but I wasn't sure if there was a good / convenient way to add a test for the `editor/js/ui/library.js` change. I'm open to ideas on how to add an additional test for the latter change. I did at least open the UI with both an org-scoped and non-org scoped package containing examples and saw that the menu item name appeared as expected in recent versions of several browsers - Firefox, Chrome, Safari, and Internet Explorer.

Thanks in advance for considering this PR!