### PR TITLE
Show icon path of a subflow node

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -837,7 +837,9 @@ RED.editor = (function() {
                     RED.utils.createIconElement(icon_url, iconContainer, true);
                 });
             })
-            $('<div class="uneditable-input" id="node-settings-icon">').text(node.icon).appendTo(iconRow);
+            var icon_url = RED.utils.getNodeIcon(node._def,node);
+            var iconPath = RED.utils.separateIconPath(icon_url);
+            $('<div class="uneditable-input" id="node-settings-icon">').text(iconPath.module+"/"+iconPath.file).appendTo(iconRow);
         }
     }
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

The icon path of a subflow node does not show correctly.  How to reproduce it is as follows.
1. Create a subflow node.
2. Open an edit dialog.
3. Click `Appearance` tab and check icon path.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
