### PR TITLE
Exec: Preserve existing properties on msg object

### DIFF
--- a/nodes/core/core/75-exec.js
+++ b/nodes/core/core/75-exec.js
@@ -138,14 +138,16 @@ module.exports = function(RED) {
                         //console.log('[exec] stdout: ' + stdout);
                         //console.log('[exec] stderr: ' + stderr);
                         if (error !== null) {
-                            msg3 = {payload:{code:error.code, message:error.message}};
+                            msg3 = RED.util.cloneMessage(msg);
+                            msg3.payload = {code:error.code, message:error.message};
                             if (error.signal) { msg3.payload.signal = error.signal; }
                             if (error.code === null) { node.status({fill:"red",shape:"dot",text:"killed"}); }
                             else { node.status({fill:"red",shape:"dot",text:"error:"+error.code}); }
                             node.log('error:' + error);
                         }
                         else if (node.oldrc === "false") {
-                            msg3 = {payload:{code:0}};
+                            msg3 = RED.util.cloneMessage(msg);
+                            msg3.payload = {code:0};
                         }
                         if (!msg3) { node.status({}); }
                         else {

--- a/test/nodes/core/core/75-exec_spec.js
+++ b/test/nodes/core/core/75-exec_spec.js
@@ -365,6 +365,138 @@ describe('exec node', function() {
             });
         });
 
+        it('should preserve existing properties on msg object', function(done) {
+            var flow = [{id:"n1",type:"exec",wires:[["n2"],["n3"],["n4"]],command:"echo", addpay:false, append:"", oldrc:"false"},
+                        {id:"n2", type:"helper"},{id:"n3", type:"helper"},{id:"n4", type:"helper"}];
+            var spy = sinon.stub(child_process, 'exec',
+            function(arg1, arg2, arg3, arg4) {
+                // arg3(error,stdout,stderr);
+                arg3(null,arg1,arg1.toUpperCase());
+            });
+
+            helper.load(execNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                var n3 = helper.getNode("n3");
+                var n4 = helper.getNode("n4");
+                var received = 0;
+                var messages = [null,null,null];
+                var completeTest = function() {
+                    received = received + 1;
+                    if (received < 3) {
+                        return;
+                    }
+                    try {
+                        var msg = messages[0];
+                        msg.should.have.property("payload");
+                        msg.payload.should.be.a.String();
+                        msg.payload.should.equal("echo");
+                        msg.should.have.property("rc");
+                        msg.rc.should.have.property("code",0);
+                        msg.should.have.property("foo","bar");
+
+                        msg = messages[1];
+                        msg.should.have.property("payload");
+                        msg.payload.should.be.a.String();
+                        msg.payload.should.equal("ECHO");
+                        msg.should.have.property("rc");
+                        msg.rc.should.have.property("code",0);
+                        msg.should.have.property("foo","bar");
+
+                        msg = messages[2];
+                        msg.should.have.property("payload");
+                        msg.payload.should.have.property("code",0);
+                        msg.should.have.property("foo","bar");
+
+                        child_process.exec.restore();
+                        done();
+                    }
+                    catch(err) {
+                        child_process.exec.restore();
+                        done(err);
+                    }
+                };
+                n2.on("input", function(msg) {
+                    messages[0] = msg;
+                    completeTest();
+                });
+                n3.on("input", function(msg) {
+                    messages[1] = msg;
+                    completeTest();
+                });
+                n4.on("input", function(msg) {
+                    messages[2] = msg;
+                    completeTest();
+                });
+                n1.receive({payload:"and", foo:"bar"});
+            });
+        });
+
+        it('should preserve existing properties on msg object for a failing command', function(done) {
+            var flow = [{id:"n1",type:"exec",wires:[["n2"],["n3"],["n4"]],command:"error", addpay:false, append:"", oldrc:"false"},
+                        {id:"n2", type:"helper"},{id:"n3", type:"helper"},{id:"n4", type:"helper"}];
+            var spy = sinon.stub(child_process, 'exec',
+            function(arg1, arg2, arg3, arg4) {
+                // arg3(error,stdout,stderr);
+                arg3({code: 1},arg1,arg1.toUpperCase());
+            });
+            helper.load(execNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                var n3 = helper.getNode("n3");
+                var n4 = helper.getNode("n4");
+                var received = 0;
+                var messages = [null,null,null];
+                var completeTest = function() {
+                    received++;
+                    if (received < 3) {
+                        return;
+                    }
+                    try {
+                        var msg = messages[0];
+                        msg.should.have.property("payload");
+                        msg.payload.should.be.a.String();
+                        msg.payload.should.equal("error");
+                        msg.should.have.property("rc");
+                        msg.rc.should.have.property("code",1);
+                        msg.rc.should.have.property("message",undefined);
+                        msg.should.have.property("foo",null);
+
+                        msg = messages[1];
+                        msg.should.have.property("payload");
+                        msg.payload.should.be.a.String();
+                        msg.payload.should.equal("ERROR");
+                        msg.should.have.property("foo",null);
+
+                        msg = messages[2];
+                        msg.should.have.property("payload");
+                        msg.payload.should.have.property("code",1);
+                        msg.should.have.property("foo",null);
+
+                        child_process.exec.restore();
+                        done();
+                    }
+                    catch(err) {
+                        child_process.exec.restore();
+                        done(err);
+                    }
+                };
+                n2.on("input", function(msg) {
+                    messages[0] = msg;
+                    completeTest();
+                });
+                n3.on("input", function(msg) {
+                    messages[1] = msg;
+                    completeTest();
+                });
+                n4.on("input", function(msg) {
+                    messages[2] = msg;
+                    completeTest();
+                });
+                n1.receive({payload:"and", foo:null});
+            });
+        });
+
     });
 
     describe('calling spawn', function() {
@@ -669,6 +801,117 @@ describe('exec node', function() {
                     n1.receive({kill:"SIGINT"});
                 },150);
                 n1.receive({});
+            });
+        });
+
+        it('should preserve existing properties on msg object', function(done) {
+            var flow;
+            var expected;
+            if (osType === "Windows_NT") {
+                flow = [{id:"n1",type:"exec",wires:[["n2"],["n3"],["n4"]],command:"cmd /C echo this now works", addpay:false, append:"", useSpawn:"true", oldrc:"false"},
+                        {id:"n2", type:"helper"},{id:"n3", type:"helper"},{id:"n4", type:"helper"}];
+                expected = "this now works\r\n";
+            } else {
+                flow = [{id:"n1",type:"exec",wires:[["n2"],["n3"],["n4"]],command:"echo this now works", addpay:false, append:"", useSpawn:"true", oldrc:"false"},
+                        {id:"n2", type:"helper"},{id:"n3", type:"helper"},{id:"n4", type:"helper"}];
+                expected = "this now works\n";
+            }
+            helper.load(execNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                var n3 = helper.getNode("n3");
+                var n4 = helper.getNode("n4");
+                var received = 0;
+                var messages = [null,null];
+                var completeTest = function() {
+                    received++;
+                    if (received < 2) {
+                        return;
+                    }
+                    try {
+                        var msg = messages[0];
+                        msg.should.have.property("payload");
+                        msg.payload.should.be.a.String();
+                        msg.payload.should.equal(expected);
+                        msg.should.have.property("foo",123);
+
+                        msg = messages[1];
+                        msg.should.have.property("payload");
+                        should.exist(msg.payload);
+                        msg.payload.should.have.property("code",0);
+                        msg.should.have.property("foo",123);
+
+                        done();
+                    }
+                    catch(err) {
+                        done(err);
+                    }
+                };
+
+                n2.on("input", function(msg) {
+                    messages[0] = msg;
+                    completeTest();
+                });
+                n4.on("input", function(msg) {
+                    messages[1] = msg;
+                    completeTest();
+                });
+                n1.receive({payload:null,foo:123});
+            });
+        });
+
+        it('should preserve existing properties on msg object for a failing command', function(done) {
+            var flow;
+            var expected;
+            if (osType === "Windows_NT") {
+                // Cannot use mkdir because Windows mkdir command automatically creates non-existent directories.
+                flow = [{id:"n1",type:"exec",wires:[["n2"],["n3"],["n4"]],command:"ping /foo/bar/doo/dah", addpay:false, append:"", useSpawn:"true", oldrc:"false"},
+                            {id:"n2", type:"helper"},{id:"n3", type:"helper"},{id:"n4", type:"helper"}];
+                expected = "IP address must be specified.";
+            } else {
+                flow = [{id:"n1",type:"exec",wires:[["n2"],["n3"],["n4"]],command:"mkdir /foo/bar/doo/dah", addpay:false, append:"", useSpawn:"true", oldrc:"false"},
+                            {id:"n2", type:"helper"},{id:"n3", type:"helper"},{id:"n4", type:"helper"}];
+                expected = ' directory';
+            }
+            helper.load(execNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                var n3 = helper.getNode("n3");
+                var n4 = helper.getNode("n4");
+                var received = 0;
+                var messages = [null,null];
+                var completeTest = function() {
+                    received++;
+                    if (received < 2) {
+                        return;
+                    }
+                    try {
+                        var msg = messages[0];
+                        msg.should.have.property("payload");
+                        msg.payload.should.be.a.String();
+                        msg.should.have.property("foo","baz");
+
+                        msg = messages[1];
+                        msg.should.have.property("payload");
+                        msg.payload.should.have.property("code",1);
+                        msg.should.have.property("foo","baz");
+
+                        done();
+                    }
+                    catch(err) {
+                        done(err);
+                    }
+                };
+
+                n3.on("input", function(msg) {
+                    messages[0] = msg;
+                    completeTest();
+                });
+                n4.on("input", function(msg) {
+                    messages[1] = msg;
+                    completeTest();
+                });
+                n1.receive({payload:null,foo:"baz"});
             });
         });
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

[Exec Node] has three outputs (stdout, stderr and return code)

According to the [documentation](https://nodered.org/docs/creating-nodes/node-js#sending-messages), if a node has an input, it should preserve the existing properties on the message for the rest of the flow. This rule is obeyed by 2 inputs (stdout and stderr) but not by the third (return code)

After this fix, all the 3 outputs of [Exec Node] will start preserving the existing properties on the msg object

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality

[Exec Node]: https://github.com/node-red/node-red/blob/master/nodes/core/core/75-exec.js