### PR TITLE
Allow i18n translation in runtime

### DIFF
--- a/red/runtime/i18n.js
+++ b/red/runtime/i18n.js
@@ -81,7 +81,7 @@ var MessageFileLoader = {
 
 }
 
-function current_locale() {
+function getCurrentLocale() {
     var env = process.env;
     for (var name of ['LC_ALL', 'LC_MESSAGES', 'LANG']) {
         if (name in env) {
@@ -102,7 +102,7 @@ function init() {
             },
             fallbackLng: [defaultLang]
         };
-        var lang = current_locale();
+        var lang = getCurrentLocale();
         if (lang) {
             opt.lng = lang;
         }

--- a/red/runtime/i18n.js
+++ b/red/runtime/i18n.js
@@ -81,16 +81,32 @@ var MessageFileLoader = {
 
 }
 
+function current_locale() {
+    var env = process.env;
+    for (var name of ['LC_ALL', 'LC_MESSAGES', 'LANG']) {
+        if (name in env) {
+            var val = env[name];
+            return val.substring(0, 2);
+        }
+    }
+    return undefined;
+}
+
 function init() {
     return when.promise(function(resolve,reject) {
         i18n.backend(MessageFileLoader);
-        i18n.init({
+        var opt = {
             ns: {
                 namespaces: [],
                 defaultNs: "runtime"
             },
             fallbackLng: [defaultLang]
-        },function() {
+        };
+        var lang = current_locale();
+        if (lang) {
+            opt.lng = lang;
+        }
+        i18n.init(opt ,function() {
             resolve();
         });
     });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Currently, Node-RED runtime do not perform i18n translation because a target locale of the translation  is not specified.  This PR fixes the problem by using value of LC_*/LANG variables as the target locale.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
