### PR TITLE
Fix to remove unnecessary typedInput option element

### DIFF
--- a/editor/js/ui/common/typedInput.js
+++ b/editor/js/ui/common/typedInput.js
@@ -440,6 +440,9 @@
             }
         },
         _destroy: function() {
+            if (this.optionMenu) {
+                this.optionMenu.remove();
+            }
             this.menu.remove();
         },
         types: function(types) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
<!-- Describe the nature of this change. What problem does it address? -->
We found a problem by UI testing.

When TypedInput is displayed, some html elements are created as option.
Then close the edit dialog, typedInput option element remains as following.  

![typedinput_remain](https://user-images.githubusercontent.com/31908137/43299955-93d21f8a-9197-11e8-9645-2475a12f2489.png)

I fixed this.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
