### PR TITLE
Remove padding for label for SUBFLOW UI row without icon

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -1381,7 +1381,8 @@ RED.subflow = (function() {
             }
         }
         if (ui.type !== "checkbox") {
-            $('<span>').css({"padding-left":"5px"}).text(labelText).appendTo(label);
+            var css = ui.icon ? {"padding-left":"5px"} : {};
+            $('<span>').css(css).text(labelText).appendTo(label);
             if (ui.type === 'none') {
                 label.width('100%');
             }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
When no icon is defined for SUBFLOW UI row, there is a small padding on the left side of the label.
This PR removes this.

![スクリーンショット 2019-09-13 23 15 46](https://user-images.githubusercontent.com/30289092/64870113-a50f2500-d67d-11e9-9fd1-207c58e4eabe.png)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
