### PR TITLE
Add node-red-hashpwd to bin commands

### DIFF
--- a/packages/node_modules/node-red/bin/node-red-hashpwd
+++ b/packages/node_modules/node-red/bin/node-red-hashpwd
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log(require('bcryptjs').hashSync(process.argv[1], 8));

--- a/packages/node_modules/node-red/bin/node-red-hashpwd
+++ b/packages/node_modules/node-red/bin/node-red-hashpwd
@@ -1,2 +1,7 @@
 #!/usr/bin/env node
-console.log(require('bcryptjs').hashSync(process.argv[1], 8));
+if (process.argv.length === 3) {
+    console.log(require('bcryptjs').hashSync(process.argv[2], 8));
+}
+else {
+    console.log("\nUsage  -  node-red-hashpwd your_memorable_password\n")
+}

--- a/packages/node_modules/node-red/package.json
+++ b/packages/node_modules/node-red/package.json
@@ -14,7 +14,8 @@
     },
     "bin": {
         "node-red": "./red.js",
-        "node-red-pi": "bin/node-red-pi"
+        "node-red-pi": "bin/node-red-pi",
+        "node-red-hashpwd": "bin/node-red-hashpwd"
     },
     "contributors": [
         { "name": "Nick O'Leary" },


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

add a node-red-hashpwd command to the bin directory so make creating a hash of the admin password easier for user.... (rather than having to install node-red-admin or find the install directory and run a long command line)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
