### PR TITLE
labels-width-ui-changes

### DIFF
--- a/editor/js/ui/common/typedInput.js
+++ b/editor/js/ui/common/typedInput.js
@@ -116,7 +116,9 @@
             this.options.types = this.options.types||Object.keys(allOptions);
 
             this.selectTrigger = $('<button tabindex="0"></button>').prependTo(this.uiSelect);
-            $('<i class="fa fa-sort-desc"></i>').appendTo(this.selectTrigger);
+            if (this.options.types.length > 1) {
+                $('<i class="fa fa-sort-desc"></i>').appendTo(this.selectTrigger);
+            }
             this.selectLabel = $('<span></span>').appendTo(this.selectTrigger);
 
             this.types(this.options.types);

--- a/editor/sass/editor.scss
+++ b/editor/sass/editor.scss
@@ -178,7 +178,7 @@
 }
 .form-row label {
     display: inline-block;
-    width: 100px;
+    min-width: 100px;
 }
 .form-row input, .form-row div[contenteditable="true"] {
     width:70%;
@@ -323,6 +323,7 @@
         margin-right: 20px;
         text-align: right;
         width: 30px;
+        min-width: 30px;
     }
     button {
         margin-left: 10px;

--- a/editor/sass/ui/common/typedInput.scss
+++ b/editor/sass/ui/common/typedInput.scss
@@ -64,9 +64,10 @@
         vertical-align: middle;
         color: #555;
         i {
-            position:relative;
-            top:-3px;
-            margin-right:4px;
+            position: relative;
+            top: -3px;
+            margin-left: 1px;
+            margin-right: 2px;
             margin-top: 1px;
             vertical-align: middle;
             &.fa-ellipsis-h {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)

## Proposed changes

This does two things….
1) changes the <label> styling to have a min-width rather than a fixed width - so longer English label names will expand right rather than wrap. But more usefully it will automatically accommodate shorter Chinese and Japanese labels without them looking too short.
2) remove the down carat on the typed input if there is only one possible thing to select. (nothing to dropdown)

## Checklist

- [ x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
