### PR TITLE
 Allow http request node to avoid encoding cookie

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
@@ -161,7 +161,9 @@ module.exports = function(RED) {
                             // This case clears a cookie for HTTP In/Response nodes.
                             // Ignore for this node.
                         } else if (typeof msg.cookies[name] === 'object') {
-                            opts.jar.setCookie(cookie.serialize(name, msg.cookies[name].value), url);
+                            // If the encode option is specified, pass it.
+                            var options = msg.cookies[name].encode ? {encode: msg.cookies[name].encode} : undefined;
+                            opts.jar.setCookie(cookie.serialize(name, msg.cookies[name].value, options), url);
                         } else {
                             opts.jar.setCookie(cookie.serialize(name, msg.cookies[name]), url);
                         }

--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
@@ -161,9 +161,13 @@ module.exports = function(RED) {
                             // This case clears a cookie for HTTP In/Response nodes.
                             // Ignore for this node.
                         } else if (typeof msg.cookies[name] === 'object') {
-                            // If the encode option is specified, pass it.
-                            var options = msg.cookies[name].encode ? {encode: msg.cookies[name].encode} : undefined;
-                            opts.jar.setCookie(cookie.serialize(name, msg.cookies[name].value, options), url);
+                            if(msg.cookies[name].encode === false){
+                                // If the encode option is false, the value is not encoded.
+                                opts.jar.setCookie(cookie.serialize(name, msg.cookies[name].value, {encode: String}), url);
+                            } else {
+                                // The value is encoded by encodeURIComponent().
+                                opts.jar.setCookie(cookie.serialize(name, msg.cookies[name].value), url);
+                            }
                         } else {
                             opts.jar.setCookie(cookie.serialize(name, msg.cookies[name]), url);
                         }

--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
@@ -148,16 +148,9 @@ module.exports = function(RED) {
                 };
             }
             if (opts.headers.hasOwnProperty('cookie')) {
-                var cookies = cookie.parse(opts.headers.cookie);
+                var cookies = cookie.parse(opts.headers.cookie, {decode:String});
                 for (var name in cookies) {
-                    if (cookies.hasOwnProperty(name)) {
-                        if (cookies[name] === null) {
-                            // This case clears a cookie for HTTP In/Response nodes.
-                            // Ignore for this node.
-                        } else {
-                            opts.jar.setCookie(name + '=' + cookies[name], url);
-                        }
-                    }
+                    opts.jar.setCookie(cookie.serialize(name, cookies[name], {encode:String}), url);
                 }
                 delete opts.headers.cookie;
             }
@@ -168,9 +161,9 @@ module.exports = function(RED) {
                             // This case clears a cookie for HTTP In/Response nodes.
                             // Ignore for this node.
                         } else if (typeof msg.cookies[name] === 'object') {
-                            opts.jar.setCookie(name + '=' + msg.cookies[name].value, url);
+                            opts.jar.setCookie(cookie.serialize(name, msg.cookies[name].value), url);
                         } else {
-                            opts.jar.setCookie(name + '=' + msg.cookies[name], url);
+                            opts.jar.setCookie(cookie.serialize(name, msg.cookies[name]), url);
                         }
                     }
                 }

--- a/test/nodes/core/io/21-httprequest_spec.js
+++ b/test/nodes/core/io/21-httprequest_spec.js
@@ -120,7 +120,7 @@ describe('HTTP Request Node', function() {
     before(function(done) {
         testApp = express();
         testApp.use(bodyParser.raw({type:"*/*"}));
-        testApp.use(cookieParser());
+        testApp.use(cookieParser(undefined,{decode:String}));
         testApp.get('/statusCode204', function(req,res) { res.status(204).end();});
         testApp.get('/text', function(req, res){ res.send('hello'); });
         testApp.get('/redirectToText', function(req, res){ res.status(302).set('Location', getTestURL('/text')).end(); });
@@ -138,8 +138,7 @@ describe('HTTP Request Node', function() {
             }, 50);
         });
         testApp.get('/checkCookie', function(req, res){
-            var value = req.cookies.data;
-            res.send(value);
+            res.send(req.cookies);
         });
         testApp.get('/setCookie', function(req, res){
             res.cookie('data','hello');
@@ -1001,7 +1000,7 @@ describe('HTTP Request Node', function() {
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
                     try {
-                        msg.should.have.property('payload','abc');
+                        msg.payload.should.have.property('data','abc');
                         msg.should.have.property('statusCode',200);
                         done();
                     } catch(err) {
@@ -1009,6 +1008,26 @@ describe('HTTP Request Node', function() {
                     }
                 });
                 n1.receive({payload:"foo", cookies:{data:'abc'}});
+            });
+        });
+
+        it('should send multiple cookies with string', function(done) {
+            var flow = [{id:"n1",type:"http request",wires:[["n2"]],method:"GET",ret:"obj",url:getTestURL('/checkCookie')},
+                {id:"n2", type:"helper"}];
+            helper.load(httpRequestNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                n2.on("input", function(msg) {
+                    try {
+                        msg.payload.should.have.property('data','abc');
+                        msg.payload.should.have.property('foo','bar');
+                        msg.should.have.property('statusCode',200);
+                        done();
+                    } catch(err) {
+                        done(err);
+                    }
+                });
+                n1.receive({payload:"foo", cookies:{data:'abc',foo:'bar'}});
             });
         });
 
@@ -1020,7 +1039,7 @@ describe('HTTP Request Node', function() {
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
                     try {
-                        msg.should.have.property('payload','abc');
+                        msg.payload.should.have.property('data','abc');
                         msg.should.have.property('statusCode',200);
                         done();
                     } catch(err) {
@@ -1028,6 +1047,86 @@ describe('HTTP Request Node', function() {
                     }
                 });
                 n1.receive({payload:"foo", cookies:{data:{value:'abc'}}});
+            });
+        });
+
+        it('should send multiple cookies with object data', function(done) {
+            var flow = [{id:"n1",type:"http request",wires:[["n2"]],method:"GET",ret:"obj",url:getTestURL('/checkCookie')},
+                {id:"n2", type:"helper"}];
+            helper.load(httpRequestNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                n2.on("input", function(msg) {
+                    try {
+                        msg.payload.should.have.property('data','abc');
+                        msg.payload.should.have.property('foo','bar');
+                        msg.should.have.property('statusCode',200);
+                        done();
+                    } catch(err) {
+                        done(err);
+                    }
+                });
+                n1.receive({payload:"foo", cookies:{data:{value:'abc'},foo:{value:'bar'}}});
+            });
+        });
+
+        it('should encode cookie value', function(done) {
+            var flow = [{id:"n1",type:"http request",wires:[["n2"]],method:"GET",ret:"obj",url:getTestURL('/checkCookie')},
+                {id:"n2", type:"helper"}];
+            helper.load(httpRequestNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                var value = ';,/?:@ &=+$#';
+                n2.on("input", function(msg) {
+                    try {
+                        msg.payload.should.have.property('data',encodeURIComponent(value));
+                        msg.should.have.property('statusCode',200);
+                        done();
+                    } catch(err) {
+                        done(err);
+                    }
+                });
+                n1.receive({payload:"foo", cookies:{data:value}});
+            });
+        });
+
+        it('should encode cookie object', function(done) {
+            var flow = [{id:"n1",type:"http request",wires:[["n2"]],method:"GET",ret:"obj",url:getTestURL('/checkCookie')},
+                {id:"n2", type:"helper"}];
+            helper.load(httpRequestNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                var value = ';,/?:@ &=+$#';
+                n2.on("input", function(msg) {
+                    try {
+                        msg.payload.should.have.property('data',encodeURIComponent(value));
+                        msg.should.have.property('statusCode',200);
+                        done();
+                    } catch(err) {
+                        done(err);
+                    }
+                });
+                n1.receive({payload:"foo", cookies:{data:{value:value}}});
+            });
+        });
+
+        it('should encode cookie by specified function', function(done) {
+            var flow = [{id:"n1",type:"http request",wires:[["n2"]],method:"GET",ret:"obj",url:getTestURL('/checkCookie')},
+                {id:"n2", type:"helper"}];
+            helper.load(httpRequestNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                var value = ',/?:@ &+$#';
+                n2.on("input", function(msg) {
+                    try {
+                        msg.payload.should.have.property('data',encodeURI(value));
+                        msg.should.have.property('statusCode',200);
+                        done();
+                    } catch(err) {
+                        done(err);
+                    }
+                });
+                n1.receive({payload:"foo", cookies:{data:{value:value,encode:encodeURI}}});
             });
         });
 
@@ -1039,7 +1138,7 @@ describe('HTTP Request Node', function() {
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
                     try {
-                        msg.should.have.property('payload','abc');
+                        msg.payload.should.have.property('data','abc');
                         msg.should.have.property('statusCode',200);
                         done();
                     } catch(err) {
@@ -1047,6 +1146,26 @@ describe('HTTP Request Node', function() {
                     }
                 });
                 n1.receive({payload:"foo", cookies:{boo:'123'}, headers:{'cookie':'data=abc'}});
+            });
+        });
+
+        it('should send multiple cookies by msg.headers', function(done) {
+            var flow = [{id:"n1",type:"http request",wires:[["n2"]],method:"GET",ret:"obj",url:getTestURL('/checkCookie')},
+                {id:"n2", type:"helper"}];
+            helper.load(httpRequestNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                n2.on("input", function(msg) {
+                    try {
+                        msg.payload.should.have.property('data','abc');
+                        msg.payload.should.have.property('foo','bar');
+                        msg.should.have.property('statusCode',200);
+                        done();
+                    } catch(err) {
+                        done(err);
+                    }
+                });
+                n1.receive({payload:"foo", cookies:{boo:'123'}, headers:{'cookie':'data=abc; foo=bar;'}});
             });
         });
 

--- a/test/nodes/core/io/21-httprequest_spec.js
+++ b/test/nodes/core/io/21-httprequest_spec.js
@@ -1106,27 +1106,27 @@ describe('HTTP Request Node', function() {
                         done(err);
                     }
                 });
-                n1.receive({payload:"foo", cookies:{data:{value:value}}});
+                n1.receive({payload:"foo", cookies:{data:{value:value, encode:true}}});
             });
         });
 
-        it('should encode cookie by specified function', function(done) {
+        it('should not encode cookie when encode option is false', function(done) {
             var flow = [{id:"n1",type:"http request",wires:[["n2"]],method:"GET",ret:"obj",url:getTestURL('/checkCookie')},
                 {id:"n2", type:"helper"}];
             helper.load(httpRequestNode, flow, function() {
                 var n1 = helper.getNode("n1");
                 var n2 = helper.getNode("n2");
-                var value = ',/?:@ &+$#';
+                var value = '!#$%&\'()*+-./:<>?@[]^_`{|}~';
                 n2.on("input", function(msg) {
                     try {
-                        msg.payload.should.have.property('data',encodeURI(value));
+                        msg.payload.should.have.property('data',value);
                         msg.should.have.property('statusCode',200);
                         done();
                     } catch(err) {
                         done(err);
                     }
                 });
-                n1.receive({payload:"foo", cookies:{data:{value:value,encode:encodeURI}}});
+                n1.receive({payload:"foo", cookies:{data:{value:value, encode:false}}});
             });
         });
 


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes
Fix #2025
Cookie values in http request node are always encoded and you cannot change encoding.
~~This PR allows http request node to change cookie value encoding.~~
This PR allows http request node to avoid encoding cookie.

```javascript
msg.cookies = { };
// Set encode option to `false` if you do not want to encode a cookie value
msg.cookies["demo-hello"] = {value:"hello+world", encode:false}; 
// Set it to true or nothing to use encodeURIComponent function
msg.cookies["demo-hello2"] = {value:"hello+world", encode:true};
msg.cookies["demo-hello2"] = {value:"hello+world"};
```

This PR also fixes encoding behavior in the dev branch in order to be same behavior as the master branch.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
