### PR TITLE
Ignore empty examples directories (don't add to import menu)

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/library.js
+++ b/packages/node_modules/@node-red/registry/lib/library.js
@@ -51,9 +51,6 @@ function getFlowsFromPath(path) {
                     }
                     i++;
                 })
-                if (!result.hasOwnProperty("f")) {
-                    reject(result);
-                }
                 resolve(result);
             })
         });
@@ -63,9 +60,10 @@ function getFlowsFromPath(path) {
 function addNodeExamplesDir(module,path) {
     exampleRoots[module] = path;
     return getFlowsFromPath(path).then(function(result) {
+        if (JSON.stringify(result).indexOf('{"f":') === -1) { return; }
         exampleFlows = exampleFlows||{};
         exampleFlows[module] = result;
-    }, function() { return; });
+    });
 }
 function removeNodeExamplesDir(module) {
     delete exampleRoots[module];

--- a/packages/node_modules/@node-red/registry/lib/library.js
+++ b/packages/node_modules/@node-red/registry/lib/library.js
@@ -51,7 +51,9 @@ function getFlowsFromPath(path) {
                     }
                     i++;
                 })
-
+                if (!result.hasOwnProperty("f")) {
+                    reject(result);
+                }
                 resolve(result);
             })
         });
@@ -63,7 +65,7 @@ function addNodeExamplesDir(module,path) {
     return getFlowsFromPath(path).then(function(result) {
         exampleFlows = exampleFlows||{};
         exampleFlows[module] = result;
-    });
+    }, function() { return; });
 }
 function removeNodeExamplesDir(module) {
     delete exampleRoots[module];


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

When looking at the Examples import list it currently shows nodes that have an examples directory even if they have nothing in it (eg if they were copied from another node as a template file structure). We may as well not show them in the list.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
