### PR TITLE
Fix the problem that the last flow tab can be deleted

### DIFF
--- a/editor/js/ui/common/tabs.js
+++ b/editor/js/ui/common/tabs.js
@@ -333,7 +333,9 @@ RED.tabs = (function() {
             previousTab: activatePreviousTab,
             resize: updateTabWidths,
             count: function() {
-                return ul.find("li.red-ui-tab").size();
+                var numOfTabs = ul.find("li.red-ui-tab").size();
+                var numOfSubflow = ul.find('img[src="red/images/subflow_tab.png"]').size();
+                return numOfTabs - numOfSubflow;
             },
             contains: function(id) {
                 return ul.find("a[href='#"+id+"']").length > 0;

--- a/editor/js/ui/common/tabs.js
+++ b/editor/js/ui/common/tabs.js
@@ -333,9 +333,7 @@ RED.tabs = (function() {
             previousTab: activatePreviousTab,
             resize: updateTabWidths,
             count: function() {
-                var numOfTabs = ul.find("li.red-ui-tab").size();
-                var numOfSubflow = ul.find('img[src="red/images/subflow_tab.png"]').size();
-                return numOfTabs - numOfSubflow;
+                return ul.find("li.red-ui-tab").size();
             },
             contains: function(id) {
                 return ul.find("a[href='#"+id+"']").length > 0;

--- a/editor/js/ui/workspaces.js
+++ b/editor/js/ui/workspaces.js
@@ -43,7 +43,7 @@ RED.workspaces = (function() {
         return ws;
     }
     function deleteWorkspace(ws) {
-        if (workspace_tabs.count() == 1) {
+        if (workspaceTabCount === 1) {
             return;
         }
         removeWorkspace(ws);
@@ -65,7 +65,7 @@ RED.workspaces = (function() {
             buttons: [
                 {
                     id: "node-dialog-delete",
-                    class: 'leftButton'+((workspace_tabs.count() == 1)?" disabled":""),
+                    class: 'leftButton'+((workspaceTabCount === 1)?" disabled":""),
                     text: RED._("common.label.delete"), //'<i class="fa fa-trash"></i>',
                     click: function() {
                         deleteWorkspace(workspace);
@@ -214,6 +214,7 @@ RED.workspaces = (function() {
 
 
     var workspace_tabs;
+    var workspaceTabCount = 0;
     function createWorkspaceTabs() {
         workspace_tabs = RED.tabs.create({
             id: "workspace-tabs",
@@ -240,18 +241,20 @@ RED.workspaces = (function() {
                 }
             },
             onadd: function(tab) {
+                workspaceTabCount = tab.type === "tab"?workspaceTabCount+1:workspaceTabCount;
                 $('<span class="workspace-disabled-icon"><i class="fa fa-ban"></i> </span>').prependTo("#red-ui-tab-"+(tab.id.replace(".","-"))+" .red-ui-tab-label");
                 if (tab.disabled) {
                     $("#red-ui-tab-"+(tab.id.replace(".","-"))).addClass('workspace-disabled');
                 }
-                RED.menu.setDisabled("menu-item-workspace-delete",workspace_tabs.count() <= 1);
-                if (workspace_tabs.count() === 1) {
+                RED.menu.setDisabled("menu-item-workspace-delete",workspaceTabCount <= 1);
+                if (workspaceTabCount === 1) {
                     showWorkspace();
                 }
             },
             onremove: function(tab) {
-                RED.menu.setDisabled("menu-item-workspace-delete",workspace_tabs.count() <= 1);
-                if (workspace_tabs.count() === 0) {
+                workspaceTabCount = tab.type === "tab"?workspaceTabCount-1:workspaceTabCount;
+                RED.menu.setDisabled("menu-item-workspace-delete",workspaceTabCount <= 1);
+                if (workspaceTabCount === 0) {
                     hideWorkspace();
                 }
             },
@@ -266,6 +269,7 @@ RED.workspaces = (function() {
                 addWorkspace();
             }
         });
+        workspaceTabCount = 0;
     }
     function showWorkspace() {
         $("#workspace .red-ui-tabs").show()
@@ -334,7 +338,7 @@ RED.workspaces = (function() {
             return workspace_tabs.contains(id);
         },
         count: function() {
-            return workspace_tabs.count();
+            return workspaceTabCount;
         },
         active: function() {
             return activeWorkspace

--- a/editor/js/ui/workspaces.js
+++ b/editor/js/ui/workspaces.js
@@ -241,7 +241,9 @@ RED.workspaces = (function() {
                 }
             },
             onadd: function(tab) {
-                workspaceTabCount = tab.type === "tab"?workspaceTabCount+1:workspaceTabCount;
+                if (tab.type === "tab") {
+                    workspaceTabCount++;
+                }
                 $('<span class="workspace-disabled-icon"><i class="fa fa-ban"></i> </span>').prependTo("#red-ui-tab-"+(tab.id.replace(".","-"))+" .red-ui-tab-label");
                 if (tab.disabled) {
                     $("#red-ui-tab-"+(tab.id.replace(".","-"))).addClass('workspace-disabled');
@@ -252,7 +254,9 @@ RED.workspaces = (function() {
                 }
             },
             onremove: function(tab) {
-                workspaceTabCount = tab.type === "tab"?workspaceTabCount-1:workspaceTabCount;
+                if (tab.type === "tab") {
+                    workspaceTabCount--;
+                }
                 RED.menu.setDisabled("menu-item-workspace-delete",workspaceTabCount <= 1);
                 if (workspaceTabCount === 0) {
                     hideWorkspace();


### PR DESCRIPTION
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.


## Proposed changes

see #1613.
I checked all callers of `workspace_tabs.count()`.  It looks that all of them expect that the count does not include subflow tabs.

## Checklist
_Put an `x` in the boxes that apply_

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
