### PR TITLE
Add i18n support for project

### DIFF
--- a/editor/js/ui/diff.js
+++ b/editor/js/ui/diff.js
@@ -1747,7 +1747,7 @@ RED.diff = (function() {
                         try {
                             commonFlow = JSON.parse(commonVersion.content||"[]");
                         } catch(err) {
-                            console.log("Common Version doesn't contain valid JSON:",commonVersionUrl);
+                            console.log(RED._("diff.commonVersionError"),commonVersionUrl);
                             console.log(err);
                             return;
                         }
@@ -1755,7 +1755,7 @@ RED.diff = (function() {
                     try {
                         oldFlow = JSON.parse(oldVersion.content||"[]");
                     } catch(err) {
-                        console.log("Old Version doesn't contain valid JSON:",oldVersionUrl);
+                        console.log(RED._("diff.oldVersionError"),oldVersionUrl);
                         console.log(err);
                         return;
                     }
@@ -1765,7 +1765,7 @@ RED.diff = (function() {
                     try {
                         newFlow = JSON.parse(newVersion.content||"[]");
                     } catch(err) {
-                        console.log("New Version doesn't contain valid JSON:",newFlow);
+                        console.log(RED._("diff.newVersionError"),newFlow);
                         console.log(err);
                         return;
                     }
@@ -1801,7 +1801,7 @@ RED.diff = (function() {
 
             } else {
                 if (commitOptions.unmerged) {
-                    conflictHeader = $('<span style="float: right;"><span>'+resolvedConflicts+'</span> of <span>'+unresolvedConflicts+'</span> conflicts resolved</span>').appendTo(content);
+                    conflictHeader = $('<span style="float: right;">'+RED._("diff.conflictHeader",{resolved:resolvedConflicts, unresolved:unresolvedConflicts})+'</span>').appendTo(content);
                 }
                 hunks.forEach(function(hunk) {
                     var diffRow = $('<tr class="node-text-diff-header">').appendTo(codeBody);
@@ -1914,7 +1914,7 @@ RED.diff = (function() {
                                         diffRow.remove();
                                         addedRows.find(".linetext").addClass('added');
                                         conflictHeader.empty();
-                                        $('<span><span>'+resolvedConflicts+'</span> of <span>'+unresolvedConflicts+'</span> conflicts resolved</span>').appendTo(conflictHeader);
+                                        $('<span>'+RED._("diff.conflictHeader",{resolved:resolvedConflicts, unresolved:unresolvedConflicts})+'</span>').appendTo(conflictHeader);
 
                                         conflictResolutions[file.file] = conflictResolutions[file.file] || {};
                                         conflictResolutions[file.file][hunk.localChangeStart] = {

--- a/editor/js/ui/diff.js
+++ b/editor/js/ui/diff.js
@@ -1233,7 +1233,7 @@ RED.diff = (function() {
         // currentDiff = diff;
 
         var trayOptions = {
-            title: options.title||"Review Changes", //TODO: nls
+            title: options.title||RED._("diff.reviewChanges"),
             width: Infinity,
             overlay: true,
             buttons: [
@@ -1416,7 +1416,7 @@ RED.diff = (function() {
 
     function showTextDiff(textA,textB) {
         var trayOptions = {
-            title: "Compare Changes", //TODO: nls
+            title: RED._("diff.compareChanges"),
             width: Infinity,
             overlay: true,
             buttons: [
@@ -1797,7 +1797,7 @@ RED.diff = (function() {
             if (isBinary) {
                 var diffBinaryRow = $('<tr class="node-text-diff-header">').appendTo(codeBody);
                 var binaryContent = $('<td colspan="3"></td>').appendTo(diffBinaryRow);
-                $('<span></span>').text("Cannot show binary file contents").appendTo(binaryContent);
+                $('<span></span>').text(RED._("diff.noBinaryFileShowed")).appendTo(binaryContent);
 
             } else {
                 if (commitOptions.unmerged) {
@@ -1946,7 +1946,7 @@ RED.diff = (function() {
     function showCommitDiff(options) {
         var commit = parseCommitDiff(options.commit);
         var trayOptions = {
-            title: "View Commit Changes", //TODO: nls
+            title: RED._("diff.viewCommitDiff"),
             width: Infinity,
             overlay: true,
             buttons: [
@@ -2008,7 +2008,7 @@ RED.diff = (function() {
         }
 
         var trayOptions = {
-            title: title||"Compare Changes", //TODO: nls
+            title: title|| RED._("diff.compareChanges"),
             width: Infinity,
             overlay: true,
             buttons: [
@@ -2041,7 +2041,7 @@ RED.diff = (function() {
             trayOptions.buttons.push(
                 {
                     id: "node-diff-view-resolve-diff",
-                    text: "Save conflict resolution",
+                    text: RED._("diff.saveConflict"),
                     class: "primary disabled",
                     click: function() {
                         if (!$("#node-diff-view-resolve-diff").hasClass('disabled')) {

--- a/red/api/editor/locales/en-US/editor.json
+++ b/red/api/editor/locales/en-US/editor.json
@@ -198,7 +198,11 @@
         "noBinaryFileShowed": "Cannot show binary file contents",
         "viewCommitDiff": "View Commit Changes",
         "compareChanges": "Compare Changes",
-        "saveConflict": "Save conflict resolution"
+        "saveConflict": "Save conflict resolution",
+        "conflictHeader": "<span>__resolved__</span> of <span>__unresolved__</span> conflicts resolved",
+        "commonVersionError": "Common Version doesn't contain valid JSON:",
+        "oldVersionError": "Old Version doesn't contain valid JSON:",
+        "newVersionError": "New Version doesn't contain valid JSON:"
     },
     "subflow": {
         "editSubflow": "Edit flow template: __name__",

--- a/red/api/editor/locales/en-US/editor.json
+++ b/red/api/editor/locales/en-US/editor.json
@@ -193,8 +193,12 @@
         "nodeCount": "__count__ node",
         "nodeCount_plural": "__count__ nodes",
         "local":"Local changes",
-        "remote":"Remote changes"
-
+        "remote":"Remote changes",
+        "reviewChanges": "Review Changes",
+        "noBinaryFileShowed": "Cannot show binary file contents",
+        "viewCommitDiff": "View Commit Changes",
+        "compareChanges": "Compare Changes",
+        "saveConflict": "Save conflict resolution"
     },
     "subflow": {
         "editSubflow": "Edit flow template: __name__",

--- a/red/api/editor/locales/ja/editor.json
+++ b/red/api/editor/locales/ja/editor.json
@@ -188,7 +188,12 @@
         "nodeCount": "__count__ 個のノード",
         "nodeCount_plural": "__count__ 個のノード",
         "local": "ローカルの変更",
-        "remote": "リモートの変更"
+        "remote": "リモートの変更",
+        "reviewChanges": "変更を表示",
+        "noBinaryFileShowed": "バイナリファイルの中身は表示することができません",
+        "viewCommitDiff": "コミットの内容を表示",
+        "compareChanges": "変更を比較",
+        "saveConflict": "解決して保存"
     },
     "subflow": {
         "editSubflow": "フローのテンプレートを編集: __name__",

--- a/red/api/editor/locales/ja/editor.json
+++ b/red/api/editor/locales/ja/editor.json
@@ -193,7 +193,11 @@
         "noBinaryFileShowed": "バイナリファイルの中身は表示することができません",
         "viewCommitDiff": "コミットの内容を表示",
         "compareChanges": "変更を比較",
-        "saveConflict": "解決して保存"
+        "saveConflict": "解決して保存",
+        "conflictHeader": "<span>__unresolved__</span> 個中 <span>__resolved__</span> 個のコンフリクトを解決",
+        "commonVersionError": "共通バージョンは正しいJSON形式ではありません:",
+        "oldVersionError": "古いバージョンは正しいJSON形式ではありません:",
+        "newVersionError": "新しいバージョンは正しいJSON形式ではありません:"
     },
     "subflow": {
         "editSubflow": "フローのテンプレートを編集: __name__",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
This PR supports i18n for projects and adds Japanese translation.

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
