### PR TITLE
Fix subflow UI for select

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -1365,11 +1365,6 @@ RED.subflow = (function() {
             ui.type = "input";
             ui.opts = {types:['str','num','bool','json','bin','env']}
         } else {
-            var typeOptions = {
-                'input': {types:['str','num','bool','json','bin','env']},
-                'select': {opts:[]},
-                'spinner': {}
-            };
             if (!ui.opts) {
                 ui.opts = (ui.type === "select") ? {opts:[]} : {};
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -1360,14 +1360,19 @@ RED.subflow = (function() {
     }
 
     function buildEnvUIRow(row, tenv, ui) {
-
         ui.label = ui.label||{};
-        ui.opts = ui.opts||{};
         if (!ui.type) {
             ui.type = "input";
             ui.opts = {types:['str','num','bool','json','bin','env']}
         } else {
-            ui.opts = ui.opts || {};
+            var typeOptions = {
+                'input': {types:['str','num','bool','json','bin','env']},
+                'select': {opts:[]},
+                'spinner': {}
+            };
+            if (!ui.opts) {
+                ui.opts = (ui.type === "select") ? {opts:[]} : {};
+            }
         }
 
         var labels = ui.label || {};


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
For `select` type SUBFLOW UI definition with no menu item definition, following operation causes reference of undefined value:
1. load a flow with `select` type SUBFLOW UI definition with no menu item definition,
2. open instance of the SUBFLOW,
3. open edit SUBFLOW template,
4. open environment variable definition panel,
5. open menu definition 

This is caused by initialization of internal ui options for `select` item without required field.

Sample Flow:
```
[{"id":"e8d2465c.e012c8","type":"tab","label":"Flow 1","disabled":false,"info":""},{"id":"e07ed459.72e398","type":"subflow","name":"Subflow 1","info":"","category":"","in":[],"out":[],"env":[{"name":"V","type":"str","value":"","ui":{"type":"select"}}],"color":"#da9"},{"id":"15e42ee8.649301","type":"function","z":"e07ed459.72e398","name":"","func":"\nreturn msg;","outputs":1,"noerr":0,"x":200,"y":80,"wires":[[]]},{"id":"a8d042ba.ecb5a","type":"subflow:e07ed459.72e398","z":"e8d2465c.e012c8","name":"","env":[],"x":120,"y":160,"wires":[]}]
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
