### PR TITLE
add multipart/form-data support to http request node

### DIFF
--- a/nodes/core/io/21-httprequest.html
+++ b/nodes/core/io/21-httprequest.html
@@ -132,7 +132,9 @@
     <p>For form-based file uploads, some services require that <code>msg.headers["content-type"]</code> be set to <code>multipart/form-data</code>.
     To construct <code>msg.payload</code> for this type of request, use the following structure and substitue the <code>KEY</code>, <code>DATA</code>, and <code>FILENAME</code> 
     values for your own.
-<pre><code>req.formData = { 
+<pre><code>msg.headers = {'content-type':'multipart/form-data'}
+
+msg.payload = { 
     KEY: { 
         value: DATA, 
         options: { 

--- a/nodes/core/io/21-httprequest.html
+++ b/nodes/core/io/21-httprequest.html
@@ -129,7 +129,18 @@
     <p>If <code>msg.payload</code> is an Object, the node will automatically set the content type
     of the request to <code>application/json</code> and encode the body as such.</p>
     <p>To encode the request as form data, <code>msg.headers["content-type"]</code> should be set to <code>application/x-www-form-urlencoded</code>.</p>
-
+    <p>For form-based file uploads, some services require that <code>msg.headers["content-type"]</code> be set to <code>multipart/form-data</code>.
+    To construct <code>msg.payload</code> for this type of request, use the following structure and substitue the <code>KEY</code>, <code>DATA</code>, and <code>FILENAME</code> 
+    values for your own.
+<pre><code>req.formData = { 
+    KEY: { 
+        value: DATA, 
+        options: { 
+            filename: ‘FILENAME’ 
+        } 
+    } 
+}
+</code></pre>
 </script>
 
 <script type="text/javascript">

--- a/nodes/core/io/21-httprequest.js
+++ b/nodes/core/io/21-httprequest.js
@@ -78,7 +78,6 @@ module.exports = function(RED) {
             }
             var opts = {};
             opts.url = url;
-            opts.formData = {};
             opts.timeout = node.reqTimeout;
             opts.method = method;
             opts.headers = {};
@@ -170,8 +169,7 @@ module.exports = function(RED) {
                         }
                     }
                     opts.body = payload;
-            }
-
+                }
             }
             // revert to user supplied Capitalisation if needed.
             if (opts.headers.hasOwnProperty('content-type') && (ctSet !== 'content-type')) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This change would add support for `multipart/form-data` type data in `POST` requests with the standard `http request` node.

The payload structure has been reviewed on the forums at [this link](https://discourse.nodered.org/t/add-support-for-multipart-form-data-in-request-node/8111) and I've added some documentation to the node's info panel to indicate this.

The change also incorporates a check for payload type, to ensure that won't attempt this with headers that are mistakenly set to `multipart/form-data` but come with a `msg.payload` of Buffer or String (only accepts type `Object`).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
