### PR TITLE
JSON node: delete msg.schema before sending msg to avoid conflicts

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/parsers/70-JSON.js
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-JSON.js
@@ -56,6 +56,7 @@ module.exports = function(RED) {
                             RED.util.setMessageProperty(msg,node.property,JSON.parse(value));
                             if (validate) {
                                 if (this.compiledSchema(msg[node.property])) {
+                                    delete msg.schema;
                                     node.send(msg);
                                 } else {
                                     msg.schemaError = this.compiledSchema.errors;
@@ -70,6 +71,7 @@ module.exports = function(RED) {
                         // If node.action is str and value is str
                         if (validate) {
                             if (this.compiledSchema(JSON.parse(msg[node.property]))) {
+                                delete msg.schema;
                                 node.send(msg);
                             } else {
                                 msg.schemaError = this.compiledSchema.errors;
@@ -87,6 +89,7 @@ module.exports = function(RED) {
                                 if (validate) {
                                     if (this.compiledSchema(value)) {
                                         RED.util.setMessageProperty(msg,node.property,JSON.stringify(value,null,node.indent));
+                                        delete msg.schema;
                                         node.send(msg);
                                     } else {
                                         msg.schemaError = this.compiledSchema.errors;
@@ -104,6 +107,7 @@ module.exports = function(RED) {
                         // If node.action is obj and value is object
                         if (validate) {
                             if (this.compiledSchema(value)) {
+                                delete msg.schema;
                                 node.send(msg);
                             } else {
                                 msg.schemaError = this.compiledSchema.errors;

--- a/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-JSON.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-JSON.html
@@ -21,7 +21,8 @@
         <dt>payload<span class="property-type">object | string</span></dt>
         <dd>A JavaScript object or JSON string.</dd>
         <dt>schema<span class="property-type">object</span></dt>
-        <dd>An optional JSON Schema object to validate the payload against.</dd>
+        <dd>An optional JSON Schema object to validate the payload against.
+        The property will be deleted before the <code>msg</code> is sent to the next flow.</dd>
     </dl>
     <h3>Outputs</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-JSON.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-JSON.html
@@ -22,7 +22,7 @@
         <dd>A JavaScript object or JSON string.</dd>
         <dt>schema<span class="property-type">object</span></dt>
         <dd>An optional JSON Schema object to validate the payload against.
-        The property will be deleted before the <code>msg</code> is sent to the next flow.</dd>
+        The property will be deleted before the <code>msg</code> is sent to the next node.</dd>
     </dl>
     <h3>Outputs</h3>
     <dl class="message-properties">

--- a/test/nodes/core/parsers/70-JSON_spec.js
+++ b/test/nodes/core/parsers/70-JSON_spec.js
@@ -433,4 +433,36 @@ describe('JSON node', function() {
             }
         });
     });
+
+    it('msg.schema property should be deleted before sending to next node (string input)', function(done) {
+        var flow = [{id:"jn1",type:"json",action:"str",wires:[["jn2"]]},
+                    {id:"jn2", type:"helper"}];
+        helper.load(jsonNode, flow, function() {
+            var jn1 = helper.getNode("jn1");
+            var jn2 = helper.getNode("jn2");
+            jn2.on("input", function(msg) {
+                should.equal(msg.schema, undefined);
+                done();
+            });
+            var jsonString =  '{"number":3,"string":"allo"}';
+            var schema = {title: "testSchema", type: "object", properties: {number: {type: "number"}, string: {type: "string" }}};
+            jn1.receive({payload:jsonString, schema:schema});
+        });
+    });
+
+    it('msg.schema property should be deleted before sending to next node (object input)', function(done) {
+        var flow = [{id:"jn1",type:"json",action:"str",wires:[["jn2"]]},
+                    {id:"jn2", type:"helper"}];
+        helper.load(jsonNode, flow, function() {
+            var jn1 = helper.getNode("jn1");
+            var jn2 = helper.getNode("jn2");
+            jn2.on("input", function(msg) {
+                should.equal(msg.schema, undefined);
+                done();
+            });
+            var jsonObject =  {"number":3,"string":"allo"};
+            var schema = {title: "testSchema", type: "object", properties: {number: {type: "number"}, string: {type: "string" }}};
+            jn1.receive({payload:jsonObject, schema:schema});
+        });
+    });
 });


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

This deletes the msg.schema property before sending the msg to avoir conflicts with further JSON nodes.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
