### PR TITLE
Show arrow-in node when invalid font-awesome icon name was specified …

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
@@ -498,7 +498,7 @@ RED.diff = (function() {
         nodeDiv.css('backgroundColor',colour);
 
         var iconContainer = $('<div/>',{class:"palette_icon_container"}).appendTo(nodeDiv);
-        RED.utils.createIconElement(icon_url, iconContainer, false, def, node);
+        RED.utils.createIconElement(icon_url, iconContainer, false);
 
         return nodeDiv;
     }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -830,7 +830,7 @@ RED.editor = (function() {
             var icon_url = RED.utils.getNodeIcon(node._def,node);
             nodeDiv.css('backgroundColor',colour);
             var iconContainer = $('<div/>',{class:"palette_icon_container"}).appendTo(nodeDiv);
-            RED.utils.createIconElement(icon_url, iconContainer, true, node._def, node);
+            RED.utils.createIconElement(icon_url, iconContainer, true);
 
             iconButton.click(function(e) {
                 e.preventDefault();
@@ -844,7 +844,7 @@ RED.editor = (function() {
                 showIconPicker(iconRow,node,iconPath,function(newIcon) {
                     $("#node-settings-icon").text(newIcon||"");
                     var icon_url = RED.utils.getNodeIcon(node._def,{type:node.type,icon:newIcon});
-                    RED.utils.createIconElement(icon_url, iconContainer, true, node._def, node);
+                    RED.utils.createIconElement(icon_url, iconContainer, true);
                 });
             });
             $('<div id="node-settings-icon">').text(node.icon).appendTo(iconButton);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -144,7 +144,7 @@ RED.palette = (function() {
     function setIcon(element,sf) {
         var icon_url = RED.utils.getNodeIcon(sf._def);
         var iconContainer = element.find(".palette_icon_container");
-        RED.utils.createIconElement(icon_url, iconContainer, true, sf._def);
+        RED.utils.createIconElement(icon_url, iconContainer, true);
     }
 
     function escapeNodeType(nt) {
@@ -182,7 +182,7 @@ RED.palette = (function() {
             if (def.icon) {
                 var icon_url = RED.utils.getNodeIcon(def);
                 var iconContainer = $('<div/>',{class:"palette_icon_container"+(def.align=="right"?" palette_icon_container_right":"")}).appendTo(d);
-                RED.utils.createIconElement(icon_url, iconContainer, true, def);
+                RED.utils.createIconElement(icon_url, iconContainer, true);
             }
 
             d.style.backgroundColor = RED.utils.getNodeColor(nt,def);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
@@ -203,7 +203,7 @@ RED.search = (function() {
                     nodeDiv.css('backgroundColor',colour);
 
                     var iconContainer = $('<div/>',{class:"palette_icon_container"}).appendTo(nodeDiv);
-                    RED.utils.createIconElement(icon_url, iconContainer, true, node._def, node);
+                    RED.utils.createIconElement(icon_url, iconContainer, true);
 
                     var contentDiv = $('<div>',{class:"red-ui-search-result-description"}).appendTo(div);
                     if (node.z) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js
@@ -133,7 +133,7 @@ RED.typeSearch = (function() {
                 nodeDiv.css('backgroundColor',colour);
 
                 var iconContainer = $('<div/>',{class:"palette_icon_container"}).appendTo(nodeDiv);
-                RED.utils.createIconElement(icon_url, iconContainer, false, def);
+                RED.utils.createIconElement(icon_url, iconContainer, false);
 
                 if (def.inputs > 0) {
                     $('<div/>',{class:"red-ui-search-result-node-port"}).appendTo(nodeDiv);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -782,15 +782,18 @@ RED.utils = (function() {
         }
 
         var iconPath = getDefaultNodeIcon(def, node);
-        if (def.category === 'subflows') {
-            if (!isIconExists(iconPath)) {
-                return RED.settings.apiRootUrl+"icons/node-red/subflow.png";
+        if (isIconExists(iconPath)) {
+            if (iconPath.module === "font-awesome") {
+                return iconPath.module+"/"+iconPath.file;
+            } else {
+                return RED.settings.apiRootUrl+"icons/"+iconPath.module+"/"+iconPath.file;
             }
-        }
-        if (iconPath.module === "font-awesome") {
-            return iconPath.module+"/"+iconPath.file;
         } else {
-            return RED.settings.apiRootUrl+"icons/"+iconPath.module+"/"+iconPath.file;
+            if (def.category === 'subflows') {
+                return RED.settings.apiRootUrl+"icons/node-red/subflow.png";
+            } else {
+                return RED.settings.apiRootUrl+"icons/node-red/arrow-in.png";
+            }
         }
     }
 
@@ -904,10 +907,8 @@ RED.utils = (function() {
       * @param iconUrl - Url of icon.
       * @param iconContainer - Icon container element with palette_icon_container class.
       * @param isLarge - Whether the icon size is large.
-      * @param def - Default definition of a node.
-      * @param node - If the icon is a specific node instance, this parameter must be specified. If it is icon template such as an icon on the palette, this must be omitted.
       */
-    function createIconElement(iconUrl, iconContainer, isLarge, def, node) {
+    function createIconElement(iconUrl, iconContainer, isLarge) {
         // Removes the previous icon when icon was changed.
         var iconElement = iconContainer.find(".palette_icon");
         if (iconElement.length !== 0) {
@@ -928,13 +929,8 @@ RED.utils = (function() {
                 faIconElement.addClass("palette_icon_fa fa fa-fw " + faLarge + iconPath.file);
                 return;
             }
-            // If the specified name is not defined in font-awesome, show the default icon.
-            if (def) {
-                var iconPath = RED.utils.getDefaultNodeIcon(def, node);
-                iconUrl = RED.settings.apiRootUrl+"icons/"+iconPath.module+"/"+iconPath.file;
-            } else {
-                iconUrl = RED.settings.apiRootUrl+"icons/node-red/arrow-in.png"
-            }
+            // If the specified name is not defined in font-awesome, show arrow-in icon.
+            iconUrl = RED.settings.apiRootUrl+"icons/node-red/arrow-in.png"
         }
         var imageIconElement = $('<div/>',{class:"palette_icon"}).appendTo(iconContainer);
         imageIconElement.css("backgroundImage", "url("+iconUrl+")");


### PR DESCRIPTION
…for default icon

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Show arrow-in node when invalid font-awesome icon name was specified for default icon in HTML node definition.
As I modified `getNodeIcon` function, basically no code will come to line 933 of util.js.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
