### PR TITLE
Fix context access appearance of inject node in editor

### DIFF
--- a/nodes/core/core/20-inject.html
+++ b/nodes/core/core/20-inject.html
@@ -238,12 +238,8 @@ If you want every 20 minutes from now - use the <i>"interval"</i> option.</p>
                     return this._("inject.timestamp")+suffix;
                 }
             } else if (this.payloadType === 'flow' || this.payloadType === 'global') {
-                var key = this.payload;
-                var m = /^#:\((\S+?)\)::(.*)$/.exec(key);
-                if (m) {
-                    key = m[2];
-                }
-                return 'flow.'+key+suffix;
+                var key = RED.utils.parseContextKey(this.payload);
+                return this.payloadType+"."+key.key+suffix;
             } else {
                 return this._("inject.inject")+suffix;
             }
@@ -505,7 +501,13 @@ If you want every 20 minutes from now - use the <i>"interval"</i> option.</p>
                 if (this.changed) {
                     return RED.notify(RED._("notification.warning", {message:RED._("notification.warnings.undeployedChanges")}),"warning");
                 }
-                var label = (this.name||this.payload);
+                var payload = this.payload;
+                if ((this.payloadType === 'flow') ||
+                    (this.payloadType === 'global')) {
+                    var key = RED.utils.parseContextKey(payload);
+                    payload = this.payloadType+"."+key.key;
+                }
+                var label = (this.name||payload);
                 if (label.length > 30) {
                     label = label.substring(0,50)+"...";
                 }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This PR fixes following problems in persistable context access  of inject node:
- target is always shown as `flow` even if it is `global`,
- notification message is show in raw format (e.g. `#:(store)::name`) without target information,
- parsing context storage access speficication do not use `RED.utils.parseContextKey`.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
