### PR TITLE
Add quotation marks for basic auth challenge

### DIFF
--- a/red.js
+++ b/red.js
@@ -240,7 +240,7 @@ function basicAuthMiddleware(user,pass) {
         }
         var requestUser = basicAuth(req);
         if (!requestUser || requestUser.name !== user || !checkPasswordAndCache(requestUser.pass)) {
-            res.set('WWW-Authenticate', 'Basic realm=Authorization Required');
+            res.set('WWW-Authenticate', 'Basic realm="Authorization Required"');
             return res.sendStatus(401);
         }
         next();


### PR DESCRIPTION
This is required by RFC 2617

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

I try to connect our node-red enpoint with a iOS application . The node-red instance is secured over Basic Auth . Problem right now is that node-red returns www-authenticate: Basic realm=Authorization Required … The std Apple API does not recognise the realm because it is not “quotated” .. The Standard says it must be in quotation marks (https://tools.ietf.org/html/rfc2617#page-4 chapter 2) .. The issue is in red.js (node-red/red.js) line 243

I changed the code and put the Realm into quotation marks like it is specified in the RFC 2617 doc

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
