### PR TITLE
Allow `get` and `keys` to be called without callback

### DIFF
--- a/red/runtime/nodes/context/index.js
+++ b/red/runtime/nodes/context/index.js
@@ -220,7 +220,7 @@ function createContext(id,seed) {
                 callback = storage;
                 storage = "_";
             }
-            if (typeof callback !== 'function'){
+            if (callback && typeof callback !== 'function'){
                 throw new Error("Callback must be a function");
             }
             context = getContextStorage(storage);
@@ -279,7 +279,7 @@ function createContext(id,seed) {
                 callback = storage;
                 storage = "_";
             }
-            if (typeof callback !== 'function') {
+            if (callback && typeof callback !== 'function') {
                 throw new Error("Callback must be a function");
             }
             context = getContextStorage(storage);

--- a/test/red/runtime/nodes/context/index_spec.js
+++ b/test/red/runtime/nodes/context/index_spec.js
@@ -793,15 +793,13 @@ describe('context', function() {
                 });
             });
 
-            it('should throw an error if callback of context.get is not specified', function (done) {
+            it('should not throw an error if callback of context.get is not specified', function (done) {
                 Context.init({ contextStorage: memoryStorage });
                 Context.load().then(function () {
                     var context = Context.get("1", "flow");
                     context.get("foo", "memory");
-                    done("should throw an error.");
-                }).catch(function () {
                     done();
-                });
+                }).catch(done);
             });
 
             it('should throw an error if callback of context.set is not a function', function (done) {
@@ -835,15 +833,13 @@ describe('context', function() {
                 });
             });
 
-            it('should throw an error if callback of context.keys is not specified', function (done) {
+            it('should not throw an error if callback of context.keys is not specified', function (done) {
                 Context.init({ contextStorage: memoryStorage });
                 Context.load().then(function () {
                     var context = Context.get("1", "flow");
                     context.keys("memory");
-                    done("should throw an error.");
-                }).catch(function () {
                     done();
-                });
+                }).catch(done);
             });
 
         });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Allow `context.get` and `context.keys` to be called without callback when `store` is specified.
You can call these as followings.
```javascript
context.get("key","store");
context.keys("store");
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
