### PR TITLE
Fix warning message appearance of node management dialog

### DIFF
--- a/editor/js/ui/palette-editor.js
+++ b/editor/js/ui/palette-editor.js
@@ -220,7 +220,7 @@ RED.palette.editor = (function() {
                         var setElements = nodeEntry.sets[setName];
                         if (set.err) {
                             errorCount++;
-                            $("<li>").text(set.err).appendTo(nodeEntry.errorList);
+                            $("<li>").text(set.err.msg).appendTo(nodeEntry.errorList);
                         }
                         if (set.enabled) {
                             activeTypeCount += set.types.length;

--- a/red/runtime/nodes/registry/registry.js
+++ b/red/runtime/nodes/registry/registry.js
@@ -193,6 +193,7 @@ function addModule(module) {
                 set.types.forEach(function(t) {
                     if (nodeTypeToId.hasOwnProperty(t)) {
                         set.err = new Error("Type already registered");
+                        set.err.msg = set.err.toString();
                         set.err.code = "type_already_registered";
                         set.err.details = {
                             type: t,


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

When two module with same node type are installed, warning message will be shown in node management dialogue.  However, current implementation shows "[object Object]" on conflicting node instead of error message.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
