### PR TITLE
Mqtt close ui

### DIFF
--- a/nodes/core/io/10-mqtt.html
+++ b/nodes/core/io/10-mqtt.html
@@ -212,48 +212,89 @@
                 <input type="password" id="node-config-input-password">
             </div>
         </div>
-        <div id="mqtt-broker-tab-birth" style="display:none">
-            <div class="form-row">
-                <label for="node-config-input-birthTopic"><i class="fa fa-tasks"></i> <span data-i18n="common.label.topic"></span></label>
-                <input type="text" id="node-config-input-birthTopic" data-i18n="[placeholder]mqtt.placeholder.birth-topic">
+        <div id="mqtt-broker-tab-messages" style="display:none">
+            <div id="mqtt-broker-section-birth">
+                <div class="palette-header">
+                    <i class="fa fa-angle-down expanded"></i><span>Message sent on connection (birth message)</span>
+                </div>
+                <div class="section-content" style="padding: 12px">
+                    <div class="form-row">
+                        <label for="node-config-input-birthTopic"><i class="fa fa-tasks"></i> <span data-i18n="common.label.topic"></span></label>
+                        <input type="text" id="node-config-input-birthTopic" data-i18n="[placeholder]mqtt.placeholder.birth-topic">
+                    </div>
+                    <div class="form-row">
+                        <label for="node-config-input-birthQos"><i class="fa fa-empire"></i> <span data-i18n="mqtt.label.qos"></span></label>
+                        <select id="node-config-input-birthQos" style="width:125px !important">
+                            <option value="0">0</option>
+                            <option value="1">1</option>
+                            <option value="2">2</option>
+                        </select>
+                        &nbsp;&nbsp;<i class="fa fa-history"></i>&nbsp;<span data-i18n="mqtt.retain"></span> &nbsp;<select id="node-config-input-birthRetain" style="width:125px !important">
+                            <option value="false" data-i18n="mqtt.false"></option>
+                            <option value="true" data-i18n="mqtt.true"></option>
+                        </select>
+                    </div>
+                    <div class="form-row">
+                        <label for="node-config-input-birthPayload"><i class="fa fa-envelope"></i> <span data-i18n="common.label.payload"></span></label>
+                        <input type="text" id="node-config-input-birthPayload" data-i18n="[placeholder]common.label.payload">
+                    </div>
+                </div>
             </div>
-            <div class="form-row">
-                <label for="node-config-input-birthQos"><i class="fa fa-empire"></i> <span data-i18n="mqtt.label.qos"></span></label>
-                <select id="node-config-input-birthQos" style="width:125px !important">
-                    <option value="0">0</option>
-                    <option value="1">1</option>
-                    <option value="2">2</option>
-                </select>
-                &nbsp;&nbsp;<i class="fa fa-history"></i>&nbsp;<span data-i18n="mqtt.retain"></span> &nbsp;<select id="node-config-input-birthRetain" style="width:125px !important">
-                    <option value="false" data-i18n="mqtt.false"></option>
-                    <option value="true" data-i18n="mqtt.true"></option>
-                </select>
+            <div id="mqtt-broker-section-will">
+                <div class="palette-header">
+                    <i class="fa fa-angle-down expanded"></i><span>Message sent on an unexpected disconnection (will message)</span>
+                </div>
+                <div class="section-content" style="padding: 12px">
+                    <div class="form-row">
+                        <label for="node-config-input-willTopic"><i class="fa fa-tasks"></i> <span data-i18n="common.label.topic"></span></label>
+                        <input type="text" id="node-config-input-willTopic" data-i18n="[placeholder]mqtt.placeholder.will-topic">
+                    </div>
+                    <div class="form-row">
+                        <label for="node-config-input-willQos"><i class="fa fa-empire"></i> <span data-i18n="mqtt.label.qos"></span></label>
+                        <select id="node-config-input-willQos" style="width:125px !important">
+                            <option value="0">0</option>
+                            <option value="1">1</option>
+                            <option value="2">2</option>
+                        </select>
+                        &nbsp;&nbsp;<i class="fa fa-history"></i>&nbsp;<span data-i18n="mqtt.retain"></span> &nbsp;<select id="node-config-input-willRetain" style="width:125px !important">
+                            <option value="false" data-i18n="mqtt.false"></option>
+                            <option value="true" data-i18n="mqtt.true"></option>
+                        </select>
+                    </div>
+                    <div class="form-row">
+                        <label for="node-config-input-willPayload"><i class="fa fa-envelope"></i> <span data-i18n="common.label.payload"></span></label>
+                        <input type="text" id="node-config-input-willPayload" data-i18n="[placeholder]common.label.payload">
+                    </div>
+                </div>
             </div>
-            <div class="form-row">
-                <label for="node-config-input-birthPayload"><i class="fa fa-envelope"></i> <span data-i18n="common.label.payload"></span></label>
-                <input type="text" id="node-config-input-birthPayload" data-i18n="[placeholder]common.label.payload">
-            </div>
-        </div>
-        <div id="mqtt-broker-tab-will" style="display:none">
-            <div class="form-row">
-                <label for="node-config-input-willTopic"><i class="fa fa-tasks"></i> <span data-i18n="common.label.topic"></span></label>
-                <input type="text" id="node-config-input-willTopic" data-i18n="[placeholder]mqtt.placeholder.will-topic">
-            </div>
-            <div class="form-row">
-                <label for="node-config-input-willQos"><i class="fa fa-empire"></i> <span data-i18n="mqtt.label.qos"></span></label>
-                <select id="node-config-input-willQos" style="width:125px !important">
-                    <option value="0">0</option>
-                    <option value="1">1</option>
-                    <option value="2">2</option>
-                </select>
-                &nbsp;&nbsp;<i class="fa fa-history"></i>&nbsp;<span data-i18n="mqtt.retain"></span> &nbsp;<select id="node-config-input-willRetain" style="width:125px !important">
-                    <option value="false" data-i18n="mqtt.false"></option>
-                    <option value="true" data-i18n="mqtt.true"></option>
-                </select>
-            </div>
-            <div class="form-row">
-                <label for="node-config-input-willPayload"><i class="fa fa-envelope"></i> <span data-i18n="common.label.payload"></span></label>
-                <input type="text" id="node-config-input-willPayload" data-i18n="[placeholder]common.label.payload">
+            <div id="mqtt-broker-section-close">
+                <div class="palette-header">
+                    <i class="fa fa-angle-down"></i><span>Message sent before disconnecting (close message)</span>
+                </div>
+                <div class="section-content" style="padding: 12px; display:none">
+                    <div style="padding: 12px;">
+                        <div class="form-row">
+                            <label for="node-config-input-willTopic"><i class="fa fa-tasks"></i> <span data-i18n="common.label.topic"></span></label>
+                            <input type="text" id="node-config-input-willTopic" data-i18n="[placeholder]mqtt.placeholder.will-topic">
+                        </div>
+                        <div class="form-row">
+                            <label for="node-config-input-willQos"><i class="fa fa-empire"></i> <span data-i18n="mqtt.label.qos"></span></label>
+                            <select id="node-config-input-willQos" style="width:125px !important">
+                                <option value="0">0</option>
+                                <option value="1">1</option>
+                                <option value="2">2</option>
+                            </select>
+                            &nbsp;&nbsp;<i class="fa fa-history"></i>&nbsp;<span data-i18n="mqtt.retain"></span> &nbsp;<select id="node-config-input-willRetain" style="width:125px !important">
+                                <option value="false" data-i18n="mqtt.false"></option>
+                                <option value="true" data-i18n="mqtt.true"></option>
+                            </select>
+                        </div>
+                        <div class="form-row">
+                            <label for="node-config-input-willPayload"><i class="fa fa-envelope"></i> <span data-i18n="common.label.payload"></span></label>
+                            <input type="text" id="node-config-input-willPayload" data-i18n="[placeholder]common.label.payload">
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -277,6 +318,29 @@
        field should be configured with a full URI for the connection. For example:</p>
     <pre>ws://example.com:4000/mqtt</pre>
 
+</script>
+
+<script type="text/x-red" data-template-name="mqtt-broker-section-birth">
+    <div class="form-row">
+        <label for="node-config-input-birthTopic"><i class="fa fa-tasks"></i> <span data-i18n="common.label.topic"></span></label>
+        <input type="text" id="node-config-input-birthTopic" data-i18n="[placeholder]mqtt.placeholder.birth-topic">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-birthQos"><i class="fa fa-empire"></i> <span data-i18n="mqtt.label.qos"></span></label>
+        <select id="node-config-input-birthQos" style="width:125px !important">
+            <option value="0">0</option>
+            <option value="1">1</option>
+            <option value="2">2</option>
+        </select>
+        &nbsp;&nbsp;<i class="fa fa-history"></i>&nbsp;<span data-i18n="mqtt.retain"></span> &nbsp;<select id="node-config-input-birthRetain" style="width:125px !important">
+            <option value="false" data-i18n="mqtt.false"></option>
+            <option value="true" data-i18n="mqtt.true"></option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-birthPayload"><i class="fa fa-envelope"></i> <span data-i18n="common.label.payload"></span></label>
+        <input type="text" id="node-config-input-birthPayload" data-i18n="[placeholder]common.label.payload">
+    </div>
 </script>
 
 <script type="text/javascript">
@@ -307,7 +371,11 @@
             birthTopic: {value:""},
             birthQos: {value:"0"},
             birthRetain: {value:false},
-            birthPayload: {value:""}
+            birthPayload: {value:""},
+            closeTopic: {value:""},
+            closeTopic: {value:"0"},
+            closeTopic: {value:false},
+            closeTopic: {value:""}
         },
         credentials: {
             user: {type:"text"},
@@ -343,14 +411,29 @@
                 id: "mqtt-broker-tab-security",
                 label: this._("mqtt.tabs-label.security")
             });
+            
             tabs.addTab({
-                id: "mqtt-broker-tab-birth",
-                label: this._("mqtt.tabs-label.birth")
+                id: "mqtt-broker-tab-messages",
+                label: this._("mqtt.tabs-label.messages")
             });
-            tabs.addTab({
-                id: "mqtt-broker-tab-will",
-                label: this._("mqtt.tabs-label.will")
-            });
+
+            function setUpSection(sectionId) {
+                var birthMessageSection = $(sectionId);
+                var paletteHeader = birthMessageSection.find('.palette-header');
+                var sectionContent = birthMessageSection.find('.section-content');
+
+                paletteHeader.click(function(e) {
+                    e.preventDefault();
+                    var twistie = $(this).find('i');
+                    var isExpanded = twistie.hasClass('expanded');
+                    sectionContent.toggle(!isExpanded);
+                    twistie.toggleClass('expanded',!isExpanded);
+                });
+            }
+            setUpSection('#mqtt-broker-section-birth');
+            setUpSection('#mqtt-broker-section-will');
+            setUpSection('#mqtt-broker-section-close');
+
             setTimeout(function() { tabs.resize(); },0);
             if (typeof this.cleansession === 'undefined') {
                 this.cleansession = true;
@@ -375,6 +458,10 @@
             if (typeof this.birthQos === 'undefined') {
                 this.birthQos = "0";
                 $("#node-config-input-birthQos").val("0");
+            }
+            if (typeof this.closeQos === 'undefined') {
+                this.willQos = "0";
+                $("#node-config-input-willQos").val("0");
             }
 
             function updateTLSOptions() {

--- a/nodes/core/io/10-mqtt.html
+++ b/nodes/core/io/10-mqtt.html
@@ -215,84 +215,82 @@
         <div id="mqtt-broker-tab-messages" style="display:none">
             <div id="mqtt-broker-section-birth">
                 <div class="palette-header">
-                    <i class="fa fa-angle-down expanded"></i><span>Message sent on connection (birth message)</span>
+                    <i class="fa fa-angle-down expanded"></i><span data-i18n="mqtt.sections-label.birth-message"></span>
                 </div>
                 <div class="section-content" style="padding: 12px">
                     <div class="form-row">
                         <label for="node-config-input-birthTopic"><i class="fa fa-tasks"></i> <span data-i18n="common.label.topic"></span></label>
-                        <input type="text" id="node-config-input-birthTopic" data-i18n="[placeholder]mqtt.placeholder.birth-topic">
-                    </div>
-                    <div class="form-row">
-                        <label for="node-config-input-birthQos"><i class="fa fa-empire"></i> <span data-i18n="mqtt.label.qos"></span></label>
-                        <select id="node-config-input-birthQos" style="width:125px !important">
-                            <option value="0">0</option>
-                            <option value="1">1</option>
-                            <option value="2">2</option>
-                        </select>
-                        &nbsp;&nbsp;<i class="fa fa-history"></i>&nbsp;<span data-i18n="mqtt.retain"></span> &nbsp;<select id="node-config-input-birthRetain" style="width:125px !important">
+                        <input type="text" id="node-config-input-birthTopic" data-i18n="[placeholder]mqtt.placeholder.birth-topic" style="width:300px !important">
+                        &nbsp;&nbsp;
+                        <i class="fa fa-history"></i> <span data-i18n="mqtt.label.retain"></span> <select id="node-config-input-birthRetain" style="float: right; width:75px !important">
                             <option value="false" data-i18n="mqtt.false"></option>
                             <option value="true" data-i18n="mqtt.true"></option>
                         </select>
                     </div>
                     <div class="form-row">
                         <label for="node-config-input-birthPayload"><i class="fa fa-envelope"></i> <span data-i18n="common.label.payload"></span></label>
-                        <input type="text" id="node-config-input-birthPayload" data-i18n="[placeholder]common.label.payload">
+                        <input type="text" id="node-config-input-birthPayload" style="width:300px" data-i18n="[placeholder]common.label.payload">
+                        &nbsp;&nbsp;
+                        <i class="fa fa-empire"></i> <span data-i18n="mqtt.label.qos"></span></label>
+                        <select id="node-config-input-birthQos" style="float: right; width:75px !important">
+                            <option value="0">0</option>
+                            <option value="1">1</option>
+                            <option value="2">2</option>
+                        </select>
                     </div>
                 </div>
             </div>
             <div id="mqtt-broker-section-will">
                 <div class="palette-header">
-                    <i class="fa fa-angle-down expanded"></i><span>Message sent on an unexpected disconnection (will message)</span>
+                    <i class="fa fa-angle-down expanded"></i><span data-i18n="mqtt.sections-label.will-message"></span>
                 </div>
                 <div class="section-content" style="padding: 12px">
                     <div class="form-row">
                         <label for="node-config-input-willTopic"><i class="fa fa-tasks"></i> <span data-i18n="common.label.topic"></span></label>
-                        <input type="text" id="node-config-input-willTopic" data-i18n="[placeholder]mqtt.placeholder.will-topic">
-                    </div>
-                    <div class="form-row">
-                        <label for="node-config-input-willQos"><i class="fa fa-empire"></i> <span data-i18n="mqtt.label.qos"></span></label>
-                        <select id="node-config-input-willQos" style="width:125px !important">
-                            <option value="0">0</option>
-                            <option value="1">1</option>
-                            <option value="2">2</option>
-                        </select>
-                        &nbsp;&nbsp;<i class="fa fa-history"></i>&nbsp;<span data-i18n="mqtt.retain"></span> &nbsp;<select id="node-config-input-willRetain" style="width:125px !important">
+                        <input type="text" id="node-config-input-willTopic" style="width:300px" data-i18n="[placeholder]mqtt.placeholder.will-topic">
+                        &nbsp;&nbsp;
+                        <i class="fa fa-history"></i> <span data-i18n="mqtt.label.retain"></span> <select id="node-config-input-willRetain" style="float:right; width:75px !important">
                             <option value="false" data-i18n="mqtt.false"></option>
                             <option value="true" data-i18n="mqtt.true"></option>
                         </select>
                     </div>
                     <div class="form-row">
                         <label for="node-config-input-willPayload"><i class="fa fa-envelope"></i> <span data-i18n="common.label.payload"></span></label>
-                        <input type="text" id="node-config-input-willPayload" data-i18n="[placeholder]common.label.payload">
+                        <input type="text" id="node-config-input-willPayload" style="width:300px" data-i18n="[placeholder]common.label.payload">
+                        &nbsp;&nbsp;
+                        <i class="fa fa-empire"></i> <span data-i18n="mqtt.label.qos"></span></label>
+                        <select id="node-config-input-willQos" style="float:right; width:75px !important">
+                            <option value="0">0</option>
+                            <option value="1">1</option>
+                            <option value="2">2</option>
+                        </select>
                     </div>
                 </div>
             </div>
             <div id="mqtt-broker-section-close">
                 <div class="palette-header">
-                    <i class="fa fa-angle-down"></i><span>Message sent before disconnecting (close message)</span>
+                    <i class="fa fa-angle-down"></i><span data-i18n="mqtt.sections-label.close-message"></span>
                 </div>
-                <div class="section-content" style="padding: 12px; display:none">
-                    <div style="padding: 12px;">
-                        <div class="form-row">
-                            <label for="node-config-input-willTopic"><i class="fa fa-tasks"></i> <span data-i18n="common.label.topic"></span></label>
-                            <input type="text" id="node-config-input-willTopic" data-i18n="[placeholder]mqtt.placeholder.will-topic">
-                        </div>
-                        <div class="form-row">
-                            <label for="node-config-input-willQos"><i class="fa fa-empire"></i> <span data-i18n="mqtt.label.qos"></span></label>
-                            <select id="node-config-input-willQos" style="width:125px !important">
-                                <option value="0">0</option>
-                                <option value="1">1</option>
-                                <option value="2">2</option>
-                            </select>
-                            &nbsp;&nbsp;<i class="fa fa-history"></i>&nbsp;<span data-i18n="mqtt.retain"></span> &nbsp;<select id="node-config-input-willRetain" style="width:125px !important">
-                                <option value="false" data-i18n="mqtt.false"></option>
-                                <option value="true" data-i18n="mqtt.true"></option>
-                            </select>
-                        </div>
-                        <div class="form-row">
-                            <label for="node-config-input-willPayload"><i class="fa fa-envelope"></i> <span data-i18n="common.label.payload"></span></label>
-                            <input type="text" id="node-config-input-willPayload" data-i18n="[placeholder]common.label.payload">
-                        </div>
+                <div class="section-content" style="display:none; padding: 12px">
+                    <div class="form-row">
+                        <label for="node-config-input-willTopic"><i class="fa fa-tasks"></i> <span data-i18n="common.label.topic"></span></label>
+                        <input type="text" id="node-config-input-willTopic" style="width:300px" data-i18n="[placeholder]mqtt.placeholder.close-topic">
+                        &nbsp;&nbsp;
+                        <i class="fa fa-history"></i> <span data-i18n="mqtt.label.retain"></span> <select id="node-config-input-closeRetain" style="float:right; width:75px !important">
+                            <option value="false" data-i18n="mqtt.false"></option>
+                            <option value="true" data-i18n="mqtt.true"></option>
+                        </select>
+                    </div>
+                    <div class="form-row">
+                        <label for="node-config-input-closePayload"><i class="fa fa-envelope"></i> <span data-i18n="common.label.payload"></span></label>
+                        <input type="text" id="node-config-input-willPayload" style="width:300px" data-i18n="[placeholder]common.label.payload">
+                        &nbsp;&nbsp;
+                        <i class="fa fa-empire"></i> <span data-i18n="mqtt.label.qos"></span></label>
+                        <select id="node-config-input-closeQos" style="float:right; width:75px !important">
+                            <option value="0">0</option>
+                            <option value="1">1</option>
+                            <option value="2">2</option>
+                        </select>
                     </div>
                 </div>
             </div>
@@ -318,29 +316,6 @@
        field should be configured with a full URI for the connection. For example:</p>
     <pre>ws://example.com:4000/mqtt</pre>
 
-</script>
-
-<script type="text/x-red" data-template-name="mqtt-broker-section-birth">
-    <div class="form-row">
-        <label for="node-config-input-birthTopic"><i class="fa fa-tasks"></i> <span data-i18n="common.label.topic"></span></label>
-        <input type="text" id="node-config-input-birthTopic" data-i18n="[placeholder]mqtt.placeholder.birth-topic">
-    </div>
-    <div class="form-row">
-        <label for="node-config-input-birthQos"><i class="fa fa-empire"></i> <span data-i18n="mqtt.label.qos"></span></label>
-        <select id="node-config-input-birthQos" style="width:125px !important">
-            <option value="0">0</option>
-            <option value="1">1</option>
-            <option value="2">2</option>
-        </select>
-        &nbsp;&nbsp;<i class="fa fa-history"></i>&nbsp;<span data-i18n="mqtt.retain"></span> &nbsp;<select id="node-config-input-birthRetain" style="width:125px !important">
-            <option value="false" data-i18n="mqtt.false"></option>
-            <option value="true" data-i18n="mqtt.true"></option>
-        </select>
-    </div>
-    <div class="form-row">
-        <label for="node-config-input-birthPayload"><i class="fa fa-envelope"></i> <span data-i18n="common.label.payload"></span></label>
-        <input type="text" id="node-config-input-birthPayload" data-i18n="[placeholder]common.label.payload">
-    </div>
 </script>
 
 <script type="text/javascript">
@@ -373,9 +348,9 @@
             birthRetain: {value:false},
             birthPayload: {value:""},
             closeTopic: {value:""},
-            closeTopic: {value:"0"},
-            closeTopic: {value:false},
-            closeTopic: {value:""}
+            closeQos: {value:"0"},
+            closeRetain: {value:false},
+            closePayload: {value:""}
         },
         credentials: {
             user: {type:"text"},

--- a/nodes/core/io/10-mqtt.html
+++ b/nodes/core/io/10-mqtt.html
@@ -273,8 +273,8 @@
                 </div>
                 <div class="section-content" style="display:none; padding: 12px">
                     <div class="form-row">
-                        <label for="node-config-input-willTopic"><i class="fa fa-tasks"></i> <span data-i18n="common.label.topic"></span></label>
-                        <input type="text" id="node-config-input-willTopic" style="width:300px" data-i18n="[placeholder]mqtt.placeholder.close-topic">
+                        <label for="node-config-input-closeTopic"><i class="fa fa-tasks"></i> <span data-i18n="common.label.topic"></span></label>
+                        <input type="text" id="node-config-input-closeTopic" style="width:300px" data-i18n="[placeholder]mqtt.placeholder.close-topic">
                         &nbsp;&nbsp;
                         <i class="fa fa-history"></i> <span data-i18n="mqtt.label.retain"></span> <select id="node-config-input-closeRetain" style="float:right; width:75px !important">
                             <option value="false" data-i18n="mqtt.false"></option>
@@ -283,7 +283,7 @@
                     </div>
                     <div class="form-row">
                         <label for="node-config-input-closePayload"><i class="fa fa-envelope"></i> <span data-i18n="common.label.payload"></span></label>
-                        <input type="text" id="node-config-input-willPayload" style="width:300px" data-i18n="[placeholder]common.label.payload">
+                        <input type="text" id="node-config-input-closePayload" style="width:300px" data-i18n="[placeholder]common.label.payload">
                         &nbsp;&nbsp;
                         <i class="fa fa-empire"></i> <span data-i18n="mqtt.label.qos"></span></label>
                         <select id="node-config-input-closeQos" style="float:right; width:75px !important">
@@ -392,22 +392,31 @@
                 label: this._("mqtt.tabs-label.messages")
             });
 
-            function setUpSection(sectionId) {
+            function setUpSection(sectionId, isExpanded) {
                 var birthMessageSection = $(sectionId);
                 var paletteHeader = birthMessageSection.find('.palette-header');
+                var twistie = paletteHeader.find('i');
                 var sectionContent = birthMessageSection.find('.section-content');
 
+                function toggleSection(expanded) {
+                    twistie.toggleClass('expanded', expanded);
+                    sectionContent.toggle(expanded);
+                }
                 paletteHeader.click(function(e) {
                     e.preventDefault();
-                    var twistie = $(this).find('i');
                     var isExpanded = twistie.hasClass('expanded');
-                    sectionContent.toggle(!isExpanded);
-                    twistie.toggleClass('expanded',!isExpanded);
+                    toggleSection(!isExpanded);
                 });
+                toggleSection(isExpanded);
             }
-            setUpSection('#mqtt-broker-section-birth');
-            setUpSection('#mqtt-broker-section-will');
-            setUpSection('#mqtt-broker-section-close');
+            // show first section if none are set so the user gets the idea
+            var showBirthSection = this.birthTopic !== ""
+                || this.willTopic === ""
+                && this.birthTopic === ""
+                && this.closeTopic == "";
+            setUpSection('#mqtt-broker-section-birth', showBirthSection);
+            setUpSection('#mqtt-broker-section-will', this.willTopic !== "");
+            setUpSection('#mqtt-broker-section-close', this.closeTopic !== "");
 
             setTimeout(function() { tabs.resize(); },0);
             if (typeof this.cleansession === 'undefined') {

--- a/nodes/core/io/10-mqtt.js
+++ b/nodes/core/io/10-mqtt.js
@@ -60,6 +60,15 @@ module.exports = function(RED) {
             };
         }
 
+        if (n.closeTopic) {
+            this.closeMessage = {
+                topic: n.closeTopic,
+                payload: n.closePayload || "",
+                qos: Number(n.closeQos||0),
+                retain: n.closeRetain=="true"|| n.closeRetain===true
+            }; 
+        }
+
         if (this.credentials) {
             this.username = this.credentials.user;
             this.password = this.credentials.password;
@@ -314,6 +323,10 @@ module.exports = function(RED) {
         this.on('close', function(done) {
             this.closing = true;
             if (this.connected) {
+                // Send close message
+                if (node.closeMessage) {
+                    node.publish(node.closeMessage);
+                }
                 this.client.once('close', function() {
                     done();
                 });

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -335,24 +335,24 @@
         "tabs-label": {
             "connection": "Connection",
             "security": "Security",
-            "will": "Will Message",
-            "birth": "Birth Message"
+            "messages": "Messages"
         },
         "placeholder": {
             "clientid": "Leave blank for auto generated",
             "clientid-nonclean":"Must be set for non-clean sessions",
             "will-topic": "Leave blank to disable will message",
-            "birth-topic": "Leave blank to disable birth message"
+            "birth-topic": "Leave blank to disable birth message",
+            "close-topic": "Leave blank to use the will message on close"
         },
         "state": {
             "connected": "Connected to broker: __broker__",
             "disconnected": "Disconnected from broker: __broker__",
             "connect-failed": "Connection failed to broker: __broker__"
         },
-        "retain": "Retain",
+        "": "",
         "true": "true",
         "false": "false",
-        "tip": "Tip: Leave topic, qos or retain blank if you want to set them via msg properties.",
+        "tip": "Tip: Leave topic, qos or  blank if you want to set them via msg properties.",
         "errors": {
             "not-defined": "topic not defined",
             "missing-config": "missing broker configuration",

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -355,10 +355,9 @@
             "disconnected": "Disconnected from broker: __broker__",
             "connect-failed": "Connection failed to broker: __broker__"
         },
-        "": "",
         "true": "true",
         "false": "false",
-        "tip": "Tip: Leave topic, qos or  blank if you want to set them via msg properties.",
+        "tip": "Tip: Leave topic, qos or retain blank if you want to set them via msg properties.",
         "errors": {
             "not-defined": "topic not defined",
             "missing-config": "missing broker configuration",

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -323,6 +323,7 @@
             "broker": "Server",
             "example": "e.g. localhost",
             "qos": "QoS",
+            "retain": "Retain",
             "clientid": "Client ID",
             "port": "Port",
             "keepalive": "Keep alive time (s)",
@@ -331,6 +332,11 @@
             "tls-config":"TLS Configuration",
             "verify-server-cert":"Verify server certificate",
             "compatmode": "Use legacy MQTT 3.1 support"
+        },
+        "sections-label":{
+            "birth-message": "Message sent on connection (birth message)",
+            "will-message":"Message sent on an unexpected disconnection (will message)",
+            "close-message":"Message sent before disconnecting (close message)"
         },
         "tabs-label": {
             "connection": "Connection",
@@ -342,7 +348,7 @@
             "clientid-nonclean":"Must be set for non-clean sessions",
             "will-topic": "Leave blank to disable will message",
             "birth-topic": "Leave blank to disable birth message",
-            "close-topic": "Leave blank to use the will message on close"
+            "close-topic": "Leave blank to disable close message"
         },
         "state": {
             "connected": "Connected to broker: __broker__",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

Discussed on slack in the #def channel

## Proposed changes

Add support for a 'close' message in the MQTT node.  This is a message sent when the node disconnects from the broker, either because of a redeploy, or when Node-RED shuts down normally.  The UI, as discussed combines the `birth`, `will` and `close` message configuration in a single tab using collapsible sections.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [X] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality

Manually tested to ensure close message is sent on shutdown.

work in progress:
* currently no automated tests for the MQTT node
* reorder sections - birth, close, will?
* may want typed payloads - binary or string?