### PR TITLE
Prevent invalid value for batch node property

### DIFF
--- a/nodes/core/logic/19-batch.html
+++ b/nodes/core/logic/19-batch.html
@@ -100,9 +100,9 @@
         defaults: {
             name: {value:""},
             mode: {value:"count"},
-            count: {value:10},
-            overlap: {value:0},
-            interval: {value:10},
+            count: {value:10,validate:function(v) { return RED.validators.number(v) && (v >= 1); }},
+            overlap: {value:0,validate:function(v) { return RED.validators.number(v) && (v >= 0); }},
+            interval: {value:10,validate:function(v) { return RED.validators.number(v) && (v >= 1); }},
             allowEmptySequence: {value:false},
             topics: {value:[{topic:""}]}
         },
@@ -149,12 +149,9 @@
                     removable: true
                 });
 
-            $("#node-input-count").spinner({
-            });
-            $("#node-input-overlap").spinner({
-            });
-            $("#node-input-interval").spinner({
-            });
+            $("#node-input-count").spinner({min:1});
+            $("#node-input-overlap").spinner({min:0});
+            $("#node-input-interval").spinner({min:1});
             $("#node-input-mode").change(function(e) {
                 var val = $(this).val();
                 $(".node-row-msg-count").toggle(val==="count");


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Because the minimum value for batch node property is not set, we can input invalid values, such as a negative number.
I fixed to set minimum values of properties and spinners to prevent invalid value.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
