### PR TITLE
refuse to enable palette if npm too old

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/installer.js
+++ b/packages/node_modules/@node-red/registry/lib/installer.js
@@ -235,12 +235,17 @@ function checkPrereq() {
         return Promise.resolve();
     } else {
         return new Promise(resolve => {
-            child_process.execFile(npmCommand,['-v'],function(err) {
+            child_process.execFile(npmCommand,['-v'],function(err,stdout) {
                 if (err) {
                     log.info(log._("server.palette-editor.npm-not-found"));
                     paletteEditorEnabled = false;
                 } else {
-                    paletteEditorEnabled = true;
+                    if (parseInt(stdout.split(".")[0]) < 3) {
+                        log.info(log._("server.palette-editor.npm-too-old"));
+                        paletteEditorEnabled = false;
+                    } else {
+                        paletteEditorEnabled = true;
+                    }
                 }
                 resolve();
             });

--- a/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
@@ -13,7 +13,8 @@
         "loading": "Loading palette nodes",
         "palette-editor": {
             "disabled": "Palette editor disabled : user settings",
-            "npm-not-found": "Palette editor disabled : npm command not found"
+            "npm-not-found": "Palette editor disabled : npm command not found",
+            "npm-too-old": "Palette editor disabled : npm version too old - please update"
         },
         "errors": "Failed to register __count__ node type",
         "errors_plural": "Failed to register __count__ node types",

--- a/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
@@ -14,7 +14,7 @@
         "palette-editor": {
             "disabled": "Palette editor disabled : user settings",
             "npm-not-found": "Palette editor disabled : npm command not found",
-            "npm-too-old": "Palette editor disabled : npm version too old - please update"
+            "npm-too-old": "Palette editor disabled : npm version too old. Requires npm >= 3.x"
         },
         "errors": "Failed to register __count__ node type",
         "errors_plural": "Failed to register __count__ node types",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Currently we just check for the existence of npm. We should also refuse to enable the palette if the version of npm is too old (aka 1.4.2 from debian) as it will break users with bad installs.

This PR logs the fact in the log and suggests users update.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
