### PR TITLE
Fix typedInput error on initialization

### DIFF
--- a/editor/js/ui/common/typedInput.js
+++ b/editor/js/ui/common/typedInput.js
@@ -467,7 +467,9 @@
                 var opt = this.typeMap[type];
                 if (opt && this.propertyType !== type) {
                     this.propertyType = type;
-                    this.typeField.val(type);
+                    if (this.typeField) {
+                        this.typeField.val(type);
+                    }
                     this.selectLabel.empty();
                     var image;
                     if (opt.icon) {
@@ -574,15 +576,17 @@
                             }
                             this.elementDiv.show();
                         }
-                        if (opt.expand && typeof opt.expand === 'function') {
-                            this.optionExpandButton.show();
-                            this.optionExpandButton.off('click');
-                            this.optionExpandButton.on('click',function(evt) {
-                                evt.preventDefault();
-                                opt.expand.call(that);
-                            })
-                        } else {
-                            this.optionExpandButton.hide();
+                        if (this.optionExpandButton) {
+                            if (opt.expand && typeof opt.expand === 'function') {
+                                this.optionExpandButton.show();
+                                this.optionExpandButton.off('click');
+                                this.optionExpandButton.on('click',function(evt) {
+                                    evt.preventDefault();
+                                    opt.expand.call(that);
+                                })
+                            } else {
+                                this.optionExpandButton.hide();
+                            }
                         }
                         this.input.trigger('change',this.propertyType,this.value());
                     }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Rule editing UI of switch node in current 0.19 branch is not shown in expected mannar as shown in the following figure.

![switch](https://user-images.githubusercontent.com/30289092/42276139-ab3f9a98-7fcd-11e8-9a2a-4cbb1a3141be.png)

This problem is caused by `typeField` and `optionExpandButton` field reference with `undefined` value in `type`  function.

This PR resolves this issue.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
