### PR TITLE
Update Japanese message catalog

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -80,7 +80,7 @@
             "projects-new": "新規",
             "projects-open": "開く",
             "projects-settings": "設定",
-            "showNodeLabelDefault": "追加したノードのラベルを表示する"
+            "showNodeLabelDefault": "追加したノードのラベルを表示"
         }
     },
     "actions": {
@@ -351,7 +351,8 @@
         "pasteNode": "ノードを貼り付け",
         "undoChange": "変更操作を戻す",
         "searchBox": "ノードを検索",
-        "managePalette": "パレットの管理"
+        "managePalette": "パレットの管理",
+        "actionList": "動作一覧"
     },
     "library": {
         "library": "ライブラリ",
@@ -527,11 +528,13 @@
             "none": "選択されていません",
             "refresh": "読み込みのため更新してください",
             "empty": "データが存在しません",
-            "node": "Node",
-            "flow": "Flow",
-            "global": "Global",
+            "node": "ノード",
+            "flow": "フロー",
+            "global": "グローバル",
             "deleteConfirm": "データを削除しても良いですか?",
-            "autoRefresh": "自動更新"
+            "autoRefresh": "自動更新",
+            "refrsh": "更新",
+            "delete": "削除"
         },
         "palette": {
             "name": "パレットの管理",
@@ -736,7 +739,16 @@
     },
     "jsonEditor": {
         "title": "JSONエディタ",
-        "format": "JSONフォーマット"
+        "format": "JSONフォーマット",
+        "rawMode": "JSONを編集",
+        "uiMode": "ビジュアルエディタ",
+        "insertAbove": "上に挿入",
+        "insertBelow": "下に挿入",
+        "addItem": "要素を追加",
+        "copyPath": "要素のパスをコピー",
+        "expandItems": "要素を展開",
+        "collapseItems": "要素を折り畳む",
+        "duplicate": "複製"
     },
     "markdownEditor": {
         "title": "マークダウンエディタ",
@@ -930,7 +942,7 @@
         "appearance": "外観",
         "env": "環境変数"
     },
-    "languages" : {
+    "languages": {
         "de": "ドイツ語",
         "en-US": "英語",
         "ja": "日本語",

--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -7,7 +7,8 @@
             "username": "ユーザ名",
             "password": "パスワード",
             "property": "プロパティ",
-            "selectNodes": "ノードを選択..."
+            "selectNodes": "ノードを選択...",
+            "expand": "展開"
         },
         "status": {
             "connected": "接続済",
@@ -137,7 +138,10 @@
             "debugNodes": "debugノード",
             "clearLog": "ログを削除",
             "filterLog": "ログのフィルタリング",
-            "openWindow": "新しいウィンドウで開く"
+            "openWindow": "新しいウィンドウで開く",
+            "copyPath": "パスをコピー",
+            "copyPayload": "値をコピー",
+            "pinPath": "展開を固定"
         },
         "messageMenu": {
             "collapseAll": "全パスを折りたたむ",
@@ -615,7 +619,8 @@
             "tail": "tail",
             "index": "index between",
             "exp": "JSONata式",
-            "else": "その他"
+            "else": "その他",
+            "hask": "has key"
         },
         "errors": {
             "invalid-expr": "不正な表現: __error__",


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I updated Japanese translation for Node-RED flow editor.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality