### PR TITLE
Add tests for context API 

### DIFF
--- a/test/unit/@node-red/editor-api/lib/admin/index_spec.js
+++ b/test/unit/@node-red/editor-api/lib/admin/index_spec.js
@@ -26,6 +26,7 @@ var auth = NR_TEST_UTILS.require("@node-red/editor-api/lib/auth");
 var nodes = NR_TEST_UTILS.require("@node-red/editor-api/lib/admin/nodes");
 var flows = NR_TEST_UTILS.require("@node-red/editor-api/lib/admin/flows");
 var flow = NR_TEST_UTILS.require("@node-red/editor-api/lib/admin/flow");
+var context = NR_TEST_UTILS.require("@node-red/editor-api/lib/admin/context");
 
 /**
 * Ensure all API routes are correctly mounted, with the expected permissions checks
@@ -34,8 +35,8 @@ describe("api/admin/index", function() {
     describe("Ensure all API routes are correctly mounted, with the expected permissions checks", function() {
         var app;
         var mockList = [
-            flows,flow,nodes
-        ]
+            flows,flow,nodes,context
+        ];
         var permissionChecks = {};
         var lastRequest;
         var stubApp = function(req,res,next) {
@@ -50,7 +51,7 @@ describe("api/admin/index", function() {
                 return function(req,res,next) {
                     permissionChecks[permission] = (permissionChecks[permission]||0)+1;
                     next();
-                }
+                };
             });
 
             sinon.stub(flows,"get",stubApp);
@@ -70,6 +71,9 @@ describe("api/admin/index", function() {
             sinon.stub(nodes,"putSet",stubApp);
             sinon.stub(nodes,"getModuleCatalog",stubApp);
             sinon.stub(nodes,"getModuleCatalogs",stubApp);
+
+            sinon.stub(context,"get",stubApp);
+            sinon.stub(context,"delete",stubApp);
         });
         after(function() {
             mockList.forEach(function(m) {
@@ -92,15 +96,19 @@ describe("api/admin/index", function() {
             nodes.putSet.restore();
             nodes.getModuleCatalog.restore();
             nodes.getModuleCatalogs.restore();
+            context.get.restore();
+            context.delete.restore();
 
         });
 
         before(function() {
             app = adminApi.init({});
         });
+
         beforeEach(function() {
             permissionChecks = {};
-        })
+        });
+
         it('GET /flows', function(done) {
             request(app).get("/flows").expect(200).end(function(err,res) {
                 if (err) {
@@ -108,8 +116,9 @@ describe("api/admin/index", function() {
                 }
                 permissionChecks.should.have.property('flows.read',1);
                 done();
-            })
+            });
         });
+
         it('POST /flows', function(done) {
             request(app).post("/flows").expect(200).end(function(err,res) {
                 if (err) {
@@ -117,7 +126,7 @@ describe("api/admin/index", function() {
                 }
                 permissionChecks.should.have.property('flows.write',1);
                 done();
-            })
+            });
         });
 
         it('GET /flow/1234', function(done) {
@@ -126,10 +135,11 @@ describe("api/admin/index", function() {
                     return done(err);
                 }
                 permissionChecks.should.have.property('flows.read',1);
-                lastRequest.params.should.have.property('id','1234')
+                lastRequest.params.should.have.property('id','1234');
                 done();
-            })
+            });
         });
+
         it('POST /flow', function(done) {
             request(app).post("/flow").expect(200).end(function(err,res) {
                 if (err) {
@@ -137,27 +147,29 @@ describe("api/admin/index", function() {
                 }
                 permissionChecks.should.have.property('flows.write',1);
                 done();
-            })
+            });
         });
+
         it('DELETE /flow/1234', function(done) {
             request(app).del("/flow/1234").expect(200).end(function(err,res) {
                 if (err) {
                     return done(err);
                 }
                 permissionChecks.should.have.property('flows.write',1);
-                lastRequest.params.should.have.property('id','1234')
+                lastRequest.params.should.have.property('id','1234');
                 done();
-            })
+            });
         });
+
         it('PUT /flow/1234', function(done) {
             request(app).put("/flow/1234").expect(200).end(function(err,res) {
                 if (err) {
                     return done(err);
                 }
                 permissionChecks.should.have.property('flows.write',1);
-                lastRequest.params.should.have.property('id','1234')
+                lastRequest.params.should.have.property('id','1234');
                 done();
-            })
+            });
         });
 
         it('GET /nodes', function(done) {
@@ -167,8 +179,9 @@ describe("api/admin/index", function() {
                 }
                 permissionChecks.should.have.property('nodes.read',1);
                 done();
-            })
+            });
         });
+
         it('POST /nodes', function(done) {
             request(app).post("/nodes").expect(200).end(function(err,res) {
                 if (err) {
@@ -176,27 +189,29 @@ describe("api/admin/index", function() {
                 }
                 permissionChecks.should.have.property('nodes.write',1);
                 done();
-            })
+            });
         });
+
         it('GET /nodes/module', function(done) {
             request(app).get("/nodes/module").expect(200).end(function(err,res) {
                 if (err) {
                     return done(err);
                 }
                 permissionChecks.should.have.property('nodes.read',1);
-                lastRequest.params.should.have.property(0,'module')
+                lastRequest.params.should.have.property(0,'module');
                 done();
-            })
+            });
         });
+
         it('GET /nodes/@scope/module', function(done) {
             request(app).get("/nodes/@scope/module").expect(200).end(function(err,res) {
                 if (err) {
                     return done(err);
                 }
                 permissionChecks.should.have.property('nodes.read',1);
-                lastRequest.params.should.have.property(0,'@scope/module')
+                lastRequest.params.should.have.property(0,'@scope/module');
                 done();
-            })
+            });
         });
 
         it('PUT /nodes/module', function(done) {
@@ -205,19 +220,20 @@ describe("api/admin/index", function() {
                     return done(err);
                 }
                 permissionChecks.should.have.property('nodes.write',1);
-                lastRequest.params.should.have.property(0,'module')
+                lastRequest.params.should.have.property(0,'module');
                 done();
-            })
+            });
         });
+
         it('PUT /nodes/@scope/module', function(done) {
             request(app).put("/nodes/@scope/module").expect(200).end(function(err,res) {
                 if (err) {
                     return done(err);
                 }
                 permissionChecks.should.have.property('nodes.write',1);
-                lastRequest.params.should.have.property(0,'@scope/module')
+                lastRequest.params.should.have.property(0,'@scope/module');
                 done();
-            })
+            });
         });
 
         it('DELETE /nodes/module', function(done) {
@@ -226,19 +242,20 @@ describe("api/admin/index", function() {
                     return done(err);
                 }
                 permissionChecks.should.have.property('nodes.write',1);
-                lastRequest.params.should.have.property(0,'module')
+                lastRequest.params.should.have.property(0,'module');
                 done();
-            })
+            });
         });
+
         it('DELETE /nodes/@scope/module', function(done) {
             request(app).del("/nodes/@scope/module").expect(200).end(function(err,res) {
                 if (err) {
                     return done(err);
                 }
                 permissionChecks.should.have.property('nodes.write',1);
-                lastRequest.params.should.have.property(0,'@scope/module')
+                lastRequest.params.should.have.property(0,'@scope/module');
                 done();
-            })
+            });
         });
 
         it('GET /nodes/module/set', function(done) {
@@ -247,21 +264,22 @@ describe("api/admin/index", function() {
                     return done(err);
                 }
                 permissionChecks.should.have.property('nodes.read',1);
-                lastRequest.params.should.have.property(0,'module')
-                lastRequest.params.should.have.property(2,'set')
+                lastRequest.params.should.have.property(0,'module');
+                lastRequest.params.should.have.property(2,'set');
                 done();
-            })
+            });
         });
+
         it('GET /nodes/@scope/module/set', function(done) {
             request(app).get("/nodes/@scope/module/set").expect(200).end(function(err,res) {
                 if (err) {
                     return done(err);
                 }
                 permissionChecks.should.have.property('nodes.read',1);
-                lastRequest.params.should.have.property(0,'@scope/module')
-                lastRequest.params.should.have.property(2,'set')
+                lastRequest.params.should.have.property(0,'@scope/module');
+                lastRequest.params.should.have.property(2,'set');
                 done();
-            })
+            });
         });
 
         it('PUT /nodes/module/set', function(done) {
@@ -270,21 +288,22 @@ describe("api/admin/index", function() {
                     return done(err);
                 }
                 permissionChecks.should.have.property('nodes.write',1);
-                lastRequest.params.should.have.property(0,'module')
-                lastRequest.params.should.have.property(2,'set')
+                lastRequest.params.should.have.property(0,'module');
+                lastRequest.params.should.have.property(2,'set');
                 done();
-            })
+            });
         });
+
         it('PUT /nodes/@scope/module/set', function(done) {
             request(app).put("/nodes/@scope/module/set").expect(200).end(function(err,res) {
                 if (err) {
                     return done(err);
                 }
                 permissionChecks.should.have.property('nodes.write',1);
-                lastRequest.params.should.have.property(0,'@scope/module')
-                lastRequest.params.should.have.property(2,'set')
+                lastRequest.params.should.have.property(0,'@scope/module');
+                lastRequest.params.should.have.property(2,'set');
                 done();
-            })
+            });
         });
 
         it('GET /nodes/messages', function(done) {
@@ -293,10 +312,10 @@ describe("api/admin/index", function() {
                     return done(err);
                 }
                 permissionChecks.should.have.property('nodes.read',1);
-
                 done();
-            })
+            });
         });
+
         it('GET /nodes/module/set/messages', function(done) {
             request(app).get("/nodes/module/set/messages").expect(200).end(function(err,res) {
                 if (err) {
@@ -305,8 +324,9 @@ describe("api/admin/index", function() {
                 permissionChecks.should.have.property('nodes.read',1);
                 lastRequest.params.should.have.property(0,'module/set');
                 done();
-            })
+            });
         });
+
         it('GET /nodes/@scope/module/set/messages', function(done) {
             request(app).get("/nodes/@scope/module/set/messages").expect(200).end(function(err,res) {
                 if (err) {
@@ -315,7 +335,124 @@ describe("api/admin/index", function() {
                 permissionChecks.should.have.property('nodes.read',1);
                 lastRequest.params.should.have.property(0,'@scope/module/set');
                 done();
-            })
+            });
+        });
+
+        it('GET /context/global', function(done) {
+            request(app).get("/context/global").expect(200).end(function(err,res) {
+                if (err) {
+                    return done(err);
+                }
+                permissionChecks.should.have.property('context.read',1);
+                lastRequest.params.should.have.property('scope','global');
+                done();
+            });
+        });
+
+        it('GET /context/global/key?store=memory', function(done) {
+            request(app).get("/context/global/key?store=memory").expect(200).end(function(err,res) {
+                if (err) {
+                    return done(err);
+                }
+                permissionChecks.should.have.property('context.read',1);
+                lastRequest.params.should.have.property('scope','global');
+                lastRequest.params.should.have.property(0,'key');
+                lastRequest.query.should.have.property('store','memory');
+                done();
+            });
+        });
+
+        it('GET /context/flow/1234', function(done) {
+            request(app).get("/context/flow/1234").expect(200).end(function(err,res) {
+                if (err) {
+                    return done(err);
+                }
+                permissionChecks.should.have.property('context.read',1);
+                lastRequest.params.should.have.property('scope','flow');
+                lastRequest.params.should.have.property('id','1234');
+                done();
+            });
+        });
+
+        it('GET /context/flow/1234/key?store=memory', function(done) {
+            request(app).get("/context/flow/1234/key?store=memory").expect(200).end(function(err,res) {
+                if (err) {
+                    return done(err);
+                }
+                permissionChecks.should.have.property('context.read',1);
+                lastRequest.params.should.have.property('scope','flow');
+                lastRequest.params.should.have.property('id','1234');
+                lastRequest.params.should.have.property(0,'key');
+                lastRequest.query.should.have.property('store','memory');
+                done();
+            });
+        });
+
+        it('GET /context/node/5678', function(done) {
+            request(app).get("/context/node/5678").expect(200).end(function(err,res) {
+                if (err) {
+                    return done(err);
+                }
+                permissionChecks.should.have.property('context.read',1);
+                lastRequest.params.should.have.property('scope','node');
+                lastRequest.params.should.have.property('id','5678');
+                done();
+            });
+        });
+
+        it('GET /context/node/5678/foo?store=memory', function(done) {
+            request(app).get("/context/node/5678/foo?store=memory").expect(200).end(function(err,res) {
+                if (err) {
+                    return done(err);
+                }
+                permissionChecks.should.have.property('context.read',1);
+                lastRequest.params.should.have.property('scope','node');
+                lastRequest.params.should.have.property('id','5678');
+                lastRequest.params.should.have.property(0,'foo');
+                lastRequest.query.should.have.property('store','memory');
+                done();
+            });
+        });
+
+        it('DELETE /context/global/key?store=memory', function(done) {
+            request(app).del("/context/global/key?store=memory").expect(200).end(function(err,res) {
+                if (err) {
+                    return done(err);
+                }
+                permissionChecks.should.have.property('context.write',1);
+                lastRequest.params.should.have.property('scope','global');
+                lastRequest.params.should.have.property(0,'key');
+                lastRequest.query.should.have.property('store','memory');
+                done();
+            });
+        });
+
+        it('DELETE /context/flow/1234/key?store=memory', function(done) {
+            request(app).del("/context/flow/1234/key?store=memory").expect(200).end(function(err,res) {
+                if (err) {
+                    return done(err);
+                }
+                permissionChecks.should.have.property('context.write',1);
+                lastRequest.params.should.have.property('scope','flow');
+                lastRequest.params.should.have.property('id','1234');
+                lastRequest.params.should.have.property(0,'key');
+                lastRequest.query.should.have.property('store','memory');
+                done();
+            });
+        });
+
+        it('DELETE /context/node/5678/foo?store=memory', function(done) {
+            request(app).del("/context/node/5678/foo?store=memory").expect(200).end(function(err,res) {
+                if (err) {
+                    return done(err);
+                }
+                permissionChecks.should.have.property('context.write',1);
+                lastRequest.params.should.have.property('scope','node');
+                lastRequest.params.should.have.property('id','5678');
+                lastRequest.params.should.have.property(0,'foo');
+                lastRequest.query.should.have.property('store','memory');
+                done();
+            });
         });
     });
 });

--- a/test/unit/@node-red/runtime/lib/api/context_spec.js
+++ b/test/unit/@node-red/runtime/lib/api/context_spec.js
@@ -19,7 +19,7 @@ var should = require("should");
 var sinon = require("sinon");
 
 var NR_TEST_UTILS = require("nr-test-utils");
-var context = NR_TEST_UTILS.require("@node-red/runtime/lib/api/context")
+var context = NR_TEST_UTILS.require("@node-red/runtime/lib/api/context");
 
 var mockLog = () => ({
     log: sinon.stub(),
@@ -29,8 +29,8 @@ var mockLog = () => ({
     info: sinon.stub(),
     metric: sinon.stub(),
     audit: sinon.stub(),
-    _: function() { return "abc"}
-})
+    _: function() { return "abc";}
+});
 
 var mockContext = function(contents) {
     return {
@@ -41,51 +41,65 @@ var mockContext = function(contents) {
                 callback(null,undefined);
             }
         },
-        keys: function(store,callback) {
+        set: function (key, value, store, callback) {
             if (contents.hasOwnProperty(store)) {
-                callback(null,Object.keys(contents[store]));
+                if (!value) {
+                    delete contents[store][key];
+                    callback(null);
+                }
+            } else {
+                callback("err store");
+            }
+        },
+        keys: function (store, callback) {
+            if (contents.hasOwnProperty(store)) {
+                callback(null, Object.keys(contents[store]));
             } else {
                 callback("err store");
             }
         }
-    }
-}
+    };
+};
+
 describe("runtime-api/context", function() {
-    describe("getValue", function() {
-        var contexts = {
-            global: mockContext({ default: {abc:111}, file: {abc:222}}),
-            flow1: mockContext({ default: {abc:333}, file: {abc:444}})
-        }
-        var nodeContext = mockContext({ default: {abc:555}, file: {abc:666}})
+    var globalContext, flowContext, nodeContext, contexts;
 
-        beforeEach(function() {
-            context.init({
-                nodes: {
-                    listContextStores: function() {
-                        return { default: 'default', stores: [ 'default', 'file' ] }
-                    },
-                    getContext: function(id) {
-                        return contexts[id]
-                    },
-                    getNode: function(id) {
-                        if (id === 'known') {
-                            return {
-                                context: function() { return nodeContext }
-                            }
-                        } else {
-                            return null;
-                        }
-                    }
+    beforeEach(function() {
+        globalContext = { default: { abc: 111 }, file: { abc: 222 } };
+        flowContext = { default: { abc: 333 }, file: { abc: 444 } };
+        nodeContext = { default: { abc: 555 }, file: { abc: 666 } };
+        contexts = {
+            global: mockContext(globalContext),
+            flow1: mockContext(flowContext)
+        };
+        context.init({
+            nodes: {
+                listContextStores: function() {
+                    return { default: 'default', stores: [ 'default', 'file' ] };
                 },
-                settings: {
-                    functionGlobalContext: {
-                        fgc:1234
-                    }
+                getContext: function(id) {
+                    return contexts[id];
                 },
-                log: mockLog()
-            })
+                getNode: function(id) {
+                    if (id === 'known') {
+                        return {
+                            context: function() { return mockContext(nodeContext); }
+                        };
+                    } else {
+                        return null;
+                    }
+                }
+            },
+            settings: {
+                functionGlobalContext: {
+                    fgc:1234
+                }
+            },
+            log: mockLog()
         });
+    });
 
+    describe("getValue", function() {
         it('gets global value of default store', function() {
             return context.getValue({
                 scope: 'global',
@@ -95,8 +109,9 @@ describe("runtime-api/context", function() {
             }).then(function(result) {
                 result.should.have.property('msg','111');
                 result.should.have.property('format','number');
-            })
-        })
+            });
+        });
+
         it('gets global value of specified store', function() {
             return context.getValue({
                 scope: 'global',
@@ -106,8 +121,9 @@ describe("runtime-api/context", function() {
             }).then(function(result) {
                 result.should.have.property('msg','222');
                 result.should.have.property('format','number');
-            })
-        })
+            });
+        });
+
         it('gets flow value of default store', function() {
             return context.getValue({
                 scope: 'flow',
@@ -117,8 +133,9 @@ describe("runtime-api/context", function() {
             }).then(function(result) {
                 result.should.have.property('msg','333');
                 result.should.have.property('format','number');
-            })
-        })
+            });
+        });
+
         it('gets flow value of specified store', function() {
             return context.getValue({
                 scope: 'flow',
@@ -128,8 +145,9 @@ describe("runtime-api/context", function() {
             }).then(function(result) {
                 result.should.have.property('msg','444');
                 result.should.have.property('format','number');
-            })
-        })
+            });
+        });
+
         it('gets node value of default store', function() {
             return context.getValue({
                 scope: 'node',
@@ -139,8 +157,9 @@ describe("runtime-api/context", function() {
             }).then(function(result) {
                 result.should.have.property('msg','555');
                 result.should.have.property('format','number');
-            })
-        })
+            });
+        });
+
         it('gets node value of specified store', function() {
             return context.getValue({
                 scope: 'node',
@@ -150,8 +169,8 @@ describe("runtime-api/context", function() {
             }).then(function(result) {
                 result.should.have.property('msg','666');
                 result.should.have.property('format','number');
-            })
-        })
+            });
+        });
 
         it('404s for unknown store', function(done) {
             context.getValue({
@@ -162,12 +181,11 @@ describe("runtime-api/context", function() {
             }).then(function(result) {
                 done("getValue for unknown store should not resolve");
             }).catch(function(err) {
-                err.should.have.property('code','not_found')
+                err.should.have.property('code','not_found');
                 err.should.have.property('status',404);
                 done();
-            })
-        })
-
+            });
+        });
 
         it('gets all global value properties', function() {
             return context.getValue({
@@ -180,8 +198,9 @@ describe("runtime-api/context", function() {
                     default: { abc: { msg: '111', format: 'number' } },
                     file: { abc: { msg: '222', format: 'number' } }
                 });
-            })
-        })
+            });
+        });
+
         it('gets all flow value properties', function() {
             return context.getValue({
                 scope: 'flow',
@@ -193,8 +212,9 @@ describe("runtime-api/context", function() {
                     default: { abc: { msg: '333', format: 'number' } },
                     file: { abc: { msg: '444', format: 'number' } }
                 });
-            })
-        })
+            });
+        });
+
         it('gets all node value properties', function() {
             return context.getValue({
                 scope: 'node',
@@ -206,8 +226,128 @@ describe("runtime-api/context", function() {
                     default: { abc: { msg: '555', format: 'number' } },
                     file: { abc: { msg: '666', format: 'number' } }
                 });
-            })
-        })
+            });
+        });
 
-    })
+        it('gets empty object when specified context doesn\'t exist', function() {
+            return context.getValue({
+                scope: 'node',
+                id: 'non-existent',
+                store: 'file',
+                key: 'abc'
+            }).then(function(result) {
+                result.should.be.an.Object();
+                result.should.be.empty();
+            });
+        });
+    });
+
+    describe("delete", function () {
+        it('deletes global value of default store', function () {
+            return context.delete({
+                scope: 'global',
+                id: undefined,
+                store: undefined, // use default
+                key: 'abc'
+            }).then(function () {
+                globalContext.should.eql({
+                    default: {}, file: { abc: 222 }
+                });
+            });
+        });
+
+        it('deletes global value of specified store', function () {
+            return context.delete({
+                scope: 'global',
+                id: undefined,
+                store: 'file',
+                key: 'abc'
+            }).then(function () {
+                globalContext.should.eql({
+                    default: { abc: 111 }, file: {}
+                });
+            });
+        });
+
+        it('deletes flow value of default store', function () {
+            return context.delete({
+                scope: 'flow',
+                id: 'flow1',
+                store: undefined, // use default
+                key: 'abc'
+            }).then(function () {
+                flowContext.should.eql({
+                    default: {}, file: { abc: 444 }
+                });
+            });
+        });
+
+        it('deletes flow value of specified store', function () {
+            return context.delete({
+                scope: 'flow',
+                id: 'flow1',
+                store: 'file',
+                key: 'abc'
+            }).then(function () {
+                flowContext.should.eql({
+                    default: { abc: 333 }, file: {}
+                });
+            });
+        });
+
+        it('deletes node value of default store', function () {
+            return context.delete({
+                scope: 'node',
+                id: 'known',
+                store: undefined, // use default
+                key: 'abc'
+            }).then(function () {
+                nodeContext.should.eql({
+                    default: {}, file: { abc: 666 }
+                });
+            });
+        });
+
+        it('deletes node value of specified store', function () {
+            return context.delete({
+                scope: 'node',
+                id: 'known',
+                store: 'file',
+                key: 'abc'
+            }).then(function () {
+                nodeContext.should.eql({
+                    default: { abc: 555 }, file: {}
+                });
+            });
+        });
+
+        it('does nothing when specified context doesn\'t exist', function() {
+            return context.delete({
+                scope: 'node',
+                id: 'non-existent',
+                store: 'file',
+                key: 'abc'
+            }).then(function(result) {
+                should.not.exist(result);
+                nodeContext.should.eql({
+                    default: { abc: 555 }, file: { abc: 666 }
+                });
+            });
+        });
+
+        it('404s for unknown store', function (done) {
+            context.delete({
+                scope: 'global',
+                id: undefined,
+                store: 'unknown',
+                key: 'abc'
+            }).then(function () {
+                done("delete for unknown store should not resolve");
+            }).catch(function (err) {
+                err.should.have.property('code', 'not_found');
+                err.should.have.property('status', 404);
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Currently, the test cases of admin API for context are skipped.
This PR adds test cases to cover the context API.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
