### PR TITLE
Update Japanese message catalog for nodes

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/io/22-websocket.html
+++ b/packages/node_modules/@node-red/nodes/core/io/22-websocket.html
@@ -247,7 +247,7 @@
         <input id="node-config-input-path" type="text" placeholder="/ws/example">
     </div>
     <div class="form-row">
-        <label for="node-config-input-wholemsg"></label>
+        <label for="node-config-input-wholemsg" data-i18n="websocket.sendrec"></label>
         <select type="text" id="node-config-input-wholemsg" style="width: 70%;">
             <option value="false" data-i18n="websocket.payload"></option>
             <option value="true" data-i18n="websocket.message"></option>

--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -124,6 +124,7 @@
             "filterCurrent": "現在のフロー",
             "debugNodes": "debugノード",
             "clearLog": "ログを削除",
+             "filterLog": "ログのフィルタリング",
             "openWindow": "新しいウィンドウで開く"
         },
         "messageMenu": {
@@ -361,7 +362,8 @@
         "output": {
             "buffer": "バイナリバッファ",
             "string": "文字列",
-            "base64": "Base64文字列"
+            "base64": "Base64文字列",
+            "auto": "自動判定"
         },
         "true": "する",
         "false": "しない",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This PR adds missing Japanese translation of message catalogue for nodes.
Also fixes missing label in settings UI of websocket config node.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
