### PR TITLE
Fix wrong variable name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -677,7 +677,7 @@ Nodes
  - Initial support of sequence rules for SWITCH node (#1545)
  - initial support of SORT node (#1500)
  - Inject node - let once delay be editable (#1541)
- - Introduce `nodeMaxMessageBufferLength` setting for msg sequence nodes
+ - Introduce `nodeMessageBufferMaxLength` setting for msg sequence nodes
  - Let CSV correct parts if we remove header row.
  - let default apply if msg.delay not set in override mode. (#1397)
  - let trigger node be reset by boolean message (#1554)

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -55,7 +55,7 @@ module.exports = {
     // The maximum number of messages nodes will buffer internally as part of their
     // operation. This applies across a range of nodes that operate on message sequences.
     //  defaults to no limit. A value of 0 also means no limit is applied.
-    //nodeMaxMessageBufferLength: 0,
+    //nodeMessageBufferMaxLength: 0,
 
     // To disable the option for using local files for storing keys and certificates in the TLS configuration
     //  node, set this to true


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Switch, join, sort and batch nodes use `nodeMessageBufferMaxLength` as a variable name to limit internal queue size but `nodeMaxMessageBufferLength` is used in settings.js and CHANGELOG.md. Therefore, I changed `nodeMaxMessageBufferLength` to `nodeMessageBufferMaxLength`  in the files.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality