### PR TITLE
i18 support for markdown editor tooltips

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -718,7 +718,19 @@
     },
     "markdownEditor": {
         "title": "Markdown editor",
-        "format": "Formatted with markdown"
+        "format": "Formatted with markdown",
+        "heading1": "Heading 1",
+        "heading2": "Heading 2",
+        "heading3": "Heading 3",
+        "bold": "Bold",
+        "italic": "Italic",
+        "code": "Code",
+        "ordered-list": "Ordered list",
+        "unordered-list": "Unordered list",
+        "quote": "Quote",
+        "link": "Link",
+        "horizontal-rule": "Horizontal rule",
+        "toggle-preview": "Toggle preview"
     },
     "bufferEditor": {
         "title": "Buffer editor",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -715,7 +715,19 @@
         "format": "JSONフォーマット"
     },
     "markdownEditor": {
-        "title": "マークダウンエディタ"
+        "title": "マークダウンエディタ",
+        "heading1": "見出しレベル1",
+        "heading2": "見出しレベル2",
+        "heading3": "見出しレベル3",
+        "bold": "太字",
+        "italic": "斜体",
+        "code": "コード",
+        "ordered-list": "箇条書き(番号付き)",
+        "unordered-list": "箇条書き",
+        "quote": "引用",
+        "link": "リンク",
+        "horizontal-rule": "区切り線",
+        "toggle-preview": "プレビュー表示切替え"
     },
     "bufferEditor": {
         "title": "バッファエディタ",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/markdown.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/markdown.js
@@ -51,20 +51,6 @@
 
     var panels;
 
-    var styleActions = {
-        'h1': { newline: true, before:"# ", tooltip:"Heading 1"},
-        'h2': { newline: true, before:"## ", tooltip:"Heading 2"},
-        'h3': { newline: true, before:"### ", tooltip:"Heading 3"},
-        'b': { before:"**", after: "**", tooltip: "Bold" },
-        'i': { before:"_", after: "_", tooltip: "Italic" },
-        'code': { before:"`", after: "`", tooltip: "Code" },
-        'ol': { before:" * ", newline: true, tooltip: "Ordered list" },
-        'ul': { before:" - ", newline: true, tooltip: "Unordered list"  },
-        'bq': { before:"> ", newline: true, tooltip: "Quote"  },
-        'link': { before:"[", after: "]()", tooltip: "Link"},
-        'hr': { before:"\n---\n\n", tooltip: "Horizontal rule"  }
-    }
-
     var definition = {
         show: function(options) {
             var value = options.value;
@@ -150,7 +136,7 @@
                             panels.ratio(0.5);
                         }
                     });
-                    RED.popover.tooltip($("#node-btn-markdown-preview"),"Toggle preview");
+                    RED.popover.tooltip($("#node-btn-markdown-preview"), RED._("markdownEditor.toggle-preview"));
 
                     if (options.cursor) {
                         expressionEditor.gotoLine(options.cursor.row+1,options.cursor.column,false);
@@ -170,6 +156,19 @@
         },
 
         buildToolbar: function(container, editor) {
+            var styleActions = {
+                'h1': { newline: true, before:"# ", tooltip:RED._("markdownEditor.heading1")},
+                'h2': { newline: true, before:"## ", tooltip:RED._("markdownEditor.heading2")},
+                'h3': { newline: true, before:"### ", tooltip:RED._("markdownEditor.heading3")},
+                'b': { before:"**", after: "**", tooltip: RED._("markdownEditor.bold")},
+                'i': { before:"_", after: "_", tooltip: RED._("markdownEditor.italic")},
+                'code': { before:"`", after: "`", tooltip: RED._("markdownEditor.code")},
+                'ol': { before:" * ", newline: true, tooltip: RED._("markdownEditor.ordered-list")},
+                'ul': { before:" - ", newline: true, tooltip: RED._("markdownEditor.unordered-list")},
+                'bq': { before:"> ", newline: true, tooltip: RED._("markdownEditor.quote")},
+                'link': { before:"[", after: "]()", tooltip: RED._("markdownEditor.link")},
+                'hr': { before:"\n---\n\n", tooltip: RED._("markdownEditor.horizontal-rule")}
+            }
             var toolbar = $(toolbarTemplate).appendTo(container);
             toolbar.find('button[data-style]').each(function(el) {
                 var style = styleActions[$(this).data('style')];


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Tooltips in node's markdown editor are not i18n ready.
This PR adds i18n support of these tooltips and corresponding Japanese messages.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
