### PR TITLE
Use payload properties as parameters on a GET request

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.html
@@ -25,9 +25,15 @@
         <option value="use" data-i18n="httpin.setby"></option>
         </select>
     </div>
+
     <div class="form-row">
         <label for="node-input-url"><i class="fa fa-globe"></i> <span data-i18n="httpin.label.url"></span></label>
         <input id="node-input-url" type="text" placeholder="http://">
+    </div>
+
+    <div class="form-row node-input-usePayloadAsParameters-row">
+        <input type="checkbox" id="node-input-usePayloadAsParameters" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-usePayloadAsParameters" style="width: auto" data-i18n="httpin.label.usePayloadAsParameters"></label>
     </div>
 
     <div class="form-row">
@@ -149,6 +155,7 @@
             name: {value:""},
             method:{value:"GET"},
             ret: {value:"txt"},
+            usePayloadAsParameters: {value: false},
             url:{value:"",validate:function(v) { return (v.trim().length === 0) || (v.indexOf("://") === -1) || (v.trim().indexOf("http") === 0)} },
             tls: {type:"tls-config",required: false},
             proxy: {type:"http proxy",required: false}
@@ -177,6 +184,13 @@
                     $(".node-input-useAuth-row").hide();
                     $('#node-input-user').val('');
                     $('#node-input-password').val('');
+                }
+            });
+            $("#node-input-method").change(function() {
+                if ($(this).val() == "GET") {
+                    $(".node-input-usePayloadAsParameters-row").show();
+                } else {
+                    $(".node-input-usePayloadAsParameters-row").hide();
                 }
             });
             if (this.credentials.user || this.credentials.has_password) {

--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
@@ -28,6 +28,7 @@ module.exports = function(RED) {
         var nodeUrl = n.url;
         var isTemplatedUrl = (nodeUrl||"").indexOf("{{") != -1;
         var nodeMethod = n.method || "GET";
+        var usePayloadAsParameters = n.usePayloadAsParameters;
         if (n.tls) {
             var tlsNode = RED.nodes.getNode(n.tls);
         }
@@ -199,6 +200,22 @@ module.exports = function(RED) {
                 }
                 opts.body = payload;
             }
+
+            if (method == 'GET' && typeof msg.payload !== "undefined" && usePayloadAsParameters) {
+                if (typeof msg.payload === "object") {
+                    if(opts.url.indexOf("?") !== -1) {
+                        opts.url += "&" + querystring.stringify(msg.payload);
+                    } else {
+                        opts.url += "?" + querystring.stringify(msg.payload);
+                    }
+                    
+                } else {
+                    //I'm not sure where to set "httpin.errors.unvalid-payload" :(
+                    node.error(RED._("httpin.errors.invalid-payload"),msg);
+                    return;
+                }
+            }
+            
             // revert to user supplied Capitalisation if needed.
             if (opts.headers.hasOwnProperty('content-type') && (ctSet !== 'content-type')) {
                 opts.headers[ctSet] = opts.headers['content-type'];

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -384,7 +384,8 @@
             "upload": "Accept file uploads?",
             "status": "Status code",
             "headers": "Headers",
-            "other": "other"
+            "other": "other",
+            "usePayloadAsParameters" : "Use payload properties as parameters"
         },
         "setby": "- set by msg.method -",
         "basicauth": "Use basic authentication",
@@ -412,7 +413,8 @@
             "deprecated-call":"Deprecated call to __method__",
             "invalid-transport":"non-http transport requested",
             "timeout-isnan": "Timeout value is not a valid number, ignoring",
-            "timeout-isnegative": "Timeout value is negative, ignoring"
+            "timeout-isnegative": "Timeout value is negative, ignoring",
+            "invalid-payload": "Invalid payload"
         },
         "status": {
             "requesting": "requesting"


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)

## Proposed changes

Add the ability to use payload properties as parameters on a GET request

## Checklist

- [x ] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [x ] I have added suitable unit tests to cover the new/changed functionality
