### PR TITLE
fix subflow category change on palette

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -415,7 +415,7 @@ RED.palette = (function() {
                 createCategory(newCategory,category,category,"node-red");
 
                 var currentCategoryNode = paletteNode.closest(".red-ui-palette-category");
-                var newCategoryNode = $("#palette-"+category);
+                var newCategoryNode = $("#red-ui-palette-"+category);
                 newCategoryNode.append(paletteNode);
                 if (newCategoryNode.find(".red-ui-palette-node").length === 1) {
                     categoryContainers[category].open();
@@ -428,9 +428,6 @@ RED.palette = (function() {
                         currentCategoryNode.find("i").toggleClass("expanded");
                     }
                 }
-
-
-
             }
         });
     }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
With current dev branch, subflow category change is not immediately reflected in the palette.
This PR will fix this problem. 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
