### PR TITLE
Make contributions easier

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+ports:
+- port: 1880
+  onOpen: open-preview
+tasks:
+- init: npm install && npm run build
+  command: npm start

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ If you want to run the latest code from git, here's how to get started:
 
         node red.js
 
+Alternatively, you can open the code base in a ready-to-code dev environment:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/node-red/node-red)
+
 ## Contributing
 
 Before raising a pull-request, please read our


### PR DESCRIPTION
## Proposed changes

This PR simplifies contributions and playing around with the node-red code base, by adding support for Gitpod a free online dev environment for GitHub.
I configured it so that on start it automatically runs
```
npm install
npm run build
npm start
```
Also port 1880 is exposed and the website will be opened in a preview (see below). This could be configured so you get a notification and can decide whether to open it in a preview or in a new browser tab. The latter might make more sense in the case of node-red.

You can use Gitpod for code reviews as well. Just go to a PR and prefix the URL with 'https://gitpod.io/#'. A workspace with the PR changes will be started and open in a code review mode (you can comment and submit reviews within in the IDE)

To get an idea of how it feels, please try this snapshot:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/435df204-9457-4181-a84a-198d6277d230)
<img width="1552" alt="screenshot 2019-01-14 at 08 57 35" src="https://user-images.githubusercontent.com/372735/51101590-8a796900-17db-11e9-8b87-ccb561a70876.png">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
   see https://discourse.nodered.org/t/supporting-online-dev-environment/6781