### PR TITLE
Add support of bin, data, and env type to trigger node

### DIFF
--- a/nodes/core/core/89-trigger.html
+++ b/nodes/core/core/89-trigger.html
@@ -162,7 +162,7 @@
             $("#node-input-op1").typedInput({
                 default: 'str',
                 typeField: $("#node-input-op1type"),
-                types:['flow','global','str','num','bool','json',
+                types:['flow','global','str','num','bool','json','bin','date','env',
                     optionPayload,
                     optionNothing
                 ]
@@ -170,7 +170,7 @@
             $("#node-input-op2").typedInput({
                 default: 'str',
                 typeField: $("#node-input-op2type"),
-                types:['flow','global','str','num','bool','json',
+                types:['flow','global','str','num','bool','json','bin','date','env',
                     optionOriginalPayload,
                     optionLatestPayload,
                     optionNothing


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Trigger node lacks support of binary buffer, timestamp, and environment variable for typedInput fields.
This PR fixes this problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
