### PR TITLE
Catch readonly write errors more cleanly

### DIFF
--- a/red.js
+++ b/red.js
@@ -101,8 +101,15 @@ if (parsedArgs.settings) {
             var settingsStat = fs.statSync(defaultSettings);
             if (settingsStat.mtime.getTime() <= settingsStat.ctime.getTime()) {
                 // Default settings file has not been modified - safe to copy
-                fs.copySync(defaultSettings,userSettingsFile);
-                settingsFile = userSettingsFile;
+                try {
+                    fs.copySync(defaultSettings,userSettingsFile);
+                    settingsFile = userSettingsFile;
+                }
+                catch (err) {
+                    console.log("Can't copy settings file. Is file system Read Only ?");
+                    console.log("You may want to set readOnly: true, in settings.js");
+                    process.exit(1);
+                }
             } else {
                 // Use default settings.js as it has been modified
                 settingsFile = defaultSettings;

--- a/red.js
+++ b/red.js
@@ -106,8 +106,11 @@ if (parsedArgs.settings) {
                     settingsFile = userSettingsFile;
                 }
                 catch (err) {
-                    console.log("Can't copy settings file. Is file system Read Only ?");
-                    console.log("You may want to set readOnly: true, in settings.js");
+                    console.log("Failed to copy settings file to "+userSettingsFile);
+                    console.log("Error: "+err.toString());
+                    if (err.code == "EACCES") {
+                        console.log("You may need to set readOnly: true, in settings.js");
+                    }
                     process.exit(1);
                 }
             } else {

--- a/red/runtime/locales/en-US/runtime.json
+++ b/red/runtime/locales/en-US/runtime.json
@@ -142,7 +142,7 @@
             "restore": "Restoring __type__ file backup : __path__",
             "restore-fail": "Restoring __type__ file backup failed : __message__",
             "fsync-fail": "Flushing file __path__ to disk failed : __message__",
-            "fwrite-fail": "Writing backup file __path__ to disk failed.",
+            "fwrite-fail": "Writing backup file __path__ to disk failed : __message__",
             "projects": {
                 "changing-project": "Setting active project : __project__",
                 "active-project": "Active project : __project__",

--- a/red/runtime/locales/en-US/runtime.json
+++ b/red/runtime/locales/en-US/runtime.json
@@ -142,6 +142,7 @@
             "restore": "Restoring __type__ file backup : __path__",
             "restore-fail": "Restoring __type__ file backup failed : __message__",
             "fsync-fail": "Flushing file __path__ to disk failed : __message__",
+            "fwrite-fail": "Writing backup file __path__ to disk failed.",
             "projects": {
                 "changing-project": "Setting active project : __project__",
                 "active-project": "Active project : __project__",

--- a/red/runtime/storage/localfilesystem/util.js
+++ b/red/runtime/storage/localfilesystem/util.js
@@ -81,7 +81,11 @@ module.exports = {
      writeFile: function(path,content,backupPath) {
          if (backupPath) {
             if (fs.existsSync(path)) {
-                fs.renameSync(path,backupPath);
+                try {
+                    fs.renameSync(path,backupPath);
+                } catch(e) {
+                    log.warn(log._("storage.localfilesystem.fwrite-fail",{path:path}));
+                }
             }
         }
         return when.promise(function(resolve,reject) {

--- a/red/runtime/storage/localfilesystem/util.js
+++ b/red/runtime/storage/localfilesystem/util.js
@@ -84,7 +84,7 @@ module.exports = {
                 try {
                     fs.renameSync(path,backupPath);
                 } catch(e) {
-                    log.warn(log._("storage.localfilesystem.fwrite-fail",{path:path}));
+                    log.warn(log._("storage.localfilesystem.fwrite-fail",{path:path, message:e.toString()}));
                 }
             }
         }


### PR DESCRIPTION
Fail more cleanly when run from a readonly files system without setting readOnly true.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Currently we crash if run from a 100% read only file system as the settings and config files cannot be moved and written. We should at least inform the user this is happening and exit nicely.

There are two parts to this
 - 1 at initial start we try to move the settings file
 - 2 the backup file can't be written on deploy

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
