### PR TITLE
Fix appearance of retry button of remote branch management dialog

### DIFF
--- a/editor/js/ui/notifications.js
+++ b/editor/js/ui/notifications.js
@@ -96,7 +96,7 @@ RED.notifications = (function() {
         if (options.buttons) {
             var buttonSet = $('<div style="margin-top: 20px;" class="ui-dialog-buttonset"></div>').appendTo(n)
             options.buttons.forEach(function(buttonDef) {
-                var b = $('<button>').text(buttonDef.text).click(buttonDef.click).appendTo(buttonSet);
+                var b = $('<button>').html(buttonDef.text).click(buttonDef.click).appendTo(buttonSet);
                 if (buttonDef.id) {
                     b.attr('id',buttonDef.id);
                 }

--- a/editor/js/ui/projects/projects.js
+++ b/editor/js/ui/projects/projects.js
@@ -1983,7 +1983,7 @@ RED.projects = (function() {
                                     notification.close();
                                 }
                             },{
-                                text: $('<span><i class="fa fa-refresh"></i> Retry</span>'),
+                                text: '<span><i class="fa fa-refresh"></i> ' +RED._("projects.send-req.retry") +'</span>',
                                 click: function() {
                                     body = body || {};
                                     var authBody = {};

--- a/red/api/editor/locales/en-US/editor.json
+++ b/red/api/editor/locales/en-US/editor.json
@@ -795,6 +795,7 @@
             "username": "Username",
             "password": "Password",
             "passphrase": "Passphrase",
+            "retry": "Retry",
             "update-failed": "Failed to update auth",
             "unhandled": "Unhandled error response"
         },

--- a/red/api/editor/locales/ja/editor.json
+++ b/red/api/editor/locales/ja/editor.json
@@ -785,6 +785,7 @@
             "username": "ユーザ名",
             "password": "パスワード",
             "passphrase": "パスフレーズ",
+            "retry": "リトライ",
             "update-failed": "認証の更新に失敗しました",
             "unhandled": "エラー応答が処理されませんでした"
         },


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

As described in [Issue #1768 ](https://github.com/node-red/node-red/issues/1768),
retry button of authentication management dialog appear as "[Object]".
This fixes it to apper as "Retry" with refresh icon.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality