### PR TITLE
Allow environment variable as reduce init value in split node

### DIFF
--- a/nodes/core/logic/17-split.html
+++ b/nodes/core/logic/17-split.html
@@ -415,7 +415,7 @@
                     $("#node-input-reduceExp").typedInput({types:[jsonata_or_empty]});
                     $("#node-input-reduceInit").typedInput({
                         default: 'num',
-                        types:['flow','global','str','num','bool','json','bin','date','jsonata'],
+                        types:['flow','global','str','num','bool','json','bin','date','jsonata','env'],
                         typeField: $("#node-input-reduceInitType")
                     });
                     $("#node-input-reduceFixup").typedInput({types:[jsonata_or_empty]});

--- a/nodes/core/logic/17-split.js
+++ b/nodes/core/logic/17-split.js
@@ -359,47 +359,16 @@ module.exports = function(RED) {
     }
 
     function getInitialReduceValue(node, exp, exp_type) {
-        return new Promise((resolve,reject) => {
-            if(exp_type === "flow" || exp_type === "global") {
-                node.context()[exp_type].get(exp,(err,value) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(value);
-                    }
-                });
-                return;
-            } else if(exp_type === "jsonata") {
-                var jexp = RED.util.prepareJSONataExpression(exp, node);
-                RED.util.evaluateJSONataExpression(jexp, {},(err,value) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(value);
-                    }
-                });
-                return;
-            }
-            var result;
-            if(exp_type === "str") {
-                result = exp;
-            } else if(exp_type === "num") {
-                result = Number(exp);
-            } else if(exp_type === "bool") {
-                if (exp === 'true') {
-                    result = true;
-                } else if (exp === 'false') {
-                    result = false;
-                }
-            } else if ((exp_type === "bin") || (exp_type === "json")) {
-                result = JSON.parse(exp);
-            } else if(exp_type === "date") {
-                result = Date.now();
-            } else {
-                reject(new Error("unexpected initial value type"));
-                return;
-            }
-            resolve(result);
+        return new Promise((resolve, reject) => {
+            RED.util.evaluateNodeProperty(exp, exp_type, node, {},
+                                          (err, result) => {
+                                              if(err) {
+                                                  return reject(err);
+                                              }
+                                              else {
+                                                  return resolve(result);
+                                              }
+                                          });
         });
     }
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
`split` node implementation of current 0.19 branch do not support new environment variable input of `typedInput`.  
This PR add support for this.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
