### PR TITLE
Recognize pip installs of RPi.GPIO

### DIFF
--- a/nodes/core/hardware/36-rpi-gpio.js
+++ b/nodes/core/hardware/36-rpi-gpio.js
@@ -24,8 +24,12 @@ module.exports = function(RED) {
                 try {
                     fs.statSync("/usr/lib/python2.7/dist-packages/RPi/GPIO"); // test on Hypriot
                 } catch(err) {
-                    RED.log.warn("rpi-gpio : "+RED._("rpi-gpio.errors.libnotfound"));
-                    allOK = false;
+                    try {
+                        fs.statSync("/usr/local/lib/python2.7/dist-packages/RPi/GPIO"); // installed with pip
+                    } catch(err) {
+                        RED.log.warn("rpi-gpio : "+RED._("rpi-gpio.errors.libnotfound"));
+                        allOK = false;
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Fix for `[warn] rpi-gpio : Cannot find Pi RPi.GPIO python library` when the library is installed with `pip` using the default prefix `/usr/local`, instead of a distro package manager.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
