### PR TITLE
Fix unnecessary TypedInput element

### DIFF
--- a/editor/js/ui/common/typedInput.js
+++ b/editor/js/ui/common/typedInput.js
@@ -537,6 +537,10 @@
                     } else {
                         this.selectLabel.text(opt.label);
                     }
+                    if (this.optionMenu) {
+                        this.optionMenu.remove();
+                        this.optionMenu = null;
+                    }
                     if (opt.options) {
                         if (this.optionExpandButton) {
                             this.optionExpandButton.hide();
@@ -627,10 +631,6 @@
                             }
                         }
                     } else {
-                        if (this.optionMenu) {
-                            this.optionMenu.remove();
-                            this.optionMenu = null;
-                        }
                         if (this.optionSelectTrigger) {
                             this.optionSelectTrigger.hide();
                         }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

When switching between `flow` and `global` on TypedInput several times, unnecessary TypedInput elements remain.
![typedinput](https://user-images.githubusercontent.com/31908137/47149648-2dbaff00-d30f-11e8-9445-7058f30fd54b.gif)

This is because the remove function has not been called.
I fixed it to call the function.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
