### PR TITLE
Handle and display for invalid flow credentials when project is disabled #1689

### DIFF
--- a/editor/js/main.js
+++ b/editor/js/main.js
@@ -201,7 +201,7 @@
                                     }
                                 }
                             ]
-                        }   
+                        }
                     } else if (msg.error === "missing_flow_file") {
                         if (RED.user.hasPermission("projects.write")) {
                             options.buttons = [

--- a/editor/js/main.js
+++ b/editor/js/main.js
@@ -179,17 +179,29 @@
                             ]
                         }
                     } else if (msg.error === "credentials_load_failed") {
-                        if (RED.user.hasPermission("projects.write")) {
+                        if (RED.settings.theme("projects.enabled",false)) {
+                            // projects enabled
+                            if (RED.user.hasPermission("projects.write")) {
+                                options.buttons = [
+                                    {
+                                        text: "Setup credentials",
+                                        click: function() {
+                                            persistentNotifications[notificationId].hideNotification();
+                                            RED.projects.showCredentialsPrompt();
+                                        }
+                                    }
+                                ]
+                            }
+                        } else {
                             options.buttons = [
                                 {
-                                    text: "Setup credentials",
+                                    text: "Close",
                                     click: function() {
                                         persistentNotifications[notificationId].hideNotification();
-                                        RED.projects.showCredentialsPrompt();
                                     }
                                 }
                             ]
-                        }
+                        }   
                     } else if (msg.error === "missing_flow_file") {
                         if (RED.user.hasPermission("projects.write")) {
                             options.buttons = [

--- a/red/api/editor/locales/en-US/editor.json
+++ b/red/api/editor/locales/en-US/editor.json
@@ -91,6 +91,7 @@
             "missing-types": "<p>Flows stopped due to missing node types.</p>",
             "restartRequired": "Node-RED must be restarted to enable upgraded modules",
             "credentials_load_failed": "<p>Flows stopped as the credentials could not be decrypted.</p><p>The flow credential file is encrypted, but the project's encryption key is missing or invalid.</p>",
+            "credentials_load_failed_reset":"<p>Credentials could not be decrypted</p><p>The flow credential file is encrypted, but the project's encryption key is missing or invalid.</p><p>The flow credential file will be reset on the next deployment. Any existing flow credentials will be cleared.</p>",
             "missing_flow_file": "<p>Project flow file not found.</p><p>The project is not configured with a flow file.</p>",
             "project_empty": "<p>The project is empty.</p><p>Do you want to create a default set of project files?<br/>Otherwise, you will have to manually add files to the project outside of the editor.</p>",
             "project_not_found": "<p>Project '__project__' not found.</p>",

--- a/red/runtime/nodes/flows/index.js
+++ b/red/runtime/nodes/flows/index.js
@@ -403,7 +403,7 @@ function stop(type,diff,muteLog) {
             // id to the list of subflow instance nodes is something only Flow
             // can do... so cheat by wiping the map knowing it'll be rebuilt
             // in start()
-            subflowInstancgeNodeMap = {};
+            subflowInstanceNodeMap = {};
             if (!muteLog) {
                 if (type !== "full") {
                     log.info(log._("nodes.flows.stopped-modified-"+type));

--- a/red/runtime/nodes/flows/index.js
+++ b/red/runtime/nodes/flows/index.js
@@ -37,6 +37,7 @@ var activeFlowConfig = null;
 
 var activeFlows = {};
 var started = false;
+var credentialsPendingReset = false;
 
 var activeNodesToFlow = {};
 var subflowInstanceNodeMap = {};
@@ -70,21 +71,31 @@ function init(runtime) {
 }
 
 function loadFlows() {
-    return storage.getFlows().then(function(config) {
+    var config;
+    return storage.getFlows().then(function(_config) {
+        config = _config;
         log.debug("loaded flow revision: "+config.rev);
         return credentials.load(config.credentials).then(function() {
             events.emit("runtime-event",{id:"runtime-state",retain:true});
             return config;
         });
     }).catch(function(err) {
-        activeConfig = null;
-        events.emit("runtime-event",{id:"runtime-state",payload:{type:"warning",error:err.code,project:err.project,text:"notification.warnings."+err.code},retain:true});
-        if (err.code === "project_not_found") {
-            log.warn(log._("storage.localfilesystem.projects.project-not-found",{project:err.project}));
-        } else {
+        if (err.code === "credentials_load_failed" && !storage.projects) {
+            // project disabled, credential load failed
+            credentialsPendingReset = true;
             log.warn(log._("nodes.flows.error",{message:err.toString()}));
+            events.emit("runtime-event",{id:"runtime-state",payload:{type:"warning",error:err.code,text:"notification.warnings.credentials_load_failed_reset"},retain:true});
+            return config;
+        } else {
+            activeConfig = null;
+            events.emit("runtime-event",{id:"runtime-state",payload:{type:"warning",error:err.code,project:err.project,text:"notification.warnings."+err.code},retain:true});
+            if (err.code === "project_not_found") {
+                log.warn(log._("storage.localfilesystem.projects.project-not-found",{project:err.project}));
+            } else {
+                log.warn(log._("nodes.flows.error",{message:err.toString()}));
+            }
+            throw err;
         }
-        throw err;
     });
 }
 function load(forceStart) {
@@ -317,7 +328,12 @@ function start(type,diff,muteLog) {
         }
     }
     events.emit("nodes-started");
-    events.emit("runtime-event",{id:"runtime-state",retain:true});
+
+    if (credentialsPendingReset === true) {
+        credentialsPendingReset = false;
+    } else {
+        events.emit("runtime-event",{id:"runtime-state",retain:true});
+    }
 
     if (!muteLog) {
         if (type !== "full") {
@@ -387,7 +403,7 @@ function stop(type,diff,muteLog) {
             // id to the list of subflow instance nodes is something only Flow
             // can do... so cheat by wiping the map knowing it'll be rebuilt
             // in start()
-            subflowInstanceNodeMap = {};
+            subflowInstancgeNodeMap = {};
             if (!muteLog) {
                 if (type !== "full") {
                     log.info(log._("nodes.flows.stopped-modified-"+type));


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

See issue #1689 

This pull request will revert pre 0.18 behaviour and not block the flow from starting when run time is unable to decrypt flow credentials using the `credentialSecret` supplied in `settings.js` or `.config.json`. It also adds a runtime state notification that will persist to inform the user that their credentials will be reset on the next deployment. Changes should not affect projects behaviour if it is enabled.

[Demo](https://i.imgur.com/bNUORg2.gif)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
