### PR TITLE
Update UI test for mac OS

### DIFF
--- a/test/editor/pageobjects/nodes/core/core/58-debug_page.js
+++ b/test/editor/pageobjects/nodes/core/core/58-debug_page.js
@@ -18,6 +18,8 @@ var util = require("util");
 
 var nodePage = require("../../node_page");
 
+var keyPage = require("../../../util/key_page");
+
 function debugNode(id) {
     nodePage.call(this, id);
 }
@@ -32,7 +34,7 @@ debugNode.prototype.setOutput = function(complete) {
         browser.clickWithWait('//div[@class="red-ui-typedInput-options"][1]/a[1]');
         // Input the path in msg.
         browser.clickWithWait('//*[contains(@class, "red-ui-typedInput-input")]/input');
-        browser.keys(['Control', 'a', 'Control']);
+        browser.keys(keyPage.selectAll());
         browser.keys(['Delete']);
         browser.setValue('//*[contains(@class, "red-ui-typedInput-input")]/input', complete);
     } else {

--- a/test/editor/pageobjects/nodes/core/core/80-function_page.js
+++ b/test/editor/pageobjects/nodes/core/core/80-function_page.js
@@ -18,6 +18,8 @@ var util = require("util");
 
 var nodePage = require("../../node_page");
 
+var keyPage = require("../../../util/key_page");
+
 function functionNode(id) {
     nodePage.call(this, id);
 }
@@ -25,13 +27,13 @@ function functionNode(id) {
 util.inherits(functionNode, nodePage);
 
 functionNode.prototype.setFunction = function(func) {
-    browser.click('#node-input-func-editor');
-    browser.keys(['Control', 'Home', 'Control']);
+    browser.clickWithWait('#node-input-func-editor');
+    browser.keys(keyPage.selectAll());
     for (var i = 0; i < func.length; i++) {
         browser.keys([func.charAt(i)]);
     }
     // Delete the unnecessary code that ace editor does the autocompletion.
-    browser.keys(['Control', 'Shift', 'End', 'Shift', 'Control']);
+    browser.keys(keyPage.selectToEnd());
     browser.keys(['Delete']);
     // Need to wait until ace editor correctly checks the syntax.
     browser.pause(300);

--- a/test/editor/pageobjects/nodes/core/core/80-template_page.js
+++ b/test/editor/pageobjects/nodes/core/core/80-template_page.js
@@ -18,6 +18,8 @@ var util = require("util");
 
 var nodePage = require("../../node_page");
 
+var keyPage = require("../../../util/key_page");
+
 function templateNode(id) {
     nodePage.call(this, id);
 }
@@ -33,13 +35,13 @@ templateNode.prototype.setFormat = function(format) {
 }
 
 templateNode.prototype.setTemplate = function(template) {
-    browser.click('#node-input-template-editor');
-    browser.keys(['Control', 'a', 'Control']); // call twice to release the keys.
+    browser.clickWithWait('#node-input-template-editor');
+    browser.keys(keyPage.selectAll());
     // Need to add a character one by one since some words such as 'Control' are treated as a special word.
     for (var i = 0; i < template.length; i++) {
         browser.keys([template.charAt(i)]);
     }
-    browser.keys(['Control', 'Shift', 'End', 'Shift', 'Control']);
+    browser.keys(keyPage.selectToEnd());
     browser.keys(['Delete']);
     // Need to wait until ace editor correctly checks the syntax.
     browser.pause(300);

--- a/test/editor/pageobjects/util/key_page.js
+++ b/test/editor/pageobjects/util/key_page.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+var os = require("os");
+
+var shortCutKeyMap = {
+    "selectAll": ['Control', 'a', 'Control'],
+    "selectToEnd": ['Control', 'Shift', 'End', 'Shift', 'Control'],
+};
+
+var shortCutKeyMapForMac = {
+    "selectAll": ['Command', 'a', 'Command'],
+    "selectToEnd": ['Command', 'Shift', 'ArrowDown', 'Shift', 'Command'],
+};
+
+function getShortCutKey(type) {
+    if (os.type() === "Darwin") {
+        return shortCutKeyMapForMac[type];
+    } else {
+        return shortCutKeyMap[type];
+    }
+}
+
+function selectAll() {
+    var key = getShortCutKey('selectAll');
+    return key;
+}
+
+function selectToEnd() {
+    var key = getShortCutKey('selectToEnd');
+    return key;
+}
+
+module.exports = {
+    selectAll: selectAll,
+    selectToEnd: selectToEnd,
+};

--- a/test/editor/specs/scenario/cookbook_endpoint_uispec.js
+++ b/test/editor/specs/scenario/cookbook_endpoint_uispec.js
@@ -513,7 +513,7 @@ describe('cookbook', function() {
             var changeNode = workspace.addNode("change", 400);
 
             var httpinNodeClear = workspace.addNode("httpin", 0, 200);
-            var functionNodeClear = workspace.addNode("function", 240);
+            var functionNodeClear = workspace.addNode("function", 250);
 
             httpinNodeFormat.edit();
             httpinNodeFormat.setMethod("get");


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
Several UI test cases failed on the mac OS.

1. The scenario of ` get a parsed JSON response` in cookbook_uispec.js failed.

Reason: When inputting a value into a text box, WebdriverIO fails to clear the default vaule.
Information: https://github.com/webdriverio/webdriverio/issues/1140
Workaround: Nothing (run the test on the OS other than mac OS)

2. All scenarios failed when running with WebdriverIO 4.14.1 and `--non-headless` option.

Reason: Maximizing a browser fails.
Information: https://github.com/webdriverio/webdriverio/issues/3043
Workaround: Run a UI test without `--non-headless` option, or run with WebdriverIO 4.13.1.

3. Most scenarios failed when running UI test simultaneously.

Reason: Concurrent connection to ChromeDriver fails.
Information: https://github.com/flavorjones/chromedriver-helper/issues/44
Workaround: Change the value of `maxInstances` of `capabilities` in wdio.conf.js from 2 to 1.


After you applied the workarounds of the above 2 and 3, all scenarios other than 1 will result in success.


<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
