### PR TITLE
Enable Next button when going back to "Create your project" dialog

### DIFF
--- a/editor/js/ui/projects/projects.js
+++ b/editor/js/ui/projects/projects.js
@@ -141,10 +141,10 @@ RED.projects = (function() {
             'project-details': (function() {
                 var projectNameInput;
                 var projectSummaryInput;
+                var projectNameValid;
                 return {
                     content: function(options) {
                         var projectList = null;
-                        var projectNameValid;
 
                         var pendingFormValidation = false;
                         $.getJSON("projects", function(data) {
@@ -193,7 +193,7 @@ RED.projects = (function() {
                                 }
                                 projectNameLastChecked = projectName;
                             }
-                            valid = projectNameValid;
+                            valid = !projectName?false:projectNameValid;
                             $("#projects-dialog-create-name").prop('disabled',!valid).toggleClass('disabled ui-button-disabled ui-state-disabled',!valid);
                         }
 
@@ -206,7 +206,6 @@ RED.projects = (function() {
 
                         var projectNameInputChanged = false;
                         var projectNameLastChecked = "";
-                        var projectNameValid;
                         var checkProjectName;
                         var autoInsertedName = "";
 


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.


## Proposed changes

Enable `Next` button when going back to `Create your project` dialog.

The code at line 196 is caring the following case:
1. Input a valid project name and click `Back` button on `Create your project` dialog.
2. Click `Next` button on `Setup your version control client` dialog.
This code disables `Next` button here.

## Checklist
_Put an `x` in the boxes that apply_

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
