### PR TITLE
Add output type to mqtt node

### DIFF
--- a/nodes/core/io/10-mqtt.html
+++ b/nodes/core/io/10-mqtt.html
@@ -31,8 +31,10 @@
     <div class="form-row">
         <label for="node-input-datatype"><i class="fa fa-sign-out"></i> <span data-i18n="mqtt.label.output"></span></label>
         <select id="node-input-datatype" style="width:70%;">
+            <option value="auto" data-i18n="mqtt.output.auto"></option>
             <option value="buffer" data-i18n="mqtt.output.buffer"></option>
             <option value="utf8" data-i18n="mqtt.output.string"></option>
+            <option value="base64" data-i18n="mqtt.output.base64"></option>
         </select>
     </div>
     <div class="form-row">
@@ -68,7 +70,7 @@
             name: {value:""},
             topic: {value:"",required:true,validate: RED.validators.regex(/^(#$|(\+|[^+#]*)(\/(\+|[^+#]*))*(\/(\+|#|[^+#]*))?$)/)},
             qos: {value: "2"},
-            datatype: {value:"utf8",required:true},
+            datatype: {value:"auto",required:true},
             broker: {type:"mqtt-broker", required:true}
         },
         color:"#d8bfd8",
@@ -86,7 +88,7 @@
                 $("#node-input-qos").val("2");
             }
             if (this.datatype === undefined) {
-                $("#node-input-datatype").val("utf8");
+                $("#node-input-datatype").val("auto");
             }
         }
     });

--- a/nodes/core/io/10-mqtt.html
+++ b/nodes/core/io/10-mqtt.html
@@ -29,6 +29,13 @@
         </select>
     </div>
     <div class="form-row">
+        <label for="node-input-datatype"><i class="fa fa-sign-out"></i> <span data-i18n="mqtt.label.output"></span></label>
+        <select id="node-input-datatype" style="width:70%;">
+            <option value="buffer" data-i18n="mqtt.output.buffer"></option>
+            <option value="utf8" data-i18n="mqtt.output.string"></option>
+        </select>
+    </div>
+    <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
     </div>
@@ -61,6 +68,7 @@
             name: {value:""},
             topic: {value:"",required:true,validate: RED.validators.regex(/^(#$|(\+|[^+#]*)(\/(\+|[^+#]*))*(\/(\+|#|[^+#]*))?$)/)},
             qos: {value: "2"},
+            datatype: {value:"utf8",required:true},
             broker: {type:"mqtt-broker", required:true}
         },
         color:"#d8bfd8",
@@ -76,6 +84,9 @@
         oneditprepare: function() {
             if (this.qos === undefined) {
                 $("#node-input-qos").val("2");
+            }
+            if (this.datatype === undefined) {
+                $("#node-input-datatype").val("utf8");
             }
         }
     });

--- a/nodes/core/io/10-mqtt.js
+++ b/nodes/core/io/10-mqtt.js
@@ -399,7 +399,15 @@ module.exports = function(RED) {
             if (this.topic) {
                 node.brokerConn.register(this);
                 this.brokerConn.subscribe(this.topic,this.qos,function(topic,payload,packet) {
-                    if (this.datatype == "utf8" && isUtf8(payload)) { payload = payload.toString(); }
+                    if (node.datatype =="buffer") {
+                        // payload = payload;
+                    } else if (node.datatype =="base64") {
+                        payload = payload.toString('base64');
+                    } else if (node.datatype =="utf8") {
+                        payload = payload.toString('utf8');
+                    } else {
+                        if (isUtf8(payload)) { payload = payload.toString(); }
+                    }
                     var msg = {topic:topic,payload:payload, qos: packet.qos, retain: packet.retain};
                     if ((node.brokerConn.broker === "localhost")||(node.brokerConn.broker === "127.0.0.1")) {
                         msg._topic = topic;

--- a/nodes/core/io/10-mqtt.js
+++ b/nodes/core/io/10-mqtt.js
@@ -392,13 +392,14 @@ module.exports = function(RED) {
         if (!/^(#$|(\+|[^+#]*)(\/(\+|[^+#]*))*(\/(\+|#|[^+#]*))?$)/.test(this.topic)) {
             return this.warn(RED._("mqtt.errors.invalid-topic"));
         }
+        this.datatype = n.datatype || "utf8";
         var node = this;
         if (this.brokerConn) {
             this.status({fill:"red",shape:"ring",text:"node-red:common.status.disconnected"});
             if (this.topic) {
                 node.brokerConn.register(this);
                 this.brokerConn.subscribe(this.topic,this.qos,function(topic,payload,packet) {
-                    if (isUtf8(payload)) { payload = payload.toString(); }
+                    if (this.datatype == "utf8" && isUtf8(payload)) { payload = payload.toString(); }
                     var msg = {topic:topic,payload:payload, qos: packet.qos, retain: packet.retain};
                     if ((node.brokerConn.broker === "localhost")||(node.brokerConn.broker === "127.0.0.1")) {
                         msg._topic = topic;

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -361,7 +361,9 @@
         "retain": "Retain",
         "output": {
             "buffer": "a Buffer",
-            "string": "a String"
+            "string": "a String",
+            "base64": "a Base64 encoded string",
+            "auto": "auto-detect"
         },
         "true": "true",
         "false": "false",

--- a/nodes/core/locales/en-US/messages.json
+++ b/nodes/core/locales/en-US/messages.json
@@ -324,6 +324,7 @@
         "label": {
             "broker": "Server",
             "example": "e.g. localhost",
+            "output": "Output",
             "qos": "QoS",
             "retain": "Retain",
             "clientid": "Client ID",
@@ -358,6 +359,10 @@
             "connect-failed": "Connection failed to broker: __broker__"
         },
         "retain": "Retain",
+        "output": {
+            "buffer": "a Buffer",
+            "string": "a String"
+        },
         "true": "true",
         "false": "false",
         "tip": "Tip: Leave topic, qos or retain blank if you want to set them via msg properties.",

--- a/nodes/core/locales/ja/messages.json
+++ b/nodes/core/locales/ja/messages.json
@@ -324,6 +324,7 @@
         "label": {
             "broker": "サーバ",
             "example": "例) localhost",
+            "output": "出力",
             "qos": "QoS",
             "retain": "保持",
             "clientid": "クライアント",
@@ -358,6 +359,10 @@
             "connect-failed": "ブローカへの接続に失敗しました: __broker__"
         },
         "retain": "保持",
+        "output": {
+            "buffer": "バイナリバッファ",
+            "string": "文字列"
+        },
         "true": "する",
         "false": "しない",
         "tip": "注釈: トピックやQoSをメッセージのプロパティを用いて設定する場合は、無記入にしてください。",

--- a/nodes/core/locales/ja/messages.json
+++ b/nodes/core/locales/ja/messages.json
@@ -361,7 +361,8 @@
         "retain": "保持",
         "output": {
             "buffer": "バイナリバッファ",
-            "string": "文字列"
+            "string": "文字列",
+            "base64": "Base64文字列"
         },
         "true": "する",
         "false": "しない",

--- a/nodes/core/locales/zh-CN/messages.json
+++ b/nodes/core/locales/zh-CN/messages.json
@@ -314,6 +314,7 @@
         "label": {
             "broker": "服务端",
             "example": "e.g. localhost",
+            "output": "输出",
             "qos": "QoS",
             "clientid": "客户端ID",
             "port": "端口",
@@ -342,6 +343,10 @@
             "connect-failed": "与服务端 __broker__ 的连接失败"
         },
         "retain": "保留",
+        "output": {
+            "buffer": "Buffer",
+            "string": "字符串"
+        },
         "true": "是",
         "false": "否",
         "tip": "提示: 若希望通过msg属性对topic(信息), qos及retain(保留)进行设置, 则将上述项留白",

--- a/nodes/core/locales/zh-CN/messages.json
+++ b/nodes/core/locales/zh-CN/messages.json
@@ -345,7 +345,8 @@
         "retain": "保留",
         "output": {
             "buffer": "Buffer",
-            "string": "字符串"
+            "string": "字符串",
+            "base64": "Base64编码字符串"
         },
         "true": "是",
         "false": "否",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This PR add output type to the `mqtt in` node so we can explicitly parse the message content. It is consistent with `udp in` and `http request`.
![mqtt-output](https://user-images.githubusercontent.com/3709037/47654261-b2691100-db8a-11e8-8de0-3d45099ebd0f.png)

It fixes #1912 as parsing binary messages is problematic if it has a valid UTF-8 interpretation.

As discussed with @knolleary, the default behavior is to auto-detect the format to keep compatibility with existing flows.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
