### PR TITLE
Fix padding of subflow locale selector

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -32,7 +32,7 @@ RED.subflow = (function() {
             '<div id="subflow-env-tab-edit">'+
                 '<div class="form-row node-input-env-container-row" id="subflow-input-edit-ui">'+
                     '<ol class="red-ui-editor-subflow-env-list" id="node-input-env-container"></ol>'+
-                    '<div class="node-input-env-locales-row"><i class="fa fa-language"></i> <select id="subflow-input-env-locale"></select></div>'+
+                    '<div class="node-input-env-locales-row"><i class="fa fa-language"></i> <select id="subflow-input-env-locale" style="padding: 1px;"></select></div>'+
                 '</div>'+
             '</div>'+
             '<div id="subflow-env-tab-preview">'+


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Language name of locale selection menu of subflow property definition is not properly shown 
 on Windows. 

This PR fixes this problem.

![コメント 2019-08-27 222529](https://user-images.githubusercontent.com/30289092/63775107-a3253200-c919-11e9-8b3a-a4b44d0ab3c0.png)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
