### PR TITLE
Add default shortcut (ctrl-d) for deploy

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/keymap.json
+++ b/packages/node_modules/@node-red/editor-client/src/js/keymap.json
@@ -8,7 +8,7 @@
         "ctrl-0": "core:zoom-reset",
         "ctrl-enter": "core:confirm-edit-tray",
         "ctrl-escape": "core:cancel-edit-tray",
-        "ctrl-s": "core:deploy-flows",
+        "ctrl-d": "core:deploy-flows",
         "ctrl-g i": "core:show-info-tab",
         "ctrl-g d": "core:show-debug-tab",
         "ctrl-g c": "core:show-config-tab",

--- a/packages/node_modules/@node-red/editor-client/src/js/keymap.json
+++ b/packages/node_modules/@node-red/editor-client/src/js/keymap.json
@@ -8,6 +8,7 @@
         "ctrl-0": "core:zoom-reset",
         "ctrl-enter": "core:confirm-edit-tray",
         "ctrl-escape": "core:cancel-edit-tray",
+        "ctrl-s": "core:deploy-flows",
         "ctrl-g i": "core:show-info-tab",
         "ctrl-g d": "core:show-debug-tab",
         "ctrl-g c": "core:show-config-tab",


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

This adds a shortcut for deploy (ctrl-s).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality