### PR TITLE
Add i18n support for default file set for a project

### DIFF
--- a/red/runtime/i18n.js
+++ b/red/runtime/i18n.js
@@ -81,16 +81,32 @@ var MessageFileLoader = {
 
 }
 
+function current_locale() {
+    var env = process.env;
+    for (var name of ['LC_ALL', 'LC_MESSAGES', 'LANG']) {
+        if (name in env) {
+            var val = env[name];
+            return val.substring(0, 2);
+        }
+    }
+    return undefined;
+}
+
 function init() {
     return when.promise(function(resolve,reject) {
         i18n.backend(MessageFileLoader);
-        i18n.init({
+        var opt = {
             ns: {
                 namespaces: [],
                 defaultNs: "runtime"
             },
             fallbackLng: [defaultLang]
-        },function() {
+        };
+        var lang = current_locale();
+        if (lang) {
+            opt.lng = lang;
+        }
+        i18n.init(opt ,function() {
             resolve();
         });
     });

--- a/red/runtime/locales/en-US/runtime.json
+++ b/red/runtime/locales/en-US/runtime.json
@@ -150,7 +150,9 @@
                 "disabled": "Projects disabled : editorTheme.projects.enabled=false",
                 "disabledNoFlag": "Projects disabled : set editorTheme.projects.enabled=true to enable",
                 "git-not-found": "Projects disabled : git command not found",
-                "git-version-old": "Projects disabled : git __version__ not supported. Requires 2.x"
+                "git-version-old": "Projects disabled : git __version__ not supported. Requires 2.x",
+                "summary": "A Node-RED Project",
+                "readme": "### About\n\nThis is your project's README.md file. It helps users understand what your\nproject does, how to use it and anything else they may need to know."
             }
         }
     }

--- a/red/runtime/locales/ja/runtime.json
+++ b/red/runtime/locales/ja/runtime.json
@@ -1,0 +1,10 @@
+{
+    "storage": {
+        "localfilesystem": {
+            "projects": {
+                "summary": "Node-REDプロジェクト",
+                "readme": "### 説明\nこれはプロジェクトのREADME.mdファイルです。このファイルには、\nプロジェクトの説明、利用方法、その他の情報を記載します。"
+            }
+        }
+    }
+}

--- a/red/runtime/storage/localfilesystem/projects/Project.js
+++ b/red/runtime/storage/localfilesystem/projects/Project.js
@@ -162,7 +162,7 @@ Project.prototype.initialise = function(user,data) {
         if (defaultFileSet.hasOwnProperty(file)) {
             var path = fspath.join(project.path,file);
             if (!fs.existsSync(path)) {
-                promises.push(util.writeFile(path,defaultFileSet[file](project)));
+                promises.push(util.writeFile(path,defaultFileSet[file](project, runtime)));
             }
 
         }
@@ -850,7 +850,7 @@ function createDefaultProject(user, project) {
         }
         for (var file in defaultFileSet) {
             if (defaultFileSet.hasOwnProperty(file)) {
-                promises.push(util.writeFile(fspath.join(projectPath,file),defaultFileSet[file](project)));
+                promises.push(util.writeFile(fspath.join(projectPath,file),defaultFileSet[file](project, runtime)));
             }
         }
 

--- a/red/runtime/storage/localfilesystem/projects/defaultFileSet.js
+++ b/red/runtime/storage/localfilesystem/projects/defaultFileSet.js
@@ -15,10 +15,11 @@
  **/
 
 module.exports = {
-    "package.json": function(project) {
+    "package.json": function(project, runtime) {
+        var i18n = runtime.i18n;
         var package = {
             "name": project.name,
-            "description": project.summary||"A Node-RED Project",
+            "description": project.summary||i18n._("storage.localfilesystem.projects.summary"),
             "version": "0.0.1",
             "dependencies": {},
             "node-red": {
@@ -34,13 +35,13 @@ module.exports = {
         }
         return JSON.stringify(package,"",4);
     },
-    "README.md": function(project) {
+    "README.md": function(project, runtime) {
+        var i18n = runtime.i18n;
         var content = project.name+"\n"+("=".repeat(project.name.length))+"\n\n";
         if (project.summary) {
             content += project.summary+"\n\n";
         }
-        content += "### About\n\nThis is your project's README.md file. It helps users understand what your\nproject does, how to use it and anything else they may need to know.";
-
+        content += i18n._("storage.localfilesystem.projects.readme");
         return content;
     },
     ".gitignore": function() { return "*.backup" ;}

--- a/test/red/runtime/storage/localfilesystem/projects/defaultFileSet_spec.js
+++ b/test/red/runtime/storage/localfilesystem/projects/defaultFileSet_spec.js
@@ -19,6 +19,13 @@ var should = require("should");
 var defaultFileSet = require("../../../../../../red/runtime/storage/localfilesystem/projects/defaultFileSet");
 
 describe('storage/localfilesystem/projects/defaultFileSet', function() {
+    var runtime = {
+        i18n: {
+            "_": function(name) {
+                return name;
+            }
+        }
+    };
     it('generates package.json for a project', function() {
         var generated = defaultFileSet["package.json"]({
             name: "A TEST NAME",
@@ -27,7 +34,7 @@ describe('storage/localfilesystem/projects/defaultFileSet', function() {
                 flow: "MY FLOW FILE",
                 credentials: "MY CREDENTIALS FILE"
             }
-        });
+        }, runtime);
 
         var parsed = JSON.parse(generated);
         parsed.should.have.property('name',"A TEST NAME");
@@ -42,7 +49,7 @@ describe('storage/localfilesystem/projects/defaultFileSet', function() {
         var generated = defaultFileSet["README.md"]({
             name: "A TEST NAME",
             summary: "A TEST SUMMARY"
-        });
+        }, runtime);
         generated.should.match(/A TEST NAME/);
         generated.should.match(/A TEST SUMMARY/);
     });
@@ -50,7 +57,7 @@ describe('storage/localfilesystem/projects/defaultFileSet', function() {
         var generated = defaultFileSet[".gitignore"]({
             name: "A TEST NAME",
             summary: "A TEST SUMMARY"
-        });
+        }, runtime);
         generated.length.should.be.greaterThan(0);
     });
 });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Currently automatically generated files for a project such as README.md is written in English.
This PR add i18n support for the generated files and Japanese message catalogue.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
