### PR TITLE
Use appropriate version of Node.js

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -28,7 +28,7 @@ To help us understand the issue, please fill-in as much of the following informa
 ### Please tell us about your environment:
 
 - [ ] Node-RED version:
-- [ ] node.js version:
+- [ ] Node.js version:
 - [ ] npm version:
 - [ ] Platform/OS:
 - [ ] Browser:

--- a/.github/ISSUE_TEMPLATE/--bug_report.md
+++ b/.github/ISSUE_TEMPLATE/--bug_report.md
@@ -33,7 +33,7 @@ To help us understand the issue, please fill-in as much of the following informa
 ### Please tell us about your environment:
 
 - [ ] Node-RED version:
-- [ ] node.js version:
+- [ ] Node.js version:
 - [ ] npm version:
 - [ ] Platform/OS:
 - [ ] Browser:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ relevant nodes, press Ctrl-E and copy the flow data from the Export dialog.
 At a minimum, please include:
 
  - Version of Node-RED - either release number if you downloaded a zip, or the first few lines of `git log` if you are cloning the repository directly.
- - Version of node.js - what does `node -v` say?
+ - Version of Node.js - what does `node -v` say?
 
 ## Feature requests
 

--- a/packages/node_modules/@node-red/runtime/lib/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/index.js
@@ -129,7 +129,7 @@ function start() {
             log.info(log._("runtime.version",{component:"Node.js ",version:process.version}));
             if (settings.UNSUPPORTED_VERSION) {
                 log.error("*****************************************************************");
-                log.error("* "+log._("runtime.unsupported_version",{component:"Node.js",version:process.version,requires: ">=4"})+" *");
+                log.error("* "+log._("runtime.unsupported_version",{component:"Node.js",version:process.version,requires: ">=8.9.0"})+" *");
                 log.error("*****************************************************************");
                 events.emit("runtime-event",{id:"runtime-unsupported-version",payload:{type:"error",text:"notification.errors.unsupportedVersion"},retain:true});
             }

--- a/packages/node_modules/node-red/lib/red.js
+++ b/packages/node_modules/node-red/lib/red.js
@@ -27,9 +27,9 @@ var apiEnabled = false;
 
 function checkVersion(userSettings) {
     var semver = require('semver');
-    if (!semver.satisfies(process.version,">=4.8.0")) {
+    if (!semver.satisfies(process.version,">=8.9.0")) {
         // TODO: in the future, make this a hard error.
-        // var e = new Error("Unsupported version of node.js");
+        // var e = new Error("Unsupported version of Node.js");
         // e.code = "unsupported_version";
         // throw e;
         userSettings.UNSUPPORTED_VERSION = process.version;
@@ -39,7 +39,7 @@ function checkVersion(userSettings) {
  * This module provides the full Node-RED application, with both the runtime
  * and editor components built in.
  *
- * The API this module exposes allows it to be embedded within another node.js
+ * The API this module exposes allows it to be embedded within another Node.js
  * application.
  *
  * @namespace node-red

--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -199,8 +199,6 @@ try {
     if (err.code == "unsupported_version") {
         console.log("Unsupported version of Node.js:",process.version);
         console.log("Node-RED requires Node.js v8.9.0 or later");
-    } else if (err.code == "not_built") {
-        console.log("Node-RED has not been built. See README.md for details");
     } else {
         console.log("Failed to start server:");
         if (err.stack) {

--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -197,8 +197,8 @@ try {
     RED.init(server,settings);
 } catch(err) {
     if (err.code == "unsupported_version") {
-        console.log("Unsupported version of node.js:",process.version);
-        console.log("Node-RED requires node.js v4 or later");
+        console.log("Unsupported version of Node.js:",process.version);
+        console.log("Node-RED requires Node.js v8.9.0 or later");
     } else if (err.code == "not_built") {
         console.log("Node-RED has not been built. See README.md for details");
     } else {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Node.js v6 users tend to encounter some problems because current Node-RED doesn't support Node.js v6. To know that Node.js v6 is unsupported when starting Node-RED, I added the appropriate version for handling to check the version of Node.js. And I replaced node.js with Node.js and removed handling for unused error code which is used in starting Node-RED.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality