### PR TITLE
Add Command prompt dialog

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -169,6 +169,7 @@ module.exports = function(grunt) {
                     "packages/node_modules/@node-red/editor-client/src/js/ui/library.js",
                     "packages/node_modules/@node-red/editor-client/src/js/ui/notifications.js",
                     "packages/node_modules/@node-red/editor-client/src/js/ui/search.js",
+                    "packages/node_modules/@node-red/editor-client/src/js/ui/commandPrompt.js",
                     "packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js",
                     "packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js",
                     "packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -169,7 +169,7 @@ module.exports = function(grunt) {
                     "packages/node_modules/@node-red/editor-client/src/js/ui/library.js",
                     "packages/node_modules/@node-red/editor-client/src/js/ui/notifications.js",
                     "packages/node_modules/@node-red/editor-client/src/js/ui/search.js",
-                    "packages/node_modules/@node-red/editor-client/src/js/ui/commandPrompt.js",
+                    "packages/node_modules/@node-red/editor-client/src/js/ui/actionList.js",
                     "packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js",
                     "packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js",
                     "packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js",

--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -710,7 +710,8 @@
     },
     "search": {
         "empty": "No matches found",
-        "addNode": "add a node..."
+        "addNode": "add a node...",
+        "actions": "search available actions"
     },
     "expressionEditor": {
         "functions": "Functions",

--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -351,7 +351,8 @@
         "pasteNode": "Paste nodes",
         "undoChange": "Undo the last change performed",
         "searchBox": "Open search box",
-        "managePalette": "Manage palette"
+        "managePalette": "Manage palette",
+        "actionList":"Action list"
     },
     "library": {
         "library": "Library",
@@ -710,8 +711,7 @@
     },
     "search": {
         "empty": "No matches found",
-        "addNode": "add a node...",
-        "actions": "search available actions"
+        "addNode": "add a node..."
     },
     "expressionEditor": {
         "functions": "Functions",

--- a/packages/node_modules/@node-red/editor-client/src/js/keymap.json
+++ b/packages/node_modules/@node-red/editor-client/src/js/keymap.json
@@ -23,7 +23,7 @@
         "ctrl-alt-o": "core:open-project",
         "ctrl-g v": "core:show-version-control-tab",
         "ctrl-shift-l": "core:show-event-log",
-        "ctrl-shift-p":"core:show-command-prompt"
+        "alt-shift-p":"core:show-command-prompt"
     },
     "red-ui-sidebar-node-config": {
         "backspace": "core:delete-config-selection",

--- a/packages/node_modules/@node-red/editor-client/src/js/keymap.json
+++ b/packages/node_modules/@node-red/editor-client/src/js/keymap.json
@@ -1,6 +1,6 @@
 {
     "*": {
-        "ctrl-shift-p":"core:manage-palette",
+        "alt-shift-p":"core:manage-palette",
         "ctrl-f": "core:search",
         "ctrl-shift-f": "core:list-flows",
         "ctrl-=": "core:zoom-in",
@@ -23,7 +23,7 @@
         "ctrl-alt-o": "core:open-project",
         "ctrl-g v": "core:show-version-control-tab",
         "ctrl-shift-l": "core:show-event-log",
-        "alt-shift-p":"core:show-command-prompt"
+        "ctrl-shift-p":"core:show-action-list"
     },
     "red-ui-sidebar-node-config": {
         "backspace": "core:delete-config-selection",

--- a/packages/node_modules/@node-red/editor-client/src/js/keymap.json
+++ b/packages/node_modules/@node-red/editor-client/src/js/keymap.json
@@ -22,7 +22,8 @@
         "ctrl-alt-n": "core:new-project",
         "ctrl-alt-o": "core:open-project",
         "ctrl-g v": "core:show-version-control-tab",
-        "ctrl-shift-l": "core:show-event-log"
+        "ctrl-shift-l": "core:show-event-log",
+        "ctrl-shift-p":"core:show-command-prompt"
     },
     "red-ui-sidebar-node-config": {
         "backspace": "core:delete-config-selection",

--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -451,6 +451,7 @@ var RED = (function() {
             {id:"menu-item-palette",label:RED._("menu.label.palette.show"),toggle:true,onselect:"core:toggle-palette", selected: true},
             {id:"menu-item-sidebar",label:RED._("menu.label.sidebar.show"),toggle:true,onselect:"core:toggle-sidebar", selected: true},
             {id:"menu-item-event-log",label:RED._("eventLog.title"),onselect:"core:show-event-log"},
+            {id:"menu-item-action-list",label:RED._("keyboard.actionList"),onselect:"core:show-action-list"},
             null
         ]});
         menuOptions.push(null);
@@ -521,7 +522,7 @@ var RED = (function() {
         RED.subflow.init();
         RED.clipboard.init();
         RED.search.init();
-        RED.commandPrompt.init();
+        RED.actionList.init();
         RED.editor.init();
         RED.diff.init();
 

--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -521,6 +521,7 @@ var RED = (function() {
         RED.subflow.init();
         RED.clipboard.init();
         RED.search.init();
+        RED.commandPrompt.init();
         RED.editor.init();
         RED.diff.init();
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/actionList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/actionList.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-RED.commandPrompt = (function() {
+RED.actionList = (function() {
 
     var disabled = false;
     var dialog = null;
@@ -22,34 +22,7 @@ RED.commandPrompt = (function() {
     var selected = -1;
     var visible = false;
 
-    var results = [];
-
-    var scopes = {};
-
-    function search(val) {
-        scopes = {};
-        results = [];
-        selected = -1;
-        val = val ||"";
-        searchResults.editableList('empty');
-
-        var actions = RED.actions.list();
-        actions.sort(function(A,B) {
-            return A.id.localeCompare(B.id);
-        });
-
-        val = val.trim().toLowerCase();
-
-        actions.forEach(function(action) {
-            action.label = action.id.replace(/:/,": ").replace(/-/g," ").replace(/(^| )./g,function() { return arguments[0].toUpperCase()});
-            if (val !== "" && action.label.toLowerCase().indexOf(val) === -1) {
-                return;
-            }
-            results.push(action);
-            searchResults.editableList('addItem',action)
-        })
-
-    }
+    var filterTerm = "";
 
     function ensureSelectedIsVisible() {
         var selectedEntry = searchResults.find("li.selected");
@@ -68,48 +41,50 @@ RED.commandPrompt = (function() {
     }
 
     function createDialog() {
-        dialog = $("<div>",{id:"red-ui-commandPrompt",class:"red-ui-search"}).appendTo("#red-ui-main-container");
+        dialog = $("<div>",{id:"red-ui-actionList",class:"red-ui-search"}).appendTo("#red-ui-main-container");
         var searchDiv = $("<div>",{class:"red-ui-search-container"}).appendTo(dialog);
-        searchInput = $('<input type="text" data-i18n="[placeholder]search.actions">').appendTo(searchDiv).searchBox({
-            delay: 200,
+        searchInput = $('<input type="text" data-i18n="[placeholder]keyboard.filterActions">').appendTo(searchDiv).searchBox({
             change: function() {
-                search($(this).val());
+                filterTerm = $(this).val();
+                searchResults.editableList('filter');
+                searchResults.find("li.selected").removeClass("selected");
             }
         });
 
         searchInput.on('keydown',function(evt) {
-            var children;
-            if (results.length > 0) {
-                if (evt.keyCode === 40) {
-                    // Down
-                    children = searchResults.children();
-                    if (selected < children.length-1) {
-                        if (selected > -1) {
-                            $(children[selected]).removeClass('selected');
-                        }
-                        selected++;
+            var selectedChild;
+            if (evt.keyCode === 40) {
+                // Down
+                selectedChild = searchResults.find("li.selected");
+                if (!selectedChild.length) {
+                    var children = searchResults.children(":visible");
+                    if (children.length) {
+                        $(children[0]).addClass('selected');
+                        RED.a = children[0];
                     }
-                    $(children[selected]).addClass('selected');
-                    ensureSelectedIsVisible();
-                    evt.preventDefault();
-                } else if (evt.keyCode === 38) {
-                    // Up
-                    children = searchResults.children();
-                    if (selected > 0) {
-                        if (selected < children.length) {
-                            $(children[selected]).removeClass('selected');
-                        }
-                        selected--;
-                    }
-                    $(children[selected]).addClass('selected');
-                    ensureSelectedIsVisible();
-                    evt.preventDefault();
-                } else if (evt.keyCode === 13) {
-                    // Enter
-                    if (results.length > 0) {
-                        selectCommand(results[Math.max(0,selected)]);
+                } else {
+                    var nextChild = selectedChild.nextAll(":visible").first();
+                    if (nextChild.length) {
+                        selectedChild.removeClass('selected');
+                        nextChild.addClass('selected');
                     }
                 }
+                ensureSelectedIsVisible();
+                evt.preventDefault();
+            } else if (evt.keyCode === 38) {
+                // Up
+                selectedChild = searchResults.find("li.selected");
+                var nextChild = selectedChild.prevAll(":visible").first();
+                if (nextChild.length) {
+                    selectedChild.removeClass('selected');
+                    nextChild.addClass('selected');
+                }
+                ensureSelectedIsVisible();
+                evt.preventDefault();
+            } else if (evt.keyCode === 13) {
+                // Enter
+                selectedChild = searchResults.find("li.selected");
+                selectCommand(searchResults.editableList('getItem',selectedChild));
             }
         });
         searchInput.i18n();
@@ -137,14 +112,22 @@ RED.commandPrompt = (function() {
                     });
                 }
             },
-            scrollOnAdd: false
+            scrollOnAdd: false,
+            filter: function(item) {
+                if (filterTerm !== "" && item.label.toLowerCase().indexOf(filterTerm) === -1) {
+                    return false;
+                }
+                return true;
+            }
         });
 
     }
 
     function selectCommand(command) {
         hide();
-        RED.actions.invoke(command.id);
+        if (command) {
+            RED.actions.invoke(command.id);
+        }
     }
 
     function show(v) {
@@ -163,8 +146,17 @@ RED.commandPrompt = (function() {
             }
             dialog.slideDown(300);
             searchInput.searchBox('value',v)
-            search(v);
-            RED.events.emit("commandPrompt:open");
+            searchResults.editableList('empty');
+            results = [];
+            var actions = RED.actions.list();
+            actions.sort(function(A,B) {
+                return A.id.localeCompare(B.id);
+            });
+            actions.forEach(function(action) {
+                action.label = action.id.replace(/:/,": ").replace(/-/g," ").replace(/(^| )./g,function() { return arguments[0].toUpperCase()});
+                searchResults.editableList('addItem',action)
+            })
+            RED.events.emit("actionList:open");
             visible = true;
         }
         searchInput.trigger("focus");
@@ -184,12 +176,12 @@ RED.commandPrompt = (function() {
                     searchInput.searchBox('value','');
                 });
             }
-            RED.events.emit("commandPrompt:close");
+            RED.events.emit("actionList:close");
         }
     }
 
     function init() {
-        RED.actions.add("core:show-command-prompt",show);
+        RED.actions.add("core:show-action-list",show);
 
         RED.events.on("editor:open",function() { disabled = true; });
         RED.events.on("editor:close",function() { disabled = false; });

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -742,6 +742,8 @@ RED.clipboard = (function() {
             RED.events.on("editor:close",function() { disabled = false; });
             RED.events.on("search:open",function() { disabled = true; });
             RED.events.on("search:close",function() { disabled = false; });
+            RED.events.on("commandPrompt:open",function() { disabled = true; });
+            RED.events.on("commandPrompt:close",function() { disabled = false; });
             RED.events.on("type-search:open",function() { disabled = true; });
             RED.events.on("type-search:close",function() { disabled = false; });
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -742,8 +742,8 @@ RED.clipboard = (function() {
             RED.events.on("editor:close",function() { disabled = false; });
             RED.events.on("search:open",function() { disabled = true; });
             RED.events.on("search:close",function() { disabled = false; });
-            RED.events.on("commandPrompt:open",function() { disabled = true; });
-            RED.events.on("commandPrompt:close",function() { disabled = false; });
+            RED.events.on("actionList:open",function() { disabled = true; });
+            RED.events.on("actionList:close",function() { disabled = false; });
             RED.events.on("type-search:open",function() { disabled = true; });
             RED.events.on("type-search:close",function() { disabled = false; });
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/commandPrompt.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/commandPrompt.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-RED.search = (function() {
+RED.commandPrompt = (function() {
 
     var disabled = false;
     var dialog = null;
@@ -21,113 +21,47 @@ RED.search = (function() {
     var searchResults;
     var selected = -1;
     var visible = false;
+    var activeElement;
 
-    var index = {};
-    var keys = [];
     var results = [];
 
-
-    function indexProperty(node,label,property) {
-        if (typeof property === 'string' || typeof property === 'number') {
-            property = (""+property).toLowerCase();
-            index[property] = index[property] || {};
-            index[property][node.id] = {node:node,label:label};
-        } else if (Array.isArray(property)) {
-            property.forEach(function(prop) {
-                indexProperty(node,label,prop);
-            })
-        } else if (typeof property === 'object') {
-            for (var prop in property) {
-                if (property.hasOwnProperty(prop)) {
-                    indexProperty(node,label,property[prop])
-                }
-            }
-        }
-    }
-    function indexNode(n) {
-        var l = RED.utils.getNodeLabel(n);
-        if (l) {
-            l = (""+l).toLowerCase();
-            index[l] = index[l] || {};
-            index[l][n.id] = {node:n,label:l}
-        }
-        l = l||n.label||n.name||n.id||"";
-
-
-        var properties = ['id','type','name','label','info'];
-        if (n._def && n._def.defaults) {
-            properties = properties.concat(Object.keys(n._def.defaults));
-        }
-        for (var i=0;i<properties.length;i++) {
-            if (n.hasOwnProperty(properties[i])) {
-                indexProperty(n, l, n[properties[i]]);
-            }
-        }
-    }
-
-    function indexWorkspace() {
-        index = {};
-        RED.nodes.eachWorkspace(indexNode);
-        RED.nodes.eachSubflow(indexNode);
-        RED.nodes.eachConfig(indexNode);
-        RED.nodes.eachNode(indexNode);
-        keys = Object.keys(index);
-        keys.sort();
-        keys.forEach(function(key) {
-            index[key] = Object.keys(index[key]).map(function(id) {
-                return index[key][id];
-            })
-        })
-    }
+    var scopes = {};
 
     function search(val) {
+        scopes = {};
+        val = val ||"";
         searchResults.editableList('empty');
-        var typeFilter;
-        var m = /(?:^| )type:([^ ]+)/.exec(val);
-        if (m) {
-            val = val.replace(/(?:^| )type:[^ ]+/,"");
-            typeFilter = m[1];
-        }
 
-        val = val.trim();
+        var actions = RED.actions.list();
+        actions.sort(function(A,B) {
+            return A.id.localeCompare(B.id);
+        });
 
-        selected = -1;
-        results = [];
-        if (val.length > 0 || typeFilter) {
-            val = val.toLowerCase();
-            var i;
-            var j;
-            var list = [];
-            var nodes = {};
-            for (i=0;i<keys.length;i++) {
-                var key = keys[i];
-                var kpos = keys[i].indexOf(val);
-                if (kpos > -1) {
-                    for (j=0;j<index[key].length;j++) {
-                        var node = index[key][j];
-                        if (!typeFilter || node.node.type === typeFilter) {
-                            nodes[node.node.id] = nodes[node.node.id] = node;
-                            nodes[node.node.id].index = Math.min(nodes[node.node.id].index||Infinity,kpos);
-                        }
+        val = val.trim().toLowerCase();
+
+        actions.forEach(function(action) {
+            if (action.scope && action.scope !== "*") {
+                if (!scopes.hasOwnProperty(action.scope)) {
+                    var target = activeElement;
+                    while (target.nodeName !== 'BODY' && target.id !== action.scope) {
+                        target = target.parentElement;
                     }
+                    scopes[action.scope] = (target.nodeName !== 'BODY')
+                }
+                if (!scopes[action.scope]) {
+                    return;
                 }
             }
-            list = Object.keys(nodes);
-            list.sort(function(A,B) {
-                return nodes[A].index - nodes[B].index;
-            });
+            action.label = action.id.replace(/:/,": ").replace(/-/g," ").replace(/(^| )./g,function() { return arguments[0].toUpperCase()});
+            if (val !== "" && action.label.toLowerCase().indexOf(val) === -1) {
+                return;
+            }
+            results.push(action);
+            searchResults.editableList('addItem',action)
+        })
+        // searchResults.editableList('addItem',{});
+        console.log(document.activeElement);
 
-            for (i=0;i<list.length;i++) {
-                results.push(nodes[list[i]]);
-            }
-            if (results.length > 0) {
-                for (i=0;i<Math.min(results.length,25);i++) {
-                    searchResults.editableList('addItem',results[i])
-                }
-            } else {
-                searchResults.editableList('addItem',{});
-            }
-        }
     }
 
     function ensureSelectedIsVisible() {
@@ -147,7 +81,7 @@ RED.search = (function() {
     }
 
     function createDialog() {
-        dialog = $("<div>",{id:"red-ui-search",class:"red-ui-search"}).appendTo("#red-ui-main-container");
+        dialog = $("<div>",{id:"red-ui-commandPrompt",class:"red-ui-search"}).appendTo("#red-ui-main-container");
         var searchDiv = $("<div>",{class:"red-ui-search-container"}).appendTo(dialog);
         searchInput = $('<input type="text" data-i18n="[placeholder]menu.label.searchInput">').appendTo(searchDiv).searchBox({
             delay: 200,
@@ -186,7 +120,7 @@ RED.search = (function() {
                 } else if (evt.keyCode === 13) {
                     // Enter
                     if (results.length > 0) {
-                        reveal(results[Math.max(0,selected)].node);
+                        selectCommand(results[Math.max(0,selected)]);
                     }
                 }
             }
@@ -196,45 +130,23 @@ RED.search = (function() {
         var searchResultsDiv = $("<div>",{class:"red-ui-search-results-container"}).appendTo(dialog);
         searchResults = $('<ol>',{style:"position: absolute;top: 5px;bottom: 5px;left: 5px;right: 5px;"}).appendTo(searchResultsDiv).editableList({
             addButton: false,
-            addItem: function(container,i,object) {
-                var node = object.node;
-                if (node === undefined) {
+            addItem: function(container,i,action) {
+                if (action.id === undefined) {
                     $('<div>',{class:"red-ui-search-empty"}).text(RED._('search.empty')).appendTo(container);
-
                 } else {
-                    var def = node._def;
                     var div = $('<a>',{href:'#',class:"red-ui-search-result"}).appendTo(container);
+                    var contentDiv = $('<div>',{class:"red-ui-search-result-action"}).appendTo(div);
 
-                    var nodeDiv = $('<div>',{class:"red-ui-search-result-node"}).appendTo(div);
-                    var colour = RED.utils.getNodeColor(node.type,def);
-                    var icon_url = RED.utils.getNodeIcon(def,node);
-                    if (node.type === 'tab') {
-                        colour = "#C0DEED";
+
+                    $('<div>').text(action.label).appendTo(contentDiv);
+                    // $('<div>',{class:"red-ui-search-result-node-type"}).text(node.type).appendTo(contentDiv);
+                    // $('<div>',{class:"red-ui-search-result-node-id"}).text(node.id).appendTo(contentDiv);
+                    if (action.key) {
+                        $('<div>',{class:"red-ui-search-result-action-key"}).html(RED.keyboard.formatKey(action.key)).appendTo(contentDiv);
                     }
-                    nodeDiv.css('backgroundColor',colour);
-
-                    var iconContainer = $('<div/>',{class:"red-ui-palette-icon-container"}).appendTo(nodeDiv);
-                    RED.utils.createIconElement(icon_url, iconContainer, true);
-
-                    var contentDiv = $('<div>',{class:"red-ui-search-result-node-description"}).appendTo(div);
-                    if (node.z) {
-                        var workspace = RED.nodes.workspace(node.z);
-                        if (!workspace) {
-                            workspace = RED.nodes.subflow(node.z);
-                            workspace = "subflow:"+workspace.name;
-                        } else {
-                            workspace = "flow:"+workspace.label;
-                        }
-                        $('<div>',{class:"red-ui-search-result-node-flow"}).text(workspace).appendTo(contentDiv);
-                    }
-
-                    $('<div>',{class:"red-ui-search-result-node-label"}).text(object.label || node.id).appendTo(contentDiv);
-                    $('<div>',{class:"red-ui-search-result-node-type"}).text(node.type).appendTo(contentDiv);
-                    $('<div>',{class:"red-ui-search-result-node-id"}).text(node.id).appendTo(contentDiv);
-
                     div.on("click", function(evt) {
                         evt.preventDefault();
-                        reveal(node);
+                        selectCommand(action);
                     });
                 }
             },
@@ -243,9 +155,10 @@ RED.search = (function() {
 
     }
 
-    function reveal(node) {
+    function selectCommand(command) {
         hide();
-        RED.view.reveal(node.id);
+        RED.actions.invoke(command.id);
+        console.log(command);
     }
 
     function show(v) {
@@ -253,19 +166,20 @@ RED.search = (function() {
             return;
         }
         if (!visible) {
+            activeElement = document.activeElement;
             RED.keyboard.add("*","escape",function(){hide()});
             $("#red-ui-header-shade").show();
             $("#red-ui-editor-shade").show();
             $("#red-ui-palette-shade").show();
             $("#red-ui-sidebar-shade").show();
             $("#red-ui-sidebar-separator").hide();
-            indexWorkspace();
             if (dialog === null) {
                 createDialog();
             }
             dialog.slideDown(300);
             searchInput.searchBox('value',v)
-            RED.events.emit("search:open");
+            search(v);
+            RED.events.emit("commandPrompt:open");
             visible = true;
         }
         searchInput.trigger("focus");
@@ -285,21 +199,19 @@ RED.search = (function() {
                     searchInput.searchBox('value','');
                 });
             }
-            RED.events.emit("search:close");
+            RED.events.emit("commandPrompt:close");
         }
     }
 
     function init() {
-        RED.actions.add("core:search",show);
+        RED.actions.add("core:show-command-prompt",show);
 
         RED.events.on("editor:open",function() { disabled = true; });
         RED.events.on("editor:close",function() { disabled = false; });
+        RED.events.on("search:open",function() { disabled = true; });
+        RED.events.on("search:close",function() { disabled = false; });
         RED.events.on("type-search:open",function() { disabled = true; });
         RED.events.on("type-search:close",function() { disabled = false; });
-        RED.events.on("commandPrompt:open",function() { disabled = true; });
-        RED.events.on("commandPrompt:close",function() { disabled = false; });
-
-
 
         $("#red-ui-header-shade").on('mousedown',hide);
         $("#red-ui-editor-shade").on('mousedown',hide);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/commandPrompt.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/commandPrompt.js
@@ -21,7 +21,6 @@ RED.commandPrompt = (function() {
     var searchResults;
     var selected = -1;
     var visible = false;
-    var activeElement;
 
     var results = [];
 
@@ -29,6 +28,8 @@ RED.commandPrompt = (function() {
 
     function search(val) {
         scopes = {};
+        results = [];
+        selected = -1;
         val = val ||"";
         searchResults.editableList('empty');
 
@@ -40,18 +41,6 @@ RED.commandPrompt = (function() {
         val = val.trim().toLowerCase();
 
         actions.forEach(function(action) {
-            if (action.scope && action.scope !== "*") {
-                if (!scopes.hasOwnProperty(action.scope)) {
-                    var target = activeElement;
-                    while (target.nodeName !== 'BODY' && target.id !== action.scope) {
-                        target = target.parentElement;
-                    }
-                    scopes[action.scope] = (target.nodeName !== 'BODY')
-                }
-                if (!scopes[action.scope]) {
-                    return;
-                }
-            }
             action.label = action.id.replace(/:/,": ").replace(/-/g," ").replace(/(^| )./g,function() { return arguments[0].toUpperCase()});
             if (val !== "" && action.label.toLowerCase().indexOf(val) === -1) {
                 return;
@@ -59,8 +48,6 @@ RED.commandPrompt = (function() {
             results.push(action);
             searchResults.editableList('addItem',action)
         })
-        // searchResults.editableList('addItem',{});
-        console.log(document.activeElement);
 
     }
 
@@ -83,7 +70,7 @@ RED.commandPrompt = (function() {
     function createDialog() {
         dialog = $("<div>",{id:"red-ui-commandPrompt",class:"red-ui-search"}).appendTo("#red-ui-main-container");
         var searchDiv = $("<div>",{class:"red-ui-search-container"}).appendTo(dialog);
-        searchInput = $('<input type="text" data-i18n="[placeholder]menu.label.searchInput">').appendTo(searchDiv).searchBox({
+        searchInput = $('<input type="text" data-i18n="[placeholder]search.actions">').appendTo(searchDiv).searchBox({
             delay: 200,
             change: function() {
                 search($(this).val());
@@ -158,7 +145,6 @@ RED.commandPrompt = (function() {
     function selectCommand(command) {
         hide();
         RED.actions.invoke(command.id);
-        console.log(command);
     }
 
     function show(v) {
@@ -166,7 +152,6 @@ RED.commandPrompt = (function() {
             return;
         }
         if (!visible) {
-            activeElement = document.activeElement;
             RED.keyboard.add("*","escape",function(){hide()});
             $("#red-ui-header-shade").show();
             $("#red-ui-editor-shade").show();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
@@ -323,6 +323,7 @@
         },
         empty: function() {
             this.element.empty();
+            this.uiContainer.scrollTop(0);
         },
         filter: function(filter) {
             if (filter !== undefined) {
@@ -345,6 +346,14 @@
             });
             if (items.length > 0) {
                 this.uiContainer.scrollTop(this.uiContainer.scrollTop()+items.position().top)
+            }
+        },
+        getItem: function(li) {
+            var el = li.find(".red-ui-editableList-item-content");
+            if (el.length) {
+                return el.data('data');
+            } else {
+                return null;
             }
         }
     });

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
@@ -296,8 +296,8 @@ RED.search = (function() {
         RED.events.on("editor:close",function() { disabled = false; });
         RED.events.on("type-search:open",function() { disabled = true; });
         RED.events.on("type-search:close",function() { disabled = false; });
-        RED.events.on("commandPrompt:open",function() { disabled = true; });
-        RED.events.on("commandPrompt:close",function() { disabled = false; });
+        RED.events.on("actionList:open",function() { disabled = true; });
+        RED.events.on("actionList:close",function() { disabled = false; });
 
 
 

--- a/packages/node_modules/@node-red/editor-client/src/sass/search.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/search.scss
@@ -198,7 +198,9 @@
     color: $primary-text-color;
 }
 .red-ui-search-result-action-key {
-    float:right;
+    position: absolute;
+    top: 9px;
+    right: 0;
     margin-right: 10px;
     color: $tertiary-text-color;
 }

--- a/packages/node_modules/@node-red/editor-client/src/sass/search.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/search.scss
@@ -165,7 +165,7 @@
     }
 
 }
-.red-ui-search-result-description {
+.red-ui-search-result-node-description {
     margin-left: 40px;
     margin-right: 5px;
 }
@@ -192,4 +192,13 @@
     text-align: center;
     font-style: italic;
     color: $form-placeholder-color;
+}
+
+.red-ui-search-result-action {
+    color: $primary-text-color;
+}
+.red-ui-search-result-action-key {
+    float:right;
+    margin-right: 10px;
+    color: $tertiary-text-color;
 }


### PR DESCRIPTION
- [X] New feature (non-breaking change which adds functionality)

## Proposed changes

This adds a new command-prompt dialog that lists all available actions and triggers the action when it is selected.

This will help the user discover what actions are available and what keyboard shortcuts are defined. It also allows the user to trigger any action from the keyboard even if a shortcut has not been defined for it. For example, adding a new flow tab can be done via the sequence: `Alt-Shift-P  Down-Arrow Enter` - as that action happens to be the top of the list currently.

![Jun-07-2019 12-11-43](https://user-images.githubusercontent.com/51083/59100331-9fd36900-891d-11e9-8ab8-9bbb86ed3e07.gif)

The prompt is shown via the action `core:show-command-prompt` which the default keymap maps to `Alt-Shift-P`. I have not yet added a menu item for it - but wanted to gauge feedback before doing that.

The displayed names of the actions are derived from the id of the action. Further work will be needed to support i18n of these labels.

