### PR TITLE
Transfer input attributes (placeholder, type) to generated TypedInput field

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -159,6 +159,11 @@
                 that.uiSelect.css("margin"+d,m);
                 that.input.css("margin"+d,0);
             });
+                
+            ["type","placeholder"].forEach(function(d) {
+                var m = that.element.attr(d);
+                that.input.attr(d,m);
+            });    
 
             this.uiSelect.addClass("red-ui-typedInput-container");
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Per https://github.com/node-red/node-red/issues/2059, this change addresses how the TypedInput should transfer the `type` and `placeholder` attributes from a normal configuration input field to a TypedInput field. 

Currently, the generated TypedInput can only be a text input and doesn't handle values like passwords that shouldn't be visible to the user. Additionally, the placeholder text of the original input field isn't used and presents an empty text input to the user.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
