### PR TITLE
update editor language selection UI for i18n

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -929,5 +929,12 @@
         "description": "Description",
         "appearance": "Appearance",
         "env": "Environment Variables"
+    },
+    "languages" : {
+        "de": "German",
+        "en-US": "English",
+        "ja": "Japanese",
+        "ko": "Korean",
+        "zh-CN": "Chinese(Simplified)"
     }
 }

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -42,7 +42,9 @@
                 "defaultDir": "標準",
                 "ltr": "左から右",
                 "rtl": "右から左",
-                "auto": "文脈"
+                "auto": "文脈",
+                "language": "表示言語",
+                "browserDefault": "ブラウザのデフォルト"
             },
             "sidebar": {
                 "show": "サイドバーを表示"
@@ -914,5 +916,12 @@
         "description": "説明",
         "appearance": "外観",
         "env": "環境変数"
+    },
+    "languages" : {
+        "de": "ドイツ語",
+        "en-US": "英語",
+        "ja": "日本語",
+        "ko": "韓国語",
+        "zh-CN": "中国語(簡体)"
     }
 }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
@@ -101,25 +101,19 @@ RED.userSettings = (function() {
         RED.tray.show(trayOptions);
     }
 
-    function locale2Name(lc) {
+    function localeToName(lc) {
         var name = RED._("languages."+lc);
         return {text: (name ? name : lc), val: lc};
     }
 
     function compText(a, b) {
-        if (a.text > b.text) {
-            return 1;
-        }
-        if (a.text < b.text) {
-            return -1;
-        }
-        return 0;
+        return a.text.localeCompare(b.text);
     }
     
     var viewSettings = [
         {
             options: [
-                {setting:"editor-language",local: true, label:"menu.label.view.language",options:function(done){ done([{val:'',text:RED._('menu.label.view.browserDefault')}].concat(RED.settings.theme("languages").map(locale2Name).sort(compText))) }},
+                {setting:"editor-language",local: true, label:"menu.label.view.language",options:function(done){ done([{val:'',text:RED._('menu.label.view.browserDefault')}].concat(RED.settings.theme("languages").map(localeToName).sort(compText))) }},
             ]
         },{
             title: "menu.label.view.grid",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
@@ -101,10 +101,25 @@ RED.userSettings = (function() {
         RED.tray.show(trayOptions);
     }
 
+    function locale2Name(lc) {
+        var name = RED._("languages."+lc);
+        return {text: (name ? name : lc), val: lc};
+    }
+
+    function compText(a, b) {
+        if (a.text > b.text) {
+            return 1;
+        }
+        if (a.text < b.text) {
+            return -1;
+        }
+        return 0;
+    }
+    
     var viewSettings = [
         {
             options: [
-                {setting:"editor-language",local: true, label:"menu.label.view.language",options:function(done){ done([{val:'',text:RED._('menu.label.view.browserDefault')}].concat(RED.settings.theme("languages"))) }},
+                {setting:"editor-language",local: true, label:"menu.label.view.language",options:function(done){ done([{val:'',text:RED._('menu.label.view.browserDefault')}].concat(RED.settings.theme("languages").map(locale2Name).sort(compText))) }},
             ]
         },{
             title: "menu.label.view.grid",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This PR make list of editor languages in settings displayed in i18n text instead of raw locale name.
English & Japanese language names are supported.

![lang](https://user-images.githubusercontent.com/30289092/58392199-d682c700-8073-11e9-9bf1-17b3af43643c.png)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
