### PR TITLE
Fix the error that the parent directory of the context does not exist

### DIFF
--- a/red/runtime/nodes/context/localfilesystem.js
+++ b/red/runtime/nodes/context/localfilesystem.js
@@ -145,7 +145,7 @@ LocalFileSystem.prototype.open = function(){
             });
         }).catch(function(err){
             if(err.code == 'ENOENT') {
-                return fs.mkdir(self.storageBaseDir);
+                return fs.ensureDir(self.storageBaseDir);
             }else{
                 return Promise.reject(err);
             }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
<!-- Describe the nature of this change. What problem does it address? -->

I have fixed an error when initializing the cache in #1788.
But if the parent directory does not exist, the ENOENT error is thrown.
I fixed this to use `ensureDir()` instead of `mkdir()`.
And I added test cases.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
