### PR TITLE
Allow access of scope parent

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/nodes/context/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/context/index.js
@@ -18,6 +18,7 @@ var clone = require("clone");
 var log = require("@node-red/util").log;
 var util = require("@node-red/util").util;
 var memory = require("./memory");
+var flows;
 
 var settings;
 
@@ -47,6 +48,7 @@ function logUnknownStore(name) {
 }
 
 function init(_settings) {
+    flows = require("../flows");
     settings = _settings;
     contexts = {};
     stores = {};
@@ -198,8 +200,24 @@ function getContextStorage(storage) {
     }
 }
 
+function followParentContext(parent, key) {
+    if (key === "$parent") {
+        return [parent, ""];
+    }
+    else if (key.startsWith("$parent.")) {
+        var len = "$parent.".length;
+        var new_key = key.substring(len);
+        var ctx = parent;
+        while (ctx && new_key.startsWith("$parent.")) {
+            ctx = ctx.$parent;
+            new_key = new_key.substring(len);
+        }
+        return [ctx, new_key];
+    }
+    return null;
+}
 
-function createContext(id,seed) {
+function createContext(id,seed,parent) {
     // Seed is only set for global context - sourced from functionGlobalContext
     var scope = id;
     var obj = seed || {};
@@ -253,6 +271,29 @@ function createContext(id,seed) {
                     key = keyParts.key;
                     if (!storage) {
                         storage = keyParts.store || "_";
+                    }
+                    var result = followParentContext(parent, key);
+                    if (result) {
+                        var [ctx, new_key] = result;
+                        if (ctx) {
+                            if (new_key === "") {
+                                if (callback) {
+                                    return callback(ctx);
+                                }
+                                else {
+                                    return ctx;
+                                }
+                            }
+                            return ctx.get(new_key, storage, callback);
+                        }
+                        else {
+                                if (callback) {
+                                    return callback(undefined);
+                                }
+                                else {
+                                    return undefined;
+                                }
+                        }
                     }
                 } else {
                     if (!storage) {
@@ -321,6 +362,19 @@ function createContext(id,seed) {
                     if (!storage) {
                         storage = keyParts.store || "_";
                     }
+                    var result = followParentContext(parent, key);
+                    if (result) {
+                        var [ctx, new_key] = result;
+                        if (ctx) {
+                            return ctx.set(new_key, value, storage, callback);
+                        }
+                        else {
+                            if (callback) {
+                                return callback();
+                            }
+                            return undefined;
+                        }
+                    }
                 } else {
                     if (!storage) {
                         storage = "_";
@@ -361,10 +415,36 @@ function createContext(id,seed) {
             }
         }
     });
+    if (parent) {
+        Object.defineProperty(obj, "$parent", {
+            value: parent
+        });
+    }
     return obj;
 }
 
-function getContext(localId,flowId) {
+function createRootContext() {
+    var obj = {};
+    Object.defineProperties(obj, {
+        get: {
+            value: function(key, storage, callback) {
+                return undefined;
+            }
+        },
+        set: {
+            value: function(key, value, storage, callback) {
+            }
+        },
+        keys: {
+            value: function(storage, callback) {
+                return undefined;
+            }
+        }
+    });
+    return obj;
+}
+
+function getContext(localId,flowId,parent) {
     var contextId = localId;
     if (flowId) {
         contextId = localId+":"+flowId;
@@ -372,10 +452,19 @@ function getContext(localId,flowId) {
     if (contexts.hasOwnProperty(contextId)) {
         return contexts[contextId];
     }
-    var newContext = createContext(contextId);
+    var newContext = createContext(contextId,undefined,parent);
     if (flowId) {
+        var node = flows.get(flowId);
+        var parent = undefined;
+        if (node && node.type.startsWith("subflow:")) {
+            parent = node.context().flow;
+        }
+        else {
+            parent = createRootContext();
+        }
+        var flowContext = getContext(flowId,undefined,parent);
         Object.defineProperty(newContext, 'flow', {
-            value: getContext(flowId)
+            value: flowContext
         });
     }
     Object.defineProperty(newContext, 'global', {

--- a/packages/node_modules/@node-red/runtime/lib/nodes/context/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/context/index.js
@@ -202,7 +202,7 @@ function getContextStorage(storage) {
 
 function followParentContext(parent, key) {
     if (key === "$parent") {
-        return [parent, ""];
+        return [parent, undefined];
     }
     else if (key.startsWith("$parent.")) {
         var len = "$parent.".length;
@@ -275,24 +275,16 @@ function createContext(id,seed,parent) {
                     var result = followParentContext(parent, key);
                     if (result) {
                         var [ctx, new_key] = result;
-                        if (ctx) {
-                            if (new_key === "") {
-                                if (callback) {
-                                    return callback(ctx);
-                                }
-                                else {
-                                    return ctx;
-                                }
-                            }
+                        if (ctx && new_key) {
                             return ctx.get(new_key, storage, callback);
                         }
                         else {
-                                if (callback) {
-                                    return callback(undefined);
-                                }
-                                else {
-                                    return undefined;
-                                }
+                            if (callback) {
+                                return callback(undefined);
+                            }
+                            else {
+                                return undefined;
+                            }
                         }
                     }
                 } else {
@@ -365,7 +357,7 @@ function createContext(id,seed,parent) {
                     var result = followParentContext(parent, key);
                     if (result) {
                         var [ctx, new_key] = result;
-                        if (ctx) {
+                        if (ctx && new_key) {
                             return ctx.set(new_key, value, storage, callback);
                         }
                         else {

--- a/test/unit/@node-red/runtime/lib/nodes/context/index_spec.js
+++ b/test/unit/@node-red/runtime/lib/nodes/context/index_spec.js
@@ -226,33 +226,31 @@ describe('context', function() {
         })
 
         describe("$parent", function() {
-            it('should access $parent', function() {
+            it('should get undefined for $parent without key', function() {
                 var context0 = Context.get("0","flowA");
                 var context1 = Context.get("1","flowB", context0);
                 var parent = context1.get("$parent");
-                parent.should.equal(context0);
+                should.equal(parent, undefined);
             });
 
             it('should get undefined for $parent of root', function() {
                 var context0 = Context.get("0","flowA");
                 var context1 = Context.get("1","flowB", context0);
-                var parent = context1.get("$parent.$parent");
+                var parent = context1.get("$parent.$parent.K");
                 should.equal(parent, undefined);
             });
 
-            it('should get $parent', function() {
+            it('should get value in $parent', function() {
                 var context0 = Context.get("0","flowA");
                 var context1 = Context.get("1","flowB", context0);
-                var parent = context1.get("$parent");
                 context0.set("K", "v");
                 var v = context1.get("$parent.K");
                 should.equal(v, "v");
             });
 
-            it('should set $parent', function() {
+            it('should set value in $parent', function() {
                 var context0 = Context.get("0","flowA");
                 var context1 = Context.get("1","flowB", context0);
-                var parent = context1.get("$parent");
                 context1.set("$parent.K", "v");
                 var v = context0.get("K");
                 should.equal(v, "v");
@@ -269,7 +267,6 @@ describe('context', function() {
                 keys[0].should.equal("K1");
             });
         });
-
 
     });
 

--- a/test/unit/@node-red/runtime/lib/nodes/context/index_spec.js
+++ b/test/unit/@node-red/runtime/lib/nodes/context/index_spec.js
@@ -225,6 +225,50 @@ describe('context', function() {
             });
         })
 
+        describe("$parent", function() {
+            it('should access $parent', function() {
+                var context0 = Context.get("0","flowA");
+                var context1 = Context.get("1","flowB", context0);
+                var parent = context1.get("$parent");
+                parent.should.equal(context0);
+            });
+
+            it('should get undefined for $parent of root', function() {
+                var context0 = Context.get("0","flowA");
+                var context1 = Context.get("1","flowB", context0);
+                var parent = context1.get("$parent.$parent");
+                should.equal(parent, undefined);
+            });
+
+            it('should get $parent', function() {
+                var context0 = Context.get("0","flowA");
+                var context1 = Context.get("1","flowB", context0);
+                var parent = context1.get("$parent");
+                context0.set("K", "v");
+                var v = context1.get("$parent.K");
+                should.equal(v, "v");
+            });
+
+            it('should set $parent', function() {
+                var context0 = Context.get("0","flowA");
+                var context1 = Context.get("1","flowB", context0);
+                var parent = context1.get("$parent");
+                context1.set("$parent.K", "v");
+                var v = context0.get("K");
+                should.equal(v, "v");
+            });
+
+            it('should not contain $parent in keys', function() {
+                var context0 = Context.get("0","flowA");
+                var context1 = Context.get("1","flowB", context0);
+                var parent = context1.get("$parent");
+                context0.set("K0", "v0");
+                context1.set("K1", "v1");
+                var keys = context1.keys();
+                keys.should.have.length(1);
+                keys[0].should.equal("K1");
+            });
+        });
 
 
     });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Currently, nodes in a subflow can not access flow context of enclosing flow/subflow.
New proposal to subflow enhancement 
(described at https://github.com/node-red/node-red/wiki/Design:-Subflow-Enhancements)
deals with this problem by introducing `$parent` to access enclosing flow context.

This PR implements this feature.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
