### PR TITLE
Allow subflow label row without environment variable name

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -1493,7 +1493,8 @@ RED.subflow = (function() {
                 var entry = $(this);
                 var item = entry.data('data');
                 var name = (item.parent?item.name:item.nameField.val()).trim();
-                if (name !== "") {
+                if ((name !== "") ||
+                    (item.ui && (item.ui.type === "none"))) {
                     var valueInput = item.valueField;
                     var value = valueInput.typedInput("value");
                     var type = valueInput.typedInput("type");


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
In the SUBFLOW UI definition, if the row type is `none` (label definition), the environment variable name is not needed.  
This PR fixes this problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
