### PR TITLE
add output property select to HTML parse node

### DIFF
--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -671,7 +671,8 @@
     "html": {
         "label": {
             "select": "Selector",
-            "output": "Output"
+            "output": "Output",
+            "in": "in"
         },
         "output": {
             "html": "the html content of the elements",

--- a/nodes/core/parsers/70-HTML.html
+++ b/nodes/core/parsers/70-HTML.html
@@ -2,7 +2,7 @@
 <script type="text/x-red" data-template-name="html">
     <div class="form-row">
         <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> <span data-i18n="node-red:common.label.property"></span></label>
-        <input type="text" id="node-input-property" style="width:70%;"/>
+        <input type="text" id="node-input-property" style="width:70%">
     </div>
     <div class="form-row">
         <label for="node-input-tag"><i class="fa fa-filter"></i> <span data-i18n="html.label.select"></span></label>
@@ -23,6 +23,10 @@
             <option value="single" data-i18n="html.format.single"></option>
             <option value="multi" data-i18n="html.format.multi"></option>
         </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-outproperty">&nbsp;</label>
+        <span data-i18n="html.label.in" style="padding-left:8px; padding-right:2px; vertical-align:-1px;"></span> <input type="text" id="node-input-outproperty" style="width:64%">
     </div>
     <br/>
     <div class="form-row">
@@ -59,6 +63,7 @@
         defaults: {
             name: {value:""},
             property: {value:"payload"},
+            outproperty: {value:"payload"},
             tag: {value:""},
             ret: {value:"html"},
             as: {value:"single"}
@@ -74,6 +79,7 @@
         },
         oneditprepare: function() {
             $("#node-input-property").typedInput({default:'msg',types:['msg']});
+            $("#node-input-outproperty").typedInput({default:'msg',types:['msg']});
         }
     });
 </script>

--- a/nodes/core/parsers/70-HTML.js
+++ b/nodes/core/parsers/70-HTML.js
@@ -21,6 +21,7 @@ module.exports = function(RED) {
     function CheerioNode(n) {
         RED.nodes.createNode(this,n);
         this.property = n.property||"payload";
+        this.outproperty = n.outproperty||this.property||"payload";
         this.tag = n.tag;
         this.ret = n.ret || "html";
         this.as = n.as || "single";
@@ -48,7 +49,7 @@ module.exports = function(RED) {
                             /* istanbul ignore else */
                             if (pay2) {
                                 var new_msg = RED.util.cloneMessage(msg);
-                                RED.util.setMessageProperty(new_msg,node.property,pay2);
+                                RED.util.setMessageProperty(new_msg,node.outproperty,pay2);
                                 new_msg.parts = {
                                     id: msg._msgid,
                                     index: index,
@@ -68,7 +69,7 @@ module.exports = function(RED) {
                         index++;
                     });
                     if (node.as === "single") {  // Always return an array - even if blank
-                        RED.util.setMessageProperty(msg,node.property,pay);
+                        RED.util.setMessageProperty(msg,node.outproperty,pay);
                         node.send(msg);
                     }
                 }

--- a/test/nodes/core/parsers/70-HTML_spec.js
+++ b/test/nodes/core/parsers/70-HTML_spec.js
@@ -66,7 +66,7 @@ describe('html node', function() {
         });
     });
 
-    it('should retrieve header contents if asked to by msg.select - alternative property', function(done) {
+    it('should retrieve header contents if asked to by msg.select - alternative in property', function(done) {
         fs.readFile(file, 'utf8', function(err, data) {
             var flow = [{id:"n1",type:"html",property:"foo",wires:[["n2"]],func:"return msg;"},
                         {id:"n2", type:"helper"}];
@@ -76,10 +76,28 @@ describe('html node', function() {
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
                     msg.should.have.property('topic', 'bar');
-                    should.equal(msg.foo, 'This is a test page for node 70-HTML');
+                    msg.foo[0].should.equal('This is a test page for node 70-HTML');
                     done();
                 });
                 n1.receive({foo:data,topic:"bar",select:"h1"});
+            });
+        });
+    });
+
+    it('should retrieve header contents if asked to by msg.select - alternative in and out properties', function(done) {
+        fs.readFile(file, 'utf8', function(err, data) {
+            var flow = [{id:"n1",type:"html",property:"foo",outproperty:"bar",tag:"h1",wires:[["n2"]],func:"return msg;"},
+                        {id:"n2", type:"helper"}];
+
+            helper.load(htmlNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                n2.on("input", function(msg) {
+                    msg.should.have.property('topic', 'bar');
+                    msg.bar[0].should.equal('This is a test page for node 70-HTML');
+                    done();
+                });
+                n1.receive({foo:data,topic:"bar"});
             });
         });
     });


### PR DESCRIPTION
When parsing HTML documents it makes sense to let the output actually be on a different property than the input property - so that nodes can be chained more easily.