### PR TITLE
Fix ENOENT error on first start when no user dir

### DIFF
--- a/red/runtime/storage/localfilesystem/util.js
+++ b/red/runtime/storage/localfilesystem/util.js
@@ -79,13 +79,6 @@ module.exports = {
      * the write hits disk.
      */
      writeFile: function(path,content,backupPath) {
-         if (backupPath) {
-             try {
-                 fs.renameSync(path,backupPath);
-             } catch(err) {
-                 console.log(err);
-             }
-         }
          return when.promise(function(resolve,reject) {
              var stream = fs.createWriteStream(path);
              stream.on('open',function(fd) {
@@ -96,6 +89,13 @@ module.exports = {
                          }
                          stream.end(resolve);
                      });
+                     if (backupPath) {
+                         try {
+                             fs.copySync(path,backupPath);
+                         } catch(err) {
+                             console.log(err);
+                         }
+                     }
                  });
              });
              stream.on('error',function(err) {

--- a/red/runtime/storage/localfilesystem/util.js
+++ b/red/runtime/storage/localfilesystem/util.js
@@ -79,29 +79,27 @@ module.exports = {
      * the write hits disk.
      */
      writeFile: function(path,content,backupPath) {
-         return when.promise(function(resolve,reject) {
-             var stream = fs.createWriteStream(path);
-             stream.on('open',function(fd) {
-                 stream.write(content,'utf8',function() {
-                     fs.fsync(fd,function(err) {
-                         if (err) {
-                             log.warn(log._("storage.localfilesystem.fsync-fail",{path: path, message: err.toString()}));
-                         }
-                         stream.end(resolve);
-                     });
-                     if (backupPath) {
-                         try {
-                             fs.copySync(path,backupPath);
-                         } catch(err) {
-                             console.log(err);
-                         }
-                     }
-                 });
-             });
-             stream.on('error',function(err) {
-                 reject(err);
-             });
-         });
+         if (backupPath) {
+            if (fs.existsSync(path)) {
+                fs.renameSync(path,backupPath);
+            }
+        }
+        return when.promise(function(resolve,reject) {
+            var stream = fs.createWriteStream(path);
+            stream.on('open',function(fd) {
+                stream.write(content,'utf8',function() {
+                    fs.fsync(fd,function(err) {
+                        if (err) {
+                            log.warn(log._("storage.localfilesystem.fsync-fail",{path: path, message: err.toString()}));
+                        }
+                        stream.end(resolve);
+                    });
+                });
+            });
+            stream.on('error',function(err) {
+                reject(err);
+            });
+        });
      },
     readFile: readFile,
 


### PR DESCRIPTION
This PR is related to an issue in master branch where NR attempts to backup the .config.json file before it's been written to disk. Changes backup to use `copySync` and moves it below the `fsync` to ensure file is present when backup is made.