### PR TITLE
'nodes-stopped' event propagation

### DIFF
--- a/red/runtime/nodes/flows/index.js
+++ b/red/runtime/nodes/flows/index.js
@@ -394,6 +394,7 @@ function stop(type,diff,muteLog) {
             }
         }
     }
+    events.emit("nodes-stopped");
 
     return when.promise(function(resolve,reject) {
         when.settle(promises).then(function() {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Commit provides event propagation 'nodes-stopped'. It is oposite evet to currently emitted 'nodes-started'
<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
