### PR TITLE
Fix use of HTML tag or CSS class specification as icon of TypedInput

### DIFF
--- a/editor/js/ui/common/typedInput.js
+++ b/editor/js/ui/common/typedInput.js
@@ -522,10 +522,18 @@
                     this.selectLabel.empty();
                     var image;
                     if (opt.icon) {
-                        image = new Image();
-                        image.name = opt.icon;
-                        image.src = opt.icon;
-                        $('<img>',{src:opt.icon,style:"margin-right: 4px;height: 18px;"}).prependTo(this.selectLabel);
+                        if (opt.icon.indexOf("<") === 0) {
+                            $(opt.icon).prependTo(this.selectLabel);
+                        }
+                        else if (opt.icon.indexOf("/") !== -1) {
+                            image = new Image();
+                            image.name = opt.icon;
+                            image.src = opt.icon;
+                            $('<img>',{src:opt.icon,style:"margin-right: 4px;height: 18px;"}).prependTo(this.selectLabel);
+                        }
+                        else {
+                            $('<i>',{class:"red-ui-typedInput-icon "+opt.icon}).prependTo(this.selectLabel);
+                        }
                     } else {
                         this.selectLabel.text(opt.label);
                     }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
`TypedInput` widget seems to support specification of `TypeDefinition` icon by HTML tag or CSS class.  But it fails to show when selecting from a type menu.

This PR fixes this problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
