### PR TITLE
Fix appearrence of switch node port label for flow/global ref.

### DIFF
--- a/nodes/core/logic/10-switch.html
+++ b/nodes/core/logic/10-switch.html
@@ -99,15 +99,9 @@
         }
         return v;
     }
-    function prop2name(prop) {
-        var len = prop.length;
-        if((len > 6) && (prop[0] === '#') && (prop[1] === ':')) {
-            var pos = prop.indexOf(")::", 2);
-            if (pos > 0) {
-                return prop.substring(pos +3);
-            }
-        }
-        return prop;
+    function prop2name(key) {
+        var result = RED.utils.parseContextKey(key);
+        return result.key;
     }
     function getValueLabel(t,v) {
         if (t === 'str') {

--- a/nodes/core/logic/10-switch.html
+++ b/nodes/core/logic/10-switch.html
@@ -99,11 +99,23 @@
         }
         return v;
     }
+    function prop2name(prop) {
+        var len = prop.length;
+        if((len > 6) && (prop[0] === '#') && (prop[1] === ':')) {
+            var pos = prop.indexOf(")::", 2);
+            if (pos > 0) {
+                return prop.substring(pos +3);
+            }
+        }
+        return prop;
+    }
     function getValueLabel(t,v) {
         if (t === 'str') {
             return '"'+clipValueLength(v)+'"';
-        } else if (t === 'msg' || t==='flow' || t==='global') {
+        } else if (t === 'msg') {
             return t+"."+clipValueLength(v);
+        } else if (t === 'flow' || t === 'global') {
+            return t+"."+clipValueLength(prop2name(v));
         }
         return clipValueLength(v);
     }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Current switch node implementation of 0.19 branch shows port label for flow/global context property reference in raw format (e.g. flow.#:(abc)::xyz).
This PR fixes this to be shown in propetly formatted style (e.g. flow.xyz).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality