### PR TITLE
fixed message modificcation of concat mode of BATCH node

### DIFF
--- a/nodes/core/logic/19-batch.js
+++ b/nodes/core/logic/19-batch.js
@@ -116,7 +116,7 @@ module.exports = function(RED) {
         for (var topic of topics) {
             remove_topic(pending, topic);
         }
-        send_msgs(node, msgs, false);
+        send_msgs(node, msgs, true);
         node.pending_count -= msgs.length;
     }
 

--- a/test/nodes/core/logic/19-batch_spec.js
+++ b/test/nodes/core/logic/19-batch_spec.js
@@ -54,8 +54,13 @@ describe('BATCH node', function() {
         var ix0 = 0; // seq no
         var ix1 = 0; // loc. in seq
         var seq = undefined;
+        var msgs = [];
         n2.on("input", function(msg) {
             try {
+                for (var i = 0; i < msgs.length; i++) {
+                    msg.should.not.equal(msgs[i]);
+                }
+                msgs.push(msg);
                 if (seq === undefined) {
                     seq = results[ix0];
                 }
@@ -302,6 +307,19 @@ describe('BATCH node', function() {
                 ["TB", 1, 1, 2],
                 ["TA", 2, 0, 2],
                 ["TA", 3, 1, 2]
+            ];
+            check_concat(flow, results, inputs, done);
+        });
+
+        it('should concat same seq.', function(done) {
+            var flow = [{id:"n1", type:"batch", name: "BatchNode", mode: "concat", count: 0, overlap: 0, interval: 1, allowEmptySequence: false, topics: [{topic: "TA"}, {topic: "TA"}], wires:[["n2"]]},
+                        {id:"n2", type:"helper"}];
+            var results = [
+                [9, 8, 9, 8]
+            ];
+            var inputs = [
+                ["TA", 9, 0, 2],
+                ["TA", 8, 1, 2]
             ];
             check_concat(flow, results, inputs, done);
         });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Concatenating the same message sequence using BATCH mode may corrupts `msg.parts` property because it shares same messages on output.
This PR fixes this by cloning concatenated messages before send.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
