### PR TITLE
Mqtt proxy configuration for websocket connection, #1651.

### DIFF
--- a/nodes/core/io/10-mqtt.js
+++ b/nodes/core/io/10-mqtt.js
@@ -19,6 +19,8 @@ module.exports = function(RED) {
     var mqtt = require("mqtt");
     var util = require("util");
     var isUtf8 = require('is-utf8');
+    var HttpsProxyAgent = require('https-proxy-agent');
+    var url = require('url');
 
     function matchTopic(ts,t) {
         if (ts == "#") {
@@ -87,12 +89,29 @@ module.exports = function(RED) {
         if (typeof this.cleansession === 'undefined') {
             this.cleansession = true;
         }
+        var prox;
+        if (process.env.http_proxy != null) { prox = process.env.http_proxy; }
+        if (process.env.HTTP_PROXY != null) { prox = process.env.HTTP_PROXY; }
 
         // Create the URL to pass in to the MQTT.js library
         if (this.brokerurl === "") {
             // if the broker may be ws:// or wss:// or even tcp://
             if (this.broker.indexOf("://") > -1) {
                 this.brokerurl = this.broker;
+                // Only for ws or wss, check if proxy env var for additional configuration
+                if (this.brokerurl.indexOf("wss://") > -1 || this.brokerurl.indexOf("ws://") > -1 )
+                // check if proxy is set in env
+                    if (prox) {
+                        var parsedUrl = url.parse(this.brokerurl);
+                        var proxyOpts = url.parse(prox);
+                        // true for wss
+                        proxyOpts.secureEndpoint = parsedUrl.protocol ? parsedUrl.protocol === 'wss:' : true;
+                        // Set Agent for wsOption in MQTT
+                        var agent = new HttpsProxyAgent(proxyOpts);
+                        this.options.wsOptions = {
+                            agent: agent
+                        }
+                    }
             } else {
                 // construct the std mqtt:// url
                 if (this.usetls) {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "fs-extra": "5.0.0",
         "fs.notify": "0.0.4",
         "hash-sum": "1.0.2",
+        "https-proxy-agent": "^2.1.1",
         "i18next": "1.10.6",
         "is-utf8": "0.2.1",
         "js-yaml": "3.10.0",
@@ -72,6 +73,7 @@
         "semver": "5.4.1",
         "sentiment": "2.1.0",
         "uglify-js": "3.3.6",
+        "url": "^0.11.0",
         "when": "3.7.8",
         "ws": "1.1.5",
         "xml2js": "0.4.19"


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality) 

## Proposed changes

Add proxy configuration for MQTT websocket connection. Proxy is set when an environment variable, e.g. HTTP_PROXY or http_proxy, is defined.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the  issue #1651 .
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
