### PR TITLE
Fix test failure of icon scan on Windows

### DIFF
--- a/test/red/runtime/nodes/registry/registry_spec.js
+++ b/test/red/runtime/nodes/registry/registry_spec.js
@@ -563,7 +563,7 @@ describe("red/nodes/registry/registry",function() {
                 }
             },icons: [{path:testIcon,icons:['test_icon.png']}]});
             var iconPath = typeRegistry.getNodeIconPath('test-module','test_icon.png');
-            iconPath.should.eql(testIcon+"/test_icon.png");
+            iconPath.should.eql(path.resolve(testIcon+"/test_icon.png"));
         });
 
         it('returns the debug icon when getting an unknown module', function() {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
On Windows system, *returns a registered icon* test of `test/red/runtime/nodes/registry/registry_spec.js` fail because of its use of `/` as separator.  This PR fixes this problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
