### PR TITLE
enhancement: MQTT explicit protocol version 5 support

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,5 +15,5 @@
     "shadow": true,     // allow variable shadowing (re-use of names...)
     "sub": true,        // don't warn that foo['bar'] should be written as foo.bar
     "proto": true,      // allow setting of __proto__ in node < v0.12,
-    "esversion": 6      // allow es6
+    "esversion": 8      // allow es8
 }

--- a/packages/node_modules/@node-red/nodes/core/io/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/core/io/10-mqtt.html
@@ -163,8 +163,12 @@
                 <label for="node-config-input-cleansession" style="width: auto;" data-i18n="mqtt.label.cleansession"></label>
             </div>
             <div class="form-row">
-                <input type="checkbox" id="node-config-input-compatmode" style="display: inline-block; width: auto; vertical-align: top;">
-                <label for="node-config-input-compatmode" style="width: auto;" data-i18n="mqtt.label.compatmode"></label>
+                <label for="node-config-input-protocolversion" style="width: auto;" data-i18n="mqtt.label.protocolversion"></label>
+                <select id="node-config-input-protocolversion" style="width:125px !important">
+                    <option selected value=3>3.1.1</option>
+                    <option value=4>4.0</option>
+                    <option value=5>5.0</option>
+                </select>
             </div>
         </div>
         <div id="mqtt-broker-tab-security" style="display:none">
@@ -278,7 +282,7 @@
             }},
             usetls: {value: false},
             verifyservercert: { value: false},
-            compatmode: { value: true},
+            protocolversion: { value: 3},
             keepalive: {value:60,validate:RED.validators.number()},
             cleansession: {value: true},
             birthTopic: {value:""},
@@ -370,9 +374,9 @@
                 this.usetls = false;
                 $("#node-config-input-usetls").prop("checked",false);
             }
-            if (typeof this.compatmode === 'undefined') {
-                this.compatmode = true;
-                $("#node-config-input-compatmode").prop('checked', true);
+            if (typeof this.protocolversion === 'undefined') {
+                this.protocolversion = 3;
+                $("#node-config-input-protocolversion").val(this.protocolversion);
             }
             if (typeof this.keepalive === 'undefined') {
                 this.keepalive = 15;

--- a/packages/node_modules/@node-red/nodes/core/io/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/io/10-mqtt.js
@@ -44,6 +44,7 @@ module.exports = function(RED) {
     }
 
     function MQTTBrokerNode(n) {
+
         RED.nodes.createNode(this,n);
 
         // Configuration options passed by Node Red
@@ -53,7 +54,7 @@ module.exports = function(RED) {
         this.usetls = n.usetls;
         this.usews = n.usews;
         this.verifyservercert = n.verifyservercert;
-        this.compatmode = n.compatmode;
+        this.protocolversion = n.protocolversion;
         this.keepalive = n.keepalive;
         this.cleansession = n.cleansession;
 
@@ -88,7 +89,6 @@ module.exports = function(RED) {
             this.username = this.credentials.user;
             this.password = this.credentials.password;
         }
-
         // If the config node is missing certain options (it was probably deployed prior to an update to the node code),
         // select/generate sensible options for the new fields
         if (typeof this.usetls === 'undefined') {
@@ -97,8 +97,8 @@ module.exports = function(RED) {
         if (typeof this.usews === 'undefined') {
             this.usews = false;
         }
-        if (typeof this.compatmode === 'undefined') {
-            this.compatmode = true;
+        if (typeof this.protocolversion === 'undefined') {
+            this.protocolversion = 3;
         }
         if (typeof this.verifyservercert === 'undefined') {
             this.verifyservercert = false;
@@ -111,6 +111,7 @@ module.exports = function(RED) {
         if (typeof this.cleansession === 'undefined') {
             this.cleansession = true;
         }
+
         var prox;
         if (process.env.http_proxy != null) { prox = process.env.http_proxy; }
         if (process.env.HTTP_PROXY != null) { prox = process.env.HTTP_PROXY; }
@@ -121,8 +122,8 @@ module.exports = function(RED) {
             if (this.broker.indexOf("://") > -1) {
                 this.brokerurl = this.broker;
                 // Only for ws or wss, check if proxy env var for additional configuration
-                if (this.brokerurl.indexOf("wss://") > -1 || this.brokerurl.indexOf("ws://") > -1 )
-                // check if proxy is set in env
+                if (this.brokerurl.indexOf("wss://") > -1 || this.brokerurl.indexOf("ws://") > -1 ) {
+                    // check if proxy is set in env
                     if (prox) {
                         var parsedUrl = url.parse(this.brokerurl);
                         var proxyOpts = url.parse(prox);
@@ -134,6 +135,7 @@ module.exports = function(RED) {
                             agent: agent
                         }
                     }
+                }
             } else {
                 // construct the std mqtt:// url
                 if (this.usetls) {
@@ -166,18 +168,18 @@ module.exports = function(RED) {
         this.options.password = this.password;
         this.options.keepalive = this.keepalive;
         this.options.clean = this.cleansession;
-        this.options.reconnectPeriod = RED.settings.mqttReconnectTime||5000;
-        if (this.compatmode == "true" || this.compatmode === true) {
+        this.options.protocolVersion = parseInt(this.protocolversion);
+        if (this.options.protocolVersion == 3) {
             this.options.protocolId = 'MQIsdp';
-            this.options.protocolVersion = 3;
         }
+        this.options.reconnectPeriod = RED.settings.mqttReconnectTime||5000;
+
         if (this.usetls && n.tls) {
             var tlsNode = RED.nodes.getNode(n.tls);
             if (tlsNode) {
                 tlsNode.addTLSOptions(this.options);
             }
         }
-        // console.log(this.brokerurl,this.options);
 
         // If there's no rejectUnauthorized already, then this could be an
         // old config where this option was provided on the broker node and
@@ -335,22 +337,24 @@ module.exports = function(RED) {
         };
 
         this.publish = function (msg) {
+            let publishMsg = Object.assign({}, msg);//shallow clone, we dont want the msg.payload being modified
             if (node.connected) {
-                if (msg.payload === null || msg.payload === undefined) {
-                    msg.payload = "";
-                } else if (!Buffer.isBuffer(msg.payload)) {
-                    if (typeof msg.payload === "object") {
-                        msg.payload = JSON.stringify(msg.payload);
-                    } else if (typeof msg.payload !== "string") {
-                        msg.payload = "" + msg.payload;
+                if (publishMsg.payload === null || publishMsg.payload === undefined) {
+                    publishMsg.payload = "";
+                } else if (!Buffer.isBuffer(publishMsg.payload)) {
+                    if (typeof publishMsg.payload === "object") {
+                        publishMsg.payload = JSON.stringify(publishMsg.payload);
+                    } else if (typeof publishMsg.payload !== "string") {
+                        publishMsg.payload = "" + publishMsg.payload;
                     }
                 }
-
-                var options = {
-                    qos: msg.qos || 0,
-                    retain: msg.retain || false
+                let options = {
+                    qos: publishMsg.qos || 0,
+                    retain: publishMsg.retain || false
                 };
-                node.client.publish(msg.topic, msg.payload, options, function(err) {return});
+                node.client.publish(publishMsg.topic, publishMsg.payload, options, function(err) {
+                  return;
+                });
             }
         };
 
@@ -372,7 +376,6 @@ module.exports = function(RED) {
                 done();
             }
         });
-
     }
 
     RED.nodes.registerType("mqtt-broker",MQTTBrokerNode,{

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -341,7 +341,8 @@
             "use-tls": "Enable secure (SSL/TLS) connection",
             "tls-config":"TLS Configuration",
             "verify-server-cert":"Verify server certificate",
-            "compatmode": "Use legacy MQTT 3.1 support"
+            "compatmode": "Use legacy MQTT 3.1 support",
+            "protocolversion": "MQTT Protocol Version"
         },
         "sections-label":{
             "birth-message": "Message sent on connection (birth message)",

--- a/test/nodes/core/io/10-mqtt_spec.js
+++ b/test/nodes/core/io/10-mqtt_spec.js
@@ -1,0 +1,335 @@
+describe('MQTT Node', function() {
+
+    let should = require("should");
+    let mqttNode = require("nr-test-utils").require("@node-red/nodes/core/io/10-mqtt.js");
+    let helper = require("node-red-node-test-helper");
+
+    this.timeout(10000);
+
+    function mockBroker({
+        id,
+        type,
+        z,
+        name,
+        broker,
+        port,
+        clientid,
+        usetls,
+        protocolversion,
+        keepalive,
+        cleansession,
+        birthTopic,
+        birthQos,
+        birthPayload,
+        closeTopic,
+        closeQos,
+        closePayload,
+        willTopic,
+        willQos,
+        willPayload
+    }) {
+        return {
+            "id": id || "broker",
+            "type": "mqtt-broker",
+            "z": z || "",
+            "name": name || "local",
+            "broker": broker || "127.0.0.1",
+            "port": port || "11883",
+            "clientid": clientid || "",
+            "usetls": usetls || false,
+            "protocolversion": protocolversion == null ? null : protocolversion || "5",
+            "keepalive": keepalive || "60",
+            "cleansession": cleansession || true,
+            "birthTopic": birthTopic || "",
+            "birthQos": birthQos || "0",
+            "birthPayload": birthPayload || "",
+            "closeTopic": closeTopic || "",
+            "closeQos": closeQos || "0",
+            "closePayload": closePayload || "",
+            "willTopic": willTopic || "",
+            "willQos": willQos || "0",
+            "willPayload": willPayload || ""
+        }
+    }
+
+    it('loads up with the correct default mqtt version', async () => {
+
+        let flow = [{
+            id: "broker",
+            type: "mqtt-broker",
+            broker: "127.0.0.1"
+        }];
+        let mqttBroker = await loadNode(flow, "broker");
+        mqttBroker.should.have.property("protocolversion", 3);
+        helper.unload();
+    });
+
+    it('loads up with the correct mqtt version - specified', async () => {
+
+        let flow = [{
+            id: "broker",
+            type: "mqtt-broker",
+            broker: "127.0.0.1",
+            protocolversion: 4
+        }];
+        let mqttBroker = await loadNode(flow, "broker");
+        mqttBroker.should.have.property("protocolversion", 4);
+        helper.unload();
+    });
+
+    it('gets the correct parameters from the broker - protocol version 4', async () => {
+
+        let id = "broker";
+        let protocolversion = 4;
+        let broker = mockBroker({
+            protocolversion
+        });
+
+        let flow = [
+            broker,
+            {
+                id: "n1",
+                type: "mqtt in",
+                broker: "broker"
+            }
+        ];
+
+        let mqttNode = await loadNode(flow, "n1");
+        mqttNode.brokerConn.options.should.have.property("protocolVersion", 4);
+        helper.unload();
+    });
+
+    it('gets the correct parameters from the broker - protocol version 5', async () => {
+
+        let id = "broker";
+        let protocolversion = 5;
+        let broker = mockBroker({
+            protocolversion
+        });
+
+        let flow = [
+            broker,
+            {
+                id: "n1",
+                type: "mqtt in",
+                broker: "broker"
+            }
+        ];
+
+        let mqttNode = await loadNode(flow, "n1");
+        mqttNode.brokerConn.options.should.have.property("protocolVersion", 5);
+        helper.unload();
+    });
+
+    it('tests the broker node is able to connect to an mqtt broker', async () => {
+
+        let flow = [{
+            id: "broker",
+            type: "mqtt-broker",
+            broker: "127.0.0.1",
+            protocolversion: 3
+        }];
+        let mqttServer = await startMQTTServer();
+        let mqttBroker = await loadNode(flow, "broker");
+        mqttBroker.connected.should.equal(false);
+        await connectMqttNode(mqttBroker);
+        mqttBroker.client.end();
+        helper.unload();
+        await stopMQTTServer(mqttServer);
+    });
+
+    it('tests the broker node is able to subscribe and publish', async () => {
+
+        let flow = [{
+            id: "broker",
+            type: "mqtt-broker",
+            broker: "127.0.0.1",
+            protocolversion: 3
+        }];
+
+        let publishMessage = {
+            topic: 'test/topic',
+            qos: 2,
+            payload: {
+                test: "payload"
+            }
+        };
+
+        let mqttServer = await startMQTTServer();
+        let publishMessageCloned = JSON.parse(JSON.stringify(publishMessage));
+        let mqttBroker = await loadNode(flow, "broker");
+        await connectMqttNode(mqttBroker);
+        publishMessageCloned.should.eql(publishMessage);
+        let result = await subscribeAndPublishMqttBrokerNode(mqttBroker, publishMessage);
+        publishMessageCloned.should.eql(publishMessage); //ensure that the subscribe and publish has not modified our publish message
+        result.topic.should.eql(publishMessage.topic);
+        result.payload.should.eql(publishMessage.payload);
+        mqttBroker.client.end();
+        helper.unload();
+        await stopMQTTServer(mqttServer);
+    });
+
+    it.skip('tests the broker node is able to connect, but fail to subscribe', async () => {
+
+        let flow = [{
+            id: "broker",
+            type: "mqtt-broker",
+            broker: "127.0.0.1",
+            protocolversion: 3
+        }];
+
+        let publishMessage = {
+            topic: 'test/topic',
+            qos: 2,
+            payload: {
+                test: "payload"
+            }
+        };
+
+        let mqttServer = await startMQTTServer();
+        let mqttBroker = await loadNode(flow, "broker");
+        await connectMqttNode(mqttBroker);
+        await stopMQTTServer(mqttServer);//stop the MQTT server
+
+        try{
+            let result = await subscribeMqttBrokerNode(mqttBroker, publishMessage);
+            //this should not work if we are "connected" to a dead MQTT broker
+            throw new Error('unexpected success');
+        }catch(e){
+            e.message.should.not.equal('unexpected success');
+        }
+
+        mqttBroker.client.end();
+        helper.unload();
+    });
+
+    it.skip('tests the broker node is able to connect, but fail to publish', async () => {
+
+        let flow = [{
+            id: "broker",
+            type: "mqtt-broker",
+            broker: "127.0.0.1",
+            protocolversion: 3
+        }];
+
+        let publishMessage = {
+            topic: 'test/topic',
+            qos: 2,
+            payload: {
+                test: "payload"
+            }
+        };
+
+        let mqttServer = await startMQTTServer();
+        let mqttBroker = await loadNode(flow, "broker");
+        await connectMqttNode(mqttBroker);
+        await stopMQTTServer(mqttServer);//stop the MQTT server
+
+        try{
+            let result = await publishMqttBrokerNode(mqttBroker, publishMessage);
+            //this should not work if we are "connected" to a dead MQTT broker
+            throw new Error('unexpected success');
+        }catch(e){
+            e.message.should.not.equal('unexpected success');
+        }
+
+        mqttBroker.client.end();
+        helper.unload();
+    });
+
+    //helper functions
+
+    async function startMQTTServer(){
+        return new Promise((resolve, reject)=>{
+            let mosca = require('mosca');
+            let moscaSettings = {
+                port: 1883,
+                persistence: {
+                    // Needs for retaining messages.
+                    factory: mosca.persistence.Memory
+                }
+            };
+            let mqttServer = new mosca.Server(moscaSettings, function(e){
+                if (e) {return reject(e);}
+                resolve(mqttServer);
+            });
+        });
+    }
+
+    async function stopMQTTServer(mqttServer){
+        return new Promise((resolve, reject)=>{
+            mqttServer.close(function(e){
+                if (e) {
+                    return reject(e);
+                }
+                resolve();
+            });
+        });
+    }
+
+    async function connectMqttNode(mqttBroker) {
+        return new Promise(function(resolve, reject) {
+            mqttBroker.connect();
+            setTimeout(() => {
+                try {
+                    mqttBroker.connected.should.equal(true);
+                    resolve();
+                } catch (e) {
+                    reject(e);
+                }
+            }, 1000);
+        });
+    }
+
+    async function loadNode(flow, returnNode) {
+        return new Promise(function(resolve, reject) {
+            helper.load(mqttNode, flow, function(e) {
+                if (e) {
+                    return reject(e);
+                }
+                resolve(helper.getNode(returnNode));
+            });
+        })
+    }
+
+    async function subscribeAndPublishMqttBrokerNode(mqttBroker, publishMessage) {
+        return new Promise((resolve, reject) => {
+            let timedOut = setTimeout(() => {
+                reject(new Error('subscribeAndPublishMqttBrokerNode timed out'));
+            }, 1500);
+            mqttBroker.subscribe(publishMessage.topic, publishMessage.qos, (topic, payloadBuffer) => {
+                clearTimeout(timedOut);
+                let payload = JSON.parse(payloadBuffer.toString());
+                resolve({
+                    topic,
+                    payload
+                });
+            });
+            mqttBroker.publish(publishMessage);
+        });
+    }
+
+    async function subscribeMqttBrokerNode(mqttBroker, publishMessage) {
+        return new Promise((resolve, reject) => {
+            try{
+                mqttBroker.subscribe(publishMessage.topic, publishMessage.qos, (topic, payloadBuffer) => {
+
+                });
+                resolve();
+            }catch(e){
+                reject(e);
+            }
+        });
+    }
+
+    async function publishMqttBrokerNode(mqttBroker, publishMessage) {
+        return new Promise((resolve, reject) => {
+            try{
+                mqttBroker.publish(publishMessage);
+                resolve();
+            }catch(e){
+                reject(e);
+            }
+        });
+    }
+});

--- a/test/unit/@node-red/util/lib/i18n_spec.js
+++ b/test/unit/@node-red/util/lib/i18n_spec.js
@@ -13,14 +13,83 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-
-
-
- var NR_TEST_UTILS = require("nr-test-utils");
-
- var i18n = NR_TEST_UTILS.require("@node-red/util").i18n;
-
+var NR_TEST_UTILS = require("nr-test-utils");
+var i18n = NR_TEST_UTILS.require("@node-red/util").i18n;
 
 describe("@node-red/util/i18n", function() {
-    it.skip('more tests needed', function(){})
+
+    const path = require('path');
+    const fs = require('fs-extra');
+
+    it('ensures fallback file has the mqtt.label.protocolversion key', function() {
+
+        var enUS = require(path.resolve(__dirname, '../../../../../packages/node_modules/@node-red/nodes/locales/en-US/messages.json'));
+        var keys = deepKeys(enUS, []);
+        true.should.equal(keys.indexOf('mqtt.label.protocolversion') > -1);
+    });
+
+    it.skip('ensures all messages.json files have the same keys', function() {
+        //fails, but because we do a fallback to en-us this is ok
+        //leaving this here in case we want to be able to use this to review translation coverage
+        let results = getFiles('../../../../../packages/node_modules/@node-red/nodes/locales')
+            .map((path) => {
+                //grab the paths
+                var paths = deepKeys(require(path), []);
+                return paths.join('');
+            })
+            .filter((paths, pos, arr) => {
+                //dedup
+                return arr.indexOf(paths) == pos;
+            });
+        //should only have one set of paths
+        results.length.should.equal(1);
+    });
+
+    it.skip('more tests needed', function() {});
+
+    //helper functions
+
+    function getFile(relativePath) {
+        let basePath = path.resolve(__dirname, relativePath);
+        return fs.readdirSync(basePath)
+            .map(function(path) {
+                return [basePath, path, 'messages.json'].join('/');
+            });
+    }
+
+    function getFiles(relativePath, regex) {
+        let basePath = path.resolve(__dirname, relativePath);
+        return fs.readdirSync(basePath)
+            .map(function(path) {
+                return [basePath, path, 'messages.json'].join('/');
+            });
+    }
+
+    //grabbed from deep-keys: https://github.com/a8m/deep-keys
+    //not certain of maintainer
+    function deepKeys(obj, stack, parent, intermediate) {
+        Object.keys(obj).forEach(function(el) {
+            // Escape . in the element name
+            var escaped = el.replace(/\./g, '\\\.');
+            // If it's a nested object
+            if (isObject(obj[el]) && !Array.isArray(obj[el])) {
+                // Concatenate the new parent if exist
+                var p = parent ? parent + '.' + escaped : parent;
+                // Push intermediate parent key if flag is true
+                if (intermediate) {
+                    stack.push(parent ? p : escaped);
+                }
+                deepKeys(obj[el], stack, p || escaped, intermediate);
+            } else {
+                // Create and save the key
+                var key = parent ? parent + '.' + escaped : escaped;
+                stack.push(key)
+            }
+        });
+        return stack;
+    }
+
+    function isObject(value) {
+        return value !== null && typeof value === 'object' && !(value instanceof Date);
+    }
 });


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes
Allow for the explicit selection of the mqtt protocol version in the MQTT broker editor, and to pass the configured version to the broker client when it connects to the MQTT server.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
