### PR TITLE
Fix duplicated tooltips

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-context.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-context.js
@@ -37,7 +37,7 @@ RED.sidebar.context = (function() {
         //     '</div>').appendTo(content);
 
         var footerToolbar = $('<div>'+
-            // '<span class="button-group"><a class="sidebar-footer-button" href="#" data-i18n="[title]node-red:debug.sidebar.openWindow"><i class="fa fa-desktop"></i></a></span> ' +
+            // '<span class="button-group"><a class="sidebar-footer-button" href="#"><i class="fa fa-desktop"></i></a></span> ' +
             '</div>');
 
 

--- a/packages/node_modules/@node-red/nodes/core/core/lib/debug/debug-utils.js
+++ b/packages/node_modules/@node-red/nodes/core/core/lib/debug/debug-utils.js
@@ -42,14 +42,14 @@ RED.debug = (function() {
         var content = $("<div>").css({"position":"relative","height":"100%"});
         var toolbar = $('<div class="sidebar-header">'+
             '<span class="button-group"><a id="debug-tab-filter" class="sidebar-header-button" href="#"><i class="fa fa-filter"></i> <span></span></a></span>'+
-            '<span class="button-group"><a id="debug-tab-clear" class="sidebar-header-button" href="#" data-i18n="[title]node-red:debug.sidebar.clearLog"><i class="fa fa-trash"></i></a></span></div>').appendTo(content);
+            '<span class="button-group"><a id="debug-tab-clear" class="sidebar-header-button" href="#"><i class="fa fa-trash"></i></a></span></div>').appendTo(content);
 
         var footerToolbar = $('<div>'+
             // '<span class="button-group">'+
             //     '<a class="sidebar-footer-button-toggle text-button selected" id="debug-tab-view-list" href="#"><span data-i18n="">list</span></a>'+
             //     '<a class="sidebar-footer-button-toggle text-button" id="debug-tab-view-table" href="#"><span data-i18n="">table</span></a> '+
             // '</span>'+
-            '<span class="button-group"><a id="debug-tab-open" class="sidebar-footer-button" href="#" data-i18n="[title]node-red:debug.sidebar.openWindow"><i class="fa fa-desktop"></i></a></span> ' +
+            '<span class="button-group"><a id="debug-tab-open" class="sidebar-footer-button" href="#"><i class="fa fa-desktop"></i></a></span> ' +
             '</div>');
 
         messageList = $('<div class="debug-content debug-content-list"/>').appendTo(content);


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Buttons on the debug tab have the same duplicated tooltips. Therefore, I removed the tooltip created by the `title` attribute.

![image](https://user-images.githubusercontent.com/20310935/62456676-f17c6080-b7b3-11e9-8227-b25c43e7f55f.png)
## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality