### PR TITLE
Fix node drag and drop animation

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -254,7 +254,7 @@ RED.palette = (function() {
             $(d).draggable({
                 helper: 'clone',
                 appendTo: 'body',
-                revert: true,
+                revert: 'invalid',
                 revertDuration: 50,
                 containment:'#main-container',
                 start: function() {
@@ -264,11 +264,7 @@ RED.palette = (function() {
                 },
                 stop: function() { d3.select('.link_splice').classed('link_splice',false); if (spliceTimer) { clearTimeout(spliceTimer); spliceTimer = null;}},
                 drag: function(e,ui) {
-
-                    // TODO: this is the margin-left of palette node. Hard coding
-                    // it here makes me sad
-                    //console.log(ui.helper.position());
-                    ui.position.left += 17.5;
+                    ui.originalPosition.left = $('#' + e.target.id).offset().left;
 
                     if (def.inputs > 0 && def.outputs > 0) {
                         mouseX = ui.position.left-paletteWidth+(ui.helper.width()/2) - chartOffset.left + chart.scrollLeft();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -255,7 +255,7 @@ RED.palette = (function() {
                 helper: 'clone',
                 appendTo: 'body',
                 revert: 'invalid',
-                revertDuration: 50,
+                revertDuration: 300,
                 containment:'#main-container',
                 start: function() {
                     paletteWidth = $("#palette").width();


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
After dragging and dropping a node from the palette into the central workspace on Node-RED flow editor, we can see a very short animation, the node returns to the palette. When the node is moved to the correct area, this animation is not needed in general draggable setting. And I found that the node returns to the incorrect position when the node is moved to the incorrect area because the position is hardcoded. Therefore, I changed the draggable setting in the code.
Simultaneously, I adjusted animation speed because I think that it's too fast.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality