### PR TITLE
Don't mark a subflow changed when actually modified nothing

### DIFF
--- a/editor/js/ui/deploy.js
+++ b/editor/js/ui/deploy.js
@@ -408,9 +408,12 @@ RED.deploy = (function() {
                         delete confNode.credentials;
                     }
                 });
+                RED.nodes.eachSubflow(function(subflow) {
+                    subflow.changed = false;
+                });
                 RED.nodes.eachWorkspace(function(ws) {
                     ws.changed = false;
-                })
+                });
                 // Once deployed, cannot undo back to a clean state
                 RED.history.markAllDirty();
                 RED.view.redraw();

--- a/editor/js/ui/editor.js
+++ b/editor/js/ui/editor.js
@@ -819,6 +819,47 @@ RED.editor = (function() {
         selectIconModule.removeClass("input-error");
     }
 
+    function updateLabels(editing_node, changes, outputMap) {
+        var inputLabels = $("#node-label-form-inputs").children().find("input");
+        var outputLabels = $("#node-label-form-outputs").children().find("input");
+
+        var hasNonBlankLabel = false;
+        var changed = false;
+        var newValue = inputLabels.map(function() {
+            var v = $(this).val();
+            hasNonBlankLabel = hasNonBlankLabel || v!== "";
+            return v;
+        }).toArray().slice(0,editing_node.inputs);
+        if ((editing_node.inputLabels === undefined && hasNonBlankLabel) ||
+            (editing_node.inputLabels !== undefined && JSON.stringify(newValue) !== JSON.stringify(editing_node.inputLabels))) {
+            changes.inputLabels = editing_node.inputLabels;
+            editing_node.inputLabels = newValue;
+            changed = true;
+        }
+        hasNonBlankLabel = false;
+        newValue = new Array(editing_node.outputs);
+        outputLabels.each(function() {
+            var index = $(this).attr('id').substring(23); // node-label-form-output-<index>
+            if (outputMap && outputMap.hasOwnProperty(index)) {
+                index = parseInt(outputMap[index]);
+                if (index === -1) {
+                    return;
+                }
+            }
+            var v = $(this).val();
+            hasNonBlankLabel = hasNonBlankLabel || v!== "";
+            newValue[index] = v;
+        });
+
+        if ((editing_node.outputLabels === undefined && hasNonBlankLabel) ||
+            (editing_node.outputLabels !== undefined && JSON.stringify(newValue) !== JSON.stringify(editing_node.outputLabels))) {
+            changes.outputLabels = editing_node.outputLabels;
+            editing_node.outputLabels = newValue;
+            changed = true;
+        }
+        return changed;
+    }
+
     function showEditDialog(node) {
         var editing_node = node;
         var isDefaultIcon;
@@ -1034,40 +1075,7 @@ RED.editor = (function() {
                         // }
                         var removedLinks = updateNodeProperties(editing_node,outputMap);
 
-                        var inputLabels = $("#node-label-form-inputs").children().find("input");
-                        var outputLabels = $("#node-label-form-outputs").children().find("input");
-
-                        var hasNonBlankLabel = false;
-                        newValue = inputLabels.map(function() {
-                            var v = $(this).val();
-                            hasNonBlankLabel = hasNonBlankLabel || v!== "";
-                            return v;
-                        }).toArray().slice(0,editing_node.inputs);
-                        if ((editing_node.inputLabels === undefined && hasNonBlankLabel) ||
-                            (editing_node.inputLabels !== undefined && JSON.stringify(newValue) !== JSON.stringify(editing_node.inputLabels))) {
-                            changes.inputLabels = editing_node.inputLabels;
-                            editing_node.inputLabels = newValue;
-                            changed = true;
-                        }
-                        hasNonBlankLabel = false;
-                        newValue = new Array(editing_node.outputs);
-                        outputLabels.each(function() {
-                            var index = $(this).attr('id').substring(23); // node-label-form-output-<index>
-                            if (outputMap && outputMap.hasOwnProperty(index)) {
-                                index = parseInt(outputMap[index]);
-                                if (index === -1) {
-                                    return;
-                                }
-                            }
-                            var v = $(this).val();
-                            hasNonBlankLabel = hasNonBlankLabel || v!== "";
-                            newValue[index] = v;
-                        })
-
-                        if ((editing_node.outputLabels === undefined && hasNonBlankLabel) ||
-                            (editing_node.outputLabels !== undefined && JSON.stringify(newValue) !== JSON.stringify(editing_node.outputLabels))) {
-                            changes.outputLabels = editing_node.outputLabels;
-                            editing_node.outputLabels = newValue;
+                        if (updateLabels(editing_node, changes, outputMap)) {
                             changed = true;
                         }
 
@@ -1675,19 +1683,7 @@ RED.editor = (function() {
                             editing_node.info = newDescription;
                             changed = true;
                         }
-                        var inputLabels = $("#node-label-form-inputs").children().find("input");
-                        var outputLabels = $("#node-label-form-outputs").children().find("input");
-
-                        var newValue = inputLabels.map(function() { return $(this).val();}).toArray().slice(0,editing_node.inputs);
-                        if (JSON.stringify(newValue) !== JSON.stringify(editing_node.inputLabels)) {
-                            changes.inputLabels = editing_node.inputLabels;
-                            editing_node.inputLabels = newValue;
-                            changed = true;
-                        }
-                        newValue = outputLabels.map(function() { return $(this).val();}).toArray().slice(0,editing_node.outputs);
-                        if (JSON.stringify(newValue) !== JSON.stringify(editing_node.outputLabels)) {
-                            changes.outputLabels = editing_node.outputLabels;
-                            editing_node.outputLabels = newValue;
+                        if (updateLabels(editing_node, changes, null)) {
                             changed = true;
                         }
 

--- a/editor/js/ui/view.js
+++ b/editor/js/ui/view.js
@@ -490,6 +490,7 @@ RED.view = (function() {
             }
         } else {
             var subflow = RED.nodes.subflow(m[1]);
+            nn.name = "";
             nn.inputs = subflow.in.length;
             nn.outputs = subflow.out.length;
         }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

#1662

- Clear the changed flag for each subflow when deployed.
- Applying the code for node editing to subflow.
https://github.com/node-red/node-red/commit/879c0f41142aaafd1a3e8552024d81d5e40b012d#diff-22a7b0b89bfea2828bc49b86c7537fb7
- Set a default name value for a subflow.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
