### PR TITLE
Enable user defined icon for subflow

### DIFF
--- a/editor/js/history.js
+++ b/editor/js/history.js
@@ -229,10 +229,12 @@ RED.history = (function() {
                             }
                         });
                     }
+                    RED.editor.validateNode(ev.node);
                     RED.nodes.filterNodes({type:"subflow:"+ev.node.id}).forEach(function(n) {
                         n.inputs = ev.node.in.length;
                         n.outputs = ev.node.out.length;
                         RED.editor.updateNodeProperties(n);
+                        RED.editor.validateNode(n);
                     });
                 } else {
                     var outputMap;

--- a/editor/js/nodes.js
+++ b/editor/js/nodes.js
@@ -355,7 +355,7 @@ RED.nodes = (function() {
         RED.nodes.registerType("subflow:"+sf.id, {
             defaults:{name:{value:""}},
             info: sf.info,
-            icon:"subflow.png",
+            icon: function() { return sf.icon||"subflow.png" },
             category: "subflows",
             inputs: sf.in.length,
             outputs: sf.out.length,
@@ -550,7 +550,11 @@ RED.nodes = (function() {
         if (node.out.length > 0 && n.outputLabels && !/^\s*$/.test(n.outputLabels.join(""))) {
             node.outputLabels = n.outputLabels.slice();
         }
-
+        if (n.icon) {
+            if (n.icon !== "node-red/subflow.png") {
+                node.icon = n.icon;
+            }
+        }
 
         return node;
     }

--- a/editor/js/ui/editor.js
+++ b/editor/js/ui/editor.js
@@ -787,12 +787,7 @@ RED.editor = (function() {
             var clear = $('<button class="editor-button editor-button-small"><i class="fa fa-times"></i></button>').appendTo(iconForm);
             clear.click(function(evt) {
                 evt.preventDefault();
-                var iconPath;
-                if (node.type === "subflow") {
-                    iconPath = { module:"node-red", file:"subflow.png" };
-                } else {
-                    iconPath = RED.utils.getDefaultNodeIcon(node._def, node);
-                }
+                var iconPath = RED.utils.getDefaultNodeIcon(node._def, node);
                 selectIconModule.val(iconPath.module);
                 moduleChange(selectIconModule, selectIconFile, iconModuleHidden, iconFileHidden, iconSets, true);
                 selectIconFile.removeClass("input-error");

--- a/editor/js/ui/palette.js
+++ b/editor/js/ui/palette.js
@@ -116,6 +116,12 @@ RED.palette = (function() {
         el.data('popover').setContent(popOverContent);
     }
 
+    function setIcon(element,sf) {
+        var iconElement = element.find(".palette_icon");
+        var icon_url = RED.utils.getNodeIcon(sf._def,sf);
+        iconElement.attr("style", "background-image: url("+icon_url+")");
+    }
+
     function escapeNodeType(nt) {
         return nt.replace(" ","_").replace(".","_").replace(":","_");
     }
@@ -375,6 +381,7 @@ RED.palette = (function() {
                 portOutput.remove();
             }
             setLabel(sf.type+":"+sf.id,paletteNode,sf.name,marked(sf.info||""));
+            setIcon(paletteNode,sf);
         });
     }
 

--- a/editor/js/ui/utils.js
+++ b/editor/js/ui/utils.js
@@ -708,7 +708,9 @@ RED.utils = (function() {
 
     function getDefaultNodeIcon(def,node) {
         var icon_url;
-        if (typeof def.icon === "function") {
+        if (node && node.type === "subflow") {
+            icon_url = "node-red/subflow.png";
+        } else if (typeof def.icon === "function") {
             try {
                 icon_url = def.icon.call(node);
             } catch(err) {
@@ -753,8 +755,6 @@ RED.utils = (function() {
             if (isIconExists(iconPath)) {
                 return "icons/" + node.icon;
             }
-        } else if (node && node.type === 'subflow') {
-            return "icons/node-red/subflow.png"
         }
 
         var iconPath = getDefaultNodeIcon(def, node);

--- a/editor/js/ui/utils.js
+++ b/editor/js/ui/utils.js
@@ -731,6 +731,16 @@ RED.utils = (function() {
         return iconPath;
     }
 
+    function isIconExists(iconPath) {
+        var iconSets = RED.nodes.getIconSets();
+        var iconFileList = iconSets[iconPath.module];
+        if (iconFileList && iconFileList.indexOf(iconPath.file) !== -1) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     function getNodeIcon(def,node) {
         if (def.category === 'config') {
             return "icons/node-red/cog.png"
@@ -738,18 +748,21 @@ RED.utils = (function() {
             return "icons/node-red/subflow.png"
         } else if (node && node.type === 'unknown') {
             return "icons/node-red/alert.png"
-        } else if (node && node.type === 'subflow') {
-            return "icons/node-red/subflow.png"
         } else if (node && node.icon) {
             var iconPath = separateIconPath(node.icon);
-            var iconSets = RED.nodes.getIconSets();
-            var iconFileList = iconSets[iconPath.module];
-            if (iconFileList && iconFileList.indexOf(iconPath.file) !== -1) {
+            if (isIconExists(iconPath)) {
                 return "icons/" + node.icon;
             }
+        } else if (node && node.type === 'subflow') {
+            return "icons/node-red/subflow.png"
         }
 
         var iconPath = getDefaultNodeIcon(def, node);
+        if (def.category === 'subflows') {
+            if (!isIconExists(iconPath)) {
+                return "icons/node-red/subflow.png";
+            }
+        }
         return "icons/"+iconPath.module+"/"+iconPath.file;
     }
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
#1609
Supported user defined icon for subflow.  Once an icon is specified for a subflow, the default icon of its subflow node becomes the icon instead of subflow.png.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
