### PR TITLE
bind to correct port when doing udp broadcast/multicast

### DIFF
--- a/nodes/core/io/32-udp.html
+++ b/nodes/core/io/32-udp.html
@@ -29,7 +29,7 @@
     </div>
     <div class="form-row node-input-iface">
         <label for="node-input-iface"><i class="fa fa-random"></i> <span data-i18n="udp.label.interface"></span></label>
-        <input type="text" id="node-input-iface" data-i18n="[placeholder]udp.label.interfaceprompt">
+        <input type="text" id="node-input-iface" data-i18n="[placeholder]udp.placeholder.interfaceprompt">
     </div>
     <div class="form-row">
         <label for="node-input-port"><i class="fa fa-sign-in"></i> <span data-i18n="udp.label.onport"></span></label>

--- a/nodes/core/io/32-udp.js
+++ b/nodes/core/io/32-udp.js
@@ -32,12 +32,20 @@ module.exports = function(RED) {
         var node = this;
 
         if (node.iface && node.iface.indexOf(".") === -1) {
-            try { // using ip4 in preference if specifying interface only.
+            try {
                 if ((os.networkInterfaces())[node.iface][0].hasOwnProperty("scopeid")) {
-                    node.iface = (os.networkInterfaces())[node.iface][1].address;
+                    if (node.ipv === "udp4") {
+                        node.iface = (os.networkInterfaces())[node.iface][1].address;
+                    } else {
+                        node.iface = (os.networkInterfaces())[node.iface][0].address;
+                    }
                 }
                 else {
-                    node.iface = (os.networkInterfaces())[node.iface][0].address;
+                    if (node.ipv === "udp4") {
+                        node.iface = (os.networkInterfaces())[node.iface][0].address;
+                    } else {
+                        node.iface = (os.networkInterfaces())[node.iface][1].address;
+                    }
                 }
             }
             catch(e) {
@@ -138,12 +146,20 @@ module.exports = function(RED) {
         var node = this;
 
         if (node.iface && node.iface.indexOf(".") === -1) {
-            try { // using ip4 in preference if specifying interface only.
+            try {
                 if ((os.networkInterfaces())[node.iface][0].hasOwnProperty("scopeid")) {
-                    node.iface = (os.networkInterfaces())[node.iface][1].address;
+                    if (node.ipv === "udp4") {
+                        node.iface = (os.networkInterfaces())[node.iface][1].address;
+                    } else {
+                        node.iface = (os.networkInterfaces())[node.iface][0].address;
+                    }
                 }
                 else {
-                    node.iface = (os.networkInterfaces())[node.iface][0].address;
+                    if (node.ipv === "udp4") {
+                        node.iface = (os.networkInterfaces())[node.iface][0].address;
+                    } else {
+                        node.iface = (os.networkInterfaces())[node.iface][1].address;
+                    }
                 }
             }
             catch(e) {

--- a/nodes/core/io/32-udp.js
+++ b/nodes/core/io/32-udp.js
@@ -195,7 +195,7 @@ module.exports = function(RED) {
                         try {
                             sock.setMulticastTTL(128);
                             sock.addMembership(node.addr,node.iface);   // Add to the multicast group
-                            node.log(RED._("udp.status.mc-ready",{outport:node.outport,host:node.addr,port:node.port}));
+                            node.log(RED._("udp.status.mc-ready",{iface:node.iface,outport:node.outport,host:node.addr,port:node.port}));
                         } catch (e) {
                             if (e.errno == "EINVAL") {
                                 node.error(RED._("udp.errors.bad-mcaddress"));

--- a/nodes/core/io/32-udp.js
+++ b/nodes/core/io/32-udp.js
@@ -16,6 +16,7 @@
 
 module.exports = function(RED) {
     "use strict";
+    var os = require('os');
     var dgram = require('dgram');
     var udpInputPortsInUse = {};
 
@@ -30,6 +31,21 @@ module.exports = function(RED) {
         this.ipv = n.ipv || "udp4";
         var node = this;
 
+        if (node.iface && node.iface.indexOf(".") === -1) {
+            try { // using ip4 in preference if specifying interface only.
+                if ((os.networkInterfaces())[node.iface][0].hasOwnProperty("scopeid")) {
+                    node.iface = (os.networkInterfaces())[node.iface][1].address;
+                }
+                else {
+                    node.iface = (os.networkInterfaces())[node.iface][0].address;
+                }
+            }
+            catch(e) {
+                node.warn(RED._("udp.errors.ifnotfound",{iface:node.iface}));
+                node.iface = null;
+            }
+        }
+
         var opts = {type:node.ipv, reuseAddr:true};
         if (process.version.indexOf("v0.10") === 0) { opts = node.ipv; }
         var server;
@@ -39,7 +55,7 @@ module.exports = function(RED) {
             udpInputPortsInUse[this.port] = server;
         }
         else {
-            node.warn(RED._("udp.errors.alreadyused",node.port));
+            node.warn(RED._("udp.errors.alreadyused",{port:node.port}));
             server = udpInputPortsInUse[this.port];  // re-use existing
         }
 
@@ -120,6 +136,21 @@ module.exports = function(RED) {
         this.multicast = n.multicast;
         this.ipv = n.ipv || "udp4";
         var node = this;
+
+        if (node.iface && node.iface.indexOf(".") === -1) {
+            try { // using ip4 in preference if specifying interface only.
+                if ((os.networkInterfaces())[node.iface][0].hasOwnProperty("scopeid")) {
+                    node.iface = (os.networkInterfaces())[node.iface][1].address;
+                }
+                else {
+                    node.iface = (os.networkInterfaces())[node.iface][0].address;
+                }
+            }
+            catch(e) {
+                node.warn(RED._("udp.errors.ifnotfound",{iface:node.iface}));
+                node.iface = null;
+            }
+        }
 
         var opts = {type:node.ipv, reuseAddr:true};
         if (process.version.indexOf("v0.10") === 0) { opts = node.ipv; }

--- a/nodes/core/io/32-udp.js
+++ b/nodes/core/io/32-udp.js
@@ -125,8 +125,11 @@ module.exports = function(RED) {
         if (process.version.indexOf("v0.10") === 0) { opts = node.ipv; }
 
         var sock;
-        if (udpInputPortsInUse[this.outport || this.port]) {
-            sock = udpInputPortsInUse[this.outport || this.port];
+        var p = this.port;
+        if (node.multicast != "false") { p = this.outport||"0"; }
+        if (udpInputPortsInUse[p]) {
+            sock = udpInputPortsInUse[p];
+            node.log(RED._("udp.status.re-use",{outport:node.outport,host:node.addr,port:node.port}));
         }
         else {
             sock = dgram.createSocket(opts);  // default to udp4
@@ -136,36 +139,35 @@ module.exports = function(RED) {
                 // prevent it going to the global error handler and shutting node-red
                 // down.
             });
-            udpInputPortsInUse[this.outport || this.port] = sock;
-        }
+            udpInputPortsInUse[p] = sock;
 
-        if (node.multicast != "false") {
-            if (node.outport === "") { node.outport = node.port; }
-            sock.bind(node.outport, function() {    // have to bind before you can enable broadcast...
-                sock.setBroadcast(true);            // turn on broadcast
-                if (node.multicast == "multi") {
-                    try {
-                        sock.setMulticastTTL(128);
-                        sock.addMembership(node.addr,node.iface);   // Add to the multicast group
-                        node.log(RED._("udp.status.mc-ready",{outport:node.outport,host:node.addr,port:node.port}));
-                    } catch (e) {
-                        if (e.errno == "EINVAL") {
-                            node.error(RED._("udp.errors.bad-mcaddress"));
-                        } else if (e.errno == "ENODEV") {
-                            node.error(RED._("udp.errors.interface"));
-                        } else {
-                            node.error(RED._("udp.errors.error",{error:e.errno}));
+            if (node.multicast != "false") {
+                sock.bind(node.outport, function() {    // have to bind before you can enable broadcast...
+                    sock.setBroadcast(true);            // turn on broadcast
+                    if (node.multicast == "multi") {
+                        try {
+                            sock.setMulticastTTL(128);
+                            sock.addMembership(node.addr,node.iface);   // Add to the multicast group
+                            node.log(RED._("udp.status.mc-ready",{outport:node.outport,host:node.addr,port:node.port}));
+                        } catch (e) {
+                            if (e.errno == "EINVAL") {
+                                node.error(RED._("udp.errors.bad-mcaddress"));
+                            } else if (e.errno == "ENODEV") {
+                                node.error(RED._("udp.errors.interface"));
+                            } else {
+                                node.error(RED._("udp.errors.error",{error:e.errno}));
+                            }
                         }
+                    } else {
+                        node.log(RED._("udp.status.bc-ready",{outport:node.outport,host:node.addr,port:node.port}));
                     }
-                } else {
-                    node.log(RED._("udp.status.bc-ready",{outport:node.outport,host:node.addr,port:node.port}));
-                }
-            });
-        } else if ((node.outport !== "") && (!udpInputPortsInUse[node.outport])) {
-            sock.bind(node.outport);
-            node.log(RED._("udp.status.ready",{outport:node.outport,host:node.addr,port:node.port}));
-        } else {
-            node.log(RED._("udp.status.ready-nolocal",{host:node.addr,port:node.port}));
+                });
+            } else if ((node.outport !== "") && (!udpInputPortsInUse[node.outport])) {
+                sock.bind(node.outport);
+                node.log(RED._("udp.status.ready",{outport:node.outport,host:node.addr,port:node.port}));
+            } else {
+                node.log(RED._("udp.status.ready-nolocal",{host:node.addr,port:node.port}));
+            }
         }
 
         node.on("input", function(msg) {
@@ -198,8 +200,8 @@ module.exports = function(RED) {
         });
 
         node.on("close", function() {
-            if (udpInputPortsInUse.hasOwnProperty(node.outport || node.port)) {
-                delete udpInputPortsInUse[node.outport || node.port];
+            if (udpInputPortsInUse.hasOwnProperty(p)) {
+                delete udpInputPortsInUse[p];
             }
             try {
                 sock.close();

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -539,7 +539,8 @@
             "ip-notset": "udp: ip address not set",
             "port-notset": "udp: port not set",
             "port-invalid": "udp: port number not valid",
-            "alreadyused": "udp: port already in use"
+            "alreadyused": "udp: port __port__ already in use",
+            "ifnotfound": "udp: interface __iface__ not found"
         }
     },
     "switch": {

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -489,15 +489,15 @@
             "using": "using",
             "output": "Output",
             "group": "Group",
-            "interface": "Local IP",
-            "interfaceprompt": "(optional) local ip address to bind to",
+            "interface": "Local IF",
             "send": "Send a",
             "toport": "to port",
             "address": "Address",
             "decode-base64": "Decode Base64 encoded payload?"
         },
         "placeholder": {
-            "interface": "(optional) ip address of eth0",
+            "interface": "(optional) local interface or address to bind to",
+            "interfaceprompt": "(optional) local interface or address to bind to",
             "address": "destination ip"
         },
         "udpmsgs": "udp messages",

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -528,7 +528,8 @@
             "mc-ready": "udp multicast ready: __outport__ -> __host__:__port__",
             "bc-ready": "udp broadcast ready: __outport__ -> __host__:__port__",
             "ready": "udp ready: __outport__ -> __host__:__port__",
-            "ready-nolocal": "udp ready: __host__:__port__"
+            "ready-nolocal": "udp ready: __host__:__port__",
+            "re-use": "udp re-use socket: __outport__ -> __host__:__port__"
         },
         "errors": {
             "access-error": "UDP access error, you may need root access for ports below 1024",

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -525,7 +525,7 @@
             "mc-group": "udp multicast group __group__",
             "listener-stopped": "udp listener stopped",
             "output-stopped": "udp output stopped",
-            "mc-ready": "udp multicast ready: __outport__ -> __host__:__port__",
+            "mc-ready": "udp multicast ready: __iface__:__outport__ -> __host__:__port__",
             "bc-ready": "udp broadcast ready: __outport__ -> __host__:__port__",
             "ready": "udp ready: __outport__ -> __host__:__port__",
             "ready-nolocal": "udp ready: __host__:__port__",

--- a/nodes/core/locales/ja/messages.json
+++ b/nodes/core/locales/ja/messages.json
@@ -526,7 +526,8 @@
             "mc-ready": "udpノードはマルチキャストの準備ができています: __outport__ -> __host__:__port__",
             "bc-ready": "udpノードはブロードキャストの準備ができています: __outport__ -> __host__:__port__",
             "ready": "udpノードは準備ができています: __outport__ -> __host__:__port__",
-            "ready-nolocal": "udpノードは準備ができています: __host__:__port__"
+            "ready-nolocal": "udpノードは準備ができています: __host__:__port__",
+            "re-use": "udp再利用ソケット: __outport__ -> __host__:__port__"
         },
         "errors": {
             "access-error": "UDP接続エラー 管理者権限で1024未満のポート番号にアクセスできる必要があります",

--- a/nodes/core/locales/zh-CN/messages.json
+++ b/nodes/core/locales/zh-CN/messages.json
@@ -525,7 +525,8 @@
             "mc-ready": "udp 组播已准备好: __outport__ -> __host__:__port__",
             "bc-ready": "udp 广播已准备好: __outport__ -> __host__:__port__",
             "ready": "udp 已准备好: __outport__ -> __host__:__port__",
-            "ready-nolocal": "udp 已准备好: __host__:__port__"
+            "ready-nolocal": "udp 已准备好: __host__:__port__",
+            "re-use": "udp 重用套接字: __outport__ -> __host__:__port__"
         },
         "errors": {
             "access-error": "UDP 访问错误, 你可能需要root权限才能接入1024以下的端口",


### PR DESCRIPTION
to allow better re-use of ports. Currently in order to broadcast/multicast you have to bind to a port… - if not specified we were binding the local port to the remote port number. We should be binding locally to a random port if not otherwise specified.