### PR TITLE
Fix Markdown editor

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -2425,7 +2425,6 @@ RED.editor = (function() {
         el = $("<div>").appendTo(el).addClass("red-ui-editor-text-container")[0];
         var editor = ace.edit(el);
         editor.setTheme("ace/theme/tomorrow");
-        editor.setShowPrintMargin(false);
         var session = editor.getSession();
         session.on("changeAnnotation", function () {
             var annotations = session.getAnnotations() || [];

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -2503,6 +2503,7 @@ RED.editor = (function() {
                 content: RED._("markdownEditor.format"),
                 autoClose: 50
             });
+            session.setUseWrapMode(true);
         }
         return editor;
     }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -2425,6 +2425,7 @@ RED.editor = (function() {
         el = $("<div>").appendTo(el).addClass("red-ui-editor-text-container")[0];
         var editor = ace.edit(el);
         editor.setTheme("ace/theme/tomorrow");
+        editor.setShowPrintMargin(false);
         var session = editor.getSession();
         session.on("changeAnnotation", function () {
             var annotations = session.getAnnotations() || [];

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/markdown.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/markdown.js
@@ -38,7 +38,7 @@
     var template = '<script type="text/x-red" data-template-name="_markdown">'+
         '<div id="red-ui-editor-type-markdown-panels">'+
         '<div id="red-ui-editor-type-markdown-panel-editor" class="red-ui-panel">'+
-            '<div style="height: 100%; margin: auto; max-width: 1000px;">'+
+            '<div style="height: 100%; margin: auto;">'+
                 '<div id="red-ui-editor-type-markdown-toolbar"></div>'+
                 '<div class="node-text-editor" style="height: 100%" id="red-ui-editor-type-markdown"></div>'+
             '</div>'+

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/library.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/library.js
@@ -243,7 +243,6 @@ RED.library = (function() {
                         useWorker: false
                     });
                     libraryEditor.setTheme("ace/theme/tomorrow");
-                    libraryEditor.setShowPrintMargin(false);
                     if (options.mode) {
                         libraryEditor.getSession().setMode(options.mode);
                     }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/library.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/library.js
@@ -243,6 +243,7 @@ RED.library = (function() {
                         useWorker: false
                     });
                     libraryEditor.setTheme("ace/theme/tomorrow");
+                    libraryEditor.setShowPrintMargin(false);
                     if (options.mode) {
                         libraryEditor.getSession().setMode(options.mode);
                     }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Current Markdown editor has two troubles. When the Node-RED user expands the editor,  the user cannot utilize the large resolution of the display effectively because the maximum size of the editor is 1000px. Therefore, I removed the definition of the max size. After fixing it, the user experience will be the same as JavaScript editor in the function node.
And there's an unknown vertical gray line (I found that it is a print margin while fixing it.) on the editors. I added ace editor option to remove it.

![image](https://user-images.githubusercontent.com/20310935/64842520-648fb700-d63d-11e9-83c1-08471e0cc956.png)

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality