### PR TITLE
Add explicit checkbox when configuring MQTT over web sockets.

### DIFF
--- a/nodes/core/io/10-mqtt.html
+++ b/nodes/core/io/10-mqtt.html
@@ -181,6 +181,13 @@
                 <input type="text" id="node-config-input-port" data-i18n="[placeholder]mqtt.label.port" style="width:55px">
             </div>
             <div class="form-row">
+                <input type="checkbox" id="node-config-input-usews" style="display: inline-block; width: auto; vertical-align: top;">
+                <label for="node-config-input-usews" style="width: auto" data-i18n="mqtt.label.use-ws"></label>
+                <div id="node-config-row-ws" class="hide">
+                    <label style="width: auto; margin-left: 20px; margin-right: 10px;" for="node-config-input-ws"><span data-i18n="mqtt.label.ws-config"></span></label><input style="width: 300px;" type="text" id="node-config-input-tls">
+                </div>
+            </div>
+            <div class="form-row">
                 <input type="checkbox" id="node-config-input-usetls" style="display: inline-block; width: auto; vertical-align: top;">
                 <label for="node-config-input-usetls" style="width: auto" data-i18n="mqtt.label.use-tls"></label>
                 <div id="node-config-row-tls" class="hide">
@@ -335,6 +342,7 @@
                 }
             }},
             usetls: {value: false},
+            usews: {value: false},
             verifyservercert: { value: false},
             compatmode: { value: true},
             keepalive: {value:60,validate:RED.validators.number()},
@@ -428,6 +436,10 @@
                 this.usetls = false;
                 $("#node-config-input-usetls").prop("checked",false);
             }
+            if (typeof this.usews === 'undefined') {
+                this.usews = false;
+                $("#node-config-input-usews").prop("checked",false);
+            }
             if (typeof this.compatmode === 'undefined') {
                 this.compatmode = true;
                 $("#node-config-input-compatmode").prop('checked', true);
@@ -459,6 +471,18 @@
             updateTLSOptions();
             $("#node-config-input-usetls").on("click",function() {
                 updateTLSOptions();
+            });
+
+            function updateWSOptions() {
+                if ($("#node-config-input-usews").is(':checked')) {
+                    $("#node-config-row-ws").show();
+                } else {
+                    $("#node-config-row-ws").hide();
+                }
+            }
+            updateWSOptions();
+            $("#node-config-input-usews").on("click",function() {
+                updateWSOptions();
             });
             var node = this;
             function updateClientId() {
@@ -499,6 +523,9 @@
         oneditsave: function() {
             if (!$("#node-config-input-usetls").is(':checked')) {
                 $("#node-config-input-tls").val("");
+            }
+            if (!$("#node-config-input-usews").is(':checked')) {
+                $("#node-config-input-ws").val("");
             }
         }
     });

--- a/nodes/core/io/10-mqtt.js
+++ b/nodes/core/io/10-mqtt.js
@@ -136,10 +136,11 @@ module.exports = function(RED) {
                     }
             } else {
                 // construct the std mqtt:// url
-                if (this.usetls) {
-                    this.brokerurl="mqtts://";
+                let tlsPrefix = (this.usetls) ? "s" : "";
+                if (this.usetws) {
+                    this.brokerurl="ws" + tlsPrefix + "://";
                 } else {
-                    this.brokerurl="mqtt://";
+                    this.brokerurl="mqtt" + tlsPrefix + "://";
                 }
                 if (this.broker !== "") {
                     this.brokerurl = this.brokerurl+this.broker+":";

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -332,6 +332,7 @@
             "cleansession": "Use clean session",
             "use-tls": "Enable secure (SSL/TLS) connection",
             "tls-config":"TLS Configuration",
+            "use-ws": "Enable MQTT over web sockets",
             "verify-server-cert":"Verify server certificate",
             "compatmode": "Use legacy MQTT 3.1 support"
         },


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

It appears that explicit UI support for MQTT over Web Sockets was intended, as some dead code already exists.  This code adds a checkbox on the MQTT configuration screen following the same pattern as for "use TLS".  If unchecked, current behavior stays the same.  If checked, MQTT requests default to use ws:// instead of mqtt:// for the run-time connection to the queue.

The workaround today is to include the URL scheme in the server field.
https://discourse.nodered.org/t/mqtt-broken-url-and-port/1275

I am holding off on creating unit tests for MQTT node, since there is no coverage at all at this time.  If people agree this is a good idea, I'll create tests for the full node.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
