### PR TITLE
update 10-switch.html - missing Font Awesome font

### DIFF
--- a/nodes/core/logic/10-switch.html
+++ b/nodes/core/logic/10-switch.html
@@ -20,7 +20,7 @@
         <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
     </div>
     <div class="form-row">
-        <label data-i18n="switch.label.property"></label>
+        <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> <span data-i18n="switch.label.property"></span></label>
         <input type="text" id="node-input-property" style="width: 70%"/>
         <input type="hidden" id="node-input-outputs"/>
     </div>


### PR DESCRIPTION
## Proposed changes

Lacked fa-ellipsis-h Icon for property field.
Other core nodes have this icon. range-node has its icon, rbe-node has its icon
its time switch-node joins its brothers and sisters in uniformity.


- [X] Bugfix (non-breaking change which fixes an issue)
- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] I have signed the JS Foundation's Contributor License Agreement
-[X] I have tested it on my own copy of node-red
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
