### PR TITLE
Adjust the fa icon position for the node with height

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1913,7 +1913,6 @@ RED.view = (function() {
                 .attr("xlink:href",iconUrl)
                 .attr("class","fa-lg")
                 .attr("x",15)
-                .attr("y",21)
                 .attr("stroke","none")
                 .attr("fill","#ffffff")
                 .attr("text-anchor","middle")
@@ -2414,6 +2413,7 @@ RED.view = (function() {
                             thisNode.selectAll(".node_icon").attr("y",function(d){return (d.h-d3.select(this).attr("height"))/2;});
                             thisNode.selectAll(".node_icon_shade").attr("height",function(d){return d.h;});
                             thisNode.selectAll(".node_icon_shade_border").attr("d",function(d){ return "M "+(("right" == d._def.align) ?0:30)+" 1 l 0 "+(d.h-2)});
+                            thisNode.selectAll(".fa-lg").attr("y",function(d){return (d.h+13)/2;});
 
                             thisNode.selectAll(".node_button").attr("opacity",function(d) {
                                 return (activeSubflow||!isButtonEnabled(d))?0.4:1


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

If a switch node with two or more ports uses a font-awesome icon, the icon is shown on the top of the node not the center.
This PR fixed the problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
