### PR TITLE
fix message lookup for core nodes in case of i18 locales directory ex…

### DIFF
--- a/red/runtime/nodes/registry/loader.js
+++ b/red/runtime/nodes/registry/loader.js
@@ -255,6 +255,12 @@ function loadNodeConfig(fileInfo) {
                         break;
                     }
                 }
+                if (node.module === 'node-red') {
+                    // do not look up locales directory for core nodes
+                    node.namespace = node.module;
+                    resolve(node);
+                    return;
+                }
                 fs.stat(path.join(path.dirname(file),"locales"),function(err,stat) {
                     if (!err) {
                         node.namespace = node.id;


### PR DESCRIPTION
…ists

## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.


## Proposed changes

Describe the nature of this change. What problem does it address?

As reported by issue [#1615](https://github.com/node-red/node-red/issues/1615), message catalogue lookup for core nodes become failed when i18n locales directory (`nodes/core/<category>/locales`) exists.

This is caused by `loadNodeConfig` function in `red/runtime/nodes/registry/loader.js`.  
If a `locales` directory exists, `loadNodeConfig` try to look up message catalogue (<node name>.json) for nodes in modules under the directory.  Because the combined message catalogue for core nodes are placed at different location, this look up fails and message catalogue is corrupted.

This PR fixes this problem by skipping message catalogue look up for core nodes in `loadNodeConfig`.

_My proposal is to place info text of core nodes under_ `nodes/core/locales` (or separate message catalogue of core nodes from `messages.json`).  _But, this may needs more discussion.  So, this PR expects to place info text under_ `nodes/core/<category>/locales`.

## Checklist
_Put an `x` in the boxes that apply_

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
