### PR TITLE
Fix bugs about "isEmpty" rule in Switch node 

### DIFF
--- a/nodes/core/logic/10-switch.html
+++ b/nodes/core/logic/10-switch.html
@@ -147,7 +147,7 @@
                 }
                 if ((rule.t === 'btwn') || (rule.t === 'index')) {
                     label += " "+getValueLabel(rule.vt,rule.v)+" & "+getValueLabel(rule.v2t,rule.v2);
-                } else if (rule.t !== 'true' && rule.t !== 'false' && rule.t !== 'null' && rule.t !== 'nnull' && rule.t !== 'else' ) {
+                } else if (rule.t !== 'true' && rule.t !== 'false' && rule.t !== 'null' && rule.t !== 'nnull' && rule.t !== 'empty' && rule.t !== 'nempty' && rule.t !== 'else' ) {
                     label += " "+getValueLabel(rule.vt,rule.v);
                 }
                 return label;
@@ -199,7 +199,7 @@
                 } else if (type === "istype") {
                     typeField.typedInput("width",(newWidth-selectWidth-70));
                 } else {
-                    if (type === "true" || type === "false" || type === "null" || type === "nnull" || type === "else") {
+                    if (type === "true" || type === "false" || type === "null" || type === "nnull" || type === "empty" || type === "nempty" || type === "else") {
                         // valueField.hide();
                     } else {
                         valueField.typedInput("width",(newWidth-selectWidth-70));
@@ -295,7 +295,7 @@
                             numValueField.typedInput('hide');
                             typeValueField.typedInput('hide');
                             valueField.typedInput('hide');
-                            if (type === "true" || type === "false" || type === "null" || type === "nnull" || type === "else") {
+                            if (type === "true" || type === "false" || type === "null" || type === "nnull" || type === "empty" || type === "nempty" || type === "else") {
                                 valueField.typedInput('hide');
                                 typeValueField.typedInput('hide');
                             }
@@ -396,7 +396,7 @@
                 var rule = $(this);
                 var type = rule.find("select").val();
                 var r = {t:type};
-                if (!(type === "true" || type === "false" || type === "null" || type === "nnull" || type === "else")) {
+                if (!(type === "true" || type === "false" || type === "null" || type === "nnull" || type === "empty" || type === "nempty" || type === "else")) {
                     if ((type === "btwn") || (type === "index")) {
                         r.v = rule.find(".node-input-rule-btwn-value").typedInput('value');
                         r.vt = rule.find(".node-input-rule-btwn-value").typedInput('type');

--- a/nodes/core/logic/10-switch.js
+++ b/nodes/core/logic/10-switch.js
@@ -34,7 +34,7 @@ module.exports = function(RED) {
         'empty': function(a) {
             if (typeof a === 'string' || Array.isArray(a) || Buffer.isBuffer(a)) {
                 return a.length === 0;
-            } else if (typeof a === 'object') {
+            } else if (typeof a === 'object' && a !== null) {
                 return Object.keys(a).length === 0;
             }
             return false;
@@ -42,7 +42,7 @@ module.exports = function(RED) {
         'nempty': function(a) {
             if (typeof a === 'string' || Array.isArray(a) || Buffer.isBuffer(a)) {
                 return a.length !== 0;
-            } else if (typeof a === 'object') {
+            } else if (typeof a === 'object' && a !== null) {
                 return Object.keys(a).length !== 0;
             }
             return false;

--- a/test/nodes/core/logic/10-switch_spec.js
+++ b/test/nodes/core/logic/10-switch_spec.js
@@ -379,7 +379,7 @@ describe('switch Node', function() {
         singularSwitchTest("empty", true, false, undefined, done);
     });
     it('should check if payload is empty (0)', function(done) {
-        singularSwitchTest("empty", true, false, null, done);
+        singularSwitchTest("empty", true, false, 0, done);
     });
 
     it('should check if payload is not empty (string)', function(done) {
@@ -413,7 +413,7 @@ describe('switch Node', function() {
         singularSwitchTest("nempty", true, false, undefined, done);
     });
     it('should check if payload is not empty (0)', function(done) {
-        singularSwitchTest("nempty", true, false, null, done);
+        singularSwitchTest("nempty", true, false, 0, done);
     });
 
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
<!-- Describe the nature of this change. What problem does it address? -->

I fixed bugs about followings in Switch node .
* Editor
  * A typedInput is displayed when `isEmpty` or `isNotEmpty` rule is selected.
  * `outputlavel` of  `isEmpty` or `isNotEmpty` displays unnecesarry typedInput value.
  * `isEmpty` or `isNotEmpty` passes unnecesarry typedInput value to runtime.
* Runtime
  * An error occurs when evaluating `null` on `isEmpty` or `isNotEmpty` rule.
* Test case
  *  Evaluating `null` instead of `0` by mistake.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
