### PR TITLE
Fix backquote in info text

### DIFF
--- a/nodes/core/hardware/36-rpi-gpio.html
+++ b/nodes/core/hardware/36-rpi-gpio.html
@@ -179,7 +179,7 @@
         <dt>payload <span class="property-type">number</span></dt>
         <dd>the payload will be a 1 or a 0.</dd>
         <dt>topic <span class="property-type">string</span></dt>
-        <dd>the topic will be set to `pi/{the pin number}`.</dd>
+        <dd>the topic will be set to <code>pi/{the pin number}</code>.</dd>
     </dl>
     <h3>Details</h3>
     <p>You may also enable the input pullup resistor or the pulldown resistor.</p>

--- a/nodes/core/io/21-httpin.html
+++ b/nodes/core/io/21-httpin.html
@@ -75,7 +75,7 @@
     <p>The node will listen on the configured path for requests of a particular type.
        The path can be fully specified, such as <code>/user</code>, or include
        named parameters that accept any value, such as <code>/user/:name</code>.
-       When named parameters are used, their actual value in a request can be accessed under `msg.req.params`.</p>
+       When named parameters are used, their actual value in a request can be accessed under <code>msg.req.params</code>.</p>
     <p>For requests that include a body, such as a POST or PUT, the contents of
        the request is made available as <code>msg.payload</code>.</p>
     <p>If the content type of the request can be determined, the body will be parsed to

--- a/nodes/core/io/21-httprequest.html
+++ b/nodes/core/io/21-httprequest.html
@@ -117,7 +117,7 @@
     the response headers. The next node will then use those headers for its request - this
     is not usually the right thing to do. If <code>msg.headers</code> property is left unchanged
     between nodes, it will be ignored by the second node. To set custom headers, <code>msg.headers</code>
-    should first be deleted or reset to an empty object: `{}`.
+    should first be deleted or reset to an empty object: <code>{}</code>.
     <h4>Cookie handling</h4>
     <p>The <code>cookies</code> property passed to the node must be an object of name/value pairs.
     The value can be either a string to set the value of the cookie or it can be an

--- a/nodes/core/logic/10-switch.html
+++ b/nodes/core/logic/10-switch.html
@@ -65,7 +65,7 @@
        that are part of a sequence.</p>
     <p>The <b>recreate message sequences</b> option can be enabled to generate new message sequences
        for each rule that matches. In this mode, the node will buffer the entire incoming
-       sequence before sending the new sequences on. The runtime setting `nodeMessageBufferMaxLength`
+       sequence before sending the new sequences on. The runtime setting <code>nodeMessageBufferMaxLength</code>
        can be used to limit how many messages nodes will buffer.</p>
 </script>
 

--- a/nodes/core/logic/17-split.html
+++ b/nodes/core/logic/17-split.html
@@ -337,7 +337,7 @@
     </p>
     <h4>Storing messages</h4>
     <p>This node will buffer messages internally in order to work across sequences. The
-       runtime setting `nodeMessageBufferMaxLength` can be used to limit how many messages nodes
+       runtime setting <code>nodeMessageBufferMaxLength</code> can be used to limit how many messages nodes
        will buffer.</p>
 </script>
 

--- a/nodes/core/logic/19-batch.html
+++ b/nodes/core/logic/19-batch.html
@@ -90,7 +90,7 @@
     </dl>
     <h4>Storing messages</h4>
     <p>This node will buffer messages internally in order to work across sequences. The
-       runtime setting `nodeMessageBufferMaxLength` can be used to limit how many messages nodes
+       runtime setting <code>nodeMessageBufferMaxLength</code> can be used to limit how many messages nodes
        will buffer.</p>
 </script>
 


### PR DESCRIPTION
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.


## Proposed changes

Describe the nature of this change. What problem does it address?

- change backquoted string in HTML info text to <code>...</code>.

## Checklist
_Put an `x` in the boxes that apply_

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
