### PR TITLE
Fix i18n of new subflow feature

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -325,16 +325,21 @@
         "locale": "Select UI Language",
         "icon": "Icon",
         "inputType": "Input type",
-        "previewUI": "Preview UI",
-        "previewOK": "Preview OK",
+        "inputs" : {
+            "input": "input",
+            "select": "select",
+            "checkbox": "checkbox",
+            "spinner": "spinner",
+            "none": "none",
+            "hidden": "hide property"
+        },
         "types": {
             "str": "string",
             "num": "number",
             "bool": "bool",
-            "json": "json",
+            "json": "JSON",
             "bin": "buffer",
-            "env": "env var",
-            "no-value": "no value"
+            "env": "env variable"
         },
         "menu": {
             "input": "input",
@@ -343,9 +348,13 @@
             "spinner": "spinner",
             "hidden": "label only"
         },
+        "select": {
+            "label": "Label",
+            "value": "Value"
+        },
         "spinner": {
-            "min": "min",
-            "max": "max"
+            "min": "Minimum",
+            "max": "Maximum"
         },
         "errors": {
             "scopeChange": "Changing the scope will make it unavailable to nodes in other flows that use it",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -327,14 +327,21 @@
         "inputType": "入力形式",
         "previewUI": "UI確認",
         "previewOK": "確認OK",
+        "inputs" : {
+            "input": "入力",
+            "select": "メニュー",
+            "checkbox": "チェックボックス",
+            "spinner": "スピナー",
+            "none": "無し",
+            "hidden": "非表示"
+        },
         "types": {
             "str": "文字列",
             "num": "数値",
             "bool": "真偽",
             "json": "JSON",
             "bin": "バッファ",
-            "env": "環境変数",
-            "no-value": "値無し"
+            "env": "環境変数"
         },
         "menu": {
             "input": "入力",
@@ -343,9 +350,13 @@
             "spinner": "数値",
             "hidden": "ラベルのみ"
         },
+        "select": {
+            "label": "ラベル",
+            "value": "値"
+        },
         "spinner": {
-            "min": "最小",
-            "max": "最大"
+            "min": "最小値",
+            "max": "最大値"
         },
         "errors": {
             "scopeChange": "スコープの変更は、他のフローで使われているノードを無効にします",
@@ -964,9 +975,11 @@
     },
     "editor-tab": {
         "properties": "プロパティ",
+        "envProperties": "環境変数",
         "description": "説明",
         "appearance": "外観",
-        "env": "サブフロープロパティ"
+        "preview": "UIプレビュー",
+        "defaultValue": "デフォルト値"
     },
     "languages": {
         "de": "ドイツ語",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -1068,14 +1068,15 @@ RED.subflow = (function() {
 
          inputCellInput.typedInput({
              types: [
-                 {value:"input",
-                    label:"input", icon:"fa fa-i-cursor",showLabel:false,multiple:true,options:[
-                         {value:"str",label:"string",icon:"red/images/typedInput/az.svg"},
-                         {value:"num",label:"number",icon:"red/images/typedInput/09.svg"},
-                         {value:"bool",label:"boolean",icon:"red/images/typedInput/bool.svg"},
-                         {value:"json",label:"JSON",icon:"red/images/typedInput/json.svg"},
-                         {value: "bin",label: "buffer",icon: "red/images/typedInput/bin.svg"},
-                         {value: "env",label: "env variable",icon: "red/images/typedInput/env.svg"}
+                 {
+                     value:"input",
+                     label:RED._("editor.inputs.input"), icon:"fa fa-i-cursor",showLabel:false,multiple:true,options:[
+                         {value:"str",label:RED._("editor.types.str"),icon:"red/images/typedInput/az.svg"},
+                         {value:"num",label:RED._("editor.types.num"),icon:"red/images/typedInput/09.svg"},
+                         {value:"bool",label:RED._("editor.types.bool"),icon:"red/images/typedInput/bool.svg"},
+                         {value:"json",label:RED._("editor.types.json"),icon:"red/images/typedInput/json.svg"},
+                         {value: "bin",label: RED._("editor.types.bin"),icon: "red/images/typedInput/bin.svg"},
+                         {value: "env",label: RED._("editor.types.env"),icon: "red/images/typedInput/env.svg"}
                      ],
                      default: ['str','num','bool','json','bin','env'],
                      valueLabel: function(container,value) {
@@ -1100,8 +1101,9 @@ RED.subflow = (function() {
                          }
                      }
                  },
-                 {value:"select",
-                    label:"select", icon:"fa fa-tasks",showLabel:false,
+                 {
+                     value:"select",
+                     label:RED._("editor.inputs.select"), icon:"fa fa-tasks",showLabel:false,
                      valueLabel: function(container,value) {
                          container.css("padding","0");
 
@@ -1131,7 +1133,7 @@ RED.subflow = (function() {
                          content: function(container) {
                              var content = $('<div class="red-ui-editor-subflow-ui-edit-panel">').appendTo(container);
                              var optList = $('<ol>').appendTo(content).editableList({
-                                 header:$("<div><div>Label</div><div>Value</div></div>"),
+                                 header:$("<div><div>"+RED._("editor.select.label")+"</div><div>"+RED._("editor.select.value")+"</div></div>"),
                                  addItem: function(row,index,itemData) {
                                      var labelDiv = $('<div>').appendTo(row);
                                      var label = lookupLabel(itemData.l, "", currentLocale);
@@ -1220,8 +1222,9 @@ RED.subflow = (function() {
                          }
                      }
                  },
-                 {value:"checkbox",
-                    label:"checkbox", icon:"fa fa-check-square-o",showLabel:false,
+                 {
+                     value:"checkbox",
+                     label:RED._("editor.inputs.checkbox"), icon:"fa fa-check-square-o",showLabel:false,
                      valueLabel: function(container,value) {
                          container.css("padding",0);
                          checkbox = $('<input type="checkbox">').appendTo(container);
@@ -1231,8 +1234,9 @@ RED.subflow = (function() {
                          checkbox.prop('checked',valueField.typedInput('value')==="true");
                      }
                  },
-                 {value:"spinner",
-                    label:"spinner", icon:"fa fa-sort-numeric-asc", showLabel:false,
+                 {
+                     value:"spinner",
+                     label:RED._("editor.inputs.spinner"), icon:"fa fa-sort-numeric-asc", showLabel:false,
                      valueLabel: function(container,value) {
                          container.css("padding",0);
                          var innerContainer = $('<div>').css({
@@ -1267,8 +1271,8 @@ RED.subflow = (function() {
                              minInput.val(min);
                              var maxInput = $('<input type="number" style="margin-bottom:0; width:60px">');
                              maxInput.val(max);
-                             $('<div class="form-row" style="margin-bottom:3px"><label>Minimum</label></div>').append(minInput).appendTo(content);
-                             $('<div class="form-row" style="margin-bottom:0"><label>Maximum</label></div>').append(maxInput).appendTo(content);
+                             $('<div class="form-row" style="margin-bottom:3px"><label>'+RED._("editor.spinner.min")+'</label></div>').append(minInput).appendTo(content);
+                             $('<div class="form-row" style="margin-bottom:0"><label>'+RED._("editor.spinner.max")+'</label></div>').append(maxInput).appendTo(content);
                              return {
                                  onclose: function() {
                                      var min = minInput.val().trim();
@@ -1289,11 +1293,14 @@ RED.subflow = (function() {
                          }
                      }
                  },
-                 {value:"none",
-                 label:"none", icon:"fa fa-times",hasValue:false},
-                 {value:"hide",
-                 label:"hide property", icon:"fa fa-ban",hasValue:false}
-
+                 {
+                     value:"none",
+                     label:RED._("editor.inputs.none"), icon:"fa fa-times",hasValue:false
+                 },
+                 {
+                     value:"hide",
+                     label:RED._("editor.inputs.hidden"), icon:"fa fa-ban",hasValue:false
+                 }
              ],
              default: 'none'
          }).on("typedinputtypechange", function(evt,type) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Some string of new subflow UI feature are not i18n ready.
This PR make them i18n ready.  
It also adds Japanese message catalogue items and remove unused catalogue items.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
