### PR TITLE
Fix problem on displaying option label on Firefox

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/storage/50-file.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/50-file.html
@@ -219,10 +219,11 @@
         oneditprepare: function() {
             var node = this;
             var encSel = $("#node-input-encoding");
+            var label = node._("file.encoding.none");
             $("<option/>", {
                 value: "none",
-                label: node._("file.encoding.none")
-            }).appendTo(encSel);
+                label: label
+            }).text(label).appendTo(encSel);
             encodings.forEach(function(item) {
                 if(Array.isArray(item)) {
                     var group = $("<optgroup/>", {
@@ -233,14 +234,14 @@
                         $("<option/>", {
                             value: enc,
                             label: enc
-                        }).appendTo(group);
+                        }).text(enc).appendTo(group);
                     }
                 }
                 else {
                     $("<option/>", {
                         value: item,
                         label: item
-                    }).appendTo(encSel);
+                    }).text(item).appendTo(encSel);
                 }
             });
             encSel.val(node.encoding);
@@ -277,10 +278,11 @@
         oneditprepare: function() {
             var node = this;
             var encSel = $("#node-input-encoding");
+            var label = node._("file.encoding.none");
             $("<option/>", {
                 value: "none",
-                label: node._("file.encoding.none")
-            }).appendTo(encSel);
+                label: label
+            }).text(label).appendTo(encSel);
             encodings.forEach(function(item) {
                 if(Array.isArray(item)) {
                     var group = $("<optgroup/>", {
@@ -291,14 +293,14 @@
                         $("<option/>", {
                             value: enc,
                             label: enc
-                        }).appendTo(group);
+                        }).text(enc).appendTo(group);
                     }
                 }
                 else {
                     $("<option/>", {
                         value: item,
                         label: item
-                    }).appendTo(encSel);
+                    }).text(item).appendTo(encSel);
                 }
             });
             encSel.val(node.encoding);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
As reported [here](https://github.com/node-red/node-red/issues/2086), encoding list of file in/out node are not shown correctly with Firefox.
This PR adds workaround on this issue.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
