### PR TITLE
Config search

### DIFF
--- a/editor/js/ui/search.js
+++ b/editor/js/ui/search.js
@@ -118,6 +118,7 @@ RED.search = (function() {
             }
         }
     }
+
     function ensureSelectedIsVisible() {
         var selectedEntry = searchResults.find("li.selected");
         if (selectedEntry.length === 1) {
@@ -143,6 +144,7 @@ RED.search = (function() {
                 search($(this).val());
             }
         });
+
         searchInput.on('keydown',function(evt) {
             var children;
             if (results.length > 0) {
@@ -229,12 +231,13 @@ RED.search = (function() {
         });
 
     }
+
     function reveal(node) {
         hide();
         RED.view.reveal(node.id);
     }
 
-    function show() {
+    function show(v) {
         if (disabled) {
             return;
         }
@@ -250,11 +253,13 @@ RED.search = (function() {
                 createDialog();
             }
             dialog.slideDown(300);
+            searchInput.searchBox('value',v)
             RED.events.emit("search:open");
             visible = true;
         }
         searchInput.focus();
     }
+
     function hide() {
         if (visible) {
             RED.keyboard.remove("escape");

--- a/editor/js/ui/tab-config.js
+++ b/editor/js/ui/tab-config.js
@@ -140,7 +140,8 @@ RED.sidebar.config = (function() {
                 var entry = $('<li class="palette_node config_node palette_node_id_'+node.id.replace(/\./g,"-")+'"></li>').appendTo(list);
                 $('<div class="palette_label"></div>').text(label).appendTo(entry);
                 if (node._def.hasUsers !== false) {
-                    var iconContainer = $('<div/>',{class:"palette_icon_container  palette_icon_container_right"}).text(node.users.length).appendTo(entry);
+                    var f = 'RED.search.show(\''+node.id+'\')'
+                    var iconContainer = $('<div/>',{class:"palette_icon_container palette_icon_container_right", onclick:f }).text(node.users.length).appendTo(entry);
                     if (node.users.length === 0) {
                         entry.addClass("config_node_unused");
                     }

--- a/editor/js/ui/tab-config.js
+++ b/editor/js/ui/tab-config.js
@@ -140,9 +140,8 @@ RED.sidebar.config = (function() {
                 var entry = $('<li class="palette_node config_node palette_node_id_'+node.id.replace(/\./g,"-")+'"></li>').appendTo(list);
                 $('<div class="palette_label"></div>').text(label).appendTo(entry);
                 if (node._def.hasUsers !== false) {
-                    var f = 'RED.search.show(\''+node.id+'\')'
                     var iconContainer = $('<div/>',{class:"palette_icon_container palette_icon_container_right"}).appendTo(entry);
-                    var butt = $('<a/>',{onclick:f}).text(node.users.length).appendTo(iconContainer);
+                    var butt = $('<a href="#"/>').click(function(e) { e.preventDefault(); RED.search.show(node.id); }).text(node.users.length).appendTo(iconContainer);
                     if (node.users.length === 0) {
                         entry.addClass("config_node_unused");
                     }

--- a/editor/js/ui/tab-config.js
+++ b/editor/js/ui/tab-config.js
@@ -141,7 +141,8 @@ RED.sidebar.config = (function() {
                 $('<div class="palette_label"></div>').text(label).appendTo(entry);
                 if (node._def.hasUsers !== false) {
                     var f = 'RED.search.show(\''+node.id+'\')'
-                    var iconContainer = $('<div/>',{class:"palette_icon_container palette_icon_container_right", onclick:f }).text(node.users.length).appendTo(entry);
+                    var iconContainer = $('<div/>',{class:"palette_icon_container palette_icon_container_right"}).appendTo(entry);
+                    var butt = $('<a/>',{onclick:f}).text(node.users.length).appendTo(iconContainer);
                     if (node.users.length === 0) {
                         entry.addClass("config_node_unused");
                     }
@@ -162,7 +163,6 @@ RED.sidebar.config = (function() {
                     });
                     RED.view.redraw();
                 });
-
                 entry.on('mouseout',function(e) {
                     RED.nodes.eachNode(function(node) {
                         if(node.highlighted) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

It would be useful (occasionally) to be able to find which nodes are using a particular config node. This PR does that by making the number field to the right of the node identifier in the config node window into a button that opens the search window with the result of the search for that config node id.

Also letting the search function  `RED.search.show()` accept an argument would potentially be useful to other integrations.

See - https://discourse.nodered.org/t/how-to-find-all-nodes-that-are-using-a-specific-configuration-node/2919 for original "issue" that prompted this PR.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [X] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
