### PR TITLE
add fast entry via keyboard for string of nodes

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js
@@ -48,7 +48,7 @@ RED.typeSearch = (function() {
         //shade = $('<div>',{class:"red-ui-type-search-shade"}).appendTo("#main-container");
         dialog = $("<div>",{id:"red-ui-type-search",class:"red-ui-search red-ui-type-search"}).appendTo("#main-container");
         var searchDiv = $("<div>",{class:"red-ui-search-container"}).appendTo(dialog);
-        searchInput = $('<input type="text">').attr("placeholder",RED._("search.addNode")).appendTo(searchDiv).searchBox({
+        searchInput = $('<input type="text" id="red-ui-type-search-input">').attr("placeholder",RED._("search.addNode")).appendTo(searchDiv).searchBox({
             delay: 50,
             change: function() {
                 search($(this).val());
@@ -78,6 +78,17 @@ RED.typeSearch = (function() {
                     }
                     $(children[selected]).addClass('selected');
                     ensureSelectedIsVisible();
+                    evt.preventDefault();
+                } else if ((evt.metaKey || evt.ctrlKey) && evt.keyCode === 13 ) {
+                    // (ctrl or cmd) and enter 
+                    var index = Math.max(0,selected);
+                    if (index < children.length) {
+                        var n = $(children[index]).find(".red-ui-editableList-item-content").data('data');
+                        typesUsed[n.type] = Date.now();
+                        if (n.def.outputs === 0) { confirm(n); }
+                        else { addCallback(n.type,true); }
+                        $("#red-ui-type-search-input").val("");
+                    }
                     evt.preventDefault();
                 } else if (evt.keyCode === 13) {
                     // Enter
@@ -202,7 +213,7 @@ RED.typeSearch = (function() {
         }
         refreshTypeList(opts);
         addCallback = opts.add;
-        closeCallback = opts.close;
+        cancelCallback = opts.cancel;
         RED.events.emit("type-search:open");
         //shade.show();
         dialog.css({left:opts.x+"px",top:opts.y+"px"}).show();
@@ -230,7 +241,6 @@ RED.typeSearch = (function() {
             $(document).off('click.type-search');
         }
     }
-
     function getTypeLabel(type, def) {
         var label = type;
         if (typeof def.paletteLabel !== "undefined") {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -650,10 +650,8 @@ RED.view = (function() {
             mouse_mode = RED.state.PANNING;
             mouse_position = [d3.event.pageX,d3.event.pageY]
             scroll_position = [chart.scrollLeft(),chart.scrollTop()];
-
             return;
         }
-
         if (!mousedown_node && !mousedown_link) {
             selected_link = null;
             updateSelection();
@@ -692,17 +690,21 @@ RED.view = (function() {
                     cancel: function() {
                         quickAddActive = false;
                         resetMouseVars();
+                        updateSelection();
+                        hideDragLines();
+                        redraw();
                     },
-                    add: function(type) {
+                    add: function(type,auto) {
                         quickAddActive = false;
+                        if (auto === true) { mouse_mode = RED.state.QUICK_JOINING; }
                         var result = addNode(type);
                         if (!result) {
                             return;
                         }
                         var nn = result.node;
                         var historyEvent = result.historyEvent;
-                        nn.x = point[0];
-                        nn.y = point[1];
+                        nn.x = Math.ceil((point[0] - 50) / gridSize) * gridSize + 50;
+                        nn.y = parseInt(point[1] / gridSize) * gridSize;
 
                         var showLabel = RED.utils.getMessageProperty(RED.settings.get('editor'),"view.view-node-show-label");
                         if (showLabel !== undefined && !/^link (in|out)$/.test(nn._def.type) && !nn._def.defaults.hasOwnProperty("l")) {
@@ -796,6 +798,7 @@ RED.view = (function() {
                         updateActiveNodes();
                         updateSelection();
                         redraw();
+                        if (auto === true) { point[0] = point[0] + ((nn.w < 100) ? 100 : nn.w) + gridSize * 2; }
                     }
                 });
 
@@ -849,7 +852,6 @@ RED.view = (function() {
         }
 
         mouse_position = d3.touches(this)[0]||d3.mouse(this);
-
 
         if (lasso) {
             var ox = parseInt(lasso.attr("ox"));
@@ -1139,7 +1141,7 @@ RED.view = (function() {
             updateSelection();
             lasso.remove();
             lasso = null;
-        } else if (mouse_mode == RED.state.DEFAULT && mousedown_link == null && !d3.event.ctrlKey&& !d3.event.metaKey ) {
+        } else if (mouse_mode == RED.state.DEFAULT && mousedown_link == null && !d3.event.ctrlKey && !d3.event.metaKey ) {
             clearSelection();
             updateSelection();
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -703,8 +703,14 @@ RED.view = (function() {
                         }
                         var nn = result.node;
                         var historyEvent = result.historyEvent;
-                        nn.x = Math.ceil((point[0] - 50) / gridSize) * gridSize + 50;
-                        nn.y = parseInt(point[1] / gridSize) * gridSize;
+                        if (RED.settings.get("editor").view['view-snap-grid']) {
+                            nn.x = Math.ceil((point[0] - 50) / gridSize) * gridSize + 50;
+                            nn.y = parseInt(point[1] / gridSize) * gridSize;
+                        }
+                        else {
+                            nn.x = point[0];
+                            nn.y = point[1];
+                        }
 
                         var showLabel = RED.utils.getMessageProperty(RED.settings.get('editor'),"view.view-node-show-label");
                         if (showLabel !== undefined && !/^link (in|out)$/.test(nn._def.type) && !nn._def.defaults.hasOwnProperty("l")) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -685,7 +685,7 @@ RED.view = (function() {
                 quickAddActive = true;
                 RED.typeSearch.show({
                     x:d3.event.clientX-mainPos.left-node_width/2,
-                    y:d3.event.clientY-mainPos.top-node_height/2,
+                    y:d3.event.clientY-mainPos.top-node_height/2 + 30,
                     filter: filter,
                     cancel: function() {
                         quickAddActive = false;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Adds the ability to add multiple nodes quickly via the keyboard. Use ctrl/cmd click to open the select menu - then start typing the name (eg inj) - then hit cmd/ctrl enter to place the node - the select then goes back to the fill list and you can repeat - the next node will be linked to the previous node. If you select a node that ends a flow (eg debug) it will complete the flow and close the select.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
