### PR TITLE
Update I18n support for library ui

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -365,6 +365,7 @@
         "savedNodes": "Saved nodes",
         "savedType": "Saved __type__",
         "saveFailed": "Save failed: __message__",
+        "newFolder": "New folder",
         "types": {
             "local": "Local",
             "examples": "Examples"

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -356,6 +356,7 @@
         "savedNodes": "フローを保存しました",
         "savedType": "__type__ を保存しました",
         "saveFailed": "保存に失敗しました: __message__",
+        "newFolder": "新規フォルダ",
         "types": {
             "examples": "サンプル"
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/library.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/library.js
@@ -325,7 +325,7 @@ RED.library = (function() {
 
                 var menuOptionMenu = RED.menu.init({id:"red-ui-library-browser-menu",
                     options: [
-                        {id:"red-ui-library-browser-menu-addFolder",label:"New folder", onselect: function() {
+                        {id:"red-ui-library-browser-menu-addFolder",label:RED._("library.newFolder"), onselect: function() {
                             var defaultFolderName = "new-folder";
                             var defaultFolderNameMatches = {};
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This PR make new library folder creation interface i18n ready.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
