### PR TITLE
fix typo of editor-api package name

### DIFF
--- a/packages/node_modules/@node-red/editor-api/package.json
+++ b/packages/node_modules/@node-red/editor-api/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@node-red/editor",
+    "name": "@node-red/editor-api",
     "version": "0.20.0-alpha.0",
     "license": "Apache-2.0",
     "main": "./lib/index.js",


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fix package name of editor-api of dev branch.

In package.json of editor-api, editor-api is named `@node-red/editor`.

```json
// packages/node_modules/@node-red/editor-api/package.json

{
    "name": "@node-red/editor",
    "version": "0.20.0-alpha.0",
```

But [Design: Runtime Editor Split](https://github.com/node-red/node-red/wiki/Design%3A-Runtime-Editor-Split#packaging) defines this name as `editor-api`. Also node-red package.json requires `@node-red/editor-api`.

```json
// packages/node_modules/node-red/package.json

    "dependencies": {
        "@node-red/editor-api": "0.20.0-alpha.0",
        "@node-red/runtime": "0.20.0-alpha.0",
```

So I fix name property of package.json from `@node-red/editor` to `@node-red/editor-api`.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality