### PR TITLE
Remove tab menu from node property UI for subflow and configuration nodes

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1686,7 +1686,8 @@ RED.editor = (function() {
                             RED.tray.resize();
                         }
                     },
-                    collapsible: true
+                    collapsible: true,
+                    menu: false
                 });
 
                 var nodePropertiesTab = {
@@ -2226,7 +2227,8 @@ RED.editor = (function() {
                             RED.tray.resize();
                         }
                     },
-                    collapsible: true
+                    collapsible: true,
+                    menu: false
                 });
 
                 var nodePropertiesTab = {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Node property UI for general nodes has only buttons to select a tab (Property, Description, Appearance tabs) and has no menu. On the other hand, the configuration node and subflow node have the menu to select a tab in addition to buttons. To make them the same user experience, I removed the menu from the configuration node and subflow node.

![image](https://user-images.githubusercontent.com/20310935/62593658-8bf2b600-b912-11e9-970b-4d9dfaea71ec.png)

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality