### PR TITLE
Add i18n support for port label

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/core/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/core/core/20-inject.html
@@ -172,17 +172,23 @@
         inputs:0,
         outputs:1,
         outputLabels: function(index) {
-            var labels = { str:"string", num:"number", bool:"boolean", json:"object", flow:"flow context", global:"global context" };
-            var lab = labels[this.payloadType] || this.payloadType;
-            if (lab === "object") {
+            var lab = this.payloadType;
+            if (lab === "json") {
                 try {
                     lab = typeof JSON.parse(this.payload);
                     if (lab === "object") {
                         if (Array.isArray(JSON.parse(this.payload))) { lab = "Array"; }
                     }
-                } catch(e) { lab = "Invalid JSON Object"; }
+                } catch(e) {
+                    return this._("inject.label.invalid"); }
             }
-            return lab; },
+            var name = "inject.label."+lab;
+            var label = this._(name);
+            if (name !== label) {
+                return label;
+            }
+            return lab;
+        },
         label: function() {
             var suffix = "";
             // if fire once then add small indication

--- a/packages/node_modules/@node-red/nodes/core/core/75-exec.html
+++ b/packages/node_modules/@node-red/nodes/core/core/75-exec.html
@@ -66,7 +66,13 @@
         },
         inputs:1,
         outputs:3,
-        outputLabels: ["stdout","stderr","return code"],
+        outputLabels: function(i) {
+            return [
+                this._("exec.label.stdout"),
+                this._("exec.label.stderr"),
+                this._("exec.label.retcode")
+            ][i];
+        },
         icon: "arrow-in.png",
         align: "right",
         label: function() {

--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.html
@@ -102,7 +102,11 @@
         inputs:1,
         outputs:1,
         outputLabels: function(i) {
-            return ({txt:"UTF8 string", bin:"binary buffer", obj:"parsed JSON object"}[this.ret]);
+            return ({
+                txt: this._("httpin.label.utf8String"),
+                bin: this._("httpin.label.binaryBuffer"),
+                obj: this._("httpin.label.jsonObject")
+            }[this.ret]);
         },
         icon: "white-globe.png",
         label: function() {

--- a/packages/node_modules/@node-red/nodes/core/storage/50-file.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/50-file.html
@@ -100,7 +100,7 @@
         inputs:1,
         outputs:1,
         outputLabels: function(i) {
-            return (this.format === "utf8") ? "UTF8 string" : "binary buffer";
+            return (this._((this.format === "utf8") ? "file.label.utf8String" : "file.label.binaryBuffer"));
         },
         icon: "file-in.png",
         label: function() {

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -35,7 +35,22 @@
         "stopped": "stopped",
         "failed": "Inject failed: __error__",
         "label": {
-            "repeat": "Repeat"
+            "repeat": "Repeat",
+            "flow": "flow context",
+            "global": "global context",
+            "str": "string",
+            "num": "number",
+            "bool": "boolean",
+            "json": "object",
+            "bin": "buffer",
+            "date": "timestamp",
+            "env": "env variable",
+            "object": "object",
+            "string": "string",
+            "boolean": "boolean",
+            "number": "number",
+            "Array": "Array",
+            "invalid": "Invalid JSON Object"
         },
         "timestamp": "timestamp",
         "none": "none",
@@ -174,7 +189,10 @@
             "timeout": "Timeout",
             "timeoutplace": "optional",
             "return": "Output",
-            "seconds": "seconds"
+            "seconds": "seconds",
+            "stdout": "stdout",
+            "stderr": "stderr",
+            "retcode": "return code"
         },
         "placeholder": {
             "extraparams": "extra input parameters"
@@ -380,7 +398,10 @@
             "status": "Status code",
             "headers": "Headers",
             "other": "other",
-            "paytoqs" : "Append msg.payload as query string parameters"
+            "paytoqs" : "Append msg.payload as query string parameters",
+            "utf8String": "UTF8 string",
+            "binaryBuffer": "binary buffer",
+            "jsonObject": "parsed JSON object"
         },
         "setby": "- set by msg.method -",
         "basicauth": "Use basic authentication",
@@ -833,7 +854,9 @@
             "breaklines": "Break into lines",
             "filelabel": "file",
             "sendError": "Send message on error (legacy mode)",
-            "deletelabel": "delete __file__"
+            "deletelabel": "delete __file__",
+            "utf8String": "UTF8 string",
+            "binaryBuffer": "binary buffer"
         },
         "action": {
             "append": "append to file",

--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -35,9 +35,24 @@
         "stopped": "stopped",
         "failed": "inject失敗: __error__",
         "label": {
-            "repeat": "繰り返し"
+            "repeat": "繰り返し",
+            "flow": "フローコンテクスト",
+            "global": "グローバルコンテクスト",
+            "str": "文字列",
+            "num": "数値",
+            "bool": "真偽値",
+            "json": "オブジェクト",
+            "bin": "バッファ",
+            "date": "タイムスタンプ",
+            "env": "環境変数",
+            "object": "オブジェクト",
+            "string": "文字列",
+            "boolean": "真偽値",
+            "number": "数値",
+            "Array": "配列",
+            "invalid": "不正なJSON"
         },
-        "timestamp": "timestamp",
+        "timestamp": "タイムスタンプ",
         "none": "なし",
         "interval": "指定した時間間隔",
         "interval-time": "指定した時間間隔、日時",
@@ -174,7 +189,10 @@
             "timeout": "タイムアウト",
             "timeoutplace": "任意",
             "return": "出力",
-            "seconds": "秒"
+            "seconds": "秒",
+            "stdout": "標準出力",
+            "stderr": "標準エラー出力",
+            "retcode": "返却コード"
         },
         "placeholder": {
             "extraparams": "追加引数"
@@ -380,7 +398,10 @@
             "status": "状態コード",
             "headers": "ヘッダ",
             "other": "その他",
-            "paytoqs" : "msg.payloadをクエリパラメータに追加"
+            "paytoqs" : "msg.payloadをクエリパラメータに追加",
+            "utf8String": "UTF8文字列",
+            "binaryBuffer": "バイナリバッファ",
+            "jsonObject": "JSONオブジェクト"
         },
         "setby": "- msg.methodに定義 -",
         "basicauth": "ベーシック認証を使用",
@@ -390,9 +411,9 @@
         "proxy-config": "プロキシ設定",
         "use-proxyauth": "プロキシ認証を使用",
         "noproxy-hosts": "例外ホスト",
-        "utf8": "文字列",
+        "utf8": "UTF8文字列",
         "binary": "バイナリバッファ",
-        "json": "JSON",
+        "json": "JSONオブジェクト",
         "tip": {
             "in": "URLは相対パスになります。",
             "res": "本ノードに送付するメッセージは、<i>http input</i>ノードを起点としてください。",
@@ -831,7 +852,9 @@
             "breaklines": "行へ分割",
             "filelabel": "file",
             "sendError": "エラーメッセージを送信(互換モード)",
-            "deletelabel": "delete __file__"
+            "deletelabel": "delete __file__",
+            "utf8String": "UTF8文字列",
+            "binaryBuffer": "バイナリバッファ"
         },
         "action": {
             "append": "ファイルへ追記",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Port label of inject, exec, httprequest, and file node is not i18n ready.
This PR makes them i18n ready and adds Japanese messages.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
