### PR TITLE
Update node-red-node-email to 1.0.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "mqtt": "2.18.8",
     "multer": "1.4.1",
     "mustache": "2.3.2",
-    "node-red-node-email": "0.1.*",
+    "node-red-node-email": "1.0.*",
     "node-red-node-feedparser": "^0.1.12",
     "node-red-node-rbe": "0.2.*",
     "node-red-node-twitter": "^1.1.0",


### PR DESCRIPTION
When we install NodeRed 19.4 we still get the version 0.1.29 of node-red-node-email .
Can we upgrade this package ?

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
