### PR TITLE
add Japanese info text of core nodes

### DIFF
--- a/nodes/core/analysis/locales/ja/72-sentiment.html
+++ b/nodes/core/analysis/locales/ja/72-sentiment.html
@@ -1,0 +1,35 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="sentiment">
+    <p>指定したプロパティ(デフォルトは<code>payload</code>)を分析し、<code>sentiment</code>オブジェクトを追加します。</p>
+    <h3>出力</h3>
+    <dl class="message-properties">
+        <dt>sentiment <span class="property-type">オブジェクト</span></dt>
+        <dd>AFINN-111による感情分析の結果</dd>
+        <dt>sentiment.score <span class="property-type">数値</span></dt>
+        <dd>感情分析スコア</dd>
+    </dl>
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt>overrides <span class="property-type">オブジェクト</span></dt>
+        <dd>単語スコアの上書きをするためのオブジェクト - <code>{ word:score,... }</code></dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>ゼロ以上のスコアはポジティブ、ゼロ以下はネガティブを意味します。</p>
+    <p>スコアの範囲は通常-5から+5ですが、より大きかったり小さかったりすることもあります。</p>
+    <p>詳細は<a href="https://github.com/thisandagain/sentiment/blob/master/README.md" target="_blank">the Sentiment docs here</a>を参照してください。</p>
+</script>

--- a/nodes/core/core/locales/ja/20-inject.html
+++ b/nodes/core/core/locales/ja/20-inject.html
@@ -1,0 +1,34 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="inject">
+<p>手動もしくは一定間隔でメッセージをフローに注入します。メッセージのペイロードには、文字列、JavaScriptオブジェクト、現在の時刻など、さまざまな値を指定できます。</p>
+<h3>出力</h3>
+<dl class="message-properties">
+    <dt>payload<span class="property-type">各種</span></dt>
+    <dd>指定したメッセージペイロード。</dd>
+    <dt class="optional">topic <span class="property-type">文字列</span></dt>
+    <dd>任意で指定可能なプロパティ。</dd>
+</dl>
+<h3>詳細</h3>
+<p>injectノードを用いることで、指定したペイロード値を用いてフローを開始できます。デフォルトのペイロード値は現在時刻のタイムスタンプを1970年1月1日からの経過ミリ秒で表現した値です。</p>
+<p>文字列、数値、論理値、JavaScriptオブジェクト、フロー/グローバルコンテクストの値などの送出も可能です。</p>
+<p> デフォルト設定では、エディタ内に表示されるボタンをクリックすることで、ノードを手動で起動できます。指定間隔もしくはスケジュールに従ってメッセージを送出するように設定することも可能です。</p>
+<p>また、フロー開始の際に一度だけメッセージを送出させることもできます。</p>
+<p>「<i>時間間隔</i>」に指定可能な値の最大値は、約596時間(もしくは24日)です。一日より長い間隔を扱いたい場合は、電源停止や再起動にも対応可能なスケジューラノードの利用を検討すると良いでしょう。</p>
+<p><b>注</b>:「<i>指定した時間間隔、日時</i>」と「<i>指定した日時</i>」オプションは標準的なcronシステムを内部で利用します。したがって「20分」という指定は、その時点から20分後ではなく、毎時きっかり、20分、40分を意味します。現時刻から20分毎を指定するには「<i>指定した時間間隔</i>」オプションを用います。</p>
+<p><b>注</b>: 文字列に改行を含めたい場合は、functionノードを使ってペイロードを設定してください。</p>
+</script>

--- a/nodes/core/core/locales/ja/25-catch.html
+++ b/nodes/core/core/locales/ja/25-catch.html
@@ -1,0 +1,36 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="catch">
+    <p>同じタブ内のノードが送出したエラーをキャッチします。</p>
+    <h3>出力</h3>
+    <dl class="message-properties">
+        <dt>error.message <span class="property-type">文字列</span></dt>
+        <dd>エラーメッセージ</dd>
+        <dt>error.source.id <span class="property-type">文字列</span></dt>
+        <dd>エラーを送出したノードのID</dd>
+        <dt>error.source.type <span class="property-type">文字列</span></dt>
+        <dd>エラーを送出したノードの種別</dd>
+        <dt>error.source.name <span class="property-type">文字列</span></dt>
+        <dd>エラーを送出したノードの名称(設定されている場合)</dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>メッセージの処理中にノードがエラーを送出した場合、フロー実行は基本的に停止します。このノードを使うと、エラーをキャッチして対応するフローで処理させることができます。</p>
+    <p>デフォルトでは、同じタブの全てのノードが送出したエラーをキャッチします。特定のノードをキャッチ対象とすることも可能です。</p>
+    <p>エラー発生時には、マッチするすべてのcatchノードがメッセージを受け取ります。</p>
+    <p>サブフロー内でエラーが送出された場合、まずサブフロー内のcatchノードで処理されます。対応するノードが存在しない場合には、そのサブフローが配置されたタブにエラーを伝播して処理します。</p>
+    <p>メッセージが<code>error</code>プロパティを持っている場合、元の<code>error</code>は<code>_error</code>へコピーします。</p>
+</script>

--- a/nodes/core/core/locales/ja/25-status.html
+++ b/nodes/core/core/locales/ja/25-status.html
@@ -1,0 +1,33 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="status">
+    <p>同じタブ内のノードのステータスメッセージを取得します。</p>
+    <h3>出力</h3>
+    <dl class="message-properties">
+        <dt>status.text <span class="property-type">文字列</span></dt>
+        <dd>ステータス文字列</dd>
+        <dt>status.source.type <span class="property-type">文字列</span></dt>
+        <dd>ステータスを表示したノードの種別</dd>
+        <dt>status.source.id <span class="property-type">文字列</span></dt>
+        <dd>ステータスを表示したノードのID</dd>
+        <dt>status.source.name <span class="property-type">文字列</span></dt>
+        <dd>ステータスを表示したノードの名称(設定されている場合)</dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>このノードは<code>payload</code>を設定しません。</p>
+    <p>デフォルトでは、同じワークスペースタブ内の全てのノードのステータスを取得します。特定のノードのステータスを取得対象とすることも可能です。</p>
+</script>

--- a/nodes/core/core/locales/ja/58-debug.html
+++ b/nodes/core/core/locales/ja/58-debug.html
@@ -1,0 +1,27 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="debug">
+    <p>サイドバーの「デバッグ」タブに、選択したメッセージプロパティの値を表示します。設定により、ランタイムログへの出力も可能です。デフォルトの表示対象は<code>msg.payload</code>です。</p>
+    <h3>詳細</h3>
+    <p>「デバッグ」サイドバーは受け取ったメッセージの階層構造を表示する機能を備えます。この機能によりメッセージの構造を容易に理解できます。</p>
+    <p>JavaScriptオブジェクトと配列は必要に応じて折り畳んだり展開したりできます。バッファオブジェクトを生データとして表示したり、表現可能な場合に文字列として表示することも可能です。</p>
+    <p>メッセージを受信した時刻、送信ノード、メッセージの型に関する情報を「デバッグ」サイドバーに表示されたメッセージに付随して表示します。送信元ノードのIDを選択すると、ワークスペース内の対応ノードを確認できます。</p>
+    <p>出力の有効/無効はノード上のボタンで切り替えられます。フロー上で未使用のdebugノードは、無効化するか削除することを推奨します。</p>
+    <p>全てのメッセージをランタイムログに送付、もしくは、(32文字の)短いデータを
+debugノードの下のステータステキストに表示することも可能です。</p>
+</script>
+

--- a/nodes/core/core/locales/ja/60-link.html
+++ b/nodes/core/core/locales/ja/60-link.html
@@ -1,0 +1,31 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="link in">
+    <p>フロー間に仮想的なリンクを作成します。</p>
+    <h3>詳細</h3>
+    <p>任意のタブ上に存在する<code>link out</code>ノードに接続できます。この接続はあたかも直接リンクしたかのように動作します。</p>
+    <p>linkノード間のリンクはlinkノードを選択した場合にのみ表示されます。他のタブへのリンクがある場合には、仮想的なノードを表示します。この仮想的ノードをクリックすると、対応するタブに移動できます。</p>
+    <p><b>注: </b>サブフローの外から中、もしくは、中から外へのリンクを作成することはできません。</p>
+</script>
+
+<script type="text/x-red" data-help-name="link out">
+    <p>フロー間に仮想的なリンクを作成します。</p>
+    <h3>詳細</h3>
+    <p>任意のタブ上に存在する<code>link in</code>ノードに接続できます。この接続はあたかも直接リンクしたかのように動作します。</p>
+    <p>linkノード間のリンクはlinkノードを選択した場合にのみ表示されます。他のタブへのリンクがある場合には、仮想的なノードを表示します。この仮想的ノードをクリックすると、対応するタブに移動できます。</p>
+    <p><b>注: </b>サブフローの外から中、もしくは、中から外へのリンクを作成することはできません。</p>
+</script>

--- a/nodes/core/core/locales/ja/75-exec.html
+++ b/nodes/core/core/locales/ja/75-exec.html
@@ -1,0 +1,75 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="exec">
+    <p>システムのコマンドを実行し出力を返します。</p>
+    <p>コマンドの完了まで待つか、コマンドが出力を行う毎にメッセージを出力するかを指定できます。</p>
+    <p>実行対象のコマンドは、ノードの設定もしくは受信メッセージで指定します。</p>
+
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt class="optional">payload <span class="property-type">文字列</span></dt>
+        <dd>実行コマンドの最後に追加するよう設定できます</dd>
+        <dt class="optional">kill <span class="property-type">文字列</span></dt>
+        <dd>execノードのプロセスに対して送るシグナルの種別を指定します</dd>
+        <dt class="optional">pid <span class="property-type">数値|文字列</span></dt>
+        <dd>シグナル送信対象のexecノードのプロセスID</dd>
+    </dl>
+
+    <h3>出力</h3>
+    <ol class="node-ports">
+        <li>標準出力(stdout)
+            <dl class="message-properties">
+                <dt>payload <span class="property-type">文字列</span></dt>
+                <dd>コマンドの標準出力</dd>
+            </dl>
+            <dl class="message-properties">
+                <dt>rc <span class="property-type">オブジェクト</span></dt>
+                <dd>返却コードオブジェクト(3番ポートでも受取り可能)のコピー(execモードのみ)</dd>
+            </dl>
+        </li>
+        <li>標準エラー出力(stderr)
+            <dl class="message-properties">
+                <dt>payload <span class="property-type">文字列</span></dt>
+                <dd>コマンドの標準エラー出力</dd>
+            </dl>
+            <dl class="message-properties">
+                <dt>rc <span class="property-type">オブジェクト</span></dt>
+                <dd>返却コードオブジェクト(3番ポートでも受取り可能)のコピー(execモードのみ)</dd>
+            </dl>
+        </li>
+        <li>返却コード(return code)
+            <dl class="message-properties">
+                <dt>payload <span class="property-type">オブジェクト</span></dt>
+                <dd>リターンコード、<code>message</code>、<code>signal</code>プロパティを含むオブジェクト(<code>message</code>、<code>signal</code>は利用可能な場合)</dd>
+            </dl>
+        </li>
+    </ol>
+    <h3>詳細</h3>
+    <p>デフォルトでは、<code>exec</code>システムコールを用いてコマンドを呼び出してその完了を待ち、出力を返します。例えば、コマンドの実行が成功した場合には、<code>{ code: 0 }</code>と言う返却値を返します。</p>
+    <p><code>spawn</code>を使ってコマンドを実行し、
+標準出力および標準エラー出力へ出力を返すようにすることもできます。この場合、通常1行毎に値を返します。コマンドの実行が完了すると、3番目のポートにオブジェクトを出力します。例えば、コマンドの実行が成功した場合には、<code>{ code: 0 }</code>と言う返却値を返します。</p>
+    <p>エラー発生時には、3番目のポートの<code>msg.payload</code>に<code>message</code>、<code>signal</code>など付加情報を返します。</p>
+    <p>実行対象のコマンドはノード設定で定義します。<code>msg.payload</code>や追加引数をコマンドに追加することもできます。</p>
+    <p>コマンドもしくはパラメータが空白を含む場合には、引用符で囲みます。- <code>"This is a single parameter"</code></p>
+    <p>返却する<code>payload</code>は通常<i>文字列</i>ですが、UTF8文字以外が存在すると<i>バッファ</i>となります。</p>
+    <p>ノードが実行中の場合、ステータスアイコンとPIDを表示します。この状態変化は<code>status</code>ノードで検知できます。</p>
+    <h4>プロセスの停止</h4>
+    <p><code>msg.kill</code>を受信すると、実行中のプロセスを停止することができます。<code>msg.kill</code>には送出するシグナルの種別を指定します。例えば、<code>SIGINT</code>、<code>SIGQUIT</code>、<code>SIGHUP</code>などです。空の文字列を指定した場合には、<code>SIGTERM</code>を指定したものとみなします。</p>
+    <p>ノードが1つ以上のプロセスを実行している場合、<code>msg.pid</code>に停止対象のPIDを指定しなければなりません。</p>
+    <p><code>タイムアウト</code>フィールドに値を指定すると、指定した秒数以内にコマンドが完了しない場合、プロセスを自動的に停止します。</p>
+    <p>ヒント: Pythonアプリケーションを実行する場合、<code>-u</code>を指定すると出力がバッファされるのを抑止できます。</p>
+</script>

--- a/nodes/core/core/locales/ja/80-function.html
+++ b/nodes/core/core/locales/ja/80-function.html
@@ -1,0 +1,43 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="function">
+    <p>受信メッセージに対して処理を行うJavaScriptコード(関数の本体)を定義します。</p>
+    <p>入力メッセージは<code>msg</code>という名称のJavaScriptオブジェクトで受け渡されます。</p>
+    <p><code>msg</code>オブジェクトは<code>msg.payload</code>プロパティにメッセージ本体を保持するのが慣例です。</p>
+    <p>通常、コードはメッセージオブジェクト(もしくは複数のメッセージオブジェクト)を返却します。何も返却しない場合には、フロー実行を停止します。</p>
+    <h3>詳細</h3>
+    <p>コードの書き方の詳細については、<a target="_blank" href="http://nodered.org/docs/writing-functions.html">オンラインドキュメント</a>を参照してください。</p>
+    <h4>メッセージの送信</h4>
+    <p>フロー内の次ノードにメッセージを渡すためには、メッセージを返却するか<code>node.send(messages)</code>を呼び出します。</p>
+    <p>返却/sendの対象は次のとおりです:</p>
+    <ul>
+      <li>単一メッセージオブジェクト - 最初の出力に接続されたノードに渡されます</li>
+      <li>メッセージオブジェクトの配列 - 対応する出力に接続されたノードに渡されます</li>          
+    </ul>
+    <p>配列要素が配列の場合には、複数のメッセージを対応する出力に送出します。</p>
+    <p>返却方法が単一値か配列要素かにかかわらず、返却値がnullの場合メッセージの送出は行いません。</p>
+    <h4>ログ出力とエラー処理</h4>
+    <p>ログ情報の出力、エラー出力を行うには以下の関数を用います:</p>
+      <ul>
+          <li><code>node.log("ログメッセージ")</code></li>
+          <li><code>node.warn("警告")</code></li>
+          <li><code>node.error("エラー")</code></li>
+      </ul>
+    </p>
+    <p>catchノードを用いてエラー処理が可能です。catchノードで処理させるためには、<code>msg</code>を<code>node.error</code>の第二引数として渡します:</p>
+    <pre>node.error("エラー",msg);</pre>
+</script>

--- a/nodes/core/core/locales/ja/80-template.html
+++ b/nodes/core/core/locales/ja/80-template.html
@@ -1,0 +1,47 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="template">
+    <p>テンプレートに基づいてプロパティを設定します。</p>
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt>msg <span class="property-type">オブジェクト</span></dt>
+        <dd>テンプレートを生成するための情報を含むメッセージオブジェクト</dd>
+        <dt class="optional">template <span class="property-type">文字列</span></dt>
+        <dd><code>msg.payload</code>を生成するためのテンプレート。編集パネルでテンプレートを設定しない場合に、出力メッセージとして利用します</dd>
+    </dl>
+    <h3>出力</h3>
+    <dl class="message-properties">
+        <dt>msg <span class="property-type">オブジェクト</span></dt>
+        <dd>指定したテンプレートと入力メッセージのプロパティから生成した値を設定したメッセージ</dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>このノードは<i><a href="http://mustache.github.io/mustache.5.html" target="_blank">mustache</a></i>形式をデフォルトで利用しますが、使用しないようにすることもできます。</p>
+    <p>例えば、
+    <pre>こんにちは{{payload.name}}さん。今日は{{date}}です。</pre>
+    <p>というテンプレートに対して、
+    <pre>{
+  date: "月曜日"
+  payload: {
+    name: "山田",
+  }
+}</pre>
+    <p>というメッセージを受信した場合、</p>
+    <pre>こんにちは山田さん。今日は月曜日です。</pre>
+    <p>というプロパティが生成されます。</p>
+    <p>フローコンテキストもしくはグローバルコンテキストのプロパティ値を使うこともできます。それぞれ、<code>{{flow.名前}}</code>もしくは<code>{{global.名前}}</code>を用います。</p>
+    <p><b>注: </b>デフォルトでは、<i>mustache</i>形式は置換対象のHTML要素をエスケープします。これを抑止するには<code>{{{三重}}}</code>括弧形式を使います。</p>
+</script>

--- a/nodes/core/core/locales/ja/89-delay.html
+++ b/nodes/core/core/locales/ja/89-delay.html
@@ -1,0 +1,30 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="delay">
+    <p>ノードを通過するメッセージを遅延もしくは流量を制限します。</p>
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt class="optional">delay <span class="property-type">数値</span></dt>
+        <dd>メッセージの遅延時間をミリ秒単位で設定します。これはノードの設定でデフォルトの遅延時間を上書きできるようノードを設定した場合にのみ適用します。</dd>
+        <dt class="optional">reset</dt>
+        <dd>受信メッセージでこのプロパティを任意の値に設定すると、ノードが保持する全ての未送信メッセージをクリアします。</dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>メッセージを遅延させるように設定する場合、遅延時間は固定値、範囲内の乱数値、メッセージ毎の動的な指定値のいずれかを指定できます。</p>
+    <p>流量制御する場合、メッセージは指定した時間間隔内に分散して送信します。キューに残っているメッセージ数はノードのステータスに表示されます。受け取った中間メッセージを破棄することも可能です。</p>
+    <p>流量制御は全てのメッセージに適用することも、<code>msg.topic</code>値でグループ化して適用することも可能です。グループ化すると、中間メッセージは自動的に破棄されます。各時間間隔毎に全てのトピックの最新メッセージを送信するか、次のトピックの最新メッセージを送信するかを指定できます。</p>
+</script>

--- a/nodes/core/core/locales/ja/89-trigger.html
+++ b/nodes/core/core/locales/ja/89-trigger.html
@@ -1,0 +1,36 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="trigger">
+    <p>メッセージの受信すると、別のメッセージの送信を行います。延長もしくは初期化が指定されていない場合には、2つ目のメッセージを送信することもできます。</p>
+
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt class="optional">reset</dt>
+        <dd>このプロパティを持つメッセージを受け取ると、仕掛かり中の待機や繰り返しをクリアしメッセージの送信は行いません。</dd>
+    </dl>
+
+    <h3>詳細</h3>
+    <p>フロー内でタイムアウトを作成するのに利用します。メッセージを受け取ると、
+デフォルトでは<code>payload</code>に<code>1</code>を設定して送信します。送信後250ms待機し、<code>payload</code>を<code>0</code>に設定した2つ目のメッセージを送信します。この機能は、例えばRaspberry PIのGPIOピンに接続したLEDを点滅させるために活用できます。</p>
+    <p>各送信メッセージのペイロードはさまざまな種類の値に設定できます。再送信デ
+ータなしとすることも可能です。例えば、再送信データを「<i>なし</i>」とし、
+メッセージを受け取った時に遅延を延長することを選択した場合、triggerノードは監視タイマとして動作します。すなわち、指定間隔内にメッセージを受信しない場合にメッセージを送信します。</p>
+    <p>ペイロードに<i>文字列</i>を指定する場合、mustache形式のテンプレートが利用できます。</p>
+    <p><code>reset</code>プロパティを持つメッセージを受信した場合、もしくは、<code>payload</code>が設定した値にマッチする場合、仕掛かり中の待機や繰り返しをクリアしメッセージの送信は行いません。</p>
+    <p>受信メッセージでリセットするまで一定間隔でメッセージを再送するように指定することもできます。</p>
+    <p><code>msg.topic</code>毎に別のストリームとして扱うように設定することも可能です。</p>
+</script>

--- a/nodes/core/core/locales/ja/90-comment.html
+++ b/nodes/core/core/locales/ja/90-comment.html
@@ -1,0 +1,21 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="comment">
+    <p>フローにコメントを記述するために利用します。</p>
+    <h3>詳細</h3>
+    <p>編集パネルはMarkdown形式を記入可能です。入力したテキストは、「情報」サイドパネルに表示されます。</p>
+</script>

--- a/nodes/core/core/locales/ja/98-unknown.html
+++ b/nodes/core/core/locales/ja/98-unknown.html
@@ -1,0 +1,24 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="unknown">
+    <p>インストールされたNode-REDが認識できない種別のノードです。</p>
+    <h3>詳細</h3>
+    <p><i>この種別のノードをデプロイした場合、設定は保持されますが、足りないノードをインストールするまでフローを開始することはできません。</i></p>
+    <p><code>メニュー - パレットの管理</code>を使ってノードの検索とインストールを行うか、<b>npm install &lt;モジュール&gt;</b>で不足モジュールのインストールを行ってNode-REDを再起動した後、ノードを再インポートしてください。</p>
+    <p>この種別のノードがインストール済みであるが依存ライブラリがインストールされていないケースもあります。Node-REDの起動ログを参照して不足ノードに関連したエラーメッセージをチェックすると良いでしょう。</p>
+    <p>それでも解決しない場合、フローの作者に依頼して不足ノードのコピーを入手してください。</p>
+</script>

--- a/nodes/core/io/locales/ja/05-tls.html
+++ b/nodes/core/io/locales/ja/05-tls.html
@@ -1,0 +1,19 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="tls-config">
+    <p>TLS接続のためのオプション設定</p>
+</script>

--- a/nodes/core/io/locales/ja/10-mqtt.html
+++ b/nodes/core/io/locales/ja/10-mqtt.html
@@ -1,0 +1,72 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="mqtt in">
+<p>MQTTブローカに接続し、指定したトピックのメッセージをサブスクライブ(購読)します。</p>
+    <h3>出力</h3>
+    <dl class="message-properties">
+       <dt>payload <span class="property-type">文字列 | バッファ</span></dt>
+       <dd>バイナリバッファでない場合は文字列</dd>
+       <dt>topic <span class="property-type">文字列</span></dt>
+       <dd>MQTTのトピック。/を階層の区切りに使用する</dd>
+       <dt>qos <span class="property-type">数値</span> </dt>
+       <dd>0: 最大1度到着, 1: 一度以上到着, 2: 1度のみ到着</dd>
+       <dt>retain <span class="property-type">真偽値</span></dt>
+       <dd>真の場合、メッセージを保持。メッセージが古い値の場合があります。</dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>購読トピックにはMQTTのワイルドカード(+: 1レベル, #: 複数レベル)を含めることができます。</p>
+    <p>このノードの利用のためには、MQTTブローカへの接続設定が必要です。この設定は鉛筆アイコンをクリックすることで行えます。</p>
+    <p>MQTT(inおよびout)ノードはブローカへの接続設定を必要に応じて共有できます。</p>
+</script>
+
+<script type="text/x-red" data-help-name="mqtt out">
+    <p>MQTTブローカに接続し、メッセージをパブリッシュ(発行)します。</p>
+    <h3>入力</h3>
+    <dl class="message-properties">
+       <dt>payload <span class="property-type">文字列 | バッファ</span></dt>
+       <dd>多くの場合単純なテキスト形式のペイロードが使われますが、バイナリバッファを発行することも可能です。</dd>
+
+       <dt class="optional">topic <span class="property-type">文字列</span></dt>
+       <dd>発行対象のMQTTトピック</dd>
+
+       <dt class="optional">qos <span class="property-type">数値</span></dt>
+       <dd>0: 最大1度到着, 1: 一度以上到着, 2: 1度のみ到着。デフォルトは0です。</dd>
+
+       <dt class="optional">retain <span class="property-type">真偽値</span></dt>
+       <dd>真の場合、メッセージをブローカに保持します。デフォルトは偽です。</dd>
+    </dl>
+    <h3>詳細</h3>
+    <p><code>msg.payload</code>を発行するメッセージのペイロードとして用います。ペイロードがオブジェクトの場合、送信の際にJSON文字列に変換します。ペイロードがバイナリバッファの場合、そのまま送信します。</p>
+    <p>発行に利用するトピックはノードに設定するか、もしくは、<code>msg.topic</code>で指定します。</p>
+    <p>同様に、QoSとretainもノードの設定、もしくは、ノードの設定が空の場合には、それぞれ<code>msg.qos</code>および<code>msg.retain</code>で指定できます。以前ブローカに保存したトピックをクリアするには、retainフラグを設定して当該トピックにからのメッセージを発行します。</p>
+    <p>このノードの利用のためには、MQTTブローカへの接続設定が必要です。この設定は鉛筆アイコンをクリックすることで行えます。</p>
+    <p>MQTT(inおよびout)ノードはブローカへの接続設定を必要に応じて共有できます。</p>
+</script>
+
+<script type="text/x-red" data-help-name="mqtt-broker">
+    <p>MQTTブローカへの接続設定</p>
+    <p>ブローカへの接続設定を作成します。設定は<code>MQTT In</code>および<code>MQTT Out</code>ノードで再利用できます。</p>
+    <p>ノードにクライアントIDを設定しておらずセッションの初期化を設定している場合、ランダムなクライアントIDを生成します。クライアントIDを設定する場合、接続先のブローカで一意となるようにしてください。</p>
+    <h4>Birthメッセージ</h4>
+    <p>接続を確立した際に、設定したトピックに対して発行するメッセージ</p>
+    <h4>Willメッセージ</h4>
+    <p>予期せず接続が切断された場合にブローカが発行するメッセージ</p>
+    <h4>WebSocket</h4>
+    <p>WebSocketによる接続を行うように設定できます。WebSocketを利用するには、サーバフィールドに接続先のURIを完全な形式で記述します。以下に例を示します。</p>
+    <pre>ws://example.com:4000/mqtt</pre>
+
+</script>

--- a/nodes/core/io/locales/ja/21-httpin.html
+++ b/nodes/core/io/locales/ja/21-httpin.html
@@ -1,0 +1,81 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="http in">
+    <p>HTTPエンドポイントを作成し、Webサービスを構成します。</p>
+    <h3>出力</h3>
+    <dl class="message-properties">
+        <dt>payload</dt>
+        <dd>GETリクエストの場合、クエリパラメータからなるオブジェクト。それ以外の場合、HTTPリクエストの本体を指します。</dd>
+        <dt>req<span class="property-type">オブジェクト</span></dt>
+        <dd>HTTPリクエストオブジェクト。オブジェクトはリクエストの情報に関する複数のプロパティを含みます。
+            <ul>
+             <li><code>body</code> - リクエスト本体。形式はリクエストに依存します</li>
+             <li><code>headers</code> - HTTPリクエストヘッダを含むオブジェクト</li>
+             <li><code>query</code> - クエリパラメータを含むオブジェクト</li>
+             <li><code>params</code> - ルーティングパラメータを含むオブジェクト</li>
+             <li><code>cookies</code> - リクエストのクッキーを含むオブジェクト</li>
+             <li><code>files</code> - POSTリクエストでファイルのアップロードが設定で有効化されている場合、アップロード対象のファイル</li>
+            </ul>
+        </dd>
+        <dt>res<span class="property-type">オブジェクト</span></dt>
+        <dd>HTTPレスポンスオブジェクト。このプロパティを直接利用することは推奨しません。リクエストの処理方法については<code>HTTP Response</code>ノードのドキュメントを参照してください。このプロパティはresponseノードに渡すメッセージに付けたままとしてください。</dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>このノードは設定で指定したパスとリクエスト種別でリクエストを待ち受けます。パス指定は完全に指定する形式(例: <code>/user</code>)、もしくは、任意の値を受け付ける名前付きパラメータを含む形式(例: <code>/user/:name</code>)のいずれでも構いません。名前付きパラメータを指定する場合、リクエストで指定された実際の値は<code>msg.req.params</code>から参照できます。</p>
+    <p>POSTやPUTのようにリクエストボディを含むリクエストの場合、リクエストの内容は<code>msg.payload</code>で参照できます。</p>
+    <p>リクエストの要素タイプが識別可能な場合には、リクエストボディを適切な形式に変換します。例えば、<code>application/json</code>はJavaScriptオブジェクトに変換します。</p>
+    <p><b>注:</b> このノードはリクエストに対するレスポンスの送信は行いません。リクエストを処理するにはフローにHTTP Responseノードを含めてください。</p>
+</script>
+
+<script type="text/x-red" data-help-name="http response">
+    <p>HTTP Inノードで受け付けたリクエストに対するレスポンスを送り返します。</p>
+
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">文字列</span></dt>
+        <dd>レスポンス本体</dd>
+        <dt class="optional">statusCode <span class="property-type">数値</span></dt>
+        <dd>設定するとレスポンスのステータスコードとします。デフォルト: 200</dd>
+        <dt class="optional">headers <span class="property-type">オブジェクト</span></dt>
+        <dd>設定するとレスポンスのHTTPヘッダとします</dd>
+        <dt class="optional">cookies <span class="property-type">オブジェクト</span></dt>
+        <dd>設定するとクッキーを設定もしくは削除するために使用します</dd>
+    </dl>
+    <h3>詳細</h3>
+    <p><code>statusCode</code>と<code>headers</code>はノードの設定で指定することも可能です。ノードの設定でプロパティを指定した場合には、対応するメッセージプロパティは使用しません。</p>
+    <h4>クッキーの処理</h4>
+    <p><code>cookies</code>はキー/値の組からなるオブジェクトとします。値にはデフォルトオプションを使ってクッキーの値として設定する文字列、もしくは、オプションを含むオブジェクトを指定できます。<p>
+    <p>以下の例では2つのクッキーを設定しています。1つ目は<code>name</code>でその値は<code>nick</code>、2つ目は<code>session</code>で値は<code>1234,</code>、有効期限として15分を指定しています。</p>
+    <pre>
+msg.cookies = {
+    name: 'nick',
+    session: {
+        value: '1234',
+        maxAge: 900000
+    }
+}</pre>
+    <p>有効なオプションには以下があります。</p>
+    <ul>
+    <li><code>domain</code> - (文字列) クッキーのドメイン指定</li>
+    <li><code>expires</code> - (日時) GMT表現での有効期限。未指定もしくは0を指定した場合、セッション終了まで有効</li>
+    <li><code>maxAge</code> - (文字列) 現時刻からの経過ミリ秒で表した有効期限</li>
+    <li><code>path</code> - (文字列) クッキーのパス。デフォルトは「/」</li>
+    <li><code>value</code> - (文字列) クッキーの値</li>
+    </ul>
+    <p>クッキーを削除するには、<code>value</code>に<code>null</code>を設定します。</p>
+
+</script>

--- a/nodes/core/io/locales/ja/21-httprequest.html
+++ b/nodes/core/io/locales/ja/21-httprequest.html
@@ -1,0 +1,60 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="http request">
+    <p>HTTPリクエストを送信し、レスポンスを返します。</p>
+
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt class="optional">url <span class="property-type">文字列</span></dt>
+        <dd>ノードの設定で指定していない場合、このプロパティでリクエストのurlを設定します。</dd>
+        <dt class="optional">method <span class="property-type">文字列</span></dt>
+        <dd>ノードの設定で指定していない場合、このプロパティでリクエストに用いるHTTPメソッドを設定します。<code>GET</code>, <code>PUT</code>, <code>POST</code>, <code>PATCH</code>, <code>DELETE</code>のいずれかを指定してください。</dd>
+        <dt class="optional">headers <span class="property-type">オブジェクト</span></dt>
+        <dd>リクエストのHTTPヘッダを指定します。</dd>
+        <dt class="optional">cookies <span class="property-type">オブジェクト</span></dt>
+        <dd>設定すると、リクエストと共にクッキーを送ることができます。</dd>
+        <dt class="optional">payload</dt>
+        <dd>リクエストボディとして送るデータ</dd>
+        <dt class="optional">rejectUnauthorized</dt>
+        <dd><code>true</code>をセットすると、自己署名証明書を使用するhttpsサイトへのリクエストを許可します。</dd>
+    </dl>
+    <h3>出力</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">文字列 | オブジェクト | バッファ</span></dt>
+        <dd>レスポンスボディ。返却するボディデータを文字列、JSON文字列として解釈した結果、バイナリバッファのままのいずれにするかを、ノード設定により指定できます。</dd>
+        <dt>statusCode <span class="property-type">数値</span></dt>
+        <dd>レスポンスのステータスコード、もしくは、リクエストが完了しなかった場合のエラーコード。</dd>
+        <dt>headers <span class="property-type">オブジェクト</span></dt>
+        <dd>レスポンスヘッダを含むオブジェクト</dd>
+        <dt>responseUrl <span class="property-type">文字列</span></dt>
+        <dd>リクエストの処理時にリダイレクトが発生した場合、このプロパティが最後にリダイレクトされたURLを表します。リダイレクトが起こらなかった場合、最初リクエストのURLを表します。</dd>
+        <dt>responseCookies <span class="property-type">オブジェクト</span></dt>
+        <dd>レスポンスがクッキーを含む場合、このプロパティは各クッキーの名前/値を含むオブジェクトを表します。</dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>ノードの設定でurlプロパティを指定する場合、<a href="http://mustache.github.io/mustache.5.html" target="_blank">mustache形式</a>のタグを含めることができます。これにより、URLを入力メッセージの値から構成することができます。例えば、urlが<code>example.com/{{{topic}}}</code>の場合、<code>msg.topic</code>の値による置き換えを自動的に行います。{{{...}}}表記を使うと、/、&といった文字をmustacheがエスケープするのを抑止できます。</p>
+    <p><b>注</b>: proxyサーバを利用している場合、環境変数<code>http_proxy=...</code>を設定して、Node-REDを再起動してください。</p>
+    <h4>複数のHTTPリクエストノードの利用</h4>
+    <p>同一フローで本ノードを複数利用するためには、<code>msg.headers</code>プロパティの扱いに注意しなくてはなりません。例えば、最初のノードがレスポンスヘッダにこのプロパティを設定し、次のノードがこのプロパティをリクエストヘッダに利用するというのは一般的には期待する動作ではありません。<code>msg.headers</code>プロパティをノード間で変更しないままとすると、2つ目のノードで無視されることになります。カスタムヘッダを設定するためには、<code>msg.headers</code>をまず削除もしくは空のオブジェクト<code>{}</code>にリセットします。
+    <h4>クッキーの扱い</h4>
+    <p>ノードに<code>cookies</code>プロパティを渡す場合、その値はキー/値ペアからなるオブジェクトとしてください。値にはクッキーの値として設定する文字列、もしくは、単一の<code>value</code>プロパティを含むオブジェクトを指定できます。<p>
+    <p>リクエストに対して返却されたクッキーは<code>responseCookies</code>プロパティに格納されます。</p>
+    <h4>要素タイプの扱い</h4>
+    <p><code>msg.payload</code>がオブジェクトの場合、リクエストの要素タイプを<code>msg.payload</code>に自動的に設定し、ボディーをJSONに変換します。</p>
+    <p>リクエストをフォームデータにエンコードするには、<code>msg.headers["content-type"]</code>を<code>application/x-www-form-urlencoded</code>に設定します。</p>
+
+</script>

--- a/nodes/core/io/locales/ja/22-websocket.html
+++ b/nodes/core/io/locales/ja/22-websocket.html
@@ -1,0 +1,38 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="websocket in">
+    <p>WebSocket入力ノード</p>
+    <p>デフォルトでは、WebSocketにより受信したデータは<code>msg.payload</code>に格納します。
+       ソケットはJSON形式の文字列を待ち受けるように設定することができます。JSON形式の文字列を受け付けると、オブジェクトへの変換を行い、メッセージ全体として送信します。</p>
+</script>
+
+<script type="text/x-red" data-help-name="websocket out">
+    <p>WebSocket出力ノード</p>
+    <p>デフォルトでは、<code>msg.payload</code>をWebSocket経由で送信します。
+ソケットは<code>msg</code>全体をJSON文字列にエンコードしてWebSocketを介して送信することもできます。</p>
+
+    <p>このノードが受信したメッセージがWebSocket Inノードが生成したものである場合、メッセージはフローを起動したクライアントに送り返されます。それ以外の場合、メッセージは接続している全てのクライアントにブロードキャストされます。</p>
+    <p>WebSocket Inノードが生成したメッセージをブロードキャストしたい場合には、フロー中で<code>msg._session</code>プロパティを削除します。</p>
+</script>
+
+<script type="text/x-red" data-help-name="websocket-listener">
+    <p>この設定ノードはパスを指定してWebSocketサーバのエンドポイントを作成します。</p>
+</script>
+
+<script type="text/x-red" data-help-name="websocket-client">
+   <p>この設定ノードは指定したURLにWebSocketクライアントを接続します。</p>
+</script>

--- a/nodes/core/io/locales/ja/23-watch.html
+++ b/nodes/core/io/locales/ja/23-watch.html
@@ -1,0 +1,26 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="watch">
+    <p>ディレクトリもしくはファイルの変化を検知します。</p>
+    <p>カンマ区切りでディレクトリおよびファイルのリストを指定します。空白を含む場合は、引用符で"..."のように囲んでください。</p>
+    <p>Windowsでは、2重バックスラッシュ\\をディレクトリ名に使用します。</p>
+    <p>実際に変化したファイルのフルパス名を<code>msg.payload</code>に、
+、検知対象リストの文字列を<code>msg.topic</code>に返します。</p>
+    <p><code>msg.file</code>は変化したファイルのファイル名表します。<code>msg.type</code>は変化した対象の種別(<i>file</i>もしくは<i>directory</i>)を、<code>msg.size</code>はファイルサイズ(バイト数)を表します。</p>
+    <p>Linuxではファイルとして表されるもの<i>全て</i>が、検知対象にできます。</p>
+    <p><b>注: </b>検知対象のディレクトリもしくはファイルは存在していなくてはなりません。対象ファイルもしくはディレクトリが削除された場合、再作成されても検知対象から外れたままです。</p>
+</script>

--- a/nodes/core/io/locales/ja/31-tcpin.html
+++ b/nodes/core/io/locales/ja/31-tcpin.html
@@ -1,0 +1,37 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="tcp in">
+    <p>TCPからの入力を行います。リモートTCPポートに接続するか、外部らからのコネクションを受け付けます。</p>
+    <p><b>注: </b>1024番より小さな番号のポートをアクセスするにはroodもしくはadministrator権限が必要なシステムもあります。</p>
+</script>
+
+<script type="text/x-red" data-help-name="tcp out">
+    <p>TCPへの出力を行います。リモートTCPポートへ接続、外部からのコネクションの受け付け、もしくは、TCP Inノードで受け付けたメッセージへのリプライを行います。</p>
+    <p><code>msg.payload</code>のみが送信対象となります。</p>
+    <p><code>msg.payload</code>がバイナリデータをBase64エンコーディングの文字列に変換したものの場合、Base64デコードオプションを指定するとデータをバイナリに変化んして送信します。</p>
+    <p><code>msg._session</code>が存在しない場合、接続している<b>全ての</b>クライアントに送信します。</p>
+    <p><b>注: </b>1024番より小さな番号のポートをアクセスするにはroodもしくはadministrator権限が必要なシステムもあります。</p>
+</script>
+
+<script type="text/x-red" data-help-name="tcp request">
+    <p>シンプルなTCPリクエストノード。<code>msg.payload</code>をサーバのTCPポートに送信し、レスポンスを待ちます。</p>
+    <p>
+サーバに接続、"リクエスト"送信、"レスポンス"受信を行います。固定長の文字数、指定文字へのマッチ、最初のリプライの到着から指定した時間待つ、データの到着待ち、データ送信を行いリプライを待たず接続を即時解除、などから動作を選択できます。</p>
+    <p>
+レスポンスはバッファ形式で<code>msg.payload</code>に出力されます。文字列として扱いには、toString()を使用してください。</p>
+    <p>TCPホストのポート番号設定を空にした場合、<code>msg.host</code>および<code>msg.port</code>プロパティを設定しなくてはなりません。</p>
+</script>

--- a/nodes/core/io/locales/ja/32-udp.html
+++ b/nodes/core/io/locales/ja/32-udp.html
@@ -1,0 +1,29 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="udp in">
+    <p>UDP入力ノード。<code>msg.payload</code>にバッファ、文字列、もしくは、Base64エンコーディング文字列を生成します。マルチキャストをサポートしています。</p>
+    <p><code>msg.ip</code>と<code>msg.port</code>に受信したメッセージのIPアドレスとポートを設定します。</p>
+    <p><b>注</b>: 1024番より小さな番号のポートへのアクセス、ブロードキャストを行うにはroodもしくはadministrator権限が必要なシステムもあります。</p>
+</script>
+
+<script type="text/x-red" data-help-name="udp out">
+    <p><code>msg.payload</code>を指定したUDPのホストとポートに送信します。マルチキャストをサポートします。</p>
+    <p><code>msg.ip</code>と<code>msg.port</code>に接続先を設定できますが、ノード設定の方が優先されます。</p>
+    <p>
+ブロードキャストを行うには、アドレスをローカルブロードキャストIPアドレスに設定するか、グローバルブロードキャストアドレスである255.255.255.255を試してください。</p>
+    <p><b>注</b>: 1024番より小さな番号のポートへのアクセス、ブロードキャストを行うにはroodもしくはadministrator権限が必要なシステムもあります。</p>
+</script>

--- a/nodes/core/logic/locales/ja/10-switch.html
+++ b/nodes/core/logic/locales/ja/10-switch.html
@@ -1,0 +1,36 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="switch">
+    <p>プロパティの値によってメッセージの振り分けを行います。</p>
+    <h3>詳細</h3>
+    <p>受信したメッセージに対し、指定されたルールを順に評価し、マッチしたルールに対応する出力ポートにメッセージを送出します。</p>
+    <p>最初にルールがマッチしたところで評価を止めることも可能です。</p>
+    <p>評価ルールには、メッセージプロパティ、フローコンテキスト/グローバルコンテキストのプロパティ、JSONata式の評価結果が利用できます。</p>
+    <h3>ルール</h3>
+    <p>振り分けルールは以下の4つに分類されます。</p>
+    <ol>
+        <li><b>値(value)</b>ルール - 指定したプロパティに対して評価</li>
+        <li><b>列(sequence)</b>ルール - メッセージ列に対して適用(メッセージ列はsplitノードなどで生成)</li>
+        <li><b>JSONata式</b> - メッセージ全体に対して評価を行い、結果が真の場合にマッチ</li>
+        <li><b>その他</b> - これより前のルールにマッチするものがなかった場合に適用</li>
+    </ol>
+
+    <h3>メッセージ列の扱い</h3>
+    <p>switchノードは入力メッセージの列に関する情報を保持する<code>msg.parts</code>をデフォルトでは変更しません。</p>
+    <p>「<b>メッセージ列の補正</b>」オプションを指定すると、マッチした各ルールに対して新しいメッセージ列を生成します。このモードでは、switchノードは新たなメッセージ列を送信する前に、入力メッセージ列全体を内部に蓄積します。<code>nodeMessageBufferMaxLength</code>を設定すると、蓄積するメッセージ数を制限できます。</p>
+
+</script>

--- a/nodes/core/logic/locales/ja/15-change.html
+++ b/nodes/core/logic/locales/ja/15-change.html
@@ -1,0 +1,34 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="change">
+    <p>メッセージ、フローコンテキスト、グローバルコンテキストのプロパティを変更、削除、移動します。</p>
+    <p>ルールを複数指定した場合、定義した順に適用します。</p>
+    <h3>詳細</h3>
+    <p>利用可能な処理</p>
+    <dl class="message-properties">
+    <dt>代入</dt>
+    <dd>プロパティをセットします。設定値には、さまざまな型の値、メッセージやコンテキストの既存プロパティを利用できます。<dd>
+    <dt>置換</dt>
+    <dd>プロパティに対して検索と置換を行います。正規表現を指定した場合、「置換後の文字列」には<code>$1</code>のようなキャプチャグループが指定できます。置換処理では、ルールが完全マッチの場合のみプロパティの型を変更できます。</dd>
+    <dt>削除</dt>
+    <dd>プロパティを削除します。</dd>
+    <dt>移動</dt>
+    <dd>プロパティの移動または名前の変更を行います。</dd>
+    </dl>
+    <p>「expression」には<a href="http://jsonata.org/" target="_new">JSONata</a>言語を指定できます。
+    </p>
+</script>

--- a/nodes/core/logic/locales/ja/16-range.html
+++ b/nodes/core/logic/locales/ja/16-range.html
@@ -1,0 +1,33 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="range">
+    <p>数値を異なる範囲の値に変換します。</p>
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">数値</span></dt>
+        <dd>数値以外の場合は、数値に変換します。変換不能な場合はラーとなります。</dd>
+    </dl>
+    <h3>出力</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">数値</span></dt>
+        <dd>新しい範囲に変換した結果の値。</dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>このノードは受け取った数値を線形スケーリングします。デフォルトでは、結果の値はノードに設定した範囲内に限定しません。</p>
+    <p>「<i>入力値の範囲外の値を最小値/最大値として拡大/縮小</i>」を指定すると、値が指定した範囲外の値にならないようにします。</p>
+    <p>「<i>入力値の範囲外の値を範囲幅で割った余りとし拡大/縮小</i>」を指定すると、結果を範囲幅で折り返します。</p>
+</script>

--- a/nodes/core/logic/locales/ja/17-split.html
+++ b/nodes/core/logic/locales/ja/17-split.html
@@ -1,0 +1,137 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="split">
+    <p>メッセージをメッセージ列に分割します。</p>
+
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">オブジェクト | 文字列 | 配列 | バッファ</span></dt>
+        <dd><code>msg.payload</code>の型によってノードの動作が異なります。
+            <ul>
+                <li><b>文字列</b>/<b>バッファ</b> - 指定された文字列 (デフォルト: <code>\n</code>)、バッファ列、もしくは固定の長さによりメッセージを分割します。</li>
+                <li><b>配列</b> - メッセージを配列要素毎もしくは固定の長さの配列に分割します。</li>
+                <li><b>オブジェクト</b> - キー/値の各組に対してメッセージを送信します。</li>
+            </ul>
+        </dd>
+    </dl>
+    <h3>出力</h3>
+    <dl class="message-properties">
+        <dt>parts<span class="property-type">オブジェクト</span></dt>
+        <dd>元のメッセージをどのように分割したかに関する情報をこのプロパティに保持します。例えば、<b>join</b>ノードに渡すことで、メッセージ列を一つのメッセージに再構成することができます。<code>parts</code>プロパティは次のプロパティを含みます。
+        <ul>
+            <li><code>id</code> - メッセージグループの識別子</li>
+            <li><code>index</code> - グループ内の位置</li>
+            <li><code>count</code> - 既知の場合、グループ内のメッセージ数を設定。下記「ストリームモード」を参照</li>
+            <li><code>type</code> - メッセージの型 - 文字列/配列/オブジェクト/バッファ</li>
+            <li><code>ch</code> - 文字列もしくはバッファの場合、メッセージを分割するのに用いた文字列もしくはバイト配列</li>
+            <li><code>key</code> - オブジェクトの場合、メッセージ生成元のキー。
+ノードの設定によりキーを<code>msg.topic</code>など他のメッセージプロパティにコピーすることもできます。</li>
+            <li><code>len</code> - メッセージを固定の長さで分割した場合の長さ。</li>
+        </ul>
+        </dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>このノードは、メッセージ列を構成するメッセージに対して共通処理を行い、<b>join</b>ノードで一つのメッセージに纏めるようなフローを作成する際に有用です。</p>
+    <p><code>msg.parts</code>プロパティを用いて元のメッセージとメッセージ列との対応関係を記憶します。</p>
+    <h4>ストリームモード</h4>
+    <p>このノードはメッセージ列を再構成して送信する際にも有用です。例えば、改行終端のコマンドを送信するようなシリアルデバイスでは、メッセージの最後のコマンド部分が途切れたメッセージを送出する場合があります。「ストリームモード」を用いることで、完結した個別コマンドにメッセージを分割することができます。入力メッセージの最後に未完部分がある場合、<b>split</b>ノードは未完部分を記憶しておいて、次に受信したメッセージの先頭に付加します。</p>
+    <p>このモードで処理する際には、メッセージ数を予め知ることができないため、<code>msg.parts.count</code>プロパティは設定されません。従って、<b>join</b>ノードの「自動モード」と組みわせることはできません。</p>
+</script>
+
+
+<script type="text/x-red" data-help-name="join">
+    <p>メッセージ列を結合して一つのメッセージにします。</p>
+    <p>メッセージの結合には次の3つのモードが利用できます。</p>
+    <dl>
+        <dt>自動</dt>
+        <dd><b>split</b>ノードと組み合わせると、splitと逆にメッセージを結合する処理を行います。</dd>
+        <dt>手動</dt>
+        <dd>メッセージ列をさまざまな方法で結合します。</dd>
+        <dt>列の集約</dt>
+        <dd>メッセージ列に対して指定した式を適用し、1つのメッセージに集約します。</dd>
+    </dl>
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt class="optional">parts<span class="property-type">オブジェクト</span></dt>
+        <dd>自動的にメッセージ列を結合するには、全メッセージがこのプロパティを持っていなければなりません。<b>split</b>ノードでこのプロパティを生成することが可能ですが、独自に生成しても構いません。<code>parts</code>プロパティは以下のプロパティを含みます。
+        <ul>
+            <li><code>id</code> - メッセージグループの識別子</li>
+            <li><code>index</code> - グループ内の順番</li>
+            <li><code>count</code> - グループを構成するメッセージの数</li>
+            <li><code>type</code> - メッセージの型 - string/array/object/buffer</li>
+            <li><code>ch</code> - 文字列もしくはバッファの場合、メッセージを分割するのに用いた文字列もしくはバイト配列</li>
+            <li><code>key</code> - オブジェクトの場合、メッセージ生成元のキー</li>
+            <li><code>len</code> - メッセージを固定の長さで分割した場合の長さ</li>
+        </ul>
+        </dd>
+        <dt class="optional">complete</dt>
+        <dd>設定されている場合、保持しているメッセージを結合して送信します。</dd>
+    </dl>
+    <h3>詳細</h3>
+
+    <h4>自動モード</h4>
+    <p>自動モードでは、入力メッセージの<code>parts</code>プロパティを用いてメッセージ列を結合します。このモードは<b>split</b>ノードの処理の逆を自動的に行います。</p>
+
+    <h4>手動モード</h4>
+    <p>手動モードでは、メッセージ列をさまざまな結果に結合できます。</p>
+    <ul>
+        <li><b>文字列</b>もしくは<b>バッファ</b> - 指定した文字列もしくはバッファ値を区切りとして各メッセージの指定プロパティを結合</li>
+        <li><b>配列</b> - 指定プロパティもしくはメッセージ全体を要素とする配列</li>
+        <li><b>key/valueオブジェクト</b> - 入力メッセージの指定プロパティの値をキーとして、プロパティ値をストアしたオブジェクト</li>
+        <li><b>統合オブジェクト</b> - 各メッセージのプロパティを一つのオブジェクトに統合</li>
+    </ul>
+    <p>出力メッセージのその他のプロパティはメッセージを送信する直前のメッセージをコピーします。</p>
+    <p>「<i>合計値</i>」には出力メッセージを送信する前に受信すべきメッセージ数を指定します。オブジェクト出力の場合、この合計値に達すると後続メッセージの到着毎にメッセージを出力するように設定することもできます。</p>
+    <p>「<i>秒</i>」には新規メッセージを送信するまでの経過時間を設定します。</p>
+    <p><code>msg.complete</code>プロパティを設定したメッセージを受信すると、出力メッセージを送信します。</p>
+
+    <h4>列の集約モード</h4>
+    <p>列の集約モードを選択すると、メッセージ列を構成する各々のメッセージに対して式を適用し、集約した値を用いて一つのメッセージを構成します。</p>
+    <dl class="message-properties">
+        <dt>初期値</dt>
+        <dd>
+            集約の初期値(<code>$A</code>)
+        </dd>
+        <dt>集約式</dt>
+        <dd>メッセージグループを構成する各メッセージに適用するJSONata式。
+            式の評価結果は次回の呼び出しの際に集約値として渡します。
+            <ul>
+                <li><code>$A</code> 集約値</li>
+                <li><code>$I</code> グループ内のメッセージの順番</li>
+                <li><code>$N</code> グループ内のメッセージ数</li>
+            </ul>
+        </dd>
+        <dt>最終調整式</dt>
+        <dd>メッセージグループの集約が完了した後で適用されるJSONata式。任意で指定可能です。式中では以下の特殊変数を参照できます。
+            <ul>
+                <li><code>$A</code> 集約値</li>
+                <li><code>$N</code> グループ内のメッセージ数</li>
+            </ul>
+        </dd>
+        <p>メッセージグループのメッセージに対し、デフォルトでは集約式は最初のメッセージから最後のメッセージに対し順に適用します。指定により適用を逆順にすることも可能です。</p>
+    </dl>
+    <p><b>例:</b> 以下の設定で、数値のメッセージ列に対して平均値を計算します。
+        <ul>
+            <li><b>集約式</b>: <code>$A+payload</code></li>
+            <li><b>初期値</b>: <code>0</code></li>
+            <li><b>最終調整式</b>: <code>$A/$N</code></li>
+        </ul>
+    </p>
+
+    <h4>メッセージの蓄積</h4>
+    <p>このノードの処理ではメッセージ列の処理のためメッセージを内部に蓄積します。<code>nodeMessageBufferMaxLength</code>を指定することで蓄積するメッセージの最大値を制限することができます。</p>
+</script>

--- a/nodes/core/logic/locales/ja/18-sort.html
+++ b/nodes/core/logic/locales/ja/18-sort.html
@@ -1,0 +1,40 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="sort">
+    <p>メッセージ列もしくは配列型のペイロードをソートします。</p>
+    <p><b>split</b>ノードと組み合わせてメッセージの並べ替えを行うことができます。</p>
+    <p>ソート順序は以下が指定可能です。</p>
+    <ul>
+        <li><b>昇順</b></li>
+        <li><b>降順</b></li>
+    </ul>
+    <p>数値による並べ替えを選択することもできます。</p>
+    <p>メッセージの並べ替えを行うためのソートキーは<code>payload</code>プロパティもしくはJSONata式が利用できます。配列型ペイロードのソートキーには、要素値もしくはJSONata式が利用できます。</p>
+    <p>sortノードの処理では受信したメッセージが<code>msg.parts</code>プロパティを持っていることを想定しています。splitノードでこのプロパティを生成することが可能ですが、独自に生成しても構いません。<code>parts</code>プロパティは以下のプロパティを含みます。</p>
+    <p>
+        <ul>
+            <li><code>id</code> -  メッセージグループの識別子</li>
+            <li><code>index</code> - グループ内の順番</li>
+            <li><code>count</code> - グループを構成するメッセージの数</li>
+        </ul>
+    </p>
+    <p><b>注:</b> このノードの処理ではメッセージを内部に蓄積します。以下により蓄積するメッセージの最大数を指定することで、予期しないメモリ使用量の増大を防ぐことができます。デフォルトではメッセージ数を制限しません。
+        <ul>
+            <li><b>settings.js</b>の<code>nodeMessageBufferMaxLength</code>プロパティ</li>
+        </ul>
+    </p>
+</script>

--- a/nodes/core/logic/locales/ja/19-batch.html
+++ b/nodes/core/logic/locales/ja/19-batch.html
@@ -1,0 +1,34 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="batch">
+    <p>指定したルールによりメッセージ列を生成します。</p>
+    <h3>詳細</h3>
+    <p>メッセージ列の生成には以下の3つのモードが利用できます。</p>
+    <dl>
+        <dt>入力メッセージ数でグループ化</dt>
+        <dd>入力メッセージを指定した長さのメッセージ列にグループ化します。メッセージ列の最後の部分を次のメッセージ列の先頭で繰り返すメッセージ数を「<b>オーバラップ</b>」で指定できます。</dd>
+
+        <dt>入力間隔(秒)でグループ化</dt>
+        <dd>指定時間間隔内に受信した入力メッセージをメッセージ列にグループ化します。指定した時間内にメッセージを受信しない場合に空のメッセージを送信するように設定することもできます。</dd>
+
+        <dt>メッセージグループの結合</dt>
+        <dd>入力メッセージ列を結合し、1つのメッセージ列にします。メッセージ列の識別のため、各メッセージは<code>msg.topic</code>プロパティと<code>msg.parts</code>プロパティを持っていなければなりません。メッセージ列の結合順は、<code>topic</code>値のリストとしてbatchノードに指定します。
+        </dd>
+    </dl>
+    <h4>メッセージの蓄積</h4>
+    <p>このノードの処理ではメッセージ列の処理のためメッセージを内部に蓄積します。<code>nodeMessageBufferMaxLength</code>を指定することで蓄積するメッセージの最大値を制限することができます。</p>
+</script>

--- a/nodes/core/parsers/locales/ja/70-CSV.html
+++ b/nodes/core/parsers/locales/ja/70-CSV.html
@@ -1,0 +1,45 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="csv">
+    <p>CSV形式の文字列とそのJavaScriptオブジェクト表現の間で双方向の変換を行います。</p>
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">オブジェクト | 配列 | 文字列</span></dt>
+        <dd>JavaScriptオブジェクト、配列、CSV文字列のいずれか</dd>
+    </dl>
+    <h3>出力</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">オブジェクト | 配列 | 文字列</span></dt>
+        <dd>
+        <ul>
+            <li>入力が文字列の場合、CSVとして解釈し、CSVの各行をキー/バリューとしたJavaScriptオブジェクトを生成します。
+                各行毎にメッセージを送信するかオブジェクトの配列からなる一つのメッセージを送信するかを選択できます。</li>
+            <li>入力がJavaScriptオブジェクトの場合、CSV文字列への変換を行います。</li>
+            <li>入力が基本型の配列の場合、1行のCSV文字列へ変換します。</li>
+            <li>入力が配列の配列、もしくは、オブジェクトの配列の場合、複数行のCSV文字列へ変換します。</li>
+        </ul>
+        </dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>「列名」にカラム名のリストを指定することができます。CSVからオブジェクトに変換を行う際、カラム名をプロパティ名として使用します。「列名」の代わりに、CSVデータの1行目にカラム名を含めることもできます。</p>
+    <p>CSVへの変換を行う際には、オブジェクトから取り出すべきプロパティとその順序を「列名」を参照して決めます。</p>
+    <p>入力が配列の場合には、「列名」はカラム名を表す行の出力指定がされた場合だけ用います。</p>
+    <p>
+<code>parts</code>プロパティが正しく設定されている場合、メッセージ列を入力として受け付けます。</p>
+    <p>CSVを複数のメッセージに変換して出力する場合、出力がメッセージ列となるよう<code>parts</code>プロパティを設定します。</p>
+    <p><b>注:</b> カンマ以外の区切り文字を設定した場合であっても、「列名」はカンマ区切りとしてください。</p>
+</script>

--- a/nodes/core/parsers/locales/ja/70-HTML.html
+++ b/nodes/core/parsers/locales/ja/70-HTML.html
@@ -1,0 +1,33 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="html">
+    <p><code>msg.payload</code>に格納したHTMLドキュメントからCSSセレクタを使用して要素を取り出します。</p>
+    <h3>入力</h3>
+    <dl class="message-properties">
+    <dt>payload <span class="property-type">文字列</span></dt>
+    <dd>要素を取り出すHTML文字列</dd>
+    <dt class="optional">select <span class="property-type">string</span></dt>
+    <dd>編集パネルでセレクタを指定していない場合、メッセージのプロパティとして設定できます</dd>
+</dl>
+    <h3>出力</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">配列 | 文字列</span></dt>
+        <dd>結果は、ペイロードにマッチした要素の配列を含む単一メッセージ、もしくは、マッチした要素毎のメッセージのいずれかを選択できます。複数メッセージを送信する場合、メッセージには<code>parts</code>を設定します</dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>このノードはCSSおよびjQueryセレクタの組み合わせをサポートします。利用可能な構文の詳細については<a href="https://github.com/fb55/CSSselect#user-content-supported-selectors" target="_blank">css-select documentation</a>を参照してください。</p>
+</script>

--- a/nodes/core/parsers/locales/ja/70-JSON.html
+++ b/nodes/core/parsers/locales/ja/70-JSON.html
@@ -1,0 +1,38 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="json">
+    <p>Converts between a JSON string and its JavaScript object representation, in either direction.</p>
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">オブジェクト | 文字列</span></dt>
+        <dd>JavaScriptオブジェクトもしくはJSON文字列</dd>
+    </dl>
+    <h3>出力</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">オブジェクト | 文字列</span></dt>
+        <dd>
+            <ul>
+                <li>入力が文字列の場合、JSONとして解釈し、JavaScriptオブジェクトに変換します。</li>
+                <li>入力がJavaScriptオブジェクトの場合、JSON文字列に変換します。JSON文字列は整形することも可能です。</li>
+            </ul>
+        </dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>デフォルトの変換対象は<code>msg.payload</code>ですが、他のメッセージプロパティを変換対象とすることも可能です。</p>
+    <p>双方向の変換を自動選択するのではなく、特定の変換のみ行うように設定できます。この機能は、例えば、<code>HTTP In</code>ノードに対するリクエストがcontent-typeを正しく設定していないであっても、JSONノードによる変換結果がJavaScriptオブジェクトであることを保証するために利用します。</p>
+    <p>JSON文字列への変換が指定されている場合、受信した文字列に対してさらなるチェックは行いません。すなわち、文字列がJSONとして正しいかどうかの検査や、整形オプションを指定していたとしても整形処理を実施しません。</p>
+</script>

--- a/nodes/core/parsers/locales/ja/70-XML.html
+++ b/nodes/core/parsers/locales/ja/70-XML.html
@@ -1,0 +1,49 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="xml">
+    <p>XML文字列とJavaScriptオブジェクトとの間で相互変換を行います。</p>
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">オブジェクト | 文字列</span></dt>
+        <dd>JavaScriptオブジェクトもしくはXML文字列</dd>
+    </dl>
+    <h3>出力</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">オブジェクト | 文字列</span></dt>
+        <dd>
+            <ul>
+                <li>入力が文字列の場合、XMLとして解釈し、JavaScriptオブジェクトに変換します。</li>
+                <li>入力がJavaScriptオブジェクトの場合、XML文字列に変換します。</li>
+            </ul>
+        </dd>
+        <dt class="optional">options <span class="property-type">オブジェクト</span></dt>
+        <dd>内部で用いているXMLへの変換ライブラリに対してオプションを渡すことができます。詳しくは<a href="https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options" target="_blank">the xml2js docs</a>を参照してください。</dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>XMLとオブジェクトの間での変換を行う場合、デフォルトでは、XML属性は<code>$</code>という名称のプロパティに追加します。
+        テキストの内容は<code>_</code>という名前のプロパティに追加します。これらのプロパティ名はノードの設定で変更できます。</p>
+    <p>例として以下のXMLの変換結果を示します。</p>
+    <pre>&lt;p class="tag"&gt;Hello World&lt;/p&gt;</pre>
+    <pre>{
+  "p": {
+    "$": {
+      "class": "tag"
+    },
+    "_": "Hello World"
+  }
+}</pre>
+</script>

--- a/nodes/core/parsers/locales/ja/70-YAML.html
+++ b/nodes/core/parsers/locales/ja/70-YAML.html
@@ -1,0 +1,34 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="yaml">
+    <p>YAML形式の文字列とJavaScriptオブジェクトの間で相互変換を行います。</p>
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">オブジェクト | 文字列</span></dt>
+        <dd>JavaScriptオブジェクトもしくはYAML形式文字列</dd>
+    </dl>
+    <h3>出力</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">オブジェクト | 文字列</span></dt>
+        <dd>
+            <ul>
+                <li>入力がYAML形式の文字列の場合、JavaScriptオブジェクトに変換します。</li>
+                <li>入力がJavaScriptオブジェクトの場合、YAML形式の文字列に変換します。</li>
+            </ul>
+        </dd>
+    </dl>
+</script>

--- a/nodes/core/storage/locales/ja/28-tail.html
+++ b/nodes/core/storage/locales/ja/28-tail.html
@@ -1,0 +1,25 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="tail">
+    <p>設定したファイルの末尾を出力(追加されたデータを監視)します。(Linux/Macのみ)</p>
+    <p>このノードは<b>tail -F</b>コマンドを内部で利用しているため、Windowsファイルシステムでは動作しません。</p>
+    <h3>出力</h3>
+    <ul>
+        <li>(UTF-8形式の)テキストファイルは文字列を返却。</li>
+        <li>バイナルファイルはバッファオブジェクトを返却。</li>
+    </ul>
+</script>

--- a/nodes/core/storage/locales/ja/50-file.html
+++ b/nodes/core/storage/locales/ja/50-file.html
@@ -1,0 +1,57 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-help-name="file">
+    <p><code>msg.payload</code>をファイルに書き出します。書き出しは、ファイルの
+最後に追記もしくは既存の内容の置き換えを選択できます。
+       この他、ファイルの削除を行うことも可能です。</p>
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt class="optional">filename <span class="property-type">文字列</span></dt>
+        <dd>対象ファイル名をノードに設定していない場合、このプロパティでファイルを指定できます</dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>入力メッセージのペイロードをファイルの最後に追記します。改行(\n)を各データの最後に追加することもできます。</p>
+    <p><code>msg.filename</code>を使う場合、書き込みを行う毎にファイルをクローズします。より良い性能を得るためにはファイル名をノードに設定してください。</p>
+    <p>追記を行う代わりに、ファイル全体を上書きするように設定することもできます。例えば、画像のようなバイナリデータをファイルに書き出す場合は、このオプションを指定し、改行を追記するオプションを指定しないようにします。</p>
+    <p>この他、ファイルの削除を行うことも可能です。</p>
+</script>
+
+<script type="text/x-red" data-help-name="file in">
+    <p>ファイルの内容を文字列もしくはバイナリバッファとして読み出します。</p>
+    <h3>入力</h3>
+    <dl class="message-properties">
+        <dt class="optional">filename <span class="property-type">文字列</span></dt>
+        <dd>読み出し対象のファイル名をノードに設定していない場合、このプロパティでファイルを指定できます</dd>
+    </dl>
+    <h3>出力</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">文字列 | バッファ</span></dt>
+        <dd>ファイルの内容を文字列もしくはバッファで表現します</dd>
+        <dt class="optional">filename <span class="property-type">文字列</span></dt>
+        <dd>読み出し対象のファイル名をノードに設定していない場合、このプロパティでファイルを指定します</dd>
+        <dt class="optional">error <span class="property-type">オブジェクト</span></dt>
+        <dd><i>非推奨</i>: 設定で有効にした場合、ファイルの読み込み時にエラーが発生すると<code>payload</code>を持たず<code>error</code>プロパティにエラーの詳細情報を設定したメッセージを送信します。この動作モードは非推奨であり、新しいノード実装ではデフォルトでは無効としています。詳細については、以下を参照してください。</dd>
+    </dl>
+    <h3>詳細</h3>
+    <p>ファイルネームは絶対パスでの指定を推奨します。絶対パスを指定しない場合は、Node-REDプロセスのワーキングディレクトリからの相対パスとして扱います。</p>
+    <p>Windowsではパスの区切り文字を(例えば、<code>\\ユーザー\\名前</code>のように)エスケープする必要があります。</p>
+    <p>テキストファイルの場合、行毎に分割して各々メッセージを送信することができます。また、バイナリファイルの場合、小さな塊のバッファに分割して送信できます。バッファの分割単位はオペレーティングシステム依存ですが、一般に64k(Linux/Mac)もしくは41k(Windows)です。</p>
+    <p>複数のメッセージに分割する場合、各メッセージには<code>parts</code>プロパティが設定され、メッセージ列を構成します。</p>
+    <h4>旧式のエラー処理</h4>
+    <p>Node-RED 0.17より前の版では、ファイルの読み込み時にエラーが発生すると<code>payload</code>を持たず<code>error</code>プロパティにエラーの詳細情報を設定したメッセージを送信します。この動作モードは非推奨であり、新しいノード実装ではデフォルトでは無効としています。ノードの設定により、必要に応じてこのモードを有効にできます。</p>
+    <p>エラーはcatchノードで補足して処理することを推奨します。</p>
+</script>


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This PR adds Japanese info text of core nodes.
Requires fix [PR#1616](https://github.com/node-red/node-red/pull/1616) for message lookup of core nodes.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality