### PR TITLE
Change JS Foundation to OpenJS Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This project adheres to the [Contributor Covenant 1.4](http://contributor-covena
 
 ## Authors
 
-Node-RED is a project of the [JS Foundation](http://js.foundation).
+Node-RED is a project of the [OpenJS Foundation](http://js.foundation).
 
 It was created by [IBM Emerging Technology](https://www.ibm.com/blogs/emerging-technology/).
 


### PR DESCRIPTION
The JS Foundation is merged with the Node Foundation and is now called the [OpenJS Foundation](https://js.foundation/about). Link is to the about me of the JS Foundation website. 

I was wondering if the copyright should be altered but that information appears more vague.

I thought this should be altered as the sentence:

`Node-RED is a project of the JS Foundation.` is present tense.

And in the present, the JS Foundation is titled the OpenJS Foundation