### PR TITLE
Fix output of multi-byte string with file node

### DIFF
--- a/nodes/core/storage/50-file.js
+++ b/nodes/core/storage/50-file.js
@@ -75,15 +75,16 @@ module.exports = function(RED) {
                 if (typeof data === "boolean") { data = data.toString(); }
                 if (typeof data === "number") { data = data.toString(); }
                 if ((node.appendNewline) && (!Buffer.isBuffer(data))) { data += os.EOL; }
+                var buf = Buffer.from(data);
                 if (node.overwriteFile === "true") {
-                    var wstream = fs.createWriteStream(filename, { encoding:'utf8', flags:'w', autoClose:true });
+                    var wstream = fs.createWriteStream(filename, { encoding:'binary', flags:'w', autoClose:true });
                     node.wstream = wstream;
                     wstream.on("error", function(err) {
                         node.error(RED._("file.errors.writefail",{error:err.toString()}),msg);
                         done();
                     });
                     wstream.on("open", function() {
-                        wstream.end(data, function() {
+                        wstream.end(buf, function() {
                             node.send(msg);
                             done();
                         });
@@ -117,7 +118,7 @@ module.exports = function(RED) {
                         }
                     }
                     if (recreateStream) {
-                        node.wstream = fs.createWriteStream(filename, { encoding:'utf8', flags:'a', autoClose:true });
+                        node.wstream = fs.createWriteStream(filename, { encoding:'binary', flags:'a', autoClose:true });
                         node.wstream.on("open", function(fd) {
                             try {
                                 var stat = fs.statSync(filename);
@@ -132,13 +133,13 @@ module.exports = function(RED) {
                     }
                     if (node.filename) {
                         // Static filename - write and reuse the stream next time
-                        node.wstream.write(data, function() {
+                        node.wstream.write(buf, function() {
                             node.send(msg);
                             done();
                         });
                     } else {
                         // Dynamic filename - write and close the stream
-                        node.wstream.end(data, function() {
+                        node.wstream.end(buf, function() {
                             node.send(msg);
                             delete node.wstream;
                             delete node.wstreamIno;

--- a/nodes/core/storage/50-file.js
+++ b/nodes/core/storage/50-file.js
@@ -76,7 +76,7 @@ module.exports = function(RED) {
                 if (typeof data === "number") { data = data.toString(); }
                 if ((node.appendNewline) && (!Buffer.isBuffer(data))) { data += os.EOL; }
                 if (node.overwriteFile === "true") {
-                    var wstream = fs.createWriteStream(filename, { encoding:'binary', flags:'w', autoClose:true });
+                    var wstream = fs.createWriteStream(filename, { encoding:'utf8', flags:'w', autoClose:true });
                     node.wstream = wstream;
                     wstream.on("error", function(err) {
                         node.error(RED._("file.errors.writefail",{error:err.toString()}),msg);
@@ -117,7 +117,7 @@ module.exports = function(RED) {
                         }
                     }
                     if (recreateStream) {
-                        node.wstream = fs.createWriteStream(filename, { encoding:'binary', flags:'a', autoClose:true });
+                        node.wstream = fs.createWriteStream(filename, { encoding:'utf8', flags:'a', autoClose:true });
                         node.wstream.on("open", function(fd) {
                             try {
                                 var stat = fs.statSync(filename);

--- a/test/nodes/core/storage/50-file_spec.js
+++ b/test/nodes/core/storage/50-file_spec.js
@@ -79,6 +79,29 @@ describe('file Nodes', function() {
             });
         });
 
+        it('should write multi-byte string to a file', function(done) {
+            var flow = [{id:"fileNode1", type:"file", name: "fileNode", "filename":fileToTest, "appendNewline":false, "overwriteFile":true, wires: [["helperNode1"]]},
+                        {id:"helperNode1", type:"helper"}];
+            helper.load(fileNode, flow, function() {
+                var n1 = helper.getNode("fileNode1");
+                var n2 = helper.getNode("helperNode1");
+                n2.on("input", function(msg) {
+                    try {
+                        var f = fs.readFileSync(fileToTest).toString();
+                        f.should.have.length(2);
+                        f.should.equal("試験");
+                        fs.unlinkSync(fileToTest);
+                        msg.should.have.property("payload", "試験");
+                        done();
+                    }
+                    catch (e) {
+                        done(e);
+                    }
+                });
+                n1.receive({payload:"試験"});
+            });
+        });
+
         it('should append to a file and add newline', function(done) {
             var flow = [{id:"fileNode1", type:"file", name: "fileNode", "filename":fileToTest, "appendNewline":true, "overwriteFile":false, wires: [["helperNode1"]]},
                         {id:"helperNode1", type:"helper"}];


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Outputting multi-byte string (e.g 試験) using File node creates unexpected file contents.
This is caused by specifying `binary` (not `utf8`) as encoding of output stream.
This PR fixes this problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
