### PR TITLE
join-node-keep-top-level-properties

### DIFF
--- a/nodes/core/logic/17-split.js
+++ b/nodes/core/logic/17-split.js
@@ -280,8 +280,8 @@ module.exports = function(RED) {
         msgs.sort(function(x,y) {
             var ix = x.parts.index;
             var iy = y.parts.index;
-            if (ix < iy) return -flag;
-            if (ix > iy) return flag;
+            if (ix < iy) { return -flag; }
+            if (ix > iy) { return flag; }
             return 0;
         });
         for(var msg of msgs) {
@@ -437,7 +437,8 @@ module.exports = function(RED) {
                     newArray = newArray.concat(n);
                 })
                 group.payload = newArray;
-            } else if (group.type === 'buffer') {
+            }
+            else if (group.type === 'buffer') {
                 var buffers = [];
                 var bufferLen = 0;
                 if (group.joinChar !== undefined) {
@@ -450,7 +451,8 @@ module.exports = function(RED) {
                         buffers.push(group.payload[i]);
                         bufferLen += group.payload[i].length;
                     }
-                } else {
+                }
+                else {
                     bufferLen = group.bufferLen;
                     buffers = group.payload;
                 }
@@ -463,7 +465,8 @@ module.exports = function(RED) {
                     groupJoinChar = group.joinChar.toString();
                 }
                 RED.util.setMessageProperty(group.msg,node.property,group.payload.join(groupJoinChar));
-            } else {
+            }
+            else {
                 if (node.propertyType === 'full') {
                     group.msg = RED.util.cloneMessage(group.msg);
                 }
@@ -471,7 +474,8 @@ module.exports = function(RED) {
             }
             if (group.msg.hasOwnProperty('parts') && group.msg.parts.hasOwnProperty('parts')) {
                 group.msg.parts = group.msg.parts.parts;
-            } else {
+            }
+            else {
                 delete group.msg.parts;
             }
             delete group.msg.complete;
@@ -525,7 +529,7 @@ module.exports = function(RED) {
                     payloadType = node.build;
                     targetCount = node.count;
                     joinChar = node.joiner;
-                    if (targetCount === 0 && msg.hasOwnProperty('parts')) {
+                    if (n.count === "" && msg.hasOwnProperty('parts')) {
                         targetCount = msg.parts.count || 0;
                     }
                     if (node.build === 'object') {
@@ -554,7 +558,7 @@ module.exports = function(RED) {
                             payload:{},
                             targetCount:targetCount,
                             type:"object",
-                            msg:msg
+                            msg:RED.util.cloneMessage(msg)
                         };
                     }
                     else if (node.accumulate === true) {
@@ -564,7 +568,7 @@ module.exports = function(RED) {
                             payload:{},
                             targetCount:targetCount,
                             type:payloadType,
-                            msg:msg
+                            msg:RED.util.cloneMessage(msg)
                         }
                         if (payloadType === 'string' || payloadType === 'array' || payloadType === 'buffer') {
                             inflight[partId].payload = [];
@@ -576,7 +580,7 @@ module.exports = function(RED) {
                             payload:[],
                             targetCount:targetCount,
                             type:payloadType,
-                            msg:msg
+                            msg:RED.util.cloneMessage(msg)
                         };
                         if (payloadType === 'string') {
                             inflight[partId].joinChar = joinChar;
@@ -624,14 +628,14 @@ module.exports = function(RED) {
                     }
                     group.currentCount++;
                 }
-                // TODO: currently reuse the last received - add option to pick first received
-                group.msg = msg;
+                group.msg = Object.assign(group.msg, msg);
                 var tcnt = group.targetCount;
                 if (msg.hasOwnProperty("parts")) { tcnt = group.targetCount || msg.parts.count; }
                 if ((tcnt > 0 && group.currentCount >= tcnt) || msg.hasOwnProperty('complete')) {
                     completeSend(partId);
                 }
-            } catch(err) {
+            }
+            catch(err) {
                 console.log(err.stack);
             }
         });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

When msgs get joined into objects currently the final msg to arrive is used as the base msg to add the newly joined payload to. If anyone has added extra top level properties to any of the other messages (maybe via a divergent path) they will be dropped.

This change make the the top level message be an accumulation of previous msg top level properties then with the new payload.
This should be transparent to users as the last msg in will still set all the same properties as previously… just there may now be a few more.

Fixes the Issue #1782


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality

