### PR TITLE
use "files" prop of package.json; remove .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-.settings
-.jshintignore
-.jshintrc
-.project
-.tern-project
-.travis.yml
-.git

--- a/package.json
+++ b/package.json
@@ -110,5 +110,18 @@
     },
     "engines": {
         "node": ">=4"
-    }
+    },
+    "files": [
+        "red.js",
+        "settings.js",
+        "red/",
+        "nodes/",
+        "lib/",
+        "editor/",
+        "bin/",
+        "public/",
+        "CHANGELOG.md",
+        "CODE_OF_CONDUCT.md",
+        "CONTRIBUTING.md"
+    ]
 }


### PR DESCRIPTION
This makes the list of files to be published a *whitelist* instead of a *blacklist* (`.npmignore`).  This is typically a safer option.  Effectively, there will be no change to the list of files which are published.

`README.md`, `LICENSE` and `package.json` are automatically published by npm.

* * *

This is a refactor (if that).  Anecdotally, I've found the `files` prop of `package.json` to be safer than just relying on `.npmignore`.  This may very well be a "best practice," but I have no references.

In a nutshell, the implications are that of changing any hypothetical permission from "deny" to "allow". 

I didn't feel like anyone would feel strongly about this change (or at least any more strongly than I do), so I did not raise it on the mailing list.

