### PR TITLE
tcp node: queue pending messages while connecting to tcp server

### DIFF
--- a/nodes/core/io/31-tcpin.js
+++ b/nodes/core/io/31-tcpin.js
@@ -18,9 +18,35 @@ module.exports = function(RED) {
     "use strict";
     var reconnectTime = RED.settings.socketReconnectTime||10000;
     var socketTimeout = RED.settings.socketTimeout||null;
+    const msgQueueSize = RED.settings.tcpMsgQueueSize || 1000;
+    const Denque = require('denque');
     var net = require('net');
 
     var connectionPool = {};
+
+    /**
+     * Enqueue `item` in `queue`
+     * @param {Denque} queue - Queue
+     * @param {*} item - Item to enqueue
+     * @private
+     * @returns {Denque} `queue`
+     */
+    const enqueue = (queue, item) => {
+        // drop msgs from front of queue if size is going to be exceeded
+        if (queue.size() === msgQueueSize) {
+            queue.shift();
+        }
+        queue.push(item);
+        return queue;
+    };
+
+    /**
+     * Shifts item off front of queue
+     * @param {Deque} queue - Queue
+     * @private
+     * @returns {*} Item previously at front of queue
+     */
+    const dequeue = queue => queue.shift();
 
     function TcpIn(n) {
         RED.nodes.createNode(this,n);
@@ -430,11 +456,14 @@ module.exports = function(RED) {
             // the clients object will have:
             // clients[id].client, clients[id].msg, clients[id].timeout
             var connection_id = host + ":" + port;
-            clients[connection_id] = clients[connection_id] || {};
-            clients[connection_id].msg = msg;
-            clients[connection_id].connected = clients[connection_id].connected || false;
+            clients[connection_id] = clients[connection_id] || {
+                msgQueue: new Denque(),
+                connected: false,
+                connecting: false
+            };
+            enqueue(clients[connection_id].msgQueue, msg);
 
-            if (!clients[connection_id].connected) {
+            if (!clients[connection_id].connecting && !clients[connection_id].connected) {
                 var buf;
                 if (this.out == "count") {
                     if (this.splitc === 0) { buf = Buffer.alloc(1); }
@@ -446,14 +475,19 @@ module.exports = function(RED) {
                 if (socketTimeout !== null) { clients[connection_id].client.setTimeout(socketTimeout);}
 
                 if (host && port) {
+                    clients[connection_id].connecting = true;
                     clients[connection_id].client.connect(port, host, function() {
                         //node.log(RED._("tcpin.errors.client-connected"));
                         node.status({fill:"green",shape:"dot",text:"common.status.connected"});
                         if (clients[connection_id] && clients[connection_id].client) {
                             clients[connection_id].connected = true;
-                            clients[connection_id].client.write(clients[connection_id].msg.payload);
+                            clients[connection_id].connecting = false;
+                            let msg;
+                            while (msg = dequeue(clients[connection_id].msgQueue)) {
+                                clients[connection_id].client.write(msg.payload);
+                            }
                             if (node.out === "time" && node.splitc < 0) {
-                                clients[connection_id].connected = false;
+                                clients[connection_id].connected = clients[connection_id].connecting = false;
                                 clients[connection_id].client.end();
                                 delete clients[connection_id];
                                 node.status({});
@@ -468,9 +502,10 @@ module.exports = function(RED) {
                 clients[connection_id].client.on('data', function(data) {
                     if (node.out === "sit") { // if we are staying connected just send the buffer
                         if (clients[connection_id]) {
-                            if (!clients[connection_id].hasOwnProperty("msg")) { clients[connection_id].msg = {}; }
-                            clients[connection_id].msg.payload = data;
-                            node.send(RED.util.cloneMessage(clients[connection_id].msg));
+                            let msg = dequeue(clients[connection_id].msgQueue) || {};
+                            clients[connection_id].msgQueue.unshift(msg);
+                            msg.payload = data;
+                            node.send(RED.util.cloneMessage(msg));
                         }
                     }
                     // else if (node.splitc === 0) {
@@ -490,9 +525,11 @@ module.exports = function(RED) {
                                         clients[connection_id].timeout = setTimeout(function () {
                                             if (clients[connection_id]) {
                                                 clients[connection_id].timeout = null;
-                                                clients[connection_id].msg.payload = Buffer.alloc(i+1);
-                                                buf.copy(clients[connection_id].msg.payload,0,0,i+1);
-                                                node.send(clients[connection_id].msg);
+                                                let msg = dequeue(clients[connection_id].msgQueue) || {};
+                                                clients[connection_id].msgQueue.unshift(msg);
+                                                msg.payload = Buffer.alloc(i+1);
+                                                buf.copy(msg.payload,0,0,i+1);
+                                                node.send(msg);
                                                 if (clients[connection_id].client) {
                                                     node.status({});
                                                     clients[connection_id].client.destroy();
@@ -511,9 +548,11 @@ module.exports = function(RED) {
                                 i += 1;
                                 if ( i >= node.splitc) {
                                     if (clients[connection_id]) {
-                                        clients[connection_id].msg.payload = Buffer.alloc(i);
-                                        buf.copy(clients[connection_id].msg.payload,0,0,i);
-                                        node.send(clients[connection_id].msg);
+                                        let msg = dequeue(clients[connection_id].msgQueue) || {};
+                                        clients[connection_id].msgQueue.unshift(msg);
+                                        msg.payload = Buffer.alloc(i);
+                                        buf.copy(msg.payload,0,0,i);
+                                        node.send(msg);
                                         if (clients[connection_id].client) {
                                             node.status({});
                                             clients[connection_id].client.destroy();
@@ -529,9 +568,11 @@ module.exports = function(RED) {
                                 i += 1;
                                 if (data[j] == node.splitc) {
                                     if (clients[connection_id]) {
-                                        clients[connection_id].msg.payload = Buffer.alloc(i);
-                                        buf.copy(clients[connection_id].msg.payload,0,0,i);
-                                        node.send(clients[connection_id].msg);
+                                        let msg = dequeue(clients[connection_id].msgQueue) || {};
+                                        clients[connection_id].msgQueue.unshift(msg);
+                                        msg.payload = Buffer.alloc(i);
+                                        buf.copy(msg.payload,0,0,i);
+                                        node.send(msg);
                                         if (clients[connection_id].client) {
                                             node.status({});
                                             clients[connection_id].client.destroy();
@@ -549,7 +590,7 @@ module.exports = function(RED) {
                     //console.log("END");
                     node.status({fill:"grey",shape:"ring",text:"common.status.disconnected"});
                     if (clients[connection_id] && clients[connection_id].client) {
-                        clients[connection_id].connected = false;
+                        clients[connection_id].connected = clients[connection_id].connecting = false;
                         clients[connection_id].client = null;
                     }
                 });
@@ -557,7 +598,7 @@ module.exports = function(RED) {
                 clients[connection_id].client.on('close', function() {
                     //console.log("CLOSE");
                     if (clients[connection_id]) {
-                        clients[connection_id].connected = false;
+                        clients[connection_id].connected = clients[connection_id].connecting = false;
                     }
 
                     var anyConnected = false;
@@ -587,21 +628,23 @@ module.exports = function(RED) {
                 clients[connection_id].client.on('timeout',function() {
                     //console.log("TIMEOUT");
                     if (clients[connection_id]) {
-                        clients[connection_id].connected = false;
+                        clients[connection_id].connected = clients[connection_id].connecting = false;
                         node.status({fill:"grey",shape:"dot",text:"tcpin.errors.connect-timeout"});
                         //node.warn(RED._("tcpin.errors.connect-timeout"));
                         if (clients[connection_id].client) {
+                            clients[connection_id].connecting = true;
                             clients[connection_id].client.connect(port, host, function() {
                                 clients[connection_id].connected = true;
+                                clients[connection_id].connecting = false;
                                 node.status({fill:"green",shape:"dot",text:"common.status.connected"});
                             });
                         }
                     }
                 });
             }
-            else {
+            else if (!clients[connection_id].connecting && clients[connection_id].connected) {
                 if (clients[connection_id] && clients[connection_id].client) {
-                    clients[connection_id].client.write(clients[connection_id].msg.payload);
+                    clients[connection_id].client.write(dequeue(clients[connection_id].msgQueue));
                 }
             }
         });

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "cookie-parser": "1.4.3",
         "cors": "2.8.4",
         "cron": "1.3.0",
+        "denque": "^1.2.3",
         "express": "4.16.2",
         "express-session": "1.15.6",
         "follow-redirects": "1.3.0",

--- a/settings.js
+++ b/settings.js
@@ -40,6 +40,10 @@ module.exports = {
     //  defaults to no timeout
     //socketTimeout: 120000,
 
+    // Maximum number of messages to wait in queue while attempting to connect to TCP socket
+    //  defaults to 1000
+    //tcpMsgQueueSize: 2000,
+
     // Timeout in milliseconds for HTTP request connections
     //  defaults to 120 seconds
     //httpRequestTimeout: 120000,

--- a/test/nodes/core/io/31-tcprequest_spec.js
+++ b/test/nodes/core/io/31-tcprequest_spec.js
@@ -27,12 +27,12 @@ describe('TCP Request Node', function() {
     function startServer(done) {
         port += 1;
         server = net.createServer(function(c) {
-	    c.on('data', function(data) {
-		var rdata = "ACK:"+data.toString();
-		c.write(rdata);
-	    });
+            c.on('data', function(data) {
+                var rdata = "ACK:"+data.toString();
+                c.write(rdata);
+            });
             c.on('error', function(err) {
-		startServer(done);
+                startServer(done);
             });
         }).listen(port, "127.0.0.1", function(err) {
             done();
@@ -63,48 +63,47 @@ describe('TCP Request Node', function() {
                     done(err);
                 }
             });
-	    if((typeof val0) === 'object') {
-		n1.receive(val0);
-	    } else {
-		n1.receive({payload:val0});
-	    }
+            if((typeof val0) === 'object') {
+                n1.receive(val0);
+            } else {
+                n1.receive({payload:val0});
+            }
         });
     }
     
     it('should send & recv data', function(done) {
         var flow = [{id:"n1", type:"tcp request", server:"localhost", port:port, out:"time", splitc: "0", wires:[["n2"]] },
                     {id:"n2", type:"helper"}];
-	testTCP(flow, "foo", "ACK:foo", done)
+        testTCP(flow, "foo", "ACK:foo", done)
     });
 
     it('should send & recv data when specified character received', function(done) {
         var flow = [{id:"n1", type:"tcp request", server:"localhost", port:port, out:"char", splitc: "0", wires:[["n2"]] },
                     {id:"n2", type:"helper"}];
-	testTCP(flow, "foo0bar0", "ACK:foo0", done);
+        testTCP(flow, "foo0bar0", "ACK:foo0", done);
     });
 
     it('should send & recv data after fixed number of chars received', function(done) {
         var flow = [{id:"n1", type:"tcp request", server:"localhost", port:port, out:"count", splitc: "7", wires:[["n2"]] },
                     {id:"n2", type:"helper"}];
-	testTCP(flow, "foo bar", "ACK:foo", done);
+        testTCP(flow, "foo bar", "ACK:foo", done);
     });
 
     it('should send & receive, then keep connection', function(done) {
         var flow = [{id:"n1", type:"tcp request", server:"localhost", port:port, out:"sit", splitc: "5", wires:[["n2"]] },
                     {id:"n2", type:"helper"}];
-	testTCP(flow, "foo", "ACK:foo", done);
+        testTCP(flow, "foo", "ACK:foo", done);
     });
 
     it('should send & close', function(done) {
         var flow = [{id:"n1", type:"tcp request", server:"localhost", port:port, out:"sit", splitc: "5", wires:[["n2"]] },
                     {id:"n2", type:"helper"}];
-	testTCP(flow, "foo", "ACK:foo", done);
+        testTCP(flow, "foo", "ACK:foo", done);
     });
 
     it('should send & recv data to/from server:port from msg', function(done) {
         var flow = [{id:"n1", type:"tcp request", server:"", port:"", out:"time", splitc: "0", wires:[["n2"]] },
                     {id:"n2", type:"helper"}];
-	testTCP(flow, {payload:"foo", host:"localhost", port:port}, "ACK:foo", done)
+        testTCP(flow, {payload:"foo", host:"localhost", port:port}, "ACK:foo", done)
     });
-
 });


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

## Proposed changes

- queues messages on a per-client basis while waiting for TCP server connection
- add [`denque`](https://npm.im/denque) package for performance
- add tests
- remove a duplicate test in `31-tcp_request.spec.js`

This code uses ES6 conventions allowed in Node.js v4.x (the tests pass on this version).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
