### PR TITLE
Add HTTP Persistent (session reuse) capability

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1221,12 +1221,15 @@ RED.view = (function() {
                     removedLinks.push(drag_lines[i].link)
                 }
             }
-            historyEvent = {
-                t:"delete",
-                links: removedLinks,
-                dirty:RED.nodes.dirty()
-            };
-            RED.history.push(historyEvent);
+            if (removedLinks.length > 0) {
+                historyEvent = {
+                    t:"delete",
+                    links: removedLinks,
+                    dirty:RED.nodes.dirty()
+                };
+                RED.history.push(historyEvent);
+                RED.nodes.dirty(true);
+            }
             hideDragLines();
         }
         if (lasso) {

--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.html
@@ -69,8 +69,8 @@
     </div>
     
     <div class="form-row">
-        <input type="checkbox" id="node-input-http-persist" style="display: inline-block; width: auto; vertical-align: top;">
-        <label for="node-input-http-persist" style="width: auto" data-i18n="httpin.http-persist"></label>
+        <input type="checkbox" id="node-input-persist" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-persist" style="width: auto" data-i18n="httpin.persist"></label>
     </div>
 
     <div class="form-row">
@@ -107,7 +107,7 @@
             paytoqs: {value: false},
             url:{value:"",validate:function(v) { return (v.trim().length === 0) || (v.indexOf("://") === -1) || (v.trim().indexOf("http") === 0)} },
             tls: {type:"tls-config",required: false},
-            "http-persist":{value:true},
+            "persist":{value:true},
             proxy: {type:"http proxy",required: false},
             authType: {value: ""}
         },

--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.html
@@ -67,6 +67,11 @@
             </div>
         </div>
     </div>
+    
+    <div class="form-row">
+        <input type="checkbox" id="node-input-http-persistent" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-http-persistent" style="width: auto" data-i18n="httpin.http-persistent"></label>
+    </div>
 
     <div class="form-row">
         <input type="checkbox" id="node-input-useProxy" style="display: inline-block; width: auto; vertical-align: top;">
@@ -102,6 +107,7 @@
             paytoqs: {value: false},
             url:{value:"",validate:function(v) { return (v.trim().length === 0) || (v.indexOf("://") === -1) || (v.trim().indexOf("http") === 0)} },
             tls: {type:"tls-config",required: false},
+            "http-persistent":{value:true},
             proxy: {type:"http proxy",required: false},
             authType: {value: ""}
         },

--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.html
@@ -69,8 +69,8 @@
     </div>
     
     <div class="form-row">
-        <input type="checkbox" id="node-input-http-persistent" style="display: inline-block; width: auto; vertical-align: top;">
-        <label for="node-input-http-persistent" style="width: auto" data-i18n="httpin.http-persistent"></label>
+        <input type="checkbox" id="node-input-http-persist" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-http-persist" style="width: auto" data-i18n="httpin.http-persist"></label>
     </div>
 
     <div class="form-row">
@@ -107,7 +107,7 @@
             paytoqs: {value: false},
             url:{value:"",validate:function(v) { return (v.trim().length === 0) || (v.indexOf("://") === -1) || (v.trim().indexOf("http") === 0)} },
             tls: {type:"tls-config",required: false},
-            "http-persistent":{value:true},
+            "http-persist":{value:true},
             proxy: {type:"http proxy",required: false},
             authType: {value: ""}
         },

--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
@@ -29,6 +29,7 @@ module.exports = function(RED) {
         var isTemplatedUrl = (nodeUrl||"").indexOf("{{") != -1;
         var nodeMethod = n.method || "GET";
         var paytoqs = n.paytoqs;
+        var nodeHTTPPersistent = n["http-persistent"];
         if (n.tls) {
             var tlsNode = RED.nodes.getNode(n.tls);
         }
@@ -94,6 +95,7 @@ module.exports = function(RED) {
             opts.maxRedirects = 21;
             opts.jar = request.jar();
             opts.proxy = null;
+            opts.forever = nodeHTTPPersistent;
             if (msg.requestTimeout !== undefined) {
                 if (isNaN(msg.requestTimeout)) {
                     node.warn(RED._("httpin.errors.timeout-isnan"));

--- a/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/io/21-httprequest.js
@@ -29,7 +29,7 @@ module.exports = function(RED) {
         var isTemplatedUrl = (nodeUrl||"").indexOf("{{") != -1;
         var nodeMethod = n.method || "GET";
         var paytoqs = n.paytoqs;
-        var nodeHTTPPersistent = n["http-persistent"];
+        var nodeHTTPPersistent = n["persist"];
         if (n.tls) {
             var tlsNode = RED.nodes.getNode(n.tls);
         }

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -413,7 +413,7 @@
         "digest": "digest authentication",
         "bearer": "bearer authentication",
         "use-proxy": "Use proxy",
-        "http-persistent": "Enable connection keep-alive",
+        "http-persist": "Enable connection keep-alive",
         "proxy-config": "Proxy Configuration",
         "use-proxyauth": "Use proxy authentication",
         "noproxy-hosts": "Ignore hosts",

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -413,6 +413,7 @@
         "digest": "digest authentication",
         "bearer": "bearer authentication",
         "use-proxy": "Use proxy",
+        "http-persistent": "HTTP Persistent",
         "proxy-config": "Proxy Configuration",
         "use-proxyauth": "Use proxy authentication",
         "noproxy-hosts": "Ignore hosts",

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -413,7 +413,7 @@
         "digest": "digest authentication",
         "bearer": "bearer authentication",
         "use-proxy": "Use proxy",
-        "http-persistent": "HTTP Persistent",
+        "http-persistent": "Enable connection keep-alive",
         "proxy-config": "Proxy Configuration",
         "use-proxyauth": "Use proxy authentication",
         "noproxy-hosts": "Ignore hosts",

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -413,7 +413,7 @@
         "digest": "digest authentication",
         "bearer": "bearer authentication",
         "use-proxy": "Use proxy",
-        "http-persist": "Enable connection keep-alive",
+        "persist": "Enable connection keep-alive",
         "proxy-config": "Proxy Configuration",
         "use-proxyauth": "Use proxy authentication",
         "noproxy-hosts": "Ignore hosts",

--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/ssh/keygen.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/ssh/keygen.js
@@ -51,7 +51,7 @@ function runSshKeygenCommand(args,cwd,env) {
                 resolve(stdout);
             }
         });
-        child.error('error', function(err) {
+        child.on('error', function(err) {
             if (/ENOENT/.test(err.toString())) {
                 err.code = "command_not_found";
             }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

With this update, now the HTTP Request node can support persistent HTTP connection (HTTP session reuse). This is very useful in some cases, for instance, an API that requires subsequent communications through the first initial TCP session.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
