### PR TITLE
Show port label of subflow with input port

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -588,7 +588,7 @@ RED.editor = (function() {
             for (i=inputCount;i<childCount;i++) {
                 $(children[i]).remove();
             }
-            if (outputCount === 0) {
+            if (inputCount === 0) {
                 buildLabelRow().appendTo(inputsDiv);
             }
         }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

subflow edit dialog does not show an input port label correctly.  The reproduction procedure is as follows.

1. Create a subflow.
2. Change the number of input port from 0 to 1.
3. Click `edit properties`, and open `Appearance` tab.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
