### PR TITLE
Allows MQTT Shared Subscriptions for MQTT-In core node

### DIFF
--- a/nodes/core/io/10-mqtt.js
+++ b/nodes/core/io/10-mqtt.js
@@ -24,6 +24,19 @@ module.exports = function(RED) {
         if (ts == "#") {
             return true;
         }
+        /* The following allows shared subscriptions (as in MQTT v5)
+           http://docs.oasis-open.org/mqtt/mqtt/v5.0/cs02/mqtt-v5.0-cs02.html#_Toc514345522
+           
+           4.8.2 describes shares like:
+           $share/{ShareName}/{filter}
+           $share is a literal string that marks the Topic Filter as being a Shared Subscription Topic Filter.
+           {ShareName} is a character string that does not include "/", "+" or "#"
+           {filter} The remainder of the string has the same syntax and semantics as a Topic Filter in a non-shared subscription. Refer to section 4.7.
+        */
+        else if(ts.startsWith("$share")){
+            ts = ts.replace(/^\$share\/[^#+/]+\/(.*)/g,"$1");
+            
+        }
         var re = new RegExp("^"+ts.replace(/([\[\]\?\(\)\\\\$\^\*\.|])/g,"\\$1").replace(/\+/g,"[^/]+").replace(/\/#$/,"(\/.*)?")+"$");
         return re.test(t);
     }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This change allows to subscribe to shared subscriptions in the MQTT-In core node.
Before the topic check would fail because subscribe topic and the topic in the message are not the same for shared subscriptions.
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
  --> I created a topic on the [forum](https://discourse.nodered.org/t/core-mqtt-in-shared-subscriptions-for-core-node-mqtt-in-mqtt-v5/2475)
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
