### PR TITLE
Add new shortcut to clear debug message list

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/keymap.json
+++ b/packages/node_modules/@node-red/editor-client/src/js/keymap.json
@@ -17,6 +17,7 @@
         "ctrl-space": "core:toggle-sidebar",
         "ctrl-p": "core:toggle-palette",
         "ctrl-,": "core:show-user-settings",
+        "ctrl-alt-l": "core:clear-debug-messages",
         "ctrl-alt-r": "core:show-remote-diff",
         "ctrl-alt-n": "core:new-project",
         "ctrl-alt-o": "core:open-project",

--- a/packages/node_modules/@node-red/nodes/core/core/58-debug.html
+++ b/packages/node_modules/@node-red/nodes/core/core/58-debug.html
@@ -205,6 +205,7 @@
                 }
             };
             RED.events.on("project:change", this.clearMessageList);
+            RED.actions.add("core:clear-debug-messages", function() { RED.debug.clearMessageList(true) });
 
             $("#debug-tab-open").click(function(e) {
                 e.preventDefault();
@@ -246,7 +247,8 @@
             RED.sidebar.removeTab("debug");
             RED.events.off("workspace:change", this.refreshMessageList);
             window.removeEventListener("message",this.handleWindowMessage);
-            RED.actions.remove("core:show-debug");
+            RED.actions.remove("core:show-debug-tab");
+            RED.actions.remove("core:clear-debug-messages");
 
             delete RED._debug;
         },


### PR DESCRIPTION
Clearing the debug message list is globally scoped by default to
`ctrl+alt+l`. Mnemonic: similar to clearing a terminal shell using
ctrl+l.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Add new shortcut to clear debug message list. This is a productivity feature to aid debugging.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
