### PR TITLE
Fix typos in util.js

### DIFF
--- a/red/runtime/util.js
+++ b/red/runtime/util.js
@@ -305,7 +305,7 @@ function setMessageProperty(msg,prop,value,createMissing) {
     }
 }
 
-function evaluteEnvProperty(value) {
+function evaluateEnvProperty(value) {
     if (/^\${[^}]+}$/.test(value)) {
         // ${ENV_VAR}
         value = value.substring(2,value.length-1);
@@ -372,7 +372,7 @@ function evaluateNodeProperty(value, type, node, msg, callback) {
         var expr = prepareJSONataExpression(value,node);
         result = evaluateJSONataExpression(expr,msg);
     } else if (type === 'env') {
-        result = evaluteEnvProperty(value);
+        result = evaluateEnvProperty(value);
     }
     if (callback) {
         callback(null,result);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This PR fixes typo of function `evaluteEnvProperty` to `evaluateEnvProperty` in `red/runtime/util.js`.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality