### PR TITLE
Fix use of "memory" as default store name

### DIFF
--- a/red/runtime/nodes/context/index.js
+++ b/red/runtime/nodes/context/index.js
@@ -58,7 +58,7 @@ function init(_settings) {
     var seed = settings.functionGlobalContext || {};
     contexts['global'] = createContext("global",seed);
     stores["_"] = new memory();
-    defaultStore = "memory";
+    defaultStore = "_";
 }
 
 function load() {
@@ -150,16 +150,16 @@ function load() {
             } else {
                 // else there were no stores list the config object - fall through
                 // to below where we default to a memory store
-                storeList = ["memory"];
-                defaultStore = "memory";
+                storeList = ["_"];
+                defaultStore = "_";
             }
             hasConfiguredStore = true;
             storeList = Object.keys(stores).filter(n=>!(defaultIsAlias && n==="default") && n!== "_");
         } else {
             // No configured plugins
             promises.push(stores["_"].open())
-            storeList = ["memory"];
-            defaultStore = "memory";
+            storeList = ["_"];
+            defaultStore = "_";
         }
         return resolve(Promise.all(promises));
     });

--- a/test/red/runtime/nodes/context/index_spec.js
+++ b/test/red/runtime/nodes/context/index_spec.js
@@ -853,6 +853,16 @@ describe('context', function() {
         });
 
         describe('listStores', function () {
+            it('should list default context storages', function (done) {
+                Context.init({});
+                Context.load().then(function () {
+                    var list = Context.listStores();
+                    list.default.should.equal("_");
+                    list.stores.should.eql(["_"]);
+                    done();
+                }).catch(done);
+            });
+
             it('should list context storages', function (done) {
                 Context.init({ contextStorage: contextDefaultStorage });
                 Context.load().then(function () {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Current context store implementation uses `"memory"` as default store name if no store is defined in `settings.js`.  Since `"memory"` store is not defined in default, it fallbacks to `"_"` store.
This fix changes `"memory"` to `"_"`.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
