### PR TITLE
 Add context store support to JSONata functions 

### DIFF
--- a/red/runtime/util.js
+++ b/red/runtime/util.js
@@ -408,9 +408,9 @@ function evaluateJSONataExpression(expr,msg,callback) {
     if (callback) {
         // If callback provided, need to override the pre-assigned sync
         // context functions to be their async variants
-        bindings.flowContext = function(val) {
+        bindings.flowContext = function(val, store) {
             return new Promise((resolve,reject) => {
-                expr._node.context().flow.get(val, function(err,value) {
+                expr._node.context().flow.get(val, store, function(err,value) {
                     if (err) {
                         reject(err);
                     } else {
@@ -419,9 +419,9 @@ function evaluateJSONataExpression(expr,msg,callback) {
                 })
             });
         }
-        bindings.globalContext = function(val) {
+        bindings.globalContext = function(val, store) {
             return new Promise((resolve,reject) => {
-                expr._node.context().global.get(val, function(err,value) {
+                expr._node.context().global.get(val, store, function(err,value) {
                     if (err) {
                         reject(err);
                     } else {

--- a/test/nodes/core/logic/15-change_spec.js
+++ b/test/nodes/core/logic/15-change_spec.js
@@ -560,6 +560,102 @@ describe('change Node', function() {
             });
         });
 
+        it('changes the value using flow context with jsonata', function(done) {
+            var flow = [{"id":"changeNode1","type":"change",rules:[{"t":"set","p":"payload","to":"$flowContext(\"foo\")","tot":"jsonata"}],"name":"changeNode","wires":[["helperNode1"]],"z":"flow"},
+                        {id:"helperNode1", type:"helper", wires:[],"z":"flow"},{"id":"flow","type":"tab"}];
+            helper.load(changeNode, flow, function() {
+                initContext(function () {
+                    var changeNode1 = helper.getNode("changeNode1");
+                    var helperNode1 = helper.getNode("helperNode1");
+                    changeNode1.context().flow.set("foo","bar");
+                    helperNode1.on("input", function(msg) {
+                        try {
+                            msg.payload.should.eql("bar");
+                            done();
+                        } catch(err) {
+                            done(err);
+                        }
+                    });
+                    changeNode1.receive({payload:"Hello World!"});
+                });
+            });
+        });
+
+        it('changes the value using global context with jsonata', function(done) {
+            var flow = [{"id":"changeNode1","type":"change",rules:[{"t":"set","p":"payload","to":"$globalContext(\"foo\")","tot":"jsonata"}],"name":"changeNode","wires":[["helperNode1"]],"z":"flow"},
+                        {id:"helperNode1", type:"helper", wires:[],"z":"flow"},{"id":"flow","type":"tab"}];
+            helper.load(changeNode, flow, function() {
+                initContext(function () {
+                    var changeNode1 = helper.getNode("changeNode1");
+                    var helperNode1 = helper.getNode("helperNode1");
+                    changeNode1.context().global.set("foo","bar");
+                    helperNode1.on("input", function(msg) {
+                        try {
+                            msg.payload.should.eql("bar");
+                            done();
+                        } catch(err) {
+                            done(err);
+                        }
+                    });
+                    changeNode1.receive({payload:"Hello World!"});
+                });
+            });
+        });
+
+        it('changes the value using persistable flow context with jsonata', function(done) {
+            var flow = [{"id":"changeNode1","type":"change",rules:[{"t":"set","p":"payload","to":"$flowContext(\"foo\",\"memory1\")","tot":"jsonata"}],"name":"changeNode","wires":[["helperNode1"]],"z":"flow"},
+                        {id:"helperNode1", type:"helper", wires:[],"z":"flow"},{"id":"flow","type":"tab"}];
+            helper.load(changeNode, flow, function() {
+                initContext(function () {
+                    var changeNode1 = helper.getNode("changeNode1");
+                    var helperNode1 = helper.getNode("helperNode1");
+                    helperNode1.on("input", function(msg) {
+                        try {
+                            msg.payload.should.eql("bar");
+                            done();
+                        } catch(err) {
+                            done(err);
+                        }
+                    });
+                    changeNode1.context().flow.set("foo","bar","memory1",function(err){
+                        if(err){
+                            done(err);
+                        }else{
+                            changeNode1.context().flow.set("foo","error!");
+                            changeNode1.receive({payload:"Hello World!"});
+                        }
+                    });
+                });
+            });
+        });
+
+        it('changes the value using persistable global context with jsonata', function(done) {
+            var flow = [{"id":"changeNode1","type":"change",rules:[{"t":"set","p":"payload","to":"$globalContext(\"foo\",\"memory1\")","tot":"jsonata"}],"name":"changeNode","wires":[["helperNode1"]],"z":"flow"},
+                        {id:"helperNode1", type:"helper", wires:[],"z":"flow"},{"id":"flow","type":"tab"}];
+            helper.load(changeNode, flow, function() {
+                initContext(function () {
+                    var changeNode1 = helper.getNode("changeNode1");
+                    var helperNode1 = helper.getNode("helperNode1");
+                    helperNode1.on("input", function(msg) {
+                        try {
+                            msg.payload.should.eql("bar");
+                            done();
+                        } catch(err) {
+                            done(err);
+                        }
+                    });
+                    changeNode1.context().global.set("foo","bar","memory1",function(err){
+                        if(err){
+                            done(err);
+                        }else{
+                            changeNode1.context().global.set("foo","error!");
+                            changeNode1.receive({payload:"Hello World!"});
+                        }
+                    });
+                });
+            });
+        });
+
     });
     describe('#change', function() {
         it('changes the value of the message property', function(done) {
@@ -1431,7 +1527,7 @@ describe('change Node', function() {
                 });
             });
         });
-        
+
         it('applies multiple rules in order', function(done) {
             var flow = [{"id":"changeNode1","type":"change","wires":[["helperNode1"]],
                         rules:[
@@ -1487,7 +1583,7 @@ describe('change Node', function() {
                 });
             });
         });
-        
+
         it('can access two persistable global context property', function(done) {
             var flow = [{"id":"changeNode1", "z":"t1", "type":"change",
                          "wires":[["helperNode1"]],
@@ -1518,7 +1614,7 @@ describe('change Node', function() {
                 });
             });
         });
-        
+
         it('can access persistable global & flow context property', function(done) {
             var flow = [{"id":"changeNode1", "z":"t1", "type":"change",
                          "wires":[["helperNode1"]],
@@ -1551,6 +1647,6 @@ describe('change Node', function() {
                 });
             });
         });
-        
+
     });
 });

--- a/test/nodes/core/logic/18-sort_spec.js
+++ b/test/nodes/core/logic/18-sort_spec.js
@@ -18,20 +18,32 @@ var should = require("should");
 var sortNode = require("../../../../nodes/core/logic/18-sort.js");
 var helper = require("node-red-node-test-helper");
 var RED = require("../../../../red/red.js");
+var Context = require("../../../../red/runtime/nodes/context");
 
 describe('SORT node', function() {
 
-    before(function(done) {
+    beforeEach(function(done) {
         helper.startServer(done);
     });
 
-    after(function(done) {
-        helper.stopServer(done);
-    });
+    function initContext(done) {
+        Context.init({
+            contextStorage: {
+                memory: {
+                    module: "memory"
+                }
+            }
+        });
+        Context.load().then(function () {
+            done();
+        });
+    }
 
-    afterEach(function() {
-        helper.unload();
-        RED.settings.nodeMessageBufferMaxLength = 0;
+    afterEach(function(done) {
+        helper.unload().then(function(){
+            RED.settings.nodeMessageBufferMaxLength = 0;
+            helper.stopServer(done);
+        });
     });
 
     it('should be loaded', function(done) {
@@ -48,8 +60,8 @@ describe('SORT node', function() {
         var sort = flow[0];
         sort.target = target;
         sort.targetType = "msg";
-        sort.msgKey = key; 
-        sort.msgKeyType = key_type; 
+        sort.msgKey = key;
+        sort.msgKeyType = key_type;
         helper.load(sortNode, flow, function() {
             var n1 = helper.getNode("n1");
             var n2 = helper.getNode("n2");
@@ -213,7 +225,7 @@ describe('SORT node', function() {
             check_sort1C(flow, "$substring(payload,1)", data_in, data_out, done);
         });
     })();
-    
+
     (function() {
         var flow = [{id:"n1", type:"sort", order:"descending", as_num:false, wires:[["n2"]]},
                         {id:"n2", type:"helper"}];
@@ -226,6 +238,134 @@ describe('SORT node', function() {
             check_sort1C(flow, "$substring(payload,1)", data_in, data_out, done);
         });
     })();
+
+    it('should sort payload by context (exp, not number, ascending)', function(done) {
+        var flow = [{id:"n1", type:"sort", target:"data", targetType:"msg", msgKey:"$flowContext($)", msgKeyType:"jsonata", order:"ascending", as_num:false, wires:[["n2"]],z:"flow"},
+                    {id:"n2", type:"helper",z:"flow"},
+                    {id:"flow", type:"tab"}];
+        var data_in  = [ "first", "second", "third", "fourth" ];
+        var data_out = [ "second", "third", "first", "fourth" ];
+        helper.load(sortNode, flow, function() {
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n1.context()["flow"].set("first","3");
+            n1.context()["flow"].set("second","1");
+            n1.context()["flow"].set("third","2");
+            n1.context()["flow"].set("fourth","4");
+            n2.on("input", function(msg) {
+                msg.should.have.property("data");
+                var data = msg["data"];
+                data.length.should.equal(data_out.length);
+                for(var i = 0; i < data_out.length; i++) {
+                    data[i].should.equal(data_out[i]);
+                }
+                done();
+            });
+            var msg = {};
+            msg["data"] = data_in;
+            n1.receive(msg);
+        });
+    });
+
+    it('should sort message group by context (exp, not number, ascending)', function(done) {
+        var flow = [{id:"n1", type:"sort", target:"data", targetType:"msg", msgKey:"$globalContext(payload)", msgKeyType:"jsonata", order:"ascending", as_num:false, wires:[["n2"]],z:"flow"},
+                    {id:"n2", type:"helper",z:"flow"},
+                    {id:"flow", type:"tab"}];
+        var data_in  = [ "first", "second", "third", "fourth" ];
+        var data_out = [ "second", "fourth", "third", "first" ];
+        helper.load(sortNode, flow, function() {
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            var count = 0;
+            n1.context()["global"].set("first","4");
+            n1.context()["global"].set("second","1");
+            n1.context()["global"].set("third","3");
+            n1.context()["global"].set("fourth","2");
+            n2.on("input", function(msg) {
+                msg.should.have.property("payload");
+                msg.should.have.property("parts");
+                msg.parts.should.have.property("count", data_out.length);
+                var data = msg["payload"];
+                var index = data_out.indexOf(data);
+                msg.parts.should.have.property("index", index);
+                count++;
+                if (count === data_out.length) {
+                    done();
+                }
+            });
+            var len = data_in.length;
+            for(var i = 0; i < len; i++) {
+                var parts = { id: "X", index: i, count: len };
+                var msg = {parts: parts};
+                msg["payload"] = data_in[i];
+                n1.receive(msg);
+            }
+        });
+    });
+
+    it('should sort payload by persistable context (exp, not number, descending)', function(done) {
+        var flow = [{id:"n1", type:"sort", target:"data", targetType:"msg", msgKey:"$globalContext($,\"memory\")", msgKeyType:"jsonata", order:"descending", as_num:false, wires:[["n2"]],z:"flow"},
+                    {id:"n2", type:"helper",z:"flow"},
+                    {id:"flow", type:"tab"}];
+        var data_in  = [ "first", "second", "third", "fourth" ];
+        var data_out = [ "fourth", "first", "third", "second" ];
+        helper.load(sortNode, flow, function() {
+            initContext(function(){
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                n1.context()["global"].set(["first","second","third","fourth"],["3","1","2","4"],"memory",function(){
+                    n2.on("input", function(msg) {
+                        msg.should.have.property("data");
+                        var data = msg["data"];
+                        data.length.should.equal(data_out.length);
+                        for(var i = 0; i < data_out.length; i++) {
+                            data[i].should.equal(data_out[i]);
+                        }
+                        done();
+                    });
+                    var msg = {};
+                    msg["data"] = data_in;
+                    n1.receive(msg);
+                });
+            });
+        });
+    });
+
+    it('should sort message group by persistable context (exp, not number, descending)', function(done) {
+        var flow = [{id:"n1", type:"sort", target:"data", targetType:"msg", msgKey:"$flowContext(payload,\"memory\")", msgKeyType:"jsonata", order:"descending", as_num:false, wires:[["n2"]],z:"flow"},
+                    {id:"n2", type:"helper",z:"flow"},
+                    {id:"flow", type:"tab"}];
+        var data_in  = [ "first", "second", "third", "fourth" ];
+        var data_out = [ "first", "third", "fourth", "second" ];
+        helper.load(sortNode, flow, function() {
+            initContext(function(){
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                var count = 0;
+                n1.context()["flow"].set(["first","second","third","fourth"],["4","1","3","2"],"memory",function(){
+                    n2.on("input", function(msg) {
+                        msg.should.have.property("payload");
+                        msg.should.have.property("parts");
+                        msg.parts.should.have.property("count", data_out.length);
+                        var data = msg["payload"];
+                        var index = data_out.indexOf(data);
+                        msg.parts.should.have.property("index", index);
+                        count++;
+                        if (count === data_out.length) {
+                            done();
+                        }
+                    });
+                    var len = data_in.length;
+                    for(var i = 0; i < len; i++) {
+                        var parts = { id: "X", index: i, count: len };
+                        var msg = {parts: parts};
+                        msg["payload"] = data_in[i];
+                        n1.receive(msg);
+                    }
+                });
+            });
+        });
+    });
 
     it('should handle JSONata script error', function(done) {
         var flow = [{id:"n1", type:"sort", order:"ascending", as_num:false, target:"payload", targetType:"seq", seqKey:"$unknown()", seqKeyType:"jsonata", wires:[["n2"]]},
@@ -248,7 +388,7 @@ describe('SORT node', function() {
             n1.receive(msg1);
         });
     });
-    
+
     it('should handle too many pending messages', function(done) {
         var flow = [{id:"n1", type:"sort", order:"ascending", as_num:false, target:"payload", targetType:"seq", seqKey:"payload", seqKeyType:"msg", wires:[["n2"]]},
                     {id:"n2", type:"helper"}];

--- a/test/red/runtime/util_spec.js
+++ b/test/red/runtime/util_spec.js
@@ -459,7 +459,7 @@ describe("red/util", function() {
               should.not.exist(result);
           });
           it('handles async flow context access', function(done) {
-              var expr = util.prepareJSONataExpression('$flowContext("foo")',{context:function() { return {flow:{get: function(key,callback) { setTimeout(()=>{callback(null,{'foo':'bar'}[key])},10)}}}}});
+              var expr = util.prepareJSONataExpression('$flowContext("foo")',{context:function() { return {flow:{get: function(key,store,callback) { setTimeout(()=>{callback(null,{'foo':'bar'}[key])},10)}}}}});
               util.evaluateJSONataExpression(expr,{payload:"hello"},function(err,value) {
                   try {
                       should.not.exist(err);
@@ -471,11 +471,39 @@ describe("red/util", function() {
               });
           })
           it('handles async global context access', function(done) {
-              var expr = util.prepareJSONataExpression('$globalContext("foo")',{context:function() { return {global:{get: function(key,callback) { setTimeout(()=>{callback(null,{'foo':'bar'}[key])},10)}}}}});
+              var expr = util.prepareJSONataExpression('$globalContext("foo")',{context:function() { return {global:{get: function(key,store,callback) { setTimeout(()=>{callback(null,{'foo':'bar'}[key])},10)}}}}});
               util.evaluateJSONataExpression(expr,{payload:"hello"},function(err,value) {
                   try {
                       should.not.exist(err);
                       value.should.eql("bar");
+                      done();
+                  } catch(err2) {
+                      done(err2);
+                  }
+              });
+          })
+          it('handles persistable store in flow context access', function(done) {
+              var storeName;
+              var expr = util.prepareJSONataExpression('$flowContext("foo", "flowStoreName")',{context:function() { return {flow:{get: function(key,store,callback) { storeName = store;setTimeout(()=>{callback(null,{'foo':'bar'}[key])},10)}}}}});
+              util.evaluateJSONataExpression(expr,{payload:"hello"},function(err,value) {
+                  try {
+                      should.not.exist(err);
+                      value.should.eql("bar");
+                      storeName.should.equal("flowStoreName");
+                      done();
+                  } catch(err2) {
+                      done(err2);
+                  }
+              });
+          })
+          it('handles persistable store in global context access', function(done) {
+              var storeName;
+              var expr = util.prepareJSONataExpression('$globalContext("foo", "globalStoreName")',{context:function() { return {global:{get: function(key,store,callback) { storeName = store;setTimeout(()=>{callback(null,{'foo':'bar'}[key])},10)}}}}});
+              util.evaluateJSONataExpression(expr,{payload:"hello"},function(err,value) {
+                  try {
+                      should.not.exist(err);
+                      value.should.eql("bar");
+                      storeName.should.equal("globalStoreName");
                       done();
                   } catch(err2) {
                       done(err2);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
<!-- Describe the nature of this change. What problem does it address? -->

This PR adds context store support to the JSONata function.

```text
    $flowContext(key [, store])
    $globalContext(key [, store])
```
If the optional `store` parameter is supplied, then the function retrieves a context property from specified context store.
If it is not supplied, then the function retrieves a context property from `default` context store(e.g. existing memory).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
