### PR TITLE
Fix typedinput width calculation

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -426,6 +426,7 @@
             if (labelWidth === 0) {
                 var container = $('<div class="red-ui-typedInput-container"></div>').css({
                     position:"absolute",
+                    "white-space": "nowrap",
                     top:0
                 }).appendTo(document.body);
                 var newTrigger = label.clone().appendTo(container);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
In some cases, type selection part of typedInput field is displayed in truncated manner as shown below.

![スクリーンショット 2019-05-31 22 11 04](https://user-images.githubusercontent.com/30289092/58708702-76817d00-83f3-11e9-959d-eaca299acc47.png)

This seems to be resolved by adding `white-space: nowrap` to the calculated html elements as discussed in: https://stackoverflow.com/questions/118241/calculate-text-width-with-javascript

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
