### PR TITLE
Fix error on converting selection to subflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/history.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/history.js
@@ -276,11 +276,13 @@ RED.history = (function() {
                 ev.node.changed = ev.changed;
             } else if (ev.t == "createSubflow") {
                 if (ev.nodes) {
+                    var z = ev.activeWorkspace;
                     RED.nodes.filterNodes({z:ev.subflow.subflow.id}).forEach(function(n) {
                         n.x += ev.subflow.offsetX;
                         n.y += ev.subflow.offsetY;
                         n.z = ev.activeWorkspace;
                         n.dirty = true;
+                        RED.nodes.moveNodeToTab(n, z);
                     });
                     for (i=0;i<ev.nodes.length;i++) {
                         RED.nodes.remove(ev.nodes[i]);

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -308,7 +308,7 @@ RED.nodes = (function() {
         if (!nodeTabMap[z]) {
             nodeTabMap[z] = {};
         }
-        nodeTabMap[z][node.iz] = node;
+        nodeTabMap[z][node.id] = node;
         node.z = z;
     }
     

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -301,6 +301,17 @@ RED.nodes = (function() {
         return {links:removedLinks,nodes:removedNodes};
     }
 
+    function moveNodeToTab(node, z) {
+        if (nodeTabMap[node.z]) {
+            delete nodeTabMap[node.z][node.id];
+        }
+        if (!nodeTabMap[z]) {
+            nodeTabMap[z] = {};
+        }
+        nodeTabMap[z][node.iz] = node;
+        node.z = z;
+    }
+    
     function removeLink(l) {
         var index = links.indexOf(l);
         if (index != -1) {
@@ -1466,6 +1477,8 @@ RED.nodes = (function() {
         remove: removeNode,
         clear: clear,
 
+        moveNodeToTab: moveNodeToTab,
+        
         addLink: addLink,
         removeLink: removeLink,
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -723,7 +723,7 @@ RED.subflow = (function() {
             }
             n.x -= offsetX;
             n.y -= offsetY;
-            n.z = subflow.id;
+            RED.nodes.moveNodeToTab(n, subflow.id);
         }
 
         RED.history.push({


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

- Problem

With current dev branch, when we convert `function` node to subflow in the following flow,

<!-- Describe the nature of this change. What problem does it address? -->
![スクリーンショット 2019-07-26 23 09 18](https://user-images.githubusercontent.com/30289092/61957822-1544e700-affb-11e9-91b5-b776ac7308e2.png)

`function` node remain in original tab as follows.

![スクリーンショット 2019-07-26 23 09 40](https://user-images.githubusercontent.com/30289092/61957829-18d86e00-affb-11e9-8443-2ff32f9065bb.png)

This is caused by not maintaining the newly introduced `nodeTabMap` when converting to SUBFLOW.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
