### PR TITLE
Update i18n support for main editor interface and Japanese message …

### DIFF
--- a/editor/js/main.js
+++ b/editor/js/main.js
@@ -153,13 +153,13 @@
                     loadFlows(function() {
                         var project = RED.projects.getActiveProject();
                         var message = {
-                            "change-branch":"Change to local branch '"+project.git.branches.local+"'",
-                            "merge-abort":"Git merge aborted",
-                            "loaded":"Project '"+msg.project+"' loaded",
-                            "updated":"Project '"+msg.project+"' updated",
-                            "pull":"Project '"+msg.project+"' reloaded",
-                            "revert": "Project '"+msg.project+"' reloaded",
-                            "merge-complete":"Git merge completed"
+                            "change-branch": RED._("notification.project.change-branch", {project: project.git.branches.local}),
+                            "merge-abort": RED._("notification.project.merge-abort"),
+                            "loaded": RED._("notification.project.loaded", {project: msg.project}),
+                            "updated": RED._("notification.project.updated", {project: msg.project}),
+                            "pull": RED._("notification.project.pull", {project: msg.project}),
+                            "revert": RED._("notification.project.revert", {project: msg.project}),
+                            "merge-complete": RED._("notification.project.merge-complete")
                         }[msg.action];
                         RED.notify("<p>"+message+"</p>");
                         RED.sidebar.info.refresh()
@@ -183,7 +183,7 @@
                         if (!!RED.projects.getActiveProject()) {
                             options.buttons = [
                                 {
-                                    text: "Manage project dependencies",
+                                    text: RED._("notification.label.manage-project-dep"),
                                     click: function() {
                                         persistentNotifications[notificationId].hideNotification();
                                         RED.projects.settings.show('deps');
@@ -194,7 +194,7 @@
                         } else {
                             options.buttons = [
                                 {
-                                    text: "Close",
+                                    text: RED._("common.label.close"),
                                     click: function() {
                                         persistentNotifications[notificationId].hideNotification();
                                     }
@@ -207,7 +207,7 @@
                             if (RED.user.hasPermission("projects.write")) {
                                 options.buttons = [
                                     {
-                                        text: "Setup credentials",
+                                        text: RED._("notification.label.setup-cred"),
                                         click: function() {
                                             persistentNotifications[notificationId].hideNotification();
                                             RED.projects.showCredentialsPrompt();
@@ -218,7 +218,7 @@
                         } else {
                             options.buttons = [
                                 {
-                                    text: "Close",
+                                    text: RED._("common.label.close"),
                                     click: function() {
                                         persistentNotifications[notificationId].hideNotification();
                                     }
@@ -229,7 +229,7 @@
                         if (RED.user.hasPermission("projects.write")) {
                             options.buttons = [
                                 {
-                                    text: "Setup project files",
+                                    text: RED._("notification.label.setup-project"),
                                     click: function() {
                                         persistentNotifications[notificationId].hideNotification();
                                         RED.projects.showFilesPrompt();
@@ -241,7 +241,7 @@
                         if (RED.user.hasPermission("projects.write")) {
                             options.buttons = [
                                 {
-                                    text: "Create default package file",
+                                    text: RED._("notification.label.create-default-package"),
                                     click: function() {
                                         persistentNotifications[notificationId].hideNotification();
                                         RED.projects.createDefaultPackageFile();
@@ -253,13 +253,13 @@
                         if (RED.user.hasPermission("projects.write")) {
                             options.buttons = [
                                 {
-                                    text: "No thanks",
+                                    text: RED._("notification.label.no-thanks"),
                                     click: function() {
                                         persistentNotifications[notificationId].hideNotification();
                                     }
                                 },
                                 {
-                                    text: "Create default project files",
+                                    text: RED._("notification.label.create-default-project"),
                                     click: function() {
                                         persistentNotifications[notificationId].hideNotification();
                                         RED.projects.createDefaultFileSet();
@@ -273,7 +273,7 @@
                         if (RED.user.hasPermission("projects.write")) {
                             options.buttons = [
                                 {
-                                    text: "Show merge conflicts",
+                                    text: RED._("notification.label.show-merge-conflicts"),
                                     click: function() {
                                         persistentNotifications[notificationId].hideNotification();
                                         RED.sidebar.versionControl.showLocalChanges();
@@ -382,10 +382,10 @@
     function loadEditor() {
         var menuOptions = [];
         if (RED.settings.theme("projects.enabled",false)) {
-            menuOptions.push({id:"menu-item-projects-menu",label:"Projects",options:[
-                {id:"menu-item-projects-new",label:"New",disabled:false,onselect:"core:new-project"},
-                {id:"menu-item-projects-open",label:"Open",disabled:false,onselect:"core:open-project"},
-                {id:"menu-item-projects-settings",label:"Project Settings",disabled:false,onselect:"core:show-project-settings"}
+            menuOptions.push({id:"menu-item-projects-menu",label:RED._("menu.label.projects"),options:[
+                {id:"menu-item-projects-new",label:RED._("menu.label.projects-new"),disabled:false,onselect:"core:new-project"},
+                {id:"menu-item-projects-open",label:RED._("menu.label.projects-open"),disabled:false,onselect:"core:open-project"},
+                {id:"menu-item-projects-settings",label:RED._("menu.label.projects-settings"),disabled:false,onselect:"core:show-project-settings"}
             ]});
         }
 

--- a/red/api/editor/locales/en-US/editor.json
+++ b/red/api/editor/locales/en-US/editor.json
@@ -67,7 +67,11 @@
             "editPalette":"Manage palette",
             "other": "Other",
             "showTips": "Show tips",
-            "help": "Node-RED website"
+            "help": "Node-RED website",
+            "projects": "Projects",
+            "projects-new": "New",
+            "projects-open": "Open",
+            "projects-settings": "Project Settings"
         }
     },
     "user": {
@@ -108,6 +112,24 @@
             "cannotAddCircularReference": "Cannot add subflow - circular reference detected",
             "unsupportedVersion": "<p>Using an unsupported version of Node.js</p><p>You should upgrade to the latest Node.js LTS release</p>",
             "failedToAppendNode": "<p>Failed to load '__module__'</p><p>__error__</p>"
+        },
+        "project": {
+            "change-branch": "Change to local branch '__project__'",
+            "merge-abort": "Git merge aborted",
+            "loaded": "Project '__project__' loaded",
+            "updated": "Project '__project__' updated",
+            "pull": "Project '__project__' reloaded",
+            "revert": "Project '__project__' reloaded",
+            "merge-complete": "Git merge completed"
+        },
+        "label": {
+            "manage-project-dep": "Manage project dependencies",
+            "setup-cred": "Setup credentials",
+            "setup-project": "Setup project files",
+            "create-default-package": "Create default package file",
+            "no-thanks": "No thanks",
+            "create-default-project": "Create default project files",
+            "show-merge-conflicts": "Show merge conflicts"
         }
     },
     "clipboard": {

--- a/red/api/editor/locales/ja/editor.json
+++ b/red/api/editor/locales/ja/editor.json
@@ -67,7 +67,11 @@
             "editPalette": "パレットの管理",
             "other": "その他",
             "showTips": "ヒントを表示",
-            "help": "Node-REDウェブサイト"
+            "help": "Node-REDウェブサイト",
+            "projects": "プロジェクト",
+            "projects-new": "新規",
+            "projects-open": "開く",
+            "projects-settings": "設定"
         }
     },
     "user": {
@@ -102,7 +106,26 @@
             "lostConnectionTry": "すぐに接続",
             "cannotAddSubflowToItself": "サブフロー自身を追加できません",
             "cannotAddCircularReference": "循環参照を検出したため、サブフローを追加できません",
-            "unsupportedVersion": "サポートされていないバージョンのNode.jsを使用しています。<br/>最新のNode.js LTSに更新してください。"
+            "unsupportedVersion": "サポートされていないバージョンのNode.jsを使用しています。<br/>最新のNode.js LTSに更新してください。",
+            "failedToAppendNode": "<p>'__module__'がロードできませんでした。</p><p>__error__</p>"
+        },
+        "project": {
+            "change-branch": "ローカルブランチ'__project__'に変更しました",
+            "merge-abort": "Gitマージを中止しました",
+            "loaded": "プロジェクト'__project__'をロードしました",
+            "updated": "プロジェクト'__project__'を更新しました",
+            "pull": "プロジェクト'__project__'を再ロードしました",
+            "revert": "プロジェクト'__project__'を再ロードしました",
+            "merge-complete": "Gitマージが完了しました"
+        },
+        "label": {
+            "manage-project-dep": "プロジェクトの依存関係の管理",
+            "setup-cred": "認証情報の設定",
+            "setup-project": "プロジェクトファイルの設定",
+            "create-default-package": "デフォルトパッケージファイルの作成",
+            "no-thanks": "不要",
+            "create-default-project": "デフォルトプロジェクトファイルの作成",
+            "show-merge-conflicts": "マージ競合を表示"
         }
     },
     "clipboard": {


### PR DESCRIPTION
…catalogue

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This PR updates i18n support for main editor interface and Japanese message catalogue.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
