### PR TITLE
Speeding up display of diff for large flows

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
@@ -687,8 +687,7 @@ RED.diff = (function() {
                 diff: remoteDiff
             }
         }
-        createNodePropertiesTable(def,node,localNode,remoteNode).appendTo(div);
-
+        
         var selectState = "";
 
         if (conflicted) {
@@ -707,6 +706,10 @@ RED.diff = (function() {
         createNodeConflictRadioBoxes(node,div,localNodeDiv,remoteNodeDiv,false,!conflicted,selectState,CurrentDiff);
         row.click(function(evt) {
             $(this).parent().toggleClass('collapsed');
+
+            if($(this).siblings('.node-diff-node-entry-properties').length === 0) {
+                createNodePropertiesTable(def,node,localNode,remoteNode).appendTo(div);
+            }
         });
 
         return div;


### PR DESCRIPTION

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Speed up the display of the diff panel in the editor UI for large flows.

Currently the diff of a flow of 2500 nodes takes 3mins, 3300 nodes 5 mins...etc
This is because the DOM for the whole diff (all nodes, all properties of all nodes) is generated when the diff panel is opened.

By generating the DOM for node properties only if the user clicks on the node, the size of the flow has much less impact on the loading time of the panel.
This brings the appearance of the diff table down to a few seconds even for large flows.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
