### PR TITLE
Fix escape character handling for separator in split node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/logic/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/logic/17-split.js
@@ -42,7 +42,7 @@ module.exports = function(RED) {
         node.addname = n.addname || "";
         try {
             if (node.spltType === "str") {
-                this.splt = (n.splt || "\\n").replace(/\\n/,"\n").replace(/\\r/,"\r").replace(/\\t/,"\t").replace(/\\e/,"\e").replace(/\\f/,"\f").replace(/\\0/,"\0");
+                this.splt = (n.splt || "\\n").replace(/\\n/g,"\n").replace(/\\r/g,"\r").replace(/\\t/g,"\t").replace(/\\e/g,"\e").replace(/\\f/g,"\f").replace(/\\0/g,"\0");
             } else if (node.spltType === "bin") {
                 var spltArray = JSON.parse(n.splt);
                 if (Array.isArray(spltArray)) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I added "g" into the end of regular expressions to handle escape characters repeatedly in separator of the split node. Because join node handles escape characters repeatedly but split node doesn't do the same handle, for example, the following flow cannot split table data which uses "¥t|¥t" as a separator.

```
[{"id":"74dad08f.907508","type":"inject","z":"6c707c87.f66fe","name":"","topic":"","payload":"","payloadType":"date","repeat":"","crontab":"","once":false,"onceDelay":0.1,"x":150,"y":120,"wires":[["1c96485.4128a38"]]},{"id":"e05591e4.c7bd38","type":"split","z":"6c707c87.f66fe","name":"split by \"<tab>|<tab>\"","splt":"\\t|\\t","spltType":"str","arraySplt":1,"arraySpltType":"len","stream":false,"addname":"","x":170,"y":260,"wires":[["59d4206c.cf9358","1f98c665.fcaaaa"]]},{"id":"59d4206c.cf9358","type":"join","z":"6c707c87.f66fe","name":"join using \"<tab>|<tab>\"","mode":"custom","build":"string","property":"payload","propertyType":"msg","key":"topic","joiner":"\\t|\\t","joinerType":"str","accumulate":false,"timeout":"","count":"","reduceRight":false,"reduceExp":"","reduceInit":"","reduceInitType":"","reduceFixup":"","x":180,"y":380,"wires":[["73b2b441.42651c"]]},{"id":"1c96485.4128a38","type":"function","z":"6c707c87.f66fe","name":"table data","func":"msg.payload = \"column1\\t|\\tcolumn2\\t|\\tcolumn3\";\nreturn msg;","outputs":1,"noerr":0,"x":330,"y":120,"wires":[["e05591e4.c7bd38"]]},{"id":"73b2b441.42651c","type":"debug","z":"6c707c87.f66fe","name":"","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","x":360,"y":440,"wires":[]},{"id":"1f98c665.fcaaaa","type":"debug","z":"6c707c87.f66fe","name":"","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","x":340,"y":320,"wires":[]},{"id":"776df50f.0e2058","type":"comment","z":"6c707c87.f66fe","name":"-> column1<tab>|<tab>column2<tab>|<tab>column3","info":"","x":640,"y":120,"wires":[]},{"id":"2db4500f.62dc9c","type":"comment","z":"6c707c87.f66fe","name":"column1","info":"","x":510,"y":220,"wires":[]},{"id":"36042f7d.bd6a7c","type":"comment","z":"6c707c87.f66fe","name":"column2","info":"","x":510,"y":260,"wires":[]},{"id":"9c1ebeaa.c8be58","type":"comment","z":"6c707c87.f66fe","name":"column3","info":"","x":510,"y":300,"wires":[]},{"id":"256b4bbc.8cd8f8","type":"comment","z":"6c707c87.f66fe","name":"-> column1<tab>|<tab>column2<tab>|<tab>column3","info":"","x":520,"y":380,"wires":[]},{"id":"1654aeb1.96bb69","type":"comment","z":"6c707c87.f66fe","name":"->","info":"","x":380,"y":260,"wires":[]}]
```

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality