### PR TITLE
Fix possible memory leak of debug sidebar output

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/core/lib/debug/debug-utils.js
+++ b/packages/node_modules/@node-red/nodes/core/core/lib/debug/debug-utils.js
@@ -400,48 +400,47 @@ RED.debug = (function() {
     }
 
     function processDebugMessage(o) {
-        var msg = document.createElement("div");
+        var msg = $("<div/>");
         var sourceNode = o._source;
 
-        msg.onmouseenter = function() {
-            $(msg).addClass('debug-message-hover');
+        msg.on("mouseenter", function() {
+            msg.addClass('debug-message-hover');
             if (o._source) {
                 config.messageMouseEnter(o._source.id);
                 if (o._source._alias) {
                     config.messageMouseEnter(o._source._alias);
                 }
             }
-
-        };
-        msg.onmouseleave = function() {
-            $(msg).removeClass('debug-message-hover');
+        });
+        msg.on("mouseleave", function() {
+            msg.removeClass('debug-message-hover');
             if (o._source) {
                 config.messageMouseLeave(o._source.id);
                 if (o._source._alias) {
                     config.messageMouseLeave(o._source._alias);
                 }
             }
-        };
+        });
         var name = sanitize(((o.name?o.name:o.id)||"").toString());
         var topic = sanitize((o.topic||"").toString());
         var property = sanitize(o.property?o.property:'');
         var payload = o.msg;
         var format = sanitize((o.format||"").toString());
-        msg.className = 'debug-message'+(o.level?(' debug-message-level-'+o.level):'')+
+        msg.attr("class", 'debug-message'+(o.level?(' debug-message-level-'+o.level):'')+
             (sourceNode?(
                 " debug-message-node-"+sourceNode.id.replace(/\./g,"_")+
                 (sourceNode.z?" debug-message-flow-"+sourceNode.z.replace(/\./g,"_"):"")
-            ):"");
+            ):""));
 
         if (sourceNode) {
-            $(msg).data('source',sourceNode.id);
+            msg.data('source',sourceNode.id);
             if (filterType === "filterCurrent" && activeWorkspace) {
                 if (sourceNode.z && sourceNode.z.replace(/\./g,"_") !== activeWorkspace) {
-                    $(msg).addClass('hide');
+                    msg.addClass('hide');
                 }
             } else if (filterType === 'filterSelected'){
                 if (!!filteredNodes[sourceNode.id]) {
-                    $(msg).addClass('hide');
+                    msg.addClass('hide');
                 }
             }
         }
@@ -481,7 +480,7 @@ RED.debug = (function() {
                 errorLvl = 30;
                 errorLvlType = 'warn';
             }
-            $(msg).addClass('debug-message-level-' + errorLvl);
+            msg.addClass('debug-message-level-' + errorLvl);
             $('<span class="debug-message-topic">function : (' + errorLvlType + ')</span>').appendTo(metaRow);
         } else {
             var tools = $('<span class="debug-message-tools button-group"></span>').appendTo(metaRow);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

With current master branch of Node-RED, continuously outputting message to debug sidebar causes rapid increase in memory usage of node-red editor tab of Chrome client.  The increased memory is not reclaimed by garbage collector.

This seems to be caused by mixing jQuery with native DOM manipulation as discussed in:
https://makandracards.com/makandra/31325-how-to-create-memory-leaks-in-jquery

This PR replaces raw JavaScript DOM manipulation code by jQuery code.

Sample flow:
```
[{"id":"de885be9.b10fc8","type":"tab","label":"Flow 1","disabled":false,"info":""},{"id":"d14b1b7a.231358","type":"inject","z":"de885be9.b10fc8","name":"","topic":"","payload":"","payloadType":"date","repeat":"","crontab":"","once":false,"onceDelay":0.1,"x":120,"y":120,"wires":[["271411aa.bb864e"]]},{"id":"f49bed2d.dea01","type":"debug","z":"de885be9.b10fc8","name":"","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","x":490,"y":120,"wires":[]},{"id":"271411aa.bb864e","type":"function","z":"de885be9.b10fc8","name":"","func":"var N = 60*5;\n\nvar count = 0;\nfunction doIt(n) {\n    if (n > 0) {\n        for(var i = 0; i < 10; i++) {\n            count++;\n            node.send({payload: {val: count}});\n        }\n        setTimeout(function () {\n            doIt(n-1);\n        }, 1000);\n    }\n    else {\n        node.send({payload: \"done\"});\n    }\n}\n\n\ndoIt(N);\n","outputs":1,"noerr":0,"x":290,"y":120,"wires":[["f49bed2d.dea01"]]}]
```

With current dev branch code, this problem do not reproduce the above problem.  

I guess that recent updates of base jQuery version are affecting this result.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
