### PR TITLE
Template node - change field icon

### DIFF
--- a/nodes/core/core/80-template.html
+++ b/nodes/core/core/80-template.html
@@ -5,7 +5,7 @@
         <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
     </div>
     <div class="form-row">
-        <label for="node-input-field"><i class="fa fa-edit"></i> <span data-i18n="template.label.property"></span></label>
+        <label for="node-input-field"><i class="fa fa-ellipsis-h"></i> <span data-i18n="template.label.property"></span></label>
         <input type="text" id="node-input-field" placeholder="payload" style="width:250px;">
         <input type="hidden" id="node-input-fieldType">
     </div>


### PR DESCRIPTION
node using font  ( fa-edit )
other nodes that have been updated with property option use fa-ellipsis-h
( range, html, json, xml, jaml, rbe, sentiment ) <---- nodes all use fa-ellipsis-h
its time the template-node joins its siblings in uniformity.

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)