### PR TITLE
Optimisation for switch node

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1686,7 +1686,8 @@ RED.editor = (function() {
                             RED.tray.resize();
                         }
                     },
-                    collapsible: true
+                    collapsible: true,
+                    menu: false
                 });
 
                 var nodePropertiesTab = {
@@ -2226,7 +2227,8 @@ RED.editor = (function() {
                             RED.tray.resize();
                         }
                     },
-                    collapsible: true
+                    collapsible: true,
+                    menu: false
                 });
 
                 var nodePropertiesTab = {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1221,12 +1221,15 @@ RED.view = (function() {
                     removedLinks.push(drag_lines[i].link)
                 }
             }
-            historyEvent = {
-                t:"delete",
-                links: removedLinks,
-                dirty:RED.nodes.dirty()
-            };
-            RED.history.push(historyEvent);
+            if (removedLinks.length > 0) {
+                historyEvent = {
+                    t:"delete",
+                    links: removedLinks,
+                    dirty:RED.nodes.dirty()
+                };
+                RED.history.push(historyEvent);
+                RED.nodes.dirty(true);
+            }
             hideDragLines();
         }
         if (lasso) {

--- a/packages/node_modules/@node-red/nodes/core/logic/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/logic/10-switch.html
@@ -208,14 +208,33 @@
                             selectField.append($("<option></option>").val(operators[d].v).text(/^switch/.test(operators[d].t)?node._(operators[d].t):operators[d].t));
                         }
                     }
-                    var valueField = $('<input/>',{class:"node-input-rule-value",type:"text",style:"margin-left: 5px;"}).appendTo(row).typedInput({default:'str',types:['msg','flow','global','str','num','jsonata','env',previousValueType]});
-                    var numValueField = $('<input/>',{class:"node-input-rule-num-value",type:"text",style:"margin-left: 5px;"}).appendTo(row).typedInput({default:'num',types:['flow','global','num','jsonata','env']});
-                    var expValueField = $('<input/>',{class:"node-input-rule-exp-value",type:"text",style:"margin-left: 5px;"}).appendTo(row).typedInput({default:'jsonata',types:['jsonata']});
-                    var btwnValueField = $('<input/>',{class:"node-input-rule-btwn-value",type:"text",style:"margin-left: 5px;"}).appendTo(row).typedInput({default:'num',types:['msg','flow','global','str','num','jsonata','env',previousValueType]});
-                    var btwnAndLabel = $('<span/>',{class:"node-input-rule-btwn-label"}).text(" "+andLabel+" ").appendTo(row3);
-                    var btwnValue2Field = $('<input/>',{class:"node-input-rule-btwn-value2",type:"text",style:"margin-left:2px;"}).appendTo(row3).typedInput({default:'num',types:['msg','flow','global','str','num','jsonata','env',previousValueType]});
-                    var typeValueField = $('<input/>',{class:"node-input-rule-type-value",type:"text",style:"margin-left: 5px;"}).appendTo(row)
-                        .typedInput({default:'string',types:[
+
+                    function createValueField(){
+                        return $('<input/>',{class:"node-input-rule-value",type:"text",style:"margin-left: 5px;"}).appendTo(row).typedInput({default:'str',types:['msg','flow','global','str','num','jsonata','env',previousValueType]});
+                    }
+
+                    function createNumValueField(){
+                        return $('<input/>',{class:"node-input-rule-num-value",type:"text",style:"margin-left: 5px;"}).appendTo(row).typedInput({default:'num',types:['flow','global','num','jsonata','env']});
+                    }
+
+                    function createExpValueField(){
+                        return $('<input/>',{class:"node-input-rule-exp-value",type:"text",style:"margin-left: 5px;"}).appendTo(row).typedInput({default:'jsonata',types:['jsonata']});
+                    }
+
+                    function createBtwnValueField(){
+                        return $('<input/>',{class:"node-input-rule-btwn-value",type:"text",style:"margin-left: 5px;"}).appendTo(row).typedInput({default:'num',types:['msg','flow','global','str','num','jsonata','env',previousValueType]});
+                    }
+
+                    function createBtwnAndLabel(){
+                        return $('<span/>',{class:"node-input-rule-btwn-label"}).text(" "+andLabel+" ").appendTo(row3);
+                    }
+
+                    function createBtwnValue2Field(){
+                        return $('<input/>',{class:"node-input-rule-btwn-value2",type:"text",style:"margin-left:2px;"}).appendTo(row3).typedInput({default:'num',types:['msg','flow','global','str','num','jsonata','env',previousValueType]});
+                    }
+
+                    function createTypeValueField(){
+                        return $('<input/>',{class:"node-input-rule-type-value",type:"text",style:"margin-left: 5px;"}).appendTo(row).typedInput({default:'string',types:[
                             {value:"string",label:"string",hasValue:false},
                             {value:"number",label:"number",hasValue:false},
                             {value:"boolean",label:"boolean",hasValue:false},
@@ -226,6 +245,15 @@
                             {value:"undefined",label:"undefined",hasValue:false},
                             {value:"null",label:"null",hasValue:false}
                         ]});
+                    }
+
+                    var valueField = null;
+                    var numValueField = null;
+                    var expValueField = null;
+                    var btwnAndLabel = null;
+                    var btwnValue2Field = null;
+                    var typeValueField = null;
+                        
                     var finalspan = $('<span/>',{style:"float: right;margin-top: 6px;"}).appendTo(row);
                     finalspan.append(' &#8594; <span class="node-input-rule-index">'+(i+1)+'</span> ');
                     var caseSensitive = $('<input/>',{id:"node-input-rule-case-"+i,class:"node-input-rule-case",type:"checkbox",style:"width:auto;vertical-align:top"}).appendTo(row2);
@@ -233,43 +261,49 @@
                     selectField.change(function() {
                         resizeRule(container);
                         var type = selectField.val();
-                        if ((type === "btwn") || (type === "index")) {
+                        
+                        try {
                             valueField.typedInput('hide');
+                        } catch(e){}
+                        try {
                             expValueField.typedInput('hide');
+                        } catch(e){}
+                        try {
                             numValueField.typedInput('hide');
+                        } catch(e){}
+                        try {
                             typeValueField.typedInput('hide');
+                        } catch(e){}
+                        try {
+                            btwnValue2Field.typedInput('hide');
+                        } catch(e){}
+                        
+                        if ((type === "btwn") || (type === "index")) {
+                            if (!btwnValueField){
+                                btwnValueField = createBtwnValueField();
+                            }
                             btwnValueField.typedInput('show');
                         } else if ((type === "head") || (type === "tail")) {
-                            btwnValueField.typedInput('hide');
-                            btwnValue2Field.typedInput('hide');
-                            expValueField.typedInput('hide');
-                            numValueField.typedInput('show');
-                            typeValueField.typedInput('hide');
-                            valueField.typedInput('hide');
-                        } else if (type === "jsonata_exp") {
-                            btwnValueField.typedInput('hide');
-                            btwnValue2Field.typedInput('hide');
-                            expValueField.typedInput('show');
-                            numValueField.typedInput('hide');
-                            typeValueField.typedInput('hide');
-                            valueField.typedInput('hide');
-                        } else {
-                            btwnValueField.typedInput('hide');
-                            expValueField.typedInput('hide');
-                            numValueField.typedInput('hide');
-                            typeValueField.typedInput('hide');
-                            valueField.typedInput('hide');
-                            if (type === "true" || type === "false" || type === "null" || type === "nnull" || type === "empty" || type === "nempty" || type === "else") {
-                                valueField.typedInput('hide');
-                                typeValueField.typedInput('hide');
+                            if (!numValueField){
+                                numValueField = createNumValueField();
                             }
-                            else
+                            numValueField.typedInput('show');
+                        } else if (type === "jsonata_exp") {
+                            if (!expValueField){
+                                expValueField = createExpValueField();
+                            }
+                            expValueField.typedInput('show');
+                        } else {
                             if (type === "istype") {
-                                valueField.typedInput('hide');
+                                if (!typeValueField){
+                                    typeValueField = createTypeValueField();
+                                }
                                 typeValueField.typedInput('show');
                             }
                             else {
-                                typeValueField.typedInput('hide');
+                                if (!valueField){
+                                    valueField = createValueField();
+                                }
                                 valueField.typedInput('show');
                             }
                         }
@@ -279,6 +313,9 @@
                         } else if ((type === "btwn") || (type === "index")) {
                             row2.hide();
                             row3.show();
+                            if (!btwnValue2Field){
+                                btwnValue2Field = createBtwnValue2Field();
+                            }
                             btwnValue2Field.typedInput('show');
                         } else {
                             row2.hide();
@@ -287,20 +324,39 @@
                     });
                     selectField.val(rule.t);
                     if ((rule.t == "btwn") || (rule.t == "index")) {
+                        if (!btwnValueField){
+                            btwnValueField = createBtwnValueField();
+                        }
                         btwnValueField.typedInput('value',rule.v);
                         btwnValueField.typedInput('type',rule.vt||'num');
+
+                        if (!btwnValue2Field){
+                            btwnValue2Field = createBtwnValue2Field();
+                        }
                         btwnValue2Field.typedInput('value',rule.v2);
                         btwnValue2Field.typedInput('type',rule.v2t||'num');
                     } else if ((rule.t === "head") || (rule.t === "tail")) {
+                        if (!numValueField){
+                            numValueField = createNumValueField();
+                        }
                         numValueField.typedInput('value',rule.v);
                         numValueField.typedInput('type',rule.vt||'num');
                     } else if (rule.t === "istype") {
+                        if (!typeValueField){
+                            typeValueField =createTypeValueField();
+                        }
                         typeValueField.typedInput('value',rule.vt);
                         typeValueField.typedInput('type',rule.vt);
                     } else if (rule.t === "jsonata_exp") {
+                        if (!expValueField){
+                            expValueField = createExpValueField();
+                        }
                         expValueField.typedInput('value',rule.v);
                         expValueField.typedInput('type',rule.vt||'jsonata');
                     } else if (typeof rule.v != "undefined") {
+                        if (!valueField){
+                            valueField = createValueField();
+                        }
                         valueField.typedInput('value',rule.v);
                         valueField.typedInput('type',rule.vt||'str');
                     }

--- a/packages/node_modules/@node-red/nodes/core/logic/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/logic/10-switch.html
@@ -262,21 +262,21 @@
                         resizeRule(container);
                         var type = selectField.val();
                         
-                        try {
+                        if (valueField){
                             valueField.typedInput('hide');
-                        } catch(e){}
-                        try {
+                        }
+                        if (expValueField){
                             expValueField.typedInput('hide');
-                        } catch(e){}
-                        try {
+                        }
+                        if (numValueField){
                             numValueField.typedInput('hide');
-                        } catch(e){}
-                        try {
+                        }
+                        if (typeValueField){
                             typeValueField.typedInput('hide');
-                        } catch(e){}
-                        try {
+                        }
+                        if (btwnValue2Field){
                             btwnValue2Field.typedInput('hide');
-                        } catch(e){}
+                        }
                         
                         if ((type === "btwn") || (type === "index")) {
                             if (!btwnValueField){


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimisation (improving load time for complex switch nodes from ~1.3 secs to ~0.6 secs )

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

I usually have to work with complex switch nodes (>10 cases) and it is very slow whenever I open their configuration (~1-2 secs).

It seems it renders the typed fields eagerly, even without user interaction. It then chooses to hide and show certain DOM elements that were previously created based on the rule.

For complex switch node, this eager rendering results in tedious wait time even though the rules are very simple.

I'm proposing a simple lazy rendering of these fields to improve the load time of this node's configuration. Here we only render these fields on demand when the user choose to do so (e.g. select the rule).

With this approach, the performance could be significantly improved (tested with Chrome performance profiling, it improves load time for complex switch nodes from ~1.3 secs to ~0.6 secs ).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
