### PR TITLE
Fix html file of rpi-gpio out node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/hardware/36-rpi-gpio.html
+++ b/packages/node_modules/@node-red/nodes/core/hardware/36-rpi-gpio.html
@@ -381,7 +381,7 @@
 </script>
 
 <script type="text/x-red" data-help-name="rpi-gpio out">
-    <p>Raspberry Pi output node. Can be used in Digital or PWM modes.
+    <p>Raspberry Pi output node. Can be used in Digital or PWM modes.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">
         <dt>payload <span class="property-type">number | string | boolean</span></dt>

--- a/packages/node_modules/@node-red/nodes/locales/ja/hardware/36-rpi-gpio.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/hardware/36-rpi-gpio.html
@@ -29,7 +29,7 @@
 </script>
 
 <script type="text/x-red" data-help-name="rpi-gpio out">
-    <p>Raspberry Piの出力ノード。デジタルモードまたはPWMモードで利用できます。
+    <p>Raspberry Piの出力ノード。デジタルモードまたはPWMモードで利用できます。</p>
     <h3>入力</h3>
     <dl class="message-properties">
         <dt>payload <span class="property-type">数値 | 文字列 | 真偽値</span></dt>


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I found that `<p>` tag in html file of rpi-gpio out node are not closed.
They were in the section of the help text that gets displayed in the info sidebar tab.
It was the same  in Japanese language file.
So I fixed these html files.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
