### PR TITLE
Fix hiding Bearer token

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.html
@@ -61,7 +61,7 @@
                 <input type="text" id="node-input-user">
             </div>
             <div class="form-row">
-                <label for="node-input-password"> <i class="fa fa-lock"></i> <span data-i18n="common.label.password" id="node-span-password"></span><span data-i18n="httpin.label.bearerToken" id="node-span-token" style="hide"></span></label>
+                <label for="node-input-password"> <i class="fa fa-lock"></i> <span data-i18n="common.label.password" id="node-span-password"></span><span data-i18n="httpin.label.bearerToken" id="node-span-token" style="display:none"></span></label>
                 <input type="password" id="node-input-password">
             </div>
         </div>


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
Hi @knolleary, @dceejay,

Sorry for the last minute fix!!!
For the Digest/Bearer authentication pull request [#2061](https://github.com/node-red/node-red/pull/2061), I had executed a series of tests on existing flows.  However *at the end* we decided to replace two labels (*'password'* and *'token'*) by two spans inside a single label.

But it seems that the ```style="hide"``` (which worked fine on the labels) doesn't hide the token-span, so **both** the *'password'* **and** *'token'* text become visible at the same time.  This style is only required when - for an existing httprequest node without basic authentication - the authentication checkbox is now activated in the new version:

![digest_emtpy](https://user-images.githubusercontent.com/14224149/53670120-c11b1e00-3c79-11e9-9aac-8e4ab1d0d234.gif)

When I simply replace that style on the token-span by ```style="display:none"```, the token-span is correctly hidden at the beginning:

![digest_hidden](https://user-images.githubusercontent.com/14224149/53670127-c710ff00-3c79-11e9-9ce0-120171a8133e.gif)

Thanks for reviewing !!
Bart