### PR TITLE
WIP: Enable individual flow nodes to be disabled

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -463,7 +463,9 @@ RED.nodes = (function() {
         node.id = n.id;
         node.type = n.type;
         node.z = n.z;
-
+        if (n.d === true) {
+            node.d = true;
+        }
         if (node.type == "unknown") {
             for (var p in n._orig) {
                 if (n._orig.hasOwnProperty(p)) {
@@ -1015,6 +1017,9 @@ RED.nodes = (function() {
                     };
                     if (n.hasOwnProperty('l')) {
                         node.l = n.l;
+                    }
+                    if (n.hasOwnProperty('d')) {
+                        node.d = n.d;
                     }
                     if (createNewIds) {
                         if (subflow_blacklist[n.z]) {

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -969,6 +969,9 @@ RED.nodes = (function() {
                         users:[],
                         _config:{}
                     };
+                    if (n.hasOwnProperty('d')) {
+                        configNode.d = n.d;
+                    }
                     for (d in def.defaults) {
                         if (def.defaults.hasOwnProperty(d)) {
                             configNode[d] = n[d];

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/toggleButton.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/toggleButton.js
@@ -42,12 +42,11 @@
             var enabledLabel = this.options.enabledLabel || RED._("editor:workspace.enabled");
             var disabledLabel = this.options.disabledLabel || RED._("editor:workspace.disabled");
 
-            this.element.addClass("red-ui-toggleButton");
             this.element.css("display","none");
             this.element.on("focus", function() {
                 that.button.focus();
             });
-            this.button = $('<button type="button" class="'+baseClass+' toggle single"><i class="fa"></i> <span></span></button>');
+            this.button = $('<button type="button" class="red-ui-toggleButton '+baseClass+' toggle single"><i class="fa"></i> <span></span></button>');
             if (this.options.class) {
                 this.button.addClass(this.options.class)
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1500,6 +1500,8 @@ RED.editor = (function() {
                 var trayFooterLeft = $('<div class="red-ui-tray-footer-left"></div>').appendTo(trayFooter)
 
                 $('<input id="node-input-node-disabled" type="checkbox">').prop("checked",!!node.d).appendTo(trayFooterLeft).toggleButton({
+                    enabledIcon: "fa-circle-thin",
+                    disabledIcon: "fa-ban",
                     invertState: true
                 })
 
@@ -1683,7 +1685,9 @@ RED.editor = (function() {
 
                 var trayFooterLeft = $('<div class="red-ui-tray-footer-left"></div>').appendTo(trayFooter)
 
-                $('<input type="checkbox">').appendTo(trayFooterLeft).toggleButton({
+                $('<input id="node-config-input-node-disabled" type="checkbox">').prop("checked",!!editing_config_node.d).appendTo(trayFooterLeft).toggleButton({
+                    enabledIcon: "fa-circle-thin",
+                    disabledIcon: "fa-ban",
                     invertState: true
                 })
 
@@ -1918,6 +1922,16 @@ RED.editor = (function() {
                     editing_config_node.label = configTypeDef.label;
                     editing_config_node.z = scope;
 
+                    if ($("#node-config-input-node-disabled").prop('checked')) {
+                        if (editing_config_node.d !== true) {
+                            editing_config_node.d = true;
+                        }
+                    } else {
+                        if (editing_config_node.d === true) {
+                            delete editing_config_node.d;
+                        }
+                    }
+
                     if (scope) {
                         // Search for nodes that use this one that are no longer
                         // in scope, so must be removed
@@ -2072,7 +2086,7 @@ RED.editor = (function() {
                 RED.nodes.eachConfig(function(config) {
                     if (config.type == type && (!config.z || config.z === activeWorkspace.id)) {
                         var label = RED.utils.getNodeLabel(config,config.id);
-                        config.__label__ = label;
+                        config.__label__ = label+(config.d?" ["+RED._("workspace.disabled")+"]":"");
                         configNodes.push(config);
                     }
                 });

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -955,34 +955,19 @@ RED.editor = (function() {
 
         $('<div class="form-row">'+
             '<label for="node-input-show-label-btn" data-i18n="editor.label"></label>'+
-            '<button type="button" id="node-input-show-label-btn" class="red-ui-button" style="min-width: 80px; text-align: left;" type="button"><i id="node-input-show-label-btn-i" class="fa fa-toggle-on"></i> <span id="node-input-show-label-label"></span></button> '+
-            '<input type="checkbox" id="node-input-show-label" style="display: none;"/>'+
+            '<input type="checkbox" id="node-input-show-label"/>'+
         '</div>').appendTo(dialogForm);
 
-        var setToggleState = function(state) {
-            var i = $("#node-input-show-label-btn-i");
-            if (!state) {
-                i.addClass('fa-toggle-off');
-                i.removeClass('fa-toggle-on');
-                $("#node-input-show-label").prop("checked",false);
-                $("#node-input-show-label-label").text(RED._("editor.hide"));
-            } else {
-                i.addClass('fa-toggle-on');
-                i.removeClass('fa-toggle-off');
-                $("#node-input-show-label").prop("checked",true);
-                $("#node-input-show-label-label").text(RED._("editor.show"));
-            }
-        }
-        dialogForm.find('#node-input-show-label-btn').on("click",function(e) {
-            e.preventDefault();
-            var i = $("#node-input-show-label-btn-i");
-            setToggleState(i.hasClass('fa-toggle-off'));
+        $("#node-input-show-label").toggleButton({
+            enabledLabel: RED._("editor.show"),
+            disabledLabel: RED._("editor.hide")
         })
+
         if (!node.hasOwnProperty("l")) {
             // Show label if type not link
             node.l = !/^link (in|out)$/.test(node._def.type);
         }
-        setToggleState(node.l);
+        $("#node-input-show-label").prop("checked",node.l).trigger("change");
 
         // If a node has icon property in defaults, the icon of the node cannot be modified. (e.g, ui_button node in dashboard)
         if ((!node._def.defaults || !node._def.defaults.hasOwnProperty("icon"))) {
@@ -1396,6 +1381,20 @@ RED.editor = (function() {
                                 node.l = true;
                             }
                         }
+                        if ($("#node-input-node-disabled").prop('checked')) {
+                            if (node.d !== true) {
+                                changes.d = node.d;
+                                changed = true;
+                                node.d = true;
+                            }
+                        } else {
+                            if (node.d === true) {
+                                changes.d = node.d;
+                                changed = true;
+                                delete node.d;
+                            }
+                        }
+
                         node.resize = true;
 
                         var oldInfo = node.info;
@@ -1497,6 +1496,12 @@ RED.editor = (function() {
                 var trayFooter = tray.find(".red-ui-tray-footer");
                 var trayBody = tray.find('.red-ui-tray-body');
                 trayBody.parent().css('overflow','hidden');
+
+                var trayFooterLeft = $('<div class="red-ui-tray-footer-left"></div>').appendTo(trayFooter)
+
+                $('<input id="node-input-node-disabled" type="checkbox">').prop("checked",!!node.d).appendTo(trayFooterLeft).toggleButton({
+                    invertState: true
+                })
 
                 var editorTabEl = $('<ul></ul>').appendTo(trayBody);
                 var editorContent = $('<div></div>').appendTo(trayBody);
@@ -1675,9 +1680,15 @@ RED.editor = (function() {
                 var trayHeader = tray.find(".red-ui-tray-header");
                 var trayBody = tray.find('.red-ui-tray-body');
                 var trayFooter = tray.find(".red-ui-tray-footer");
-                var userCountDiv;
+
+                var trayFooterLeft = $('<div class="red-ui-tray-footer-left"></div>').appendTo(trayFooter)
+
+                $('<input type="checkbox">').appendTo(trayFooterLeft).toggleButton({
+                    invertState: true
+                })
+
                 if (node_def.hasUsers !== false) {
-                    userCountDiv = $('<div class="red-ui-tray-footer-left"><i class="fa fa-info-circle"></i> <span></span></div>').prependTo(trayFooter);
+                    $('<span><i class="fa fa-info-circle"></i> <span id="red-ui-editor-config-user-count"></span></span>').css("margin-left", "10px").appendTo(trayFooterLeft);
                 }
                 trayFooter.append('<span class="red-ui-tray-footer-right"><span id="red-ui-editor-config-scope-warning" data-i18n="[title]editor.errors.scopeChange"><i class="fa fa-warning"></i></span><select id="red-ui-editor-config-scope"></select></span>');
 
@@ -1771,8 +1782,8 @@ RED.editor = (function() {
                             }
                         });
                     }
-                    if (node_def.hasUsers !== false && userCountDiv) {
-                        userCountDiv.find("span").text(RED._("editor.nodesUse", {count:editing_config_node.users.length})).parent().show();
+                    if (node_def.hasUsers !== false) {
+                        $("#red-ui-editor-config-user-count").text(RED._("editor.nodesUse", {count:editing_config_node.users.length})).parent().show();
                     }
                     trayBody.i18n();
                     trayFooter.i18n();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
@@ -145,7 +145,12 @@ RED.sidebar.config = (function() {
                 var entry = $('<li class="red-ui-palette-node_id_'+node.id.replace(/\./g,"-")+'"></li>').appendTo(list);
                 var nodeDiv = $('<div class="red-ui-palette-node-config red-ui-palette-node"></div>').appendTo(entry);
                 entry.data('node',node.id);
-                $('<div class="red-ui-palette-label"></div>').text(label).appendTo(nodeDiv);
+                var label = $('<div class="red-ui-palette-label"></div>').text(label).appendTo(nodeDiv);
+                if (node.d) {
+                    nodeDiv.addClass("red-ui-palette-node-config-disabled");
+                    $('<i class="fa fa-ban"></i>').prependTo(label);
+                }
+
                 if (node._def.hasUsers !== false) {
                     var iconContainer = $('<div/>',{class:"red-ui-palette-icon-container red-ui-palette-icon-container-right"}).appendTo(nodeDiv);
                     if (node.users.length === 0) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -410,6 +410,8 @@ RED.view = (function() {
         RED.actions.add("core:zoom-in",zoomIn);
         RED.actions.add("core:zoom-out",zoomOut);
         RED.actions.add("core:zoom-reset",zoomZero);
+        RED.actions.add("core:enable-selected-nodes", function() { setSelectedNodeState(false)});
+        RED.actions.add("core:disable-selected-nodes", function() { setSelectedNodeState(true)});
 
         RED.actions.add("core:toggle-show-grid",function(state) {
             if (state === undefined) {
@@ -2376,7 +2378,7 @@ RED.view = (function() {
     function isButtonEnabled(d) {
         var buttonEnabled = true;
         var ws = RED.nodes.workspace(RED.workspaces.active());
-        if (ws && !ws.disabled) {
+        if (ws && !ws.disabled && !d.d) {
             if (d._def.button.hasOwnProperty('enabled')) {
                 if (typeof d._def.button.enabled === "function") {
                     buttonEnabled = d._def.button.enabled.call(d);
@@ -2397,7 +2399,7 @@ RED.view = (function() {
         }
         var activeWorkspace = RED.workspaces.active();
         var ws = RED.nodes.workspace(activeWorkspace);
-        if (ws && !ws.disabled) {
+        if (ws && !ws.disabled && !d.d) {
             if (d._def.button.toggle) {
                 d[d._def.button.toggle] = !d[d._def.button.toggle];
                 d.dirty = true;
@@ -3579,6 +3581,48 @@ RED.view = (function() {
         RED.nodes.eachNode(function(n) { n.dirtyStatus = true; n.dirty = true;});
         //TODO: subscribe/unsubscribe here
         redraw();
+    }
+    function setSelectedNodeState(isDisabled) {
+        if (mouse_mode === RED.state.SELECTING_NODE) {
+            return;
+        }
+        var workspaceSelection = RED.workspaces.selection();
+        var changed = false;
+        if (workspaceSelection.length > 0) {
+            // TODO: toggle workspace state
+        } else if (moving_set.length > 0) {
+            var historyEvents = [];
+            for (var i=0;i<moving_set.length;i++) {
+                var node = moving_set[i].n;
+                if (isDisabled != node.d) {
+                    historyEvents.push({
+                        t: "edit",
+                        node: node,
+                        changed: node.changed,
+                        changes: {
+                            d: node.d
+                        }
+                    });
+                    if (isDisabled) {
+                        node.d = true;
+                    } else {
+                        delete node.d;
+                    }
+                    node.dirty = true;
+                    node.changed = true;
+                }
+            }
+            if (historyEvents.length > 0) {
+                RED.history.push({
+                    t:"multi",
+                    events: historyEvents,
+                    dirty:RED.nodes.dirty()
+                })
+                RED.nodes.dirty(true)
+            }
+        }
+        RED.view.redraw();
+
     }
 
     return {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -2929,6 +2929,7 @@ RED.view = (function() {
                             d.resize = false;
                         }
                         var thisNode = d3.select(this);
+                        thisNode.classed("red-ui-flow-node-disabled", function(d) { return d.d === true});
                         thisNode.classed("red-ui-flow-subflow",function(d) { return activeSubflow != null; })
 
                         //thisNode.selectAll(".centerDot").attr({"cx":function(d) { return d.w/2;},"cy":function(d){return d.h/2}});
@@ -3248,6 +3249,7 @@ RED.view = (function() {
                         }
                         return path;
                     });
+                    link.classed("red-ui-flow-node-disabled", function(d) { return d.source.d || d.target.d; });
                 }
             })
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -201,8 +201,11 @@ RED.workspaces = (function() {
                 } else {
                     workspace.disabled = false;
                 }
-                $("#node-input-disabled").toggleButton({invertState: true})
-
+                $("#node-input-disabled").toggleButton({
+                    enabledIcon: "fa-circle-thin",
+                    disabledIcon: "fa-ban",
+                    invertState: true
+                })
 
                 $('<input type="text" style="display: none;" />').prependTo(dialogForm);
                 dialogForm.on("submit", function(e) { e.preventDefault();});

--- a/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
@@ -224,10 +224,10 @@ $node-status-colors: (
 $node-selected-color: #ff7f0e;
 $port-selected-color: #ff7f0e;
 
-$link-color: #888;
-$link-link-color: #ccc;
+$link-color: #999;
+$link-link-color: #aaa;
+$link-disabled-color: #ccc;
 $link-link-active-color: #ff7f0e;
-$link-subflow-color: #bbb;
 $link-unknown-color: #f00;
 
 $clipboard-textarea-background: #F3E7E7;

--- a/packages/node_modules/@node-red/editor-client/src/sass/editor.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/editor.scss
@@ -79,15 +79,20 @@
 .red-ui-tray-footer {
     @include component-footer;
     height: 35px;
-    font-size: 12px !important;
+    font-size: 14px !important;
     line-height: 35px;
     vertical-align: middle;
 
-    button {
-        @include editor-button;
-        padding: 3px 7px;
-        font-size: 11px;
+    button.red-ui-button {
+        padding: 0px 8px;
+        height: 26px;
+        line-height: 26px;
+        &.toggle:not(.selected) {
+            color: $workspace-button-color-selected !important;
+            background: $workspace-button-background-active;
+        }
     }
+
     .red-ui-tray-footer-left {
         display:inline-block;
         margin-right: 20px;
@@ -563,12 +568,14 @@ button.red-ui-button-small
 }
 
 
-
-
 .red-ui-editor-type-json-editor-item-handle {
     cursor: move;
 }
 .red-ui-editor-type-json-tab-content {
     position: relative;
     height: calc(100% - 40px);
+}
+
+button.red-ui-toggleButton.toggle {
+    text-align: left;
 }

--- a/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
@@ -150,28 +150,36 @@ g.red-ui-flow-node-selected {
 }
 
 .red-ui-flow-subflow .red-ui-flow-node {
-    stroke-dasharray:8, 2;
 }
+
 .red-ui-workspace-disabled {
-    .red-ui-flow-link-line {
-        stroke-dasharray: 10,5 !important;
-        stroke-width: 2 !important;
-        stroke: $link-subflow-color;
-    }
     .red-ui-flow-node {
         stroke-dasharray: 8, 3;
-        fill-opacity: 0.6;
+        fill-opacity: 0.5;
+    }
+    .red-ui-flow-link-line {
+        stroke-dasharray: 10,8 !important;
+        stroke-width: 2 !important;
+        stroke: $link-disabled-color;
+    }
+    .red-ui-flow-port {
+        fill-opacity: 1;
+        stroke-dasharray: none;
     }
 }
 .red-ui-flow-node-disabled {
     &.red-ui-flow-node, .red-ui-flow-node {
         stroke-dasharray: 8, 3;
-        fill-opacity: 0.6;
+        fill-opacity: 0.5;
     }
     &.red-ui-flow-link-line {
-        stroke-dasharray: 10,5 !important;
+        stroke-dasharray: 10,8 !important;
         stroke-width: 2 !important;
-        stroke: $link-subflow-color;
+        stroke: $link-disabled-color;
+    }
+    .red-ui-flow-port {
+        fill-opacity: 1;
+        stroke-dasharray: none;
     }
 }
 @each $current-color in red green yellow blue grey {
@@ -199,7 +207,6 @@ g.red-ui-flow-node-selected {
 }
 
 .red-ui-flow-subflow-port {
-    stroke-dasharray: 5,5;
     fill: $node-background-placeholder;
     stroke: $node-border;
 }
@@ -219,12 +226,14 @@ g.red-ui-flow-node-selected {
 }
 .red-ui-flow-link-link {
     stroke-width: 2;
-    stroke-dasharray: 10,5;
     stroke: $link-link-color;
     fill: none;
-    stroke-dasharray: 15,2;
-    // pointer-events: none;
+    stroke-dasharray: 25,4;
 }
+.red-ui-flow-link-off-flow {
+    stroke-width: 2;
+}
+
 .red-ui-flow-link-port {
     fill: $node-link-port-background;
     stroke: $link-link-color;
@@ -235,11 +244,6 @@ g.red-ui-flow-node-selected {
 }
 .red-ui-flow-link-group:hover {
     cursor: pointer;
-}
-.red-ui-flow-subflow-link {
-    stroke: $link-subflow-color;
-    stroke-dasharray: 10,5;
-    stroke-width: 2;
 }
 
 .red-ui-flow-link-outline {

--- a/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
@@ -146,11 +146,11 @@ g.red-ui-flow-node-selected {
     border-style: dashed !important;
     stroke: $node-selected-color;
     stroke-width: 2;
-    stroke-dasharray: 10, 4;
+    stroke-dasharray: 8, 3;
 }
 
 .red-ui-flow-subflow .red-ui-flow-node {
-    stroke-dasharray:8, 3;
+    stroke-dasharray:8, 2;
 }
 .red-ui-workspace-disabled {
     .red-ui-flow-link-line {
@@ -159,10 +159,21 @@ g.red-ui-flow-node-selected {
         stroke: $link-subflow-color;
     }
     .red-ui-flow-node {
-        stroke-dasharray: 10,4;
+        stroke-dasharray: 8, 3;
+        fill-opacity: 0.6;
     }
 }
-
+.red-ui-flow-node-disabled {
+    &.red-ui-flow-node, .red-ui-flow-node {
+        stroke-dasharray: 8, 3;
+        fill-opacity: 0.6;
+    }
+    &.red-ui-flow-link-line {
+        stroke-dasharray: 10,5 !important;
+        stroke-width: 2 !important;
+        stroke: $link-subflow-color;
+    }
+}
 @each $current-color in red green yellow blue grey {
     .red-ui-flow-node-status-dot-#{$current-color} {
         fill: map-get($node-status-colors,$current-color);

--- a/packages/node_modules/@node-red/editor-client/src/sass/mixins.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/mixins.scss
@@ -192,7 +192,7 @@
     right: 0;
     height: 25px;
     line-height: 25px;
-    padding: 0 10px;
+    padding: 0 6px;
     user-select: none;
 
     .button-group:not(:last-child) {

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
@@ -94,11 +94,19 @@ ul.red-ui-sidebar-node-config-list li.red-ui-palette-node-config-type {
     text-align:right;
     padding-right: 3px;
 }
-.red-ui-palette-node-config-unused {
+.red-ui-palette-node-config-unused,.red-ui-palette-node-config-disabled {
     border-color: $primary-border-color;
     background: $secondary-background-inactive;
     border-style: dashed;
     color: $tertiary-text-color;
+}
+.red-ui-palette-node-config-disabled {
+    opacity: 0.6;
+    font-style: italic;
+    i {
+        color: $secondary-text-color;
+        margin-right: 5px;
+    }
 }
 .red-ui-sidebar-node-config-filter-info {
     position: absolute;

--- a/packages/node_modules/@node-red/runtime/lib/nodes/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/flows/Flow.js
@@ -132,29 +132,39 @@ class Flow {
             id = configNodes.shift();
             node = this.flow.configs[id];
             if (!this.activeNodes[id]) {
-                var readyToCreate = true;
-                // This node doesn't exist.
-                // Check it doesn't reference another non-existent config node
-                for (var prop in node) {
-                    if (node.hasOwnProperty(prop) && prop !== 'id' && prop !== 'wires' && prop !== '_users' && this.flow.configs[node[prop]]) {
-                        if (!this.activeNodes[node[prop]]) {
-                            // References a non-existent config node
-                            // Add it to the back of the list to try again later
-                            configNodes.push(id);
-                            configNodeAttempts[id] = (configNodeAttempts[id]||0)+1;
-                            if (configNodeAttempts[id] === 100) {
-                                throw new Error("Circular config node dependency detected: "+id);
+                if (node.d !== true) {
+                    var readyToCreate = true;
+                    // This node doesn't exist.
+                    // Check it doesn't reference another non-existent config node
+                    for (var prop in node) {
+                        if (node.hasOwnProperty(prop) &&
+                        prop !== 'id' &&
+                        prop !== 'wires' &&
+                        prop !== '_users' &&
+                        this.flow.configs[node[prop]] &&
+                        this.flow.configs[node[prop]].d !== true
+                        ) {
+                            if (!this.activeNodes[node[prop]]) {
+                                // References a non-existent config node
+                                // Add it to the back of the list to try again later
+                                configNodes.push(id);
+                                configNodeAttempts[id] = (configNodeAttempts[id]||0)+1;
+                                if (configNodeAttempts[id] === 100) {
+                                    throw new Error("Circular config node dependency detected: "+id);
+                                }
+                                readyToCreate = false;
+                                break;
                             }
-                            readyToCreate = false;
-                            break;
                         }
                     }
-                }
-                if (readyToCreate) {
-                    newNode = flowUtil.createNode(this,node);
-                    if (newNode) {
-                        this.activeNodes[id] = newNode;
+                    if (readyToCreate) {
+                        newNode = flowUtil.createNode(this,node);
+                        if (newNode) {
+                            this.activeNodes[id] = newNode;
+                        }
                     }
+                } else {
+                    this.debug("not starting disabled config node : "+id);
                 }
             }
         }
@@ -206,6 +216,8 @@ class Flow {
                             }
                         }
                     }
+                } else {
+                    this.debug("not starting disabled node : "+id);
                 }
             }
         }

--- a/packages/node_modules/@node-red/runtime/lib/nodes/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/flows/Flow.js
@@ -171,37 +171,39 @@ class Flow {
         for (id in this.flow.nodes) {
             if (this.flow.nodes.hasOwnProperty(id)) {
                 node = this.flow.nodes[id];
-                if (!node.subflow) {
-                    if (!this.activeNodes[id]) {
-                        newNode = flowUtil.createNode(this,node);
-                        if (newNode) {
-                            this.activeNodes[id] = newNode;
+                if (node.d !== true) {
+                    if (!node.subflow) {
+                        if (!this.activeNodes[id]) {
+                            newNode = flowUtil.createNode(this,node);
+                            if (newNode) {
+                                this.activeNodes[id] = newNode;
+                            }
                         }
-                    }
-                } else {
-                    if (!this.subflowInstanceNodes[id]) {
-                        try {
-                            var subflowDefinition = this.flow.subflows[node.subflow]||this.global.subflows[node.subflow]
-                            // console.log("NEED TO CREATE A SUBFLOW",id,node.subflow);
-                            this.subflowInstanceNodes[id] = true;
-                            var subflow = Subflow.create(
-                                this,
-                                this.global,
-                                subflowDefinition,
-                                node
-                            );
-                            this.subflowInstanceNodes[id] = subflow;
-                            subflow.start();
-                            this.activeNodes[id] = subflow.node;
+                    } else {
+                        if (!this.subflowInstanceNodes[id]) {
+                            try {
+                                var subflowDefinition = this.flow.subflows[node.subflow]||this.global.subflows[node.subflow]
+                                // console.log("NEED TO CREATE A SUBFLOW",id,node.subflow);
+                                this.subflowInstanceNodes[id] = true;
+                                var subflow = Subflow.create(
+                                    this,
+                                    this.global,
+                                    subflowDefinition,
+                                    node
+                                );
+                                this.subflowInstanceNodes[id] = subflow;
+                                subflow.start();
+                                this.activeNodes[id] = subflow.node;
 
-                            // this.subflowInstanceNodes[id] = nodes.map(function(n) { return n.id});
-                            // for (var i=0;i<nodes.length;i++) {
-                            //     if (nodes[i]) {
-                            //         this.activeNodes[nodes[i].id] = nodes[i];
-                            //     }
-                            // }
-                        } catch(err) {
-                            console.log(err.stack)
+                                // this.subflowInstanceNodes[id] = nodes.map(function(n) { return n.id});
+                                // for (var i=0;i<nodes.length;i++) {
+                                //     if (nodes[i]) {
+                                //         this.activeNodes[nodes[i].id] = nodes[i];
+                                //     }
+                                // }
+                            } catch(err) {
+                                console.log(err.stack)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This feature allows individual flow nodes to be disabled.

<img width="556" alt="Local_Node-RED" src="https://user-images.githubusercontent.com/51083/59538512-f2022480-8ef1-11e9-8c9b-781c9493e7a1.png">

If disabled, the runtime ignores the node. Messages do *not* pass through a disabled node.

Currently Configuration nodes cannot be disabled. This would need more work to support - for example, we wouldn't want to remove it from the Config Node select boxes (because that would break flows if a user disabled then enabled a config node). But we would perhaps need some indication in the select box that the node has been disabled so the user doesn't inadvertently select it.

A node is disabled by toggling a button in the footer of the edit dialog. I'm not 100% sure about the placement of this button. Some other options I considered:

 - in the header next to the Delete button - but that doesn't work so well for Subflow Instance nodes as we already have the 'Edit subflow template' button up there and it doesn't leave much room. 
 - add it at the top of the Properties tab, above the node-contributed edit form content - but that uses up valuable vertical space in the tab
 - I also tried moving the tab bar to the right slightly and squeezing in a square button in the left corner - but that felt squashed

Would like feedback on this:

![Ta6tBxGaX7](https://user-images.githubusercontent.com/51083/59538673-82d90000-8ef2-11e9-9f34-248b5a1047b5.gif)

Outstanding tasks:

 - [x] add to configuration nodes
 - [x] review toggle button placement
 - [x] runtime logging when skipping a disabled node
 - [ ] tests
 - [x] add action to enable/disable entire selection of nodes in one go
