### PR TITLE
Fix i18n handling for ja-JP locale on Safari/MacOS

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/locales.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/locales.js
@@ -21,6 +21,18 @@ var i18n = require("@node-red/util").i18n; // TODO: separate module
 
 var runtimeAPI;
 
+function loadResource(lang, namespace) {
+    var catalog = i18n.i.getResourceBundle(lang, namespace);
+    if (!catalog) {
+        var parts = lang.split("-");
+        if (parts.length == 2) {
+            var new_lang = parts[0];
+            return i18n.i.getResourceBundle(new_lang, namespace);
+        }
+    }
+    return catalog;
+}
+
 module.exports = {
     init: function(_runtimeAPI) {
         runtimeAPI = _runtimeAPI;
@@ -33,7 +45,7 @@ module.exports = {
         var prevLang = i18n.i.language;
         // Trigger a load from disk of the language if it is not the default
         i18n.i.changeLanguage(lang, function(){
-            var catalog = i18n.i.getResourceBundle(lang, namespace);
+            var catalog = loadResource(lang, namespace);
             res.json(catalog||{});
         });
         i18n.i.changeLanguage(prevLang);

--- a/test/unit/@node-red/editor-api/lib/editor/locales_spec.js
+++ b/test/unit/@node-red/editor-api/lib/editor/locales_spec.js
@@ -91,6 +91,30 @@ describe("api/editor/locales", function() {
                     done();
                 });
         });
+
+        it('returns for locale defined only with primary tag ', function(done) {
+            var orig = i18n.i.getResourceBundle;
+            i18n.i.getResourceBundle = function (lang, ns) {
+                if (lang === "ja-JP") {
+                    return undefined;
+                }
+                return orig(lang, ns);
+            };
+            request(app)
+                 // returns `ja` instead of `ja-JP`
+                .get("/locales/message-catalog?lng=ja-JP")
+                .expect(200)
+                .end(function(err,res) {
+                    i18n.i.getResourceBundle = orig;
+                    if (err) {
+                        return done(err);
+                    }
+                    res.body.should.have.property('namespace','message-catalog');
+                    res.body.should.have.property('lang','ja');
+                    done();
+                });
+        });
+
     });
 
     // describe('get all node resource catalogs',function() {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
With Safari on MacOSX, Node-RED editor fails to translate editor messages to Japanese message.
This is becuase Safari returns `ja-JP` as locale value, but Node-RED do not contain messages for `ja-JP` locale.  Chrome do not cause this problem because it returns `ja` locale.

This PR makes Node-RED editor try to load messages for primary language tag locale if failed to load one for specified locate.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
