### PR TITLE
Fix representation of Mac ctrl key

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/keyboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/keyboard.js
@@ -339,10 +339,10 @@ RED.h = handlers;
         delete slot.handlers;
     }
 
-    var cmdCtrlKey = '<span class="help-key">'+(isMac?'&#8984;':'Ctrl')+'</span>';
+    var cmdCtrlKey = '<span class="help-key">'+(isMac?'&#8963;':'Ctrl')+'</span>';
 
     function formatKey(key,plain) {
-        var formattedKey = isMac?key.replace(/ctrl-?/,"&#8984;"):key;
+        var formattedKey = isMac?key.replace(/ctrl-?/,"&#8963;"):key;
         formattedKey = isMac?formattedKey.replace(/alt-?/,"&#8997;"):key;
         formattedKey = formattedKey.replace(/shift-?/,"&#8679;")
         formattedKey = formattedKey.replace(/left/,"&#x2190;")


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
On a Mac, the ctrl key (control) is represented by the symbol `⌃`.

The symbol currently used `⌘` represents the command key, which is often used in operating system global shortcuts.

This may confuse users, especially newcomers to Node-RED.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
