### PR TITLE
If debug set not to go to sidebar hide the button

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1961,10 +1961,7 @@ RED.view = (function() {
                     .on("mouseover",function(d){portMouseOver(d3.select(this),d,PORT_TYPE_OUTPUT,0);})
                     .on("mouseout",function(d) {portMouseOut(d3.select(this),d,PORT_TYPE_OUTPUT,0);});
 
-
                 inGroup.append("svg:text").attr("class","port_label").attr("x",18).attr("y",20).style("font-size","10px").text("input");
-
-
 
                 subflowOutputs.each(function(d,i) {
                     if (d.dirty) {
@@ -2306,7 +2303,6 @@ RED.view = (function() {
                                 }
                             }
 
-
                             thisNode.selectAll(".node_tools").attr("x",function(d){return d.w-35;}).attr("y",function(d){return d.h-20;});
 
                             thisNode.selectAll(".node_changed")
@@ -2318,8 +2314,8 @@ RED.view = (function() {
                                 .classed("hidden",function(d) { return d.valid; });
 
                             thisNode.selectAll(".port_input").each(function(d,i) {
-                                    var port = d3.select(this);
-                                    port.attr("transform",function(d){return "translate(-5,"+((d.h/2)-5)+")";})
+                                var port = d3.select(this);
+                                port.attr("transform",function(d){return "translate(-5,"+((d.h/2)-5)+")";})
                             });
 
                             thisNode.selectAll(".node_icon").attr("y",function(d){return (d.h-d3.select(this).attr("height"))/2;});
@@ -2333,21 +2329,30 @@ RED.view = (function() {
                                 return (activeSubflow||!isButtonEnabled(d))?"":"pointer";
                             });
                             thisNode.selectAll(".node_right_button").attr("transform",function(d){
-                                    var x = d.w-6;
-                                    if (d._def.button.toggle && !d[d._def.button.toggle]) {
-                                        x = x - 8;
-                                    }
-                                    return "translate("+x+",2)";
+                                var x = d.w-6;
+                                if (d._def.button.toggle && !d[d._def.button.toggle]) {
+                                    x = x - 8;
+                                }
+                                return "translate("+x+",2)";
                             });
                             thisNode.selectAll(".node_right_button rect").attr("fill-opacity",function(d){
-                                    if (d._def.button.toggle) {
-                                        return d[d._def.button.toggle]?1:0.2;
-                                    }
-                                    return 1;
+                                if (d._def.button.toggle) {
+                                    return d[d._def.button.toggle]?1:0.2;
+                                }
+                                return 1;
                             });
 
+                            if (d._def.button && (typeof d._def.button.visible === "function")) { // is defined and a function...
+                                if (d._def.button.visible.call(d) === false) {
+                                    thisNode.selectAll(".node_button").style("display","none");
+                                }
+                                else {
+                                    thisNode.selectAll(".node_button").style("display","inherit");
+                                }
+                            }
+
                             //thisNode.selectAll(".node_right_button").attr("transform",function(d){return "translate("+(d.w - d._def.button.width.call(d))+","+0+")";}).attr("fill",function(d) {
-                            //         return typeof d._def.button.color  === "function" ? d._def.button.color.call(d):(d._def.button.color != null ? d._def.button.color : d._def.color)
+                            //    return typeof d._def.button.color  === "function" ? d._def.button.color.call(d):(d._def.button.color != null ? d._def.button.color : d._def.color)
                             //});
 
                             thisNode.selectAll(".node_badge_group").attr("transform",function(d){return "translate("+(d.w-40)+","+(d.h+3)+")";});

--- a/packages/node_modules/@node-red/nodes/core/core/58-debug.html
+++ b/packages/node_modules/@node-red/nodes/core/core/58-debug.html
@@ -73,6 +73,7 @@
         align: "right",
         button: {
             toggle: "active",
+            visible: function() { return this.tosidebar; },
             onclick: function() {
                 var label = this.name||"debug";
                 var node = this;
@@ -84,7 +85,7 @@
                             t:'edit',
                             node:node,
                             changes:{
-                                active: !node.active
+                                active:!node.active
                             },
                             dirty:node.dirty,
                             changed:node.changed

--- a/packages/node_modules/@node-red/nodes/core/core/58-debug.js
+++ b/packages/node_modules/@node-red/nodes/core/core/58-debug.js
@@ -19,10 +19,7 @@ module.exports = function(RED) {
         if (this.tosidebar === undefined) { this.tosidebar = true; }
         this.severity = n.severity || 40;
         this.active = (n.active === null || typeof n.active === "undefined") || n.active;
-        if (this.tostatus) {
-            this.oldStatus = {fill:"grey", shape:"ring"};
-            this.status(this.oldStatus);
-        }
+        if (this.tostatus) { this.status({fill:"grey", shape:"ring"}); }
         else { this.status({}); }
 
         var node = this;
@@ -78,15 +75,15 @@ module.exports = function(RED) {
                         node.log(util.inspect(output, {colors:useColors}));
                     }
                 }
+                if (this.tostatus === true) {
+                    var st = util.inspect(output);
+                    var severity = node.severity;
+                    if (st.length > 32) { st = st.substr(0,32) + "..."; }
+                    node.status({fill:colors[severity], shape:"dot", text:st});
+                }
                 if (this.active) {
                     if (this.tosidebar == true) {
                         sendDebug({id:node.id, z:node.z, name:node.name, topic:msg.topic, property:property, msg:output, _path:msg._path});
-                    }
-                    if (this.tostatus === true) {
-                        var st = util.inspect(output);
-                        if (st.length > 32) { st = st.substr(0,32) + "..."; }
-                        node.oldStatus = {fill:colors[node.severity], shape:"dot", text:st};
-                        node.status(node.oldStatus);
                     }
                 }
             }


### PR DESCRIPTION
Add button.visible function to view.js
Make status independant of tosidebar setting

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Adds a .visible(boolean) function to the button handler in view.js - default true. This allows the side button on a node to be hidden completely. This allows the debug node - when set to not send to the sidepanel to not have the button that toggles reporting or not - so is a visual indication of whether it reports to the sidebar or not. 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
