### PR TITLE
http request node: warn user if msg.requestTimeout == 0

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
@@ -94,10 +94,10 @@ module.exports = function(RED) {
             opts.maxRedirects = 21;
             opts.jar = request.jar();
             opts.proxy = null;
-            if (msg.requestTimeout) {
+            if (msg.requestTimeout !== undefined) {
                 if (isNaN(msg.requestTimeout)) {
                     node.warn(RED._("httpin.errors.timeout-isnan"));
-                } else if (msg.requestTimeout < 0) {
+                } else if (msg.requestTimeout < 1) {
                     node.warn(RED._("httpin.errors.timeout-isnegative"));
                 } else {
                     opts.timeout = msg.requestTimeout;

--- a/test/nodes/core/io/21-httprequest_spec.js
+++ b/test/nodes/core/io/21-httprequest_spec.js
@@ -979,6 +979,29 @@ describe('HTTP Request Node', function() {
                 n1.receive({payload:"foo", requestTimeout: -4});
             });
         });
+        it('should show a warning if msg.requestTimeout is set to 0', function(done) {
+            var flow = [{id:"n1",type:"http request",wires:[["n2"]],method:"GET",ret:"obj",url:getTestURL('/text')},
+                {id:"n2", type:"helper"}];
+            helper.load(httpRequestNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                n2.on("input", function(msg) {
+                    try {
+                        msg.should.have.property('statusCode', 200);
+                        var logEvents = helper.log().args.filter(function(evt) {
+                            return evt[0].type == 'http request';
+                        });
+                        logEvents.should.have.length(2);
+                        var tstmp = logEvents[0][0].timestamp;
+                        logEvents[0][0].should.eql({level:helper.log().WARN, id:'n1',type:'http request',msg:'httpin.errors.timeout-isnegative', timestamp:tstmp});
+                        done();
+                    } catch(err) {
+                        done(err);
+                    }
+                });
+                n1.receive({payload:"foo", requestTimeout: 0});
+            });
+        });
         it('should pass if response time is faster than timeout set via msg.requestTimeout', function(done) {
             var flow = [{id:"n1",type:"http request",wires:[["n2"]],method:"GET",ret:"obj",url:getTestURL('/timeout50ms')},
                 {id:"n2", type:"helper"}];


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

When passing`msg.requestTimeout` with a value of 0 to the http request node it would be ignored and do the request with the default timeout.  This warns the user if he attempts to pass 0.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
