### PR TITLE
Fix appearrence of change node label for flow/global ref

### DIFF
--- a/nodes/core/logic/15-change.html
+++ b/nodes/core/logic/15-change.html
@@ -54,6 +54,17 @@
         outputs: 1,
         icon: "swap.png",
         label: function() {
+            function prop2name(type, prop) {
+                var len = prop.length;
+                if(((type === 'flow') || (type === 'global')) &&
+                   (len > 6) && (prop[0] === '#') && (prop[1] === ':')) {
+                    var pos = prop.indexOf(")::", 2);
+                    if (pos > 0) {
+                        return type+"."+prop.substring(pos +3);
+                    }
+                }
+                return type+"."+prop;
+            }
             if (this.name) {
                 return this.name;
             }
@@ -70,13 +81,13 @@
             } else {
                 if (this.rules.length == 1) {
                     if (this.rules[0].t === "set") {
-                        return this._("change.label.set",{property:(this.rules[0].pt||"msg")+"."+this.rules[0].p});
+                        return this._("change.label.set",{property:prop2name((this.rules[0].pt||"msg"), this.rules[0].p)});
                     } else if (this.rules[0].t === "change") {
-                        return this._("change.label.change",{property:(this.rules[0].pt||"msg")+"."+this.rules[0].p});
+                        return this._("change.label.change",{property:prop2name((this.rules[0].pt||"msg"), this.rules[0].p)});
                     } else if (this.rules[0].t === "move") {
-                        return this._("change.label.move",{property:(this.rules[0].pt||"msg")+"."+this.rules[0].p});
+                        return this._("change.label.move",{property:prop2name((this.rules[0].pt||"msg"), this.rules[0].p)});
                     } else {
-                        return this._("change.label.delete",{property:(this.rules[0].pt||"msg")+"."+this.rules[0].p});
+                        return this._("change.label.delete",{property:prop2name((this.rules[0].pt||"msg"), this.rules[0].p)});
                     }
                 } else {
                     return this._("change.label.changeCount",{count:this.rules.length});

--- a/nodes/core/logic/15-change.html
+++ b/nodes/core/logic/15-change.html
@@ -54,16 +54,9 @@
         outputs: 1,
         icon: "swap.png",
         label: function() {
-            function prop2name(type, prop) {
-                var len = prop.length;
-                if(((type === 'flow') || (type === 'global')) &&
-                   (len > 6) && (prop[0] === '#') && (prop[1] === ':')) {
-                    var pos = prop.indexOf(")::", 2);
-                    if (pos > 0) {
-                        return type+"."+prop.substring(pos +3);
-                    }
-                }
-                return type+"."+prop;
+            function prop2name(type, key) {
+                var result = RED.utils.parseContextKey(key);
+                return type +"." +result.key;
             }
             if (this.name) {
                 return this.name;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Current *change* node implementation of 0.19 branch shows node label for flow/global context property reference in raw format (e.g. `flow.#:(abc):xyz`).
This PR fixes this to be shown in propetly formatted style (e.g. `flow.xyz`). 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
