### PR TITLE
Support i18n in websocket node

### DIFF
--- a/nodes/core/io/22-websocket.js
+++ b/nodes/core/io/22-websocket.js
@@ -212,11 +212,11 @@ module.exports = function(RED) {
         if (this.serverConfig) {
             this.serverConfig.registerInputNode(this);
             // TODO: nls
-            this.serverConfig.on('opened', function(n) { node.status({fill:"green",shape:"dot",text:"connected "+n}); });
-            this.serverConfig.on('erro', function() { node.status({fill:"red",shape:"ring",text:"error"}); });
+            this.serverConfig.on('opened', function(n) { node.status({fill:"green",shape:"dot",text:RED._("websocket.status.connected",{count:n})}); });
+            this.serverConfig.on('erro', function() { node.status({fill:"red",shape:"ring",text:"common.status.error"}); });
             this.serverConfig.on('closed', function(n) {
-                if (n > 0) { node.status({fill:"green",shape:"dot",text:"connected "+n}); }
-                else { node.status({fill:"red",shape:"ring",text:"disconnected"}); }
+                if (n > 0) { node.status({fill:"green",shape:"dot",text:RED._("websocket.status.connected",{count:n})}); }
+                else { node.status({fill:"red",shape:"ring",text:"common.status.disconnected"}); }
             });
         } else {
             this.error(RED._("websocket.errors.missing-conf"));
@@ -240,11 +240,11 @@ module.exports = function(RED) {
         }
         else {
             // TODO: nls
-            this.serverConfig.on('opened', function(n) { node.status({fill:"green",shape:"dot",text:"connected "+n}); });
-            this.serverConfig.on('erro', function() { node.status({fill:"red",shape:"ring",text:"error"}); });
+            this.serverConfig.on('opened', function(n) { node.status({fill:"green",shape:"dot",text:RED._("websocket.status.connected",{count:n})}); });
+            this.serverConfig.on('erro', function() { node.status({fill:"red",shape:"ring",text:"common.status.error"}); });
             this.serverConfig.on('closed', function(n) {
-                if (n > 0) { node.status({fill:"green",shape:"dot",text:"connected "+n}); }
-                else { node.status({fill:"red",shape:"ring",text:"disconnected"}); }
+                if (n > 0) { node.status({fill:"green",shape:"dot",text:RED._("websocket.status.connected",{count:n})}); }
+                else { node.status({fill:"red",shape:"ring",text:"common.status.disconnected"}); }
             });
         }
         this.on("input", function(msg) {

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -420,6 +420,10 @@
             "url1": "URL should use ws:&#47;&#47; or wss:&#47;&#47; scheme and point to an existing websocket listener.",
             "url2": "By default, <code>payload</code> will contain the data to be sent over, or received from a websocket. The client can be configured to send or receive the entire message object as a JSON formatted string."
         },
+        "status": {
+            "connected": "connected __count__",
+            "connected_plural": "connected __count__"
+        },
         "errors": {
             "connect-error": "An error occured on the ws connection: ",
             "send-error": "An error occurred while sending: ",

--- a/nodes/core/locales/ja/messages.json
+++ b/nodes/core/locales/ja/messages.json
@@ -414,6 +414,10 @@
             "url1": "URLには ws:&#47;&#47; または wss:&#47;&#47; スキーマを使用して、存在するwebsocketリスナを設定してください。",
             "url2": "標準では <code>payload</code> がwebsocketから送信、受信されるデータを持ちます。クライアントはJSON形式の文字列としてメッセージ全体を送信、受信するよう設定できます。"
         },
+        "status": {
+            "connected": "接続数 __count__",
+            "connected_plural": "接続数 __count__"
+        },
         "errors": {
             "connect-error": "ws接続でエラーが発生しました: ",
             "send-error": "送信中にエラーが発生しました: ",


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I found that the status messages in websocket nodes are English. I fixed 22-websocket.js to support i18n.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality