### PR TITLE
add Node.js v10 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - "10"
   - "8"
   - "6"
   - "4"


### PR DESCRIPTION
# Proposed changes

This adds the newest Node.js LTS, v10, to the build matrix.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
