### PR TITLE
fix reduce mode of JOIN node with JSONata $append function

### DIFF
--- a/nodes/core/logic/17-split.js
+++ b/nodes/core/logic/17-split.js
@@ -273,7 +273,7 @@ module.exports = function(RED) {
         var is_right = node.reduce_right;
         var flag = is_right ? -1 : 1;
         var msgs = group.msgs;
-        var accum = node.reduce_init;
+        var accum = eval_exp(node, node.exp_init, node.exp_init_type);
         var reduce_exp = node.reduce_exp;
         var reduce_fixup = node.reduce_fixup;
         var count = group.count;
@@ -389,13 +389,12 @@ module.exports = function(RED) {
 
         this.reduce = (this.mode === "reduce");
         if (this.reduce) {
-            var exp_init = n.reduceInit;
-            var exp_init_type = n.reduceInitType;
+            this.exp_init = n.reduceInit;
+            this.exp_init_type = n.reduceInitType;
             var exp_reduce = n.reduceExp;
             var exp_fixup = exp_or_undefined(n.reduceFixup);
             this.reduce_right = n.reduceRight;
             try {
-                this.reduce_init = eval_exp(this, exp_init, exp_init_type);
                 this.reduce_exp = RED.util.prepareJSONataExpression(exp_reduce, this);
                 this.reduce_fixup = (exp_fixup !== undefined) ? RED.util.prepareJSONataExpression(exp_fixup, this) : undefined;
             } catch(e) {


### PR DESCRIPTION
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.


## Proposed changes

When a JOIN node is configured with reduce expression of `$append($A, ...)` and initial value of `[]`, the node produces unexpected result with application of multiple input message streams.

For example, if reduce expression is `$append($A, [payload])`, initial value is `[]`, and input messages are `{ payload: 0, parts: { id:<ID0>, index: 0, count: 1 }}` and `{ payload: 1, parts: { id:<ID1>, index: 0, count: 1 }}`, we receive `{ payload: [0] }` and `{ payload: [0, 1] }` instead of `{ payload: [0] }` and `{ payload: [1] }`.

The cause of this is a [bug](https://github.com/jsonata-js/jsonata/issues/139) of JSONata implementation. 
To cope with this, this PR make initial value of reduce operation evaluated each time a message stream is reduced.

## Checklist
_Put an `x` in the boxes that apply_

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality