### PR TITLE
fix multiple input message processing of file node

### DIFF
--- a/nodes/core/storage/50-file.js
+++ b/nodes/core/storage/50-file.js
@@ -189,8 +189,7 @@ module.exports = function(RED) {
             }
         }
 
-        this.on('close', function(arg1, arg2) {
-            var cb  = arg2 ? arg2 : arg1;
+        this.on('close', function(cb) {
             if (cb) {
                 node.closeCallbacks.push(done);
             }

--- a/nodes/core/storage/50-file.js
+++ b/nodes/core/storage/50-file.js
@@ -153,22 +153,23 @@ module.exports = function(RED) {
             }
         }
 
+        function processQ(queue) {
+            var msg = queue[0];
+            processMsg(msg, function() {
+                queue.shift();
+                if (queue.length > 0) {
+                    processQ(queue);
+                }
+            });
+        }
+
         this.on("input", function(msg) {
             var msgQueue = node.msgQueue;
-            function processQ() {
-                var msg = msgQueue[0];
-                processMsg(msg, function() {
-                    msgQueue.shift();
-                    if (msgQueue.length > 0) {
-                        processQ();
-                    }
-                });
-            }
             if (msgQueue.push(msg) > 1) {
                 // pending write exists
                 return;
             }
-            processQ();
+            processQ(msgQueue);
         });
 
         this.on('close', function() {

--- a/test/nodes/core/storage/50-file_spec.js
+++ b/test/nodes/core/storage/50-file_spec.js
@@ -46,14 +46,14 @@ describe('file Nodes', function() {
         it('should be loaded', function(done) {
             var flow = [{id:"fileNode1", type:"file", name: "fileNode", "filename":fileToTest, "appendNewline":true, "overwriteFile":true}];
             helper.load(fileNode, flow, function() {
-		try {
+                try {
                     var fileNode1 = helper.getNode("fileNode1");
                     fileNode1.should.have.property('name', 'fileNode');
                     done();
-		}
-		catch (e) {
-		    done(e);
-		}
+                }
+                catch (e) {
+                    done(e);
+                }
             });
         });
 
@@ -64,16 +64,16 @@ describe('file Nodes', function() {
                 var n1 = helper.getNode("fileNode1");
                 var n2 = helper.getNode("helperNode1");
                 n2.on("input", function(msg) {
-		    try {
-			var f = fs.readFileSync(fileToTest);
-			f.should.have.length(4);
-			fs.unlinkSync(fileToTest);
-			msg.should.have.property("payload", "test");
-			done();
-		    }
-		    catch (e) {
-			done(e);
-		    }
+                    try {
+                        var f = fs.readFileSync(fileToTest);
+                        f.should.have.length(4);
+                        fs.unlinkSync(fileToTest);
+                        msg.should.have.property("payload", "test");
+                        done();
+                    }
+                    catch (e) {
+                        done(e);
+                    }
                 });
                 n1.receive({payload:"test"});
             });
@@ -93,26 +93,26 @@ describe('file Nodes', function() {
                 var data = ["test2", true, 999, [2]];
 
                 n2.on("input", function (msg) {
-		    try {
-			msg.should.have.property("payload");
-			data.should.containDeep([msg.payload]);
-			if (count === 3) {
+                    try {
+                        msg.should.have.property("payload");
+                        data.should.containDeep([msg.payload]);
+                        if (count === 3) {
                             var f = fs.readFileSync(fileToTest).toString();
                             if (os.type() !== "Windows_NT") {
-				f.should.have.length(19);
-				f.should.equal("test2\ntrue\n999\n[2]\n");
+                                f.should.have.length(19);
+                                f.should.equal("test2\ntrue\n999\n[2]\n");
                             }
                             else {
-				f.should.have.length(23);
-				f.should.equal("test2\r\ntrue\r\n999\r\n[2]\r\n");
+                                f.should.have.length(23);
+                                f.should.equal("test2\r\ntrue\r\n999\r\n[2]\r\n");
                             }
                             done();
-			}
-			count++;
-		    }
-		    catch (e) {
-			done(e);
-		    }
+                        }
+                        count++;
+                    }
+                    catch (e) {
+                        done(e);
+                    }
                 });
 
                 n1.receive({payload:"test2"});    // string
@@ -142,37 +142,37 @@ describe('file Nodes', function() {
                 var count = 0;
                 
                 n2.on("input", function (msg) {
-		    try {
-			msg.should.have.property("payload");
-			data.should.containDeep([msg.payload]);
-			try {
+                    try {
+                        msg.should.have.property("payload");
+                        data.should.containDeep([msg.payload]);
+                        try {
                             if (count === 1) {
-				// Check they got appended as expected
-				var f = fs.readFileSync(fileToTest).toString();
-				f.should.equal("onetwo");
+                                // Check they got appended as expected
+                                var f = fs.readFileSync(fileToTest).toString();
+                                f.should.equal("onetwo");
 
-				// Delete the file
-				fs.unlinkSync(fileToTest);
-				setTimeout(function() {
+                                // Delete the file
+                                fs.unlinkSync(fileToTest);
+                                setTimeout(function() {
                                     // Send two more messages to the file
                                     n1.receive({payload:"three"});
                                     n1.receive({payload:"four"});
-				}, wait);
+                                }, wait);
                             }
                             if (count === 3) {
-				var f = fs.readFileSync(fileToTest).toString();
-				f.should.equal("threefour");
-				fs.unlinkSync(fileToTest);
-				done();
+                                var f = fs.readFileSync(fileToTest).toString();
+                                f.should.equal("threefour");
+                                fs.unlinkSync(fileToTest);
+                                done();
                             }
-			} catch(err) {
+                        } catch(err) {
                             done(err);
-			}
-			count++;
-		    }
-		    catch (e) {
-			done(e);
-		    }
+                        }
+                        count++;
+                    }
+                    catch (e) {
+                        done(e);
+                    }
                 });
                 
                 // Send two messages to the file
@@ -197,7 +197,7 @@ describe('file Nodes', function() {
                 n2.on("input", function (msg) {
                     try {
                         msg.should.have.property("payload");
-			data.should.containDeep([msg.payload]);
+                        data.should.containDeep([msg.payload]);
                         if (count == 1) {
                             // Check they got appended as expected
                             var f = fs.readFileSync(fileToTest).toString();
@@ -256,25 +256,25 @@ describe('file Nodes', function() {
                 var n2 = helper.getNode("helperNode1");
                 
                 n2.on("input", function (msg) {
-		    try {
-			msg.should.have.property("payload", "fine");
-			msg.should.have.property("filename", fileToTest);
+                    try {
+                        msg.should.have.property("payload", "fine");
+                        msg.should.have.property("filename", fileToTest);
 
-			var f = fs.readFileSync(fileToTest).toString();
-			if (os.type() !== "Windows_NT") {
+                        var f = fs.readFileSync(fileToTest).toString();
+                        if (os.type() !== "Windows_NT") {
                             f.should.have.length(5);
                             f.should.equal("fine\n");
-			}
-			else {
+                        }
+                        else {
                             f.should.have.length(6);
                             f.should.equal("fine\r\n");
-			}
-			done();
-		    }
-		    catch (e) {
-			done(e);
-		    }
-		});
+                        }
+                        done();
+                    }
+                    catch (e) {
+                        done(e);
+                    }
+                });
 
                 n1.receive({payload:"fine", filename:fileToTest});
             });
@@ -551,27 +551,27 @@ describe('file Nodes', function() {
                 var n2 = helper.getNode("helperNode1");
                 var count = 0;
                 n2.on("input", function(msg) {
-		    try {
+                    try {
                         count++;
                         if (count == file_count) {
                             for(var i = 0; i < file_count; i++) {
                                 var name = path.join(tmp_path, String(i));
-			        var f = fs.readFileSync(name);
-			        f.should.have.length(len);
+                                var f = fs.readFileSync(name);
+                                f.should.have.length(len);
                                 f[0].should.have.equal(i);
                             }
                             fs.removeSync(tmp_path);
-			    done();
+                            done();
                         }
-		    }
-		    catch (e) {
+                    }
+                    catch (e) {
                         try {
                             fs.removeSync(tmp_path);
                         }
                         catch (e1) {
                         }
-			done(e);
-		    }
+                        done(e);
+                    }
                 });
                 for(var i = 0; i < file_count; i++) {
                     var data = new Buffer(len);
@@ -580,6 +580,50 @@ describe('file Nodes', function() {
                     var msg = {payload:data, filename:name};
                     n1.receive(msg);
                 }
+            });
+        });
+
+        it('should write to multiple files if node is closed', function(done) {
+            var flow = [{id:"fileNode1", type:"file", name: "fileNode", "appendNewline":true, "overwriteFile":true, "createDir":true, wires: [["helperNode1"]]},
+                        {id:"helperNode1", type:"helper"}];
+            var tmp_path = path.join(resourcesDir, "tmp");
+            var len = 1024*1024*10;
+            var file_count = 5;
+            helper.load(fileNode, flow, function() {
+                var n1 = helper.getNode("fileNode1");
+                var n2 = helper.getNode("helperNode1");
+                var count = 0;
+                n2.on("input", function(msg) {
+                    try {
+                        count++;
+                        if (count == file_count) {
+                            for(var i = 0; i < file_count; i++) {
+                                var name = path.join(tmp_path, String(i));
+                                var f = fs.readFileSync(name);
+                                f.should.have.length(len);
+                                f[0].should.have.equal(i);
+                            }
+                            fs.removeSync(tmp_path);
+                            done();
+                        }
+                    }
+                    catch (e) {
+                        try {
+                            fs.removeSync(tmp_path);
+                        }
+                        catch (e1) {
+                        }
+                        done(e);
+                    }
+                });
+                for(var i = 0; i < file_count; i++) {
+                    var data = new Buffer(len);
+                    data.fill(i);
+                    var name = path.join(tmp_path, String(i));
+                    var msg = {payload:data, filename:name};
+                    n1.receive(msg);
+                }
+                n1.close();
             });
         });
 
@@ -615,7 +659,7 @@ describe('file Nodes', function() {
 
         it('should read in a file and output a buffer', function(done) {
             var flow = [{id:"fileInNode1", type:"file in", name:"fileInNode", "filename":fileToTest, "format":"", wires:[["n2"]]},
-                    {id:"n2", type:"helper"}];
+                        {id:"n2", type:"helper"}];
             helper.load(fileNode, flow, function() {
                 var n1 = helper.getNode("fileInNode1");
                 var n2 = helper.getNode("n2");
@@ -632,7 +676,7 @@ describe('file Nodes', function() {
 
         it('should read in a file and output a utf8 string', function(done) {
             var flow = [{id:"fileInNode1", type:"file in", name: "fileInNode", "filename":fileToTest, "format":"utf8", wires:[["n2"]]},
-                {id:"n2", type:"helper"}];
+                        {id:"n2", type:"helper"}];
             helper.load(fileNode, flow, function() {
                 var n1 = helper.getNode("fileInNode1");
                 var n2 = helper.getNode("n2");
@@ -653,7 +697,7 @@ describe('file Nodes', function() {
 
         it('should read in a file and output split lines with parts', function(done) {
             var flow = [{id:"fileInNode1", type:"file in", name: "fileInNode", filename:fileToTest, format:"lines", wires:[["n2"]]},
-                {id:"n2", type:"helper"}];
+                        {id:"n2", type:"helper"}];
             helper.load(fileNode, flow, function() {
                 var n1 = helper.getNode("fileInNode1");
                 var n2 = helper.getNode("n2");
@@ -691,7 +735,7 @@ describe('file Nodes', function() {
             var line = data.join("\n");
             fs.writeFileSync(fileToTest, line);
             var flow = [{id:"fileInNode1", type:"file in", name: "fileInNode", filename:fileToTest, format:"lines", wires:[["n2"]]},
-                {id:"n2", type:"helper"}];
+                        {id:"n2", type:"helper"}];
             helper.load(fileNode, flow, function() {
                 var n1 = helper.getNode("fileInNode1");
                 var n2 = helper.getNode("n2");
@@ -724,7 +768,7 @@ describe('file Nodes', function() {
 
         it('should read in a file and output a buffer with parts', function(done) {
             var flow = [{id:"fileInNode1", type:"file in", name: "fileInNode", filename:fileToTest, format:"stream", wires:[["n2"]]},
-                {id:"n2", type:"helper"}];
+                        {id:"n2", type:"helper"}];
             helper.load(fileNode, flow, function() {
                 var n1 = helper.getNode("fileInNode1");
                 var n2 = helper.getNode("n2");


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

`File` node fails to crate files when a message arrives while processing a previous message.
This is caused by the use of `File` node property as global state.
This PR fixes this problem by serializing input message processing.

**Test case that reproduces the problem**

```
{"id":"1637d5d5.ef08ea","type":"tab","label":"フロー 2","disabled":false,"info":""},{"id":"1c48b6b5.c7b7b9","type":"inject","z":"1637d5d5.ef08ea","name":"","topic":"","payload":"","payloadType":"date","repeat":"","crontab":"","once":false,"onceDelay":0.1,"x":160,"y":180,"wires":[["c430d682.c32ae8"]]},{"id":"c430d682.c32ae8","type":"function","z":"1637d5d5.ef08ea","name":"","func":"var len = 1024*1024*100;\nvar data = new Buffer(len);\nfor(var i = 0; i < 5; i++) {\n    var path = \"/tmp/quux_\"+i;\n    var msg = { payload: data, filename: path };\n    node.send(msg);\n}","outputs":1,"noerr":0,"x":230,"y":240,"wires":[["843b8204.8370f"]]},{"id":"843b8204.8370f","type":"file","z":"1637d5d5.ef08ea","name":"","filename":"","appendNewline":true,"createDir":true,"overwriteFile":"true","x":370,"y":240,"wires":[[]]}]
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality