### PR TITLE
Automatic placing of node icon

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -175,13 +175,19 @@ RED.palette = (function() {
                 }
             }
 
-            $('<div/>',{class:"palette_label"+(def.align=="right"?" palette_label_right":"")}).appendTo(d);
+            $('<div/>', {
+                class: "palette_label"
+                     + (((!def.align && def.inputs !== 0 && def.outputs === 0) || "right" === def.align) ? " palette_label_right" : "")
+            }).appendTo(d);
 
             d.className="palette_node";
 
             if (def.icon) {
                 var icon_url = RED.utils.getNodeIcon(def);
-                var iconContainer = $('<div/>',{class:"palette_icon_container"+(def.align=="right"?" palette_icon_container_right":"")}).appendTo(d);
+                var iconContainer = $('<div/>', {
+                    class: "palette_icon_container"
+                         + (((def.inputs !== 0 && def.outputs === 0) || "right" === def.align) ? " palette_icon_container_right" : "")
+                }).appendTo(d);
                 RED.utils.createIconElement(icon_url, iconContainer, true);
             }
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -186,7 +186,7 @@ RED.palette = (function() {
                 var icon_url = RED.utils.getNodeIcon(def);
                 var iconContainer = $('<div/>', {
                     class: "palette_icon_container"
-                         + (((def.inputs !== 0 && def.outputs === 0) || "right" === def.align) ? " palette_icon_container_right" : "")
+                         + (((!def.align && def.inputs !== 0 && def.outputs === 0) || "right" === def.align) ? " palette_icon_container_right" : "")
                 }).appendTo(d);
                 RED.utils.createIconElement(icon_url, iconContainer, true);
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -2801,6 +2801,15 @@ RED.view = (function() {
                             //thisNode.selectAll(".node-gradient-top").attr("width",function(d){return d.w});
                             //thisNode.selectAll(".node-gradient-bottom").attr("width",function(d){return d.w}).attr("y",function(d){return d.h-30});
 
+                            if ((!d._def.align && d.inputs !== 0 && d.outputs === 0) || "right" === d._def.align) {
+                                thisNode.selectAll(".node_icon_group").classed("node_icon_group_right", true);
+                                thisNode.selectAll(".node_label").classed("node_label_right", true).attr("text-anchor", "end");
+                            } else {
+                                thisNode.selectAll(".node_icon_group").classed("node_icon_group_right", false);
+                                thisNode.selectAll(".node_label").classed("node_label_right", false).attr("text-anchor", "start");
+                            }
+                            thisNode.selectAll(".node_icon_group").attr("transform", function (d) { return "translate(0, 0)"; });
+                            thisNode.selectAll(".node_label").attr("x", function (d) { return 38; });
                             thisNode.selectAll(".node_icon_group_right").attr("transform", function(d){return "translate("+(d.w-30)+",0)"});
                             thisNode.selectAll(".node_label_right").attr("x", function(d){return d.w-38});
                             //thisNode.selectAll(".node_icon_right").attr("x",function(d){return d.w-d3.select(this).attr("width")-1-(d.outputs>0?5:0);});
@@ -2951,7 +2960,9 @@ RED.view = (function() {
 
                             thisNode.selectAll(".node_icon").attr("y",function(d){return (d.h-d3.select(this).attr("height"))/2;});
                             thisNode.selectAll(".node_icon_shade").attr("height",function(d){return d.h;});
-                            thisNode.selectAll(".node_icon_shade_border").attr("d",function(d){ return "M "+(("right" == d._def.align) ?0:30)+" 1 l 0 "+(d.h-2)});
+                            thisNode.selectAll(".node_icon_shade_border").attr("d", function (d) {
+                                return "M " + (((!d._def.align && d.inputs !== 0 && d.outputs === 0) || "right" === d._def.align) ? 0 : 30) + " 1 l 0 " + (d.h - 2);
+                            });
                             thisNode.selectAll(".fa-lg").attr("y",function(d){return (d.h+13)/2;});
 
                             thisNode.selectAll(".node_button").attr("opacity",function(d) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I added the functionality to changes the icon location according to input and output ports. Especially, it is for  subflow and function nodes which  always have icon on the left side. 

![nodecolorandlocation](https://user-images.githubusercontent.com/20310935/53805783-73125d00-3f8e-11e9-86de-b058b605bc3e.png)

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality