### PR TITLE
Resolve path when sending example file for Windows support

### DIFF
--- a/red/api/editor/library.js
+++ b/red/api/editor/library.js
@@ -102,9 +102,10 @@ module.exports = {
                 var fullPath = redNodes.getNodeExampleFlowPath(module,path);
                 if (fullPath) {
                     try {
-                        fs.statSync(fullPath);
+                        var resolvedPath = fspath.resolve(fullPath);
+                        fs.statSync(resolvedPath);
                         log.audit({event: "library.get",type:"flow",path:req.params[0]},req);
-                        return res.sendFile(fullPath,{
+                        return res.sendFile(resolvedPath,{
                             headers:{
                                 'Content-Type': 'application/json'
                             }

--- a/test/red/api/editor/library_spec.js
+++ b/test/red/api/editor/library_spec.js
@@ -225,7 +225,7 @@ describe("api/editor/library", function() {
                         throw err;
                     }
                     res.body.should.have.property('sendFile',
-                        'node-module:example-one');
+                        fspath.resolve('node-module') + ':example-one');
                     done();
                 });
         });
@@ -243,7 +243,8 @@ describe("api/editor/library", function() {
                         throw err;
                     }
                     res.body.should.have.property('sendFile',
-                        '@org_scope/node_package:example-one');
+                        fspath.resolve('@org_scope/node_package') +
+                        ':example-one');
                     done();
                 });
         });


### PR DESCRIPTION
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Previously, when trying to import an example into the flow editor on
Windows, the load attempt would fail with an HTTP 404 error in the
browser client, with the following error being written to the Node-RED
log:

> TypeError: path must be absolute or specify root to res.sendFile

This was due to the path being passed to the `res.sendFile` function
not being fully-qualified (for example, `\Users\myuser\...\example.json`).

With the changes in this commit, the path to the example file is
resolved to a fully-qualified path before being passed into the
`res.sendFile` call. For example, a path on Windows of
`\Users\myuser\...\example.json` would be transformed to
`C:\\Users\\myuser\\...\example.json` before being passed along to the
`sendFile` function. This change allows the file to be loaded and sent
properly to the browser client and for the embedded flows in the example
to be loaded in the flow editor.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [X] I have run `grunt` to verify the unit tests pass
- [X] I have added suitable unit tests to cover the new/changed functionality