### PR TITLE
Add "has key" rule to  switch node + tests

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/logic/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/logic/10-switch.html
@@ -401,7 +401,6 @@ has<!--
                     } else {
                         r.v = rule.find(".node-input-rule-value").typedInput('value');
                         r.vt = rule.find(".node-input-rule-value").typedInput('type');
-                        console.log("DONG",r)
                     }
                     if (type === "regex") {
                         r.case = rule.find(".node-input-rule-case").prop("checked");

--- a/packages/node_modules/@node-red/nodes/core/logic/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/logic/10-switch.html
@@ -1,4 +1,4 @@
-has<!--
+<!--
   Copyright JS Foundation and other contributors, http://js.foundation
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/node_modules/@node-red/nodes/core/logic/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/logic/10-switch.html
@@ -1,4 +1,4 @@
-<!--
+has<!--
   Copyright JS Foundation and other contributors, http://js.foundation
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,7 +48,7 @@
         {v:"lte",t:"<=",kind:'V'},
         {v:"gt",t:">",kind:'V'},
         {v:"gte",t:">=",kind:'V'},
-        {v:"exists",t:"switch.rules.exists",kind:'V'},
+        {v:"hask",t:"switch.rules.hask",kind:'V'},
         {v:"btwn",t:"switch.rules.btwn",kind:'V'},
         {v:"cont",t:"switch.rules.cont",kind:'V'},
         {v:"regex",t:"switch.rules.regex",kind:'V'},
@@ -162,7 +162,7 @@
                     numField.typedInput("width",(newWidth-selectWidth-70));
                 } else if (type === "jsonata_exp") {
                     expField.typedInput("width",(newWidth-selectWidth-70));
-                } else if (type === "exists") {
+                } else if (type === "hask") {
                     keyField.typedInput("width",(newWidth-selectWidth-70));
                 } else if (type === "istype") {
                     typeField.typedInput("width",(newWidth-selectWidth-70));
@@ -253,7 +253,7 @@
                             numValueField.typedInput('show');
                             typeValueField.typedInput('hide');
                             valueField.typedInput('hide');
-                        } else if (type === "exists") {
+                        } else if (type === "hask") {
                             btwnValueField.typedInput('hide');
                             btwnValue2Field.typedInput('hide');
                             expValueField.typedInput('hide');
@@ -314,7 +314,7 @@
                     } else if (rule.t === "istype") {
                         typeValueField.typedInput('value',rule.vt);
                         typeValueField.typedInput('type',rule.vt);
-                    } else if (rule.t === "exists") {
+                    } else if (rule.t === "hask") {
                         keyValueField.typedInput('value',rule.v);
                         keyValueField.typedInput('type',rule.vt);
                     }else if (rule.t === "jsonata_exp") {
@@ -392,7 +392,7 @@
                     } else if (type === "istype") {
                         r.v = rule.find(".node-input-rule-type-value").typedInput('type');
                         r.vt = rule.find(".node-input-rule-type-value").typedInput('type');
-                    } else if (type === "exists") {
+                    } else if (type === "hask") {
                         r.v = rule.find(".node-input-rule-key-value").typedInput('value');
                         r.vt = rule.find(".node-input-rule-key-value").typedInput('type');
                     } else if (type === "jsonata_exp") {

--- a/packages/node_modules/@node-red/nodes/core/logic/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/logic/10-switch.html
@@ -48,6 +48,7 @@
         {v:"lte",t:"<=",kind:'V'},
         {v:"gt",t:">",kind:'V'},
         {v:"gte",t:">=",kind:'V'},
+        {v:"exists",t:"switch.rules.exists",kind:'V'},
         {v:"btwn",t:"switch.rules.btwn",kind:'V'},
         {v:"cont",t:"switch.rules.cont",kind:'V'},
         {v:"regex",t:"switch.rules.regex",kind:'V'},
@@ -142,6 +143,7 @@
                 var typeField = rule.find(".node-input-rule-type-value");
                 var numField = rule.find(".node-input-rule-num-value");
                 var expField = rule.find(".node-input-rule-exp-value");
+                var keyField = rule.find(".node-input-rule-key-value");
                 var btwnField1 = rule.find(".node-input-rule-btwn-value");
                 var btwnField2 = rule.find(".node-input-rule-btwn-value2");
                 var selectWidth;
@@ -160,6 +162,8 @@
                     numField.typedInput("width",(newWidth-selectWidth-70));
                 } else if (type === "jsonata_exp") {
                     expField.typedInput("width",(newWidth-selectWidth-70));
+                } else if (type === "exists") {
+                    keyField.typedInput("width",(newWidth-selectWidth-70));
                 } else if (type === "istype") {
                     typeField.typedInput("width",(newWidth-selectWidth-70));
                 } else {
@@ -214,6 +218,7 @@
                     var btwnValueField = $('<input/>',{class:"node-input-rule-btwn-value",type:"text",style:"margin-left: 5px;"}).appendTo(row).typedInput({default:'num',types:['msg','flow','global','str','num','jsonata','env',previousValueType]});
                     var btwnAndLabel = $('<span/>',{class:"node-input-rule-btwn-label"}).text(" "+andLabel+" ").appendTo(row3);
                     var btwnValue2Field = $('<input/>',{class:"node-input-rule-btwn-value2",type:"text",style:"margin-left:2px;"}).appendTo(row3).typedInput({default:'num',types:['msg','flow','global','str','num','jsonata','env',previousValueType]});
+                    var keyValueField = $('<input/>',{class:"node-input-rule-key-value",type:"text",style:"margin-left: 5px;"}).appendTo(row).typedInput({default:'str',types:['str','msg','flow','global','env']});
                     var typeValueField = $('<input/>',{class:"node-input-rule-type-value",type:"text",style:"margin-left: 5px;"}).appendTo(row)
                         .typedInput({default:'string',types:[
                             {value:"string",label:"string",hasValue:false},
@@ -236,6 +241,7 @@
                         if ((type === "btwn") || (type === "index")) {
                             valueField.typedInput('hide');
                             expValueField.typedInput('hide');
+                            keyValueField.typedInput('hide');
                             numValueField.typedInput('hide');
                             typeValueField.typedInput('hide');
                             btwnValueField.typedInput('show');
@@ -243,19 +249,30 @@
                             btwnValueField.typedInput('hide');
                             btwnValue2Field.typedInput('hide');
                             expValueField.typedInput('hide');
+                            keyValueField.typedInput('hide');
                             numValueField.typedInput('show');
+                            typeValueField.typedInput('hide');
+                            valueField.typedInput('hide');
+                        } else if (type === "exists") {
+                            btwnValueField.typedInput('hide');
+                            btwnValue2Field.typedInput('hide');
+                            expValueField.typedInput('hide');
+                            keyValueField.typedInput('show');
+                            numValueField.typedInput('hide');
                             typeValueField.typedInput('hide');
                             valueField.typedInput('hide');
                         } else if (type === "jsonata_exp") {
                             btwnValueField.typedInput('hide');
                             btwnValue2Field.typedInput('hide');
                             expValueField.typedInput('show');
+                            keyValueField.typedInput('hide');
                             numValueField.typedInput('hide');
                             typeValueField.typedInput('hide');
                             valueField.typedInput('hide');
                         } else {
                             btwnValueField.typedInput('hide');
                             expValueField.typedInput('hide');
+                            keyValueField.typedInput('hide');
                             numValueField.typedInput('hide');
                             typeValueField.typedInput('hide');
                             valueField.typedInput('hide');
@@ -297,7 +314,10 @@
                     } else if (rule.t === "istype") {
                         typeValueField.typedInput('value',rule.vt);
                         typeValueField.typedInput('type',rule.vt);
-                    } else if (rule.t === "jsonata_exp") {
+                    } else if (rule.t === "exists") {
+                        keyValueField.typedInput('value',rule.v);
+                        keyValueField.typedInput('type',rule.vt);
+                    }else if (rule.t === "jsonata_exp") {
                         expValueField.typedInput('value',rule.v);
                         expValueField.typedInput('type',rule.vt||'jsonata');
                     } else if (typeof rule.v != "undefined") {
@@ -372,12 +392,16 @@
                     } else if (type === "istype") {
                         r.v = rule.find(".node-input-rule-type-value").typedInput('type');
                         r.vt = rule.find(".node-input-rule-type-value").typedInput('type');
+                    } else if (type === "exists") {
+                        r.v = rule.find(".node-input-rule-key-value").typedInput('value');
+                        r.vt = rule.find(".node-input-rule-key-value").typedInput('type');
                     } else if (type === "jsonata_exp") {
                         r.v = rule.find(".node-input-rule-exp-value").typedInput('value');
                         r.vt = rule.find(".node-input-rule-exp-value").typedInput('type');
                     } else {
                         r.v = rule.find(".node-input-rule-value").typedInput('value');
                         r.vt = rule.find(".node-input-rule-value").typedInput('type');
+                        console.log("DONG",r)
                     }
                     if (type === "regex") {
                         r.case = rule.find(".node-input-rule-case").prop("checked");

--- a/packages/node_modules/@node-red/nodes/core/logic/10-switch.js
+++ b/packages/node_modules/@node-red/nodes/core/logic/10-switch.js
@@ -47,7 +47,6 @@ module.exports = function(RED) {
             }
             return false;
         },
-
         'istype': function(a, b) {
             if (b === "array") { return Array.isArray(a); }
             else if (b === "buffer") { return Buffer.isBuffer(a); }
@@ -71,6 +70,9 @@ module.exports = function(RED) {
             var max = Number(c);
             var index = parts.index;
             return ((min <= index) && (index <= max));
+        },
+        'exists': function(a, b) {
+            if (typeof b !== "object" ) {  return a.hasOwnProperty(b+""); }
         },
         'jsonata_exp': function(a, b) { return (b === true); },
         'else': function(a) { return a === true; }

--- a/packages/node_modules/@node-red/nodes/core/logic/10-switch.js
+++ b/packages/node_modules/@node-red/nodes/core/logic/10-switch.js
@@ -71,7 +71,7 @@ module.exports = function(RED) {
             var index = parts.index;
             return ((min <= index) && (index <= max));
         },
-        'exists': function(a, b) {
+        'hask': function(a, b) {
             if (typeof b !== "object" ) {  return a.hasOwnProperty(b+""); }
         },
         'jsonata_exp': function(a, b) { return (b === true); },

--- a/packages/node_modules/@node-red/nodes/core/logic/10-switch.js
+++ b/packages/node_modules/@node-red/nodes/core/logic/10-switch.js
@@ -72,7 +72,7 @@ module.exports = function(RED) {
             return ((min <= index) && (index <= max));
         },
         'hask': function(a, b) {
-            if (typeof b !== "object" ) {  return a.hasOwnProperty(b+""); }
+            return (typeof b !== "object" )  &&  a.hasOwnProperty(b+"");
         },
         'jsonata_exp': function(a, b) { return (b === true); },
         'else': function(a) { return a === true; }

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -622,7 +622,7 @@
             "index":"index between",
             "exp":"JSONata exp",
             "else":"otherwise",
-            "exists":"has key"
+            "hask":"has key"
         },
         "errors": {
             "invalid-expr": "Invalid JSONata expression: __error__",

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -621,7 +621,8 @@
             "tail":"tail",
             "index":"index between",
             "exp":"JSONata exp",
-            "else":"otherwise"
+            "else":"otherwise",
+            "exists":"has key"
         },
         "errors": {
             "invalid-expr": "Invalid JSONata expression: __error__",

--- a/test/nodes/core/logic/10-switch_spec.js
+++ b/test/nodes/core/logic/10-switch_spec.js
@@ -254,6 +254,16 @@ describe('switch Node', function() {
         genericSwitchTest("gte", 3, true, true, 3, done);
     });
 
+    it('should match if a payload has a required property', function(done) {
+        genericSwitchTest("exists", "a", true, true, {a:1}, done);
+    });
+    it('should not match if a payload does not have a required property', function(done) {
+        genericSwitchTest("exists", "a", true, false, {b:1}, done);
+    });
+    it('should not match if the key is not a string', function(done) {
+        genericSwitchTest("exists", 1, true, false, {a:1}, done);
+    });
+
     it('should check if payload is between given values', function(done) {
         twoFieldSwitchTest("btwn", "3", "5", true, true, 4, done);
     });
@@ -518,7 +528,6 @@ describe('switch Node', function() {
     it('should check if payload is not empty (0)', function(done) {
         singularSwitchTest("nempty", true, false, 0, done);
     });
-
 
     it('should check input against a previous value', function(done) {
         var flow = [{id:"switchNode1",type:"switch",name:"switchNode",property:"payload",rules:[{ "t": "gt", "v": "", "vt": "prev" }],checkall:true,outputs:1,wires:[["helperNode1"]]},

--- a/test/nodes/core/logic/10-switch_spec.js
+++ b/test/nodes/core/logic/10-switch_spec.js
@@ -255,13 +255,13 @@ describe('switch Node', function() {
     });
 
     it('should match if a payload has a required property', function(done) {
-        genericSwitchTest("exists", "a", true, true, {a:1}, done);
+        genericSwitchTest("hask", "a", true, true, {a:1}, done);
     });
     it('should not match if a payload does not have a required property', function(done) {
-        genericSwitchTest("exists", "a", true, false, {b:1}, done);
+        genericSwitchTest("hask", "a", true, false, {b:1}, done);
     });
     it('should not match if the key is not a string', function(done) {
-        genericSwitchTest("exists", 1, true, false, {a:1}, done);
+        genericSwitchTest("hask", 1, true, false, {a:1}, done);
     });
 
     it('should check if payload is between given values', function(done) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Adds a "Has key" option to the switch node so users can route messages based on if a property of their msg exists, as requested on mailing list- https://discourse.nodered.org/t/switch-node-jsonata-magic/12943/4

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
