### PR TITLE
add i18n & JP message for node config tab

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -889,8 +889,8 @@
         }
     },
     "editor-tab": {
-        "properties": "@Properties",
-        "description": "@Description",
-        "appearance": "@Appearance"
+        "properties": "Properties",
+        "description": "Description",
+        "appearance": "Appearance"
     }
 }

--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -887,5 +887,10 @@
             "unexpected": "An unexpected error occurred",
             "code": "code"
         }
+    },
+    "editor-tab": {
+        "properties": "@Properties",
+        "description": "@Description",
+        "appearance": "@Appearance"
     }
 }

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -423,6 +423,8 @@
             "updated": "更新済",
             "install": "ノードを追加",
             "installed": "追加しました",
+            "conflict": "競合",
+            "conflictTip": "<p>インストール済みのノードの種別と競合しているため<br/>ノードをインストールできません</p><p>競合: <code>__module__</code></p>",
             "loading": "カタログを読み込み中",
             "tab-nodes": "現在のノード",
             "tab-install": "ノードを追加",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -881,5 +881,10 @@
             "unexpected": "予期しないエラーが発生しました",
             "code": "コード"
         }
+    },
+    "editor-tab": {
+        "properties": "プロパティ",
+        "description": "説明",
+        "appearance": "外観"
     }
 }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1372,8 +1372,8 @@ RED.editor = (function() {
 
                 var nodePropertiesTab = {
                     id: "editor-tab-properties",
-                    label: "Properties",
-                    name: "Properties",
+                    label: RED._("editor-tab.properties"),
+                    name: RED._("editor-tab.properties"),
                     content: $('<div>', {class:"editor-tray-content"}).appendTo(editorContent).hide(),
                     iconClass: "fa fa-cog"
                 };
@@ -1383,8 +1383,8 @@ RED.editor = (function() {
                 if (!node._def.defaults || !node._def.defaults.hasOwnProperty('info'))  {
                     var descriptionTab = {
                         id: "editor-tab-description",
-                        label: "Description",
-                        name: "Description",
+                        label: RED._("editor-tab.description"),
+                        name: RED._("editor-tab.description"),
                         content: $('<div>', {class:"editor-tray-content"}).appendTo(editorContent).hide(),
                         iconClass: "fa fa-file-text-o",
                         onchange: function() {
@@ -1397,8 +1397,8 @@ RED.editor = (function() {
 
                 var appearanceTab = {
                     id: "editor-tab-appearance",
-                    label: "Appearance",
-                    name: "Appearance",
+                    label: RED._("editor-tab.appearance"),
+                    name: RED._("editor-tab.appearance"),
                     content: $('<div>', {class:"editor-tray-content"}).appendTo(editorContent).hide(),
                     iconClass: "fa fa-object-group",
                     onchange: function() {
@@ -1538,8 +1538,8 @@ RED.editor = (function() {
 
                 var nodePropertiesTab = {
                     id: "editor-tab-cproperties",
-                    label: "Properties",
-                    name: "Properties",
+                    label: RED._("editor-tab.properties"),
+                    name: RED._("editor-tab.properties"),
                     content: $('<div>', {class:"editor-tray-content"}).appendTo(editorContent).hide(),
                     iconClass: "fa fa-cog"
                 };
@@ -1549,8 +1549,8 @@ RED.editor = (function() {
                 if (!node_def.defaults || !node_def.defaults.hasOwnProperty('info'))  {
                     var descriptionTab = {
                         id: "editor-tab-description",
-                        label: "Description",
-                        name: "Description",
+                        label: RED._("editor-tab.description"),
+                        name: RED._("editor-tab.description"),
                         content: $('<div>', {class:"editor-tray-content"}).appendTo(editorContent).hide(),
                         iconClass: "fa fa-file-text-o",
                         onchange: function() {
@@ -2061,8 +2061,8 @@ RED.editor = (function() {
 
                 var nodePropertiesTab = {
                     id: "editor-tab-properties",
-                    label: "Properties",
-                    name: "Properties",
+                    label: RED._("editor-tab.properties"),
+                    name: RED._("editor-tab.properties"),
                     content: $('<div>', {class:"editor-tray-content"}).appendTo(editorContent).hide(),
                     iconClass: "fa fa-cog"
                 };
@@ -2071,8 +2071,8 @@ RED.editor = (function() {
 
                 var descriptionTab = {
                     id: "editor-tab-description",
-                    label: "Description",
-                    name: "Description",
+                    label: RED._("editor-tab.description"),
+                    name: RED._("editor-tab.description"),
                     content: $('<div>', {class:"editor-tray-content"}).appendTo(editorContent).hide(),
                     iconClass: "fa fa-file-text-o",
                     onchange: function() {
@@ -2084,8 +2084,8 @@ RED.editor = (function() {
 
                 var appearanceTab = {
                     id: "editor-tab-appearance",
-                    label: "Appearance",
-                    name: "Appearance",
+                    label: RED._("editor-tab.appearance"),
+                    name: RED._("editor-tab.appearance"),
                     content: $('<div>', {class:"editor-tray-content"}).appendTo(editorContent).hide(),
                     iconClass: "fa fa-object-group",
                     onchange: function() {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Title part of new node setting tab is not i18n ready.
This PR fix this and adds Japanese message translation.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
