### PR TITLE
WebSocket client connections: Allow setting Subprotocol option

### DIFF
--- a/nodes/core/io/22-websocket.html
+++ b/nodes/core/io/22-websocket.html
@@ -181,7 +181,8 @@
         defaults: {
             path: {value:"",required:true,validate:RED.validators.regex(/^((?!\/debug\/ws).)*$/)},
             tls: {type:"tls-config",required: false},
-            wholemsg: {value:"false"}
+            wholemsg: {value:"false"},
+            protocol: {value:""}
         },
         inputs:0,
         outputs:0,
@@ -280,6 +281,10 @@
             <option value="false" data-i18n="websocket.payload"></option>
             <option value="true" data-i18n="websocket.message"></option>
         </select>
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-protocol"><i class="fa fa-tag"></i> <span data-i18n="websocket.label.protocol"></span></label>
+        <input id="node-config-input-protocol" type="text" data-i18n="[placeholder]websocket.placeholder.protocol">
     </div>
     <div class="form-tips">
         <p><span data-i18n="[html]websocket.tip.url1"></span></p>

--- a/nodes/core/io/22-websocket.js
+++ b/nodes/core/io/22-websocket.js
@@ -28,6 +28,7 @@ module.exports = function(RED) {
         // Store local copies of the node configuration (as defined in the .html)
         node.path = n.path;
         node.wholemsg = (n.wholemsg === "true");
+        node.protocol = n.protocol; // optional client protocol
 
         node._inputNodes = [];    // collection of nodes that want to receive events
         node._clients = {};
@@ -45,7 +46,7 @@ module.exports = function(RED) {
                     tlsNode.addTLSOptions(options);
                 }
             }
-            var socket = new ws(node.path,options);
+            var socket = new ws(node.path,node.protocol,options);
             socket.setMaxListeners(0);
             node.server = socket; // keep for closing
             handleConnection(socket);

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -409,7 +409,11 @@
         "label": {
             "type": "Type",
             "path": "Path",
-            "url": "URL"
+            "url": "URL",
+            "protocol": "Protocol"
+        },
+        "placeholder": {
+            "protocol": "(optional) Subprotocol to negotiate"
         },
         "listenon": "Listen on",
         "connectto": "Connect to",

--- a/nodes/core/locales/ja/messages.json
+++ b/nodes/core/locales/ja/messages.json
@@ -409,7 +409,8 @@
         "label": {
             "type": "種類",
             "path": "パス",
-            "url": "URL"
+            "url": "URL",
+            "protocol": "協定"
         },
         "listenon": "待ち受け",
         "connectto": "接続",

--- a/nodes/core/locales/zh-CN/messages.json
+++ b/nodes/core/locales/zh-CN/messages.json
@@ -393,7 +393,8 @@
         "label": {
             "type": "类型",
             "path": "路径",
-            "url": "URL"
+            "url": "URL",
+            "protocol": "协议"
         },
         "listenon": "监听",
         "connectto": "连接",

--- a/test/nodes/core/io/22-websocket_spec.js
+++ b/test/nodes/core/io/22-websocket_spec.js
@@ -339,6 +339,18 @@ describe('websocket Node', function() {
             });
         });
 
+        it('should handle protocol property', function(done) {
+            var flow = [
+                { id: "server", type: "websocket-listener", path: "/ws" },
+                { id: "n1", type: "websocket-client", path: getWsUrl("/ws") },
+                { id: "n2", type: "websocket-client", path: getWsUrl("/ws"), protocol: "testprotocol" }];
+            helper.load(websocketNode, flow, function() {
+                helper.getNode("n1").should.have.property("protocol", undefined);
+                helper.getNode("n2").should.have.property("protocol", "testprotocol");
+                done();
+            });
+        });
+
         it('should connect to server', function(done) {
             var flow = [
                 { id: "server", type: "websocket-listener", path: "/ws" },


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
Add ability to specify a subprotocol for WebSocket clients, by adding a new dialog box and passing to through to the underlying web socket library
This is defined in [RFC 6455 section 11.3.4](https://tools.ietf.org/html/rfc6455#section-11.3.4)

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality