### PR TITLE
Fix encoding menu in file node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/storage/50-file.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/50-file.html
@@ -22,7 +22,7 @@
         <input type="checkbox" id="node-input-createDir" style="display: inline-block; width: auto; vertical-align: top;">
         <label for="node-input-createDir" style="width: 70%;"><span data-i18n="file.label.createdir"></span></label>
     </div>
-    <div class="form-row">
+    <div class="form-row form-row-file-encoding">
         <label for="node-input-encoding"><i class="fa fa-flag"></i> <span data-i18n="file.label.encoding"></span></label>
         <select type="text" id="node-input-encoding" style="width: 250px;">
         </select>
@@ -246,8 +246,13 @@
             });
             encSel.val(node.encoding);
             $("#node-input-overwriteFile").on("change",function() {
-                if (this.value === "delete") { $(".form-row-file-write-options").hide(); }
-                else { $(".form-row-file-write-options").show(); }
+                if (this.value === "delete") {
+                    $(".form-row-file-write-options").hide();
+                    $(".form-row-file-encoding").hide();
+                } else {
+                    $(".form-row-file-write-options").show();
+                    $(".form-row-file-encoding").show();
+                }
             });
         }
     });

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -859,6 +859,7 @@
             "breaklines": "Break into lines",
             "filelabel": "file",
             "sendError": "Send message on error (legacy mode)",
+            "encoding": "Encoding",
             "deletelabel": "delete __file__",
             "utf8String": "UTF8 string",
             "binaryBuffer": "binary buffer"

--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -143,7 +143,7 @@
             "filterCurrent": "現在のフロー",
             "debugNodes": "debugノード",
             "clearLog": "ログを削除",
-             "filterLog": "ログのフィルタリング",
+            "filterLog": "ログのフィルタリング",
             "openWindow": "新しいウィンドウで開く"
         },
         "messageMenu": {
@@ -398,7 +398,7 @@
             "status": "状態コード",
             "headers": "ヘッダ",
             "other": "その他",
-            "paytoqs" : "msg.payloadをクエリパラメータに追加",
+            "paytoqs": "msg.payloadをクエリパラメータに追加",
             "utf8String": "UTF8文字列",
             "binaryBuffer": "バイナリバッファ",
             "jsonObject": "JSONオブジェクト",
@@ -857,6 +857,7 @@
             "breaklines": "行へ分割",
             "filelabel": "file",
             "sendError": "エラーメッセージを送信(互換モード)",
+            "encoding": "文字コード",
             "deletelabel": "delete __file__",
             "utf8String": "UTF8文字列",
             "binaryBuffer": "バイナリバッファ"


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Current encoding menu in file-in and file-out nodes doesn't have title, "Encoding" because message catalog doesn't contain the message. Therefore, I added the messages into the catalogs.
Simultaneously, I added visible/hidden handling in encoding menu when Node-RED user selects "delete file" in Action menu.

![image](https://user-images.githubusercontent.com/20310935/55403382-b2819880-5590-11e9-8af3-3a2531e53caa.png)

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality