### PR TITLE
Add necessary p tag into English message catalog

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/locales/en-US/editor.json
@@ -97,7 +97,7 @@
             "undeployedChanges": "node has undeployed changes",
             "nodeActionDisabled": "node actions disabled within subflow",
             "missing-types": "<p>Flows stopped due to missing node types.</p>",
-            "safe-mode":"<p>Flows stopped in safe mode.</p><p>You can modify your flows and deploy the changes to restart.",
+            "safe-mode":"<p>Flows stopped in safe mode.</p><p>You can modify your flows and deploy the changes to restart.</p>",
             "restartRequired": "Node-RED must be restarted to enable upgraded modules",
             "credentials_load_failed": "<p>Flows stopped as the credentials could not be decrypted.</p><p>The flow credential file is encrypted, but the project's encryption key is missing or invalid.</p>",
             "credentials_load_failed_reset":"<p>Credentials could not be decrypted</p><p>The flow credential file is encrypted, but the project's encryption key is missing or invalid.</p><p>The flow credential file will be reset on the next deployment. Any existing flow credentials will be cleared.</p>",


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
While I translate English message catalog into Japanese, I found that the catalog lacks the necessary p tag. Therefore, I added it.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality