### PR TITLE
fix reference error on deleting tab

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -324,7 +324,7 @@ RED.nodes = (function() {
     }
     function removeWorkspace(id) {
         delete workspaces[id];
-        delete nodeTabMap[ws.id];
+        delete nodeTabMap[id];
         workspacesOrder.splice(workspacesOrder.indexOf(id),1);
 
         var removedNodes = [];


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Current dev branch causes following reference error on deleting workspace tab.
This PR intended to fixe this problem.

```
red.min.js:16 Uncaught ReferenceError: ws is not defined
    at Object.removeWorkspace (red.min.js:16)
    at o (red.min.js:16)
    at click (red.min.js:16)
    at HTMLButtonElement.<anonymous> (red.min.js:16)
    at HTMLButtonElement.dispatch (vendor.js:2)
    at HTMLButtonElement.v.handle (vendor.js:2)
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
