### PR TITLE
Add support for specifying subflow template color

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -310,6 +310,7 @@
         "addNewType": "Add new __type__...",
         "nodeProperties": "node properties",
         "label": "Label",
+        "color": "Color",
         "portLabels": "Port labels",
         "labelInputs": "Inputs",
         "labelOutputs": "Outputs",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -310,6 +310,7 @@
         "addNewType": "新規に __type__ を追加...",
         "nodeProperties": "プロパティ",
         "label": "ラベル",
+        "color": "色",
         "portLabels": "ポートラベル",
         "labelInputs": "入力",
         "labelOutputs": "出力",

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -366,7 +366,7 @@ RED.nodes = (function() {
             category: sf.category || "subflows",
             inputs: sf.in.length,
             outputs: sf.out.length,
-            color: "#da9",
+            color: sf.color || "#da9",
             label: function() { return this.name||RED.nodes.subflow(sf.id).name },
             labelStyle: function() { return this.name?"red-ui-flow-node-label-italic":""; },
             paletteLabel: function() { return RED.nodes.subflow(sf.id).name },
@@ -551,6 +551,7 @@ RED.nodes = (function() {
         node.in = [];
         node.out = [];
         node.env = n.env;
+        node.color = n.color;
 
         n.in.forEach(function(p) {
             var nIn = {x:p.x,y:p.y,wires:[]};

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1117,7 +1117,7 @@ RED.editor = (function() {
 
         if (node.type === "subflow") {
             // subflow template can select its color
-            var color = node.color ? node.color : "#E9967A";
+            var color = node.color ? node.color : "#da9";
             var colorRow = $("<div/>", {
                 class: "form-row"
             }).appendTo(dialogForm);
@@ -2309,7 +2309,6 @@ RED.editor = (function() {
                             changes.color = newColor;
                             changed = true;
                             RED.utils.clearNodeColorCache();
-                            RED.palette.changeSubflowColor(editing_node, newColor);
                         }
 
                         var old_env = editing_node.env;

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1001,6 +1001,41 @@ RED.editor = (function() {
             $('<div id="red-ui-editor-node-icon">').text(node.icon).appendTo(iconButton);
         }
 
+        if (node.type === "subflow") {
+            // subflow template can select its color
+            var colorRow = $("<div/>", {
+                class: "form-row"
+            }).appendTo(dialogForm);
+            $("<label/>").text(RED._("editor.color")).appendTo(colorRow);
+            var selector = $("<input/>", {
+                id: "red-ui-editor-node-color",
+                type: "color",
+                value: "#E9967A",
+                list: "red-ui-editor-node-colors"
+            }).css({
+                width: "100px"
+            }).appendTo(colorRow);
+            var colors = $("<datalist id='red-ui-editor-node-colors'>").appendTo(colorRow);
+            var recommendedColors = [
+                "#3FADB5", "#87A980", "#A6BBCF",
+                "#AAAA66", "#C0C0C0", "#C0DEED",
+                "#C7E9C0", "#D7D7A0", "#D8BFD8",
+                "#DAC4B4", "#DEB887", "#DEBD5C",
+                "#E2D96E", "#E6E0F8", "#E7E7AE",
+                "#E9967A", "#F3B567", "#FDD0A2",
+                "#FDF0C2", "#FFAAAA", "#FFCC66",
+                "#FFF0F0", "#FFFFFF"
+            ];
+            recommendedColors.forEach(function (col) {
+                var opt = $("<option>").appendTo(colors);
+                opt.val(col);
+            });
+            if (node.color) {
+                selector.val(node.color);
+            }
+            selector.change();
+        }        
+
         $('<div class="form-row"><span data-i18n="editor.portLabels"></span></div>').appendTo(dialogForm);
 
         var inputCount = node.inputs || node._def.inputs || 0;
@@ -2175,6 +2210,14 @@ RED.editor = (function() {
                         if (newCategory != editing_node.category) {
                             changes['category'] = editing_node.category;
                             editing_node.category = newCategory;
+                            changed = true;
+                        }
+
+                        var oldColor = editing_node.color;
+                        var newColor =  $("#red-ui-editor-node-color").val();
+                        if (oldColor !== newColor) {
+                            editing_node.color = newColor;
+                            changes.color = newColor;
                             changed = true;
                         }
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -2219,6 +2219,8 @@ RED.editor = (function() {
                             editing_node.color = newColor;
                             changes.color = newColor;
                             changed = true;
+                            RED.utils.clearNodeColorCache();
+                            RED.palette.changeSubflowColor(editing_node, newColor);
                         }
 
                         var old_env = editing_node.env;
@@ -2228,7 +2230,6 @@ RED.editor = (function() {
                             changes.env = editing_node.env;
                             changed = true;
                         }
-
                         RED.palette.refresh();
 
                         if (changed) {
@@ -2242,6 +2243,7 @@ RED.editor = (function() {
                                         id:n.id,
                                         changed:n.changed
                                     })
+                                    n._def.color = editing_node.color;
                                     n.changed = true;
                                     n.dirty = true;
                                     updateNodeProperties(n);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -948,6 +948,120 @@ RED.editor = (function() {
         searchInput.trigger("focus");
     }
 
+    function createColorPicker(colorRow, color) {
+        var colorSpec = $("<span/>", {
+            class: "red-ui-subflow-color-spec"
+        }).appendTo(colorRow);
+        var colorButton = $("<label/>").appendTo(colorSpec);
+        var colorIcon = $("<span><i class='fa fa-caret-down'/> </span>").css({
+            width: "30px",
+            height: "20px",
+            "padding-left": "15px",
+            "padding-right": "5px"
+        }).appendTo(colorButton);
+        var colorDisp = $("<label/>").css({
+            width: "40px",
+            height: "20px",
+            margin: "6px",
+            "vertical-align": "middle",
+            "background-color": color
+        }).appendTo(colorButton);
+        var selector = $("<input/>", {
+            id: "red-ui-editor-node-color",
+            type: "text",
+            value: color
+        }).css({
+            width: "150px",
+            border: "none"
+        }).appendTo(colorSpec);
+
+        selector.on("change", function (e) {
+            var color = selector.val();
+            colorDisp.css({
+                "background-color": color
+            });
+        });
+        selector.hover(function (e) {
+            selector.css({
+                "border": "solid 1px #ccc"
+            });
+        }, function() {
+            selector.css({
+                "border": "none"
+            });
+        });
+
+        colorButton.on("click", function (e) {
+            var recommendedColors = [
+                "#3FADB5", "#87A980", "#A6BBCF",
+                "#AAAA66", "#C0C0C0", "#C0DEED",
+                "#C7E9C0", "#D7D7A0", "#D8BFD8",
+                "#DAC4B4", "#DEB887", "#DEBD5C",
+                "#E2D96E", "#E6E0F8", "#E7E7AE",
+                "#E9967A", "#F3B567", "#FDD0A2",
+                "#FDF0C2", "#FFAAAA", "#FFCC66",
+                "#FFF0F0", "#FFFFFF"
+            ];
+            var numColors = recommendedColors.length;
+            var width = 58;
+            var height = 28;
+            var picker = $("<div/>", {
+                class: "red-ui-color-picker"
+            }).css({
+                width: (width*4)+"px",
+                height: Math.ceil(numColors/4)*height+"+px"
+            });
+
+            var pickerBackground = $('<div>').css({
+                position: "absolute",
+                top: 0,
+                bottom: 0,
+                left: 0,
+                right: 0,
+                zIndex: 20
+            }).appendTo("body");
+            var colorPos = colorDisp.offset();
+            picker.css({
+                top: (colorPos.top +32) +"px",
+                left: (colorPos.left -20) +"px"
+            }).appendTo("body");
+
+            function hide() {
+                pickerBackground.remove();
+                picker.remove();
+                RED.keyboard.remove("escape");
+            }
+
+            var count = 0;
+            var row = null;
+            recommendedColors.forEach(function (col) {
+                if ((count % 4) == 0) {
+                    row = $("<div/>").appendTo(picker);
+                }
+                var button = $("<button/>", {
+                }).css({
+                    width: "50px",
+                    height: "20px",
+                    margin: "4px",
+                    backgroundColor: col,
+                    "border-style": "none"
+                }).appendTo(row);
+                button.on("click",  function (e) {
+                    e.preventDefault();
+                    hide();
+                    selector.val(col);
+                    selector.change();
+                });
+                count++;
+            });
+
+            RED.keyboard.add("*", "escape", hide);
+            pickerBackground.on("mousedown", hide);
+            pickerBackground.show();
+            picker.show();
+        });                
+    }
+
     function buildAppearanceForm(container,node) {
         var dialogForm = $('<form class="dialog-form form-horizontal" autocomplete="off"></form>').appendTo(container);
 
@@ -1003,38 +1117,13 @@ RED.editor = (function() {
 
         if (node.type === "subflow") {
             // subflow template can select its color
+            var color = node.color ? node.color : "#E9967A";
             var colorRow = $("<div/>", {
                 class: "form-row"
             }).appendTo(dialogForm);
             $("<label/>").text(RED._("editor.color")).appendTo(colorRow);
-            var selector = $("<input/>", {
-                id: "red-ui-editor-node-color",
-                type: "color",
-                value: "#E9967A",
-                list: "red-ui-editor-node-colors"
-            }).css({
-                width: "100px"
-            }).appendTo(colorRow);
-            var colors = $("<datalist id='red-ui-editor-node-colors'>").appendTo(colorRow);
-            var recommendedColors = [
-                "#3FADB5", "#87A980", "#A6BBCF",
-                "#AAAA66", "#C0C0C0", "#C0DEED",
-                "#C7E9C0", "#D7D7A0", "#D8BFD8",
-                "#DAC4B4", "#DEB887", "#DEBD5C",
-                "#E2D96E", "#E6E0F8", "#E7E7AE",
-                "#E9967A", "#F3B567", "#FDD0A2",
-                "#FDF0C2", "#FFAAAA", "#FFCC66",
-                "#FFF0F0", "#FFFFFF"
-            ];
-            recommendedColors.forEach(function (col) {
-                var opt = $("<option>").appendTo(colors);
-                opt.val(col);
-            });
-            if (node.color) {
-                selector.val(node.color);
-            }
-            selector.change();
-        }        
+            createColorPicker(colorRow, color);
+        }
 
         $('<div class="form-row"><span data-i18n="editor.portLabels"></span></div>').appendTo(dialogForm);
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -429,10 +429,9 @@ RED.palette = (function() {
                         currentCategoryNode.find("i").toggleClass("expanded");
                     }
                 }
-
-
-
             }
+
+            paletteNode.css("backgroundColor", sf.color);
         });
     }
 
@@ -593,12 +592,6 @@ RED.palette = (function() {
         setTimeout(function() { $(window).trigger("resize"); } ,200);
     }
 
-    function changeSubflowColor(sf, color) {
-        var paletteNode = getPaletteNode('subflow:'+sf.id);
-        paletteNode.css("backgroundColor", color);
-    }
-
-
     function getCategories() {
         var categories = [];
         $("#red-ui-palette-container .red-ui-palette-category").each(function(i,d) {
@@ -613,7 +606,6 @@ RED.palette = (function() {
         hide:hideNodeType,
         show:showNodeType,
         refresh:refreshNodeTypes,
-        getCategories: getCategories,
-        changeSubflowColor: changeSubflowColor
+        getCategories: getCategories
     };
 })();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -593,6 +593,11 @@ RED.palette = (function() {
         setTimeout(function() { $(window).trigger("resize"); } ,200);
     }
 
+    function changeSubflowColor(sf, color) {
+        var paletteNode = getPaletteNode('subflow:'+sf.id);
+        paletteNode.css("backgroundColor", color);
+    }
+
 
     function getCategories() {
         var categories = [];
@@ -608,6 +613,7 @@ RED.palette = (function() {
         hide:hideNodeType,
         show:showNodeType,
         refresh:refreshNodeTypes,
-        getCategories: getCategories
+        getCategories: getCategories,
+        changeSubflowColor: changeSubflowColor
     };
 })();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -912,6 +912,10 @@ RED.utils = (function() {
     }
 
     var nodeColorCache = {};
+    function clearNodeColorCache() {
+        nodeColorCache = {};
+    }
+
     function getNodeColor(type, def) {
         var result = def.color;
         var paletteTheme = RED.settings.theme('palette.theme') || [];
@@ -1044,6 +1048,7 @@ RED.utils = (function() {
         getNodeIcon: getNodeIcon,
         getNodeLabel: getNodeLabel,
         getNodeColor: getNodeColor,
+        clearNodeColorCache: clearNodeColorCache,
         addSpinnerOverlay: addSpinnerOverlay,
         decodeObject: decodeObject,
         parseContextKey: parseContextKey,

--- a/packages/node_modules/@node-red/editor-client/src/sass/editor.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/editor.scss
@@ -579,3 +579,23 @@ button.red-ui-button-small
 button.red-ui-toggleButton.toggle {
     text-align: left;
 }
+
+.red-ui-color-picker {
+    position: absolute;
+    border: 1px solid $primary-border-color;
+    box-shadow: 0 1px 6px -3px black;
+    background: $secondary-background;
+    z-Index: 21;
+    display: none;
+}
+
+.red-ui-subflow-color-spec {
+    width: fit-content;
+    height: fit-content;
+    padding-top: 8px;
+    padding-bottom: 10px;
+    padding-left: 0px;
+    padding-right: 0px;
+    border: solid 1px $primary-border-color;
+    border-radius: 2px;
+}


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This PR add support for specifying SUBFLOW color.
Color is specified for SUBFLOW template (not instance) by its appearance tab.

![スクリーンショット 2019-07-08 23 48 13](https://user-images.githubusercontent.com/30289092/60819731-0f699c00-a1db-11e9-85ea-46047f204761.png)

Change of SUBFLOW color take effect after reloading editor. 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
