### PR TITLE
http request: add msg.requestTimeout parameter

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.html
@@ -97,6 +97,8 @@
             self signed certificates.</dd>
         <dt class="optional">followRedirects</dt>
         <dd>If set to <code>false</code> prevent following Redirect (HTTP 301).<code>true</code> by default</dd>
+        <dt class="optional">requestTimeout</dt>
+        <dd>If set to a positive number, will override the globally set <code>httpRequestTimeout</code> parameter.</dd>
     </dl>
     <h3>Outputs</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
@@ -94,9 +94,9 @@ module.exports = function(RED) {
             opts.proxy = null;
             if (msg.requestTimeout) {
                 if (isNaN(msg.requestTimeout)) {
-                    node.warn(RED._("httpin.errors.timeout-isnan"))
+                    node.warn(RED._("httpin.errors.timeout-isnan"));
                 } else if (msg.requestTimeout < 0) {
-                    node.warn(RED._("httpin.errors.timeout-isnegative"))
+                    node.warn(RED._("httpin.errors.timeout-isnegative"));
                 } else {
                     opts.timeout = msg.requestTimeout;
                 }

--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
@@ -92,6 +92,15 @@ module.exports = function(RED) {
             opts.maxRedirects = 21;
             opts.jar = request.jar();
             opts.proxy = null;
+            if (msg.requestTimeout) {
+                if (isNaN(msg.requestTimeout)) {
+                    node.warn(RED._("httpin.errors.timeout-isnan"))
+                } else if (msg.requestTimeout < 0) {
+                    node.warn(RED._("httpin.errors.timeout-isnegative"))
+                } else {
+                    opts.timeout = msg.requestTimeout;
+                }
+            }
             var ctSet = "Content-Type"; // set default camel case
             var clSet = "Content-Length";
             if (msg.headers) {

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -410,7 +410,9 @@
             "json-error": "JSON parse error",
             "no-url": "No url specified",
             "deprecated-call":"Deprecated call to __method__",
-            "invalid-transport":"non-http transport requested"
+            "invalid-transport":"non-http transport requested",
+            "timeout-isnan": "Timeout value is not a valid number, ignoring",
+            "timeout-isnegative": "Timeout value is negative, ignoring"
         },
         "status": {
             "requesting": "requesting"


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

This adds a `msg.requestTimeout` option to the http request node to override the global httpRequestTimeout parameter per message.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
