### PR TITLE
Add symbol to debug for status

### DIFF
--- a/nodes/core/core/58-debug.html
+++ b/nodes/core/core/58-debug.html
@@ -56,6 +56,11 @@
         },
         label: function() {
             var suffix = "";
+            if (this.tostatus === true || this.tostatus === "true") {
+                if (this.tosidebar === false || this.tosidebar === "false") {
+                    suffix = " ↲";
+                }
+            }
             if (this.console === true || this.console === "true") { suffix = " ⇲"; }
             if (this.complete === true || this.complete === "true") {
                 return (this.name||"msg") + suffix;


### PR DESCRIPTION
in debug node - if messages are selected to be shown only as a status info - then add a ↲ symbol.  If console is also selected - its symbol overrides this new one

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- If node status (only) is selected in a debug node, this change will add a ↲ symbol to the node label.   
 -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x ] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
