### PR TITLE
Add headless option for UI test

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,6 +24,10 @@ module.exports = function(grunt) {
         nodemonArgs.push(flowFile);
     }
 
+    var nonHeadless = grunt.option('non-headless');
+    if (nonHeadless) {
+        process.env.NODE_RED_NON_HEADLESS = 'true';
+    }
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
         paths: {

--- a/test/editor/wdio.conf.js
+++ b/test/editor/wdio.conf.js
@@ -62,10 +62,11 @@ exports.config = {
         //
         browserName: 'chrome',
         chromeOptions: {
-            // Runs tests without opening a broser.
-            args: ['--headless', '--disable-gpu', 'window-size=1920,1080'],
-            // Runs tests with opening a broser.
-            // args: ['--disable-gpu'],
+            args: process.env.NODE_RED_NON_HEADLESS
+                // Runs tests with opening a browser.
+                ? ['--disable-gpu']
+                // Runs tests without opening a browser.
+                : ['--headless', '--disable-gpu', 'window-size=1920,1080']
         },
     }],
     //


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
As @Kazuki-Nakanishi discussed before, I added headless option for UI test.
Using this option, users can choose whether to run UI test in GUI or CUI.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
