### PR TITLE
Fix use of i18n label

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -903,7 +903,6 @@
         "properties": "Properties",
         "description": "Description",
         "appearance": "Appearance",
-        "env": "Environment Variables",
-        "name": "name"
+        "env": "Environment Variables"
     }
 }

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -902,7 +902,6 @@
         "properties": "プロパティ",
         "description": "説明",
         "appearance": "外観",
-        "env": "環境変数",
-        "name": "変数名"
+        "env": "環境変数"
     }
 }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -554,7 +554,7 @@ RED.editor = (function() {
                         class: "node-input-env-name",
                         type: "text",
                         style: "margin-left: 5px; width: calc(40% - 5px)",
-                        placeholder: RED._("editor-tab.name")
+                        placeholder: RED._("common.label.name")
                     }).appendTo(row);
                     var valueField = $('<input/>',{
                         class: "node-input-env-value",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This PR changes `editor-tab.name` i18 tag to common label `common.label.name`.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
