### PR TITLE
Make it possible to set multiple values

### DIFF
--- a/red/runtime/nodes/context/index.js
+++ b/red/runtime/nodes/context/index.js
@@ -268,7 +268,29 @@ function createContext(id,seed) {
             }
             context = getContextStorage(storage);
         }
-        context.set(scope, key, value, callback);
+        if (!Array.isArray(key) || !Array.isArray(value) || key.length !== value.length) {
+            context.set(scope, key, value, callback);
+        } else {
+            // If key and value are Array and each length is same, set each key-value pair.
+            var index = 0;
+            var cb = function(err, v) {
+                if (err) {
+                    if (callback) {
+                        callback(err);
+                    }
+                } else {
+                    index++;
+                    if (index === key.length) {
+                        if (callback) {
+                            callback(null);
+                        }
+                    } else {
+                        context.set(scope, key[index], value[index], cb);
+                    }
+                }
+            };
+            context.set(scope, key[index], value[index], cb);
+        }
     };
     obj.keys = function(storage, callback) {
         var context;

--- a/red/runtime/nodes/context/index.js
+++ b/red/runtime/nodes/context/index.js
@@ -268,12 +268,14 @@ function createContext(id,seed) {
             }
             context = getContextStorage(storage);
         }
-        if (!Array.isArray(key) || !Array.isArray(value) || key.length !== value.length) {
+        if (!Array.isArray(key)) {
             context.set(scope, key, value, callback);
         } else {
-            // If key and value are Array and each length is same, set each key-value pair.
+            // If key is an array, set each key-value pair.
+            // If the value array is longer than the key array, then the extra values are ignored.
             var index = 0;
-            var cb = function(err, v) {
+            var values = [].concat(value); // Convert the value to an array
+            var cb = function(err) {
                 if (err) {
                     if (callback) {
                         callback(err);
@@ -285,11 +287,16 @@ function createContext(id,seed) {
                             callback(null);
                         }
                     } else {
-                        context.set(scope, key[index], value[index], cb);
+                        if(index < values.length) {
+                            context.set(scope, key[index], values[index], cb);
+                        } else {
+                            // If the value array is shorter than the key array, use null for missing values.
+                            context.set(scope, key[index], null, cb);
+                        }
                     }
                 }
             };
-            context.set(scope, key[index], value[index], cb);
+            context.set(scope, key[index], values[index], cb);
         }
     };
     obj.keys = function(storage, callback) {

--- a/test/red/runtime/nodes/context/index_spec.js
+++ b/test/red/runtime/nodes/context/index_spec.js
@@ -639,6 +639,125 @@ describe('context', function() {
                 });
             });
 
+            it('should deletes multiple properties', function(done) {
+                Context.init({contextStorage:memoryStorage});
+                Context.load().then(function(){
+                    var context =  Context.get("1","flow");
+                    context.set(["foo1","foo2","foo3"], ["bar1","bar2","bar3"], "memory", function(err){
+                        if (err) {
+                            done(err);
+                        } else {
+                            context.get(["foo1","foo2","foo3"], "memory", function(err,foo1,foo2,foo3){
+                                if (err) {
+                                    done(err);
+                                } else {
+                                    foo1.should.be.equal("bar1");
+                                    foo2.should.be.equal("bar2");
+                                    foo3.should.be.equal("bar3");
+                                    context.set(["foo1","foo2","foo3"], new Array(3), "memory", function(err){
+                                        if (err) {
+                                            done(err);
+                                        } else {
+                                            context.get(["foo1","foo2","foo3"], "memory", function(err,foo1,foo2,foo3){
+                                                if (err) {
+                                                    done(err);
+                                                } else {
+                                                    should.not.exist(foo1);
+                                                    should.not.exist(foo2);
+                                                    should.not.exist(foo3);
+                                                    done();
+                                                }
+                                            });
+                                        }
+                                    });
+                                }
+                            });
+                        }
+                    });
+                });
+            });
+
+            it('should use null for missing values if the value array is shorter than the key array', function(done) {
+                Context.init({contextStorage:memoryStorage});
+                Context.load().then(function(){
+                    var context =  Context.get("1","flow");
+                    context.set(["foo1","foo2","foo3"], ["bar1","bar2"], "memory", function(err){
+                        if (err) {
+                            done(err);
+                        } else {
+                            context.keys(function(err, keys){
+                                keys.should.have.length(3);
+                                keys.should.eql(["foo1","foo2","foo3"]);
+                                context.get(["foo1","foo2","foo3"], "memory", function(err,foo1,foo2,foo3){
+                                    if (err) {
+                                        done(err);
+                                    } else {
+                                        foo1.should.be.equal("bar1");
+                                        foo2.should.be.equal("bar2");
+                                        should(foo3).be.null();
+                                        done();
+                                    }
+                                });
+                            });
+                        }
+                    });
+                });
+            });
+
+            it('should use null for missing values if the value is not array', function(done) {
+                Context.init({contextStorage:memoryStorage});
+                Context.load().then(function(){
+                    var context =  Context.get("1","flow");
+                    context.set(["foo1","foo2","foo3"], "bar1", "memory", function(err){
+                        if (err) {
+                            done(err);
+                        } else {
+                            context.keys(function(err, keys){
+                                keys.should.have.length(3);
+                                keys.should.eql(["foo1","foo2","foo3"]);
+                                context.get(["foo1","foo2","foo3"], "memory", function(err,foo1,foo2,foo3){
+                                    if (err) {
+                                        done(err);
+                                    } else {
+                                        foo1.should.be.equal("bar1");
+                                        should(foo2).be.null();
+                                        should(foo3).be.null();
+                                        done();
+                                    }
+                                });
+                            });
+                        }
+                    });
+                });
+            });
+
+            it('should ignore the extra values if the value array is longer than the key array', function(done) {
+                Context.init({contextStorage:memoryStorage});
+                Context.load().then(function(){
+                    var context =  Context.get("1","flow");
+                    context.set(["foo1","foo2","foo3"], ["bar1","bar2","bar3","ignored"], "memory", function(err){
+                        if (err) {
+                            done(err);
+                        } else {
+                            context.keys(function(err, keys){
+                                keys.should.have.length(3);
+                                keys.should.eql(["foo1","foo2","foo3"]);
+                                context.get(["foo1","foo2","foo3"], "memory", function(err,foo1,foo2,foo3){
+                                    if (err) {
+                                        done(err);
+                                    } else {
+                                        foo1.should.be.equal("bar1");
+                                        foo2.should.be.equal("bar2");
+                                        foo3.should.be.equal("bar3");
+                                        done();
+                                    }
+                                });
+                            });
+                        }
+                    });
+                });
+            });
+
             it('should return an error if an error occurs in storing multiple values', function(done) {
                 Context.init({contextStorage:contextStorage});
                 stubSet.onFirstCall().callsArgWith(3, null);

--- a/test/red/runtime/nodes/context/index_spec.js
+++ b/test/red/runtime/nodes/context/index_spec.js
@@ -615,6 +615,46 @@ describe('context', function() {
                     });
                 }).catch(function(err){ done(err); });
             });
+
+            it('should store multiple properties if key and value are arrays', function(done) {
+                Context.init({contextStorage:memoryStorage});
+                Context.load().then(function(){
+                    var context =  Context.get("1","flow");
+                    context.set(["foo1","foo2","foo3"], ["bar1","bar2","bar3"], "memory", function(err){
+                        if (err) {
+                            done(err);
+                        } else {
+                            context.get(["foo1","foo2","foo3"], "memory", function(err,foo1,foo2,foo3){
+                                if (err) {
+                                    done(err);
+                                } else {
+                                    foo1.should.be.equal("bar1");
+                                    foo2.should.be.equal("bar2");
+                                    foo3.should.be.equal("bar3");
+                                    done();
+                                }
+                            });
+                        }
+                    });
+                });
+            });
+
+            it('should return an error if an error occurs in storing multiple values', function(done) {
+                Context.init({contextStorage:contextStorage});
+                stubSet.onFirstCall().callsArgWith(3, null);
+                stubSet.onSecondCall().callsArgWith(3, "error2");
+                stubSet.onThirdCall().callsArgWith(3, null);
+                Context.load().then(function(){
+                    var context =  Context.get("1","flow");
+                    context.set(["foo1","foo2","foo3"], ["bar1","bar2","bar3"], "memory", function(err){
+                        if (err === "error2") {
+                            done();
+                        } else {
+                            done("An error occurred");
+                        }
+                    });
+                }).catch(function(err){ done(err); });
+            });
         });
 
         describe('delete context',function(){


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
<!-- Describe the nature of this change. What problem does it address? -->

To minimise callback nesting, I added support for setting multiple values to `context.set ()`.
By passing arrays of key and value, you can set key/value pairs at once.

```javascript
   // Set multiple
   flow.set(['foo', 'bar'], [fooValue, barValue], function(err) {
   });
```
And I added test cases.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
