### PR TITLE
allow word breaking of node name with long word

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -98,18 +98,36 @@ RED.palette = (function() {
 
         var displayLines = [];
 
-        var currentLine = words[0];
-        var currentLineWidth = RED.view.calculateTextWidth(currentLine, "red-ui-palette-label", 0);
-
-        for (var i=1;i<words.length;i++) {
-            var newWidth = RED.view.calculateTextWidth(currentLine+" "+words[i], "red-ui-palette-label", 0);
+        var currentLine = "";
+        for (var i=0;i<words.length;i++) {
+            var word = words[i];
+            var sep = (i == 0) ? "" : " ";
+            var newWidth = RED.view.calculateTextWidth(currentLine+sep+word, "red-ui-palette-label", 0);
             if (newWidth < nodeWidth) {
-                currentLine += " "+words[i];
-                currentLineWidth = newWidth;
+                currentLine += sep +word;
             } else {
-                displayLines.push(currentLine);
-                currentLine = words[i];
-                currentLineWidth = RED.view.calculateTextWidth(currentLine, "red-ui-palette-label", 0);
+                if (i > 0) {
+                    displayLines.push(currentLine);
+                }
+                while (true) {
+                    var wordWidth = RED.view.calculateTextWidth(word, "red-ui-palette-label", 0);
+                    if (wordWidth >= nodeWidth) {
+                        // break word if too wide
+                        for(var j = word.length; j > 0; j--) {
+                            var s = word.substring(0, j);
+                            var width = RED.view.calculateTextWidth(s, "red-ui-palette-label", 0);
+                            if (width < nodeWidth) {
+                                displayLines.push(s);
+                                word = word.substring(j);
+                                break;
+                            }
+                        }
+                    }
+                    else {
+                        currentLine = word;
+                        break;
+                    }
+                }
             }
         }
         displayLines.push(currentLine);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply

-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Node/Subflow name with long words displayed incorrectly on palette as follows.

![スクリーンショット 2019-09-19 22 59 59](https://user-images.githubusercontent.com/30289092/65250863-3c1e2600-db31-11e9-8c90-28352fe838cc.png)


This PR allow breaking long words to make node name displayed appropriately.

![スクリーンショット 2019-09-19 22 56 56](https://user-images.githubusercontent.com/30289092/65250777-13962c00-db31-11e9-8ca9-aacd9a10a622.png)

Example Flow:
```
[{"id":"2ea254e1.57525c","type":"tab","label":"Flow 1","disabled":false,"info":""},{"id":"bb38aeb.bd5705","type":"subflow","name":"あいうえおかきくけこさしすせそ","info":"","category":"","in":[],"out":[],"env":[],"color":"#da9"},{"id":"f985a78b.017a88","type":"subflow","name":"ABCDEFGHIJKLMNOPQRSTUVWXYZ","info":"","category":"","in":[],"out":[],"env":[],"color":"#da9"},{"id":"a4068e80.92d37","type":"subflow","name":"ABC DEF GHI JKL MNO PQR STU VWX YZ","info":"","category":"","in":[],"out":[],"env":[],"color":"#da9"},{"id":"2dd42cc4.5050d4","type":"subflow","name":"ABCDEF GHIJKL MNO PQR","info":"","category":"","in":[],"out":[],"env":[],"color":"#da9"},{"id":"6ea92ac9.4b4cb4","type":"function","z":"bb38aeb.bd5705","name":"","func":"\nreturn msg;","outputs":1,"noerr":0,"x":200,"y":80,"wires":[[]]},{"id":"4cd3c21e.8a9bcc","type":"subflow:bb38aeb.bd5705","z":"2ea254e1.57525c","name":"","env":[],"x":190,"y":80,"wires":[]},{"id":"8713cf0f.9a174","type":"function","z":"f985a78b.017a88","name":"","func":"\nreturn msg;","outputs":1,"noerr":0,"x":200,"y":80,"wires":[[]]},{"id":"2487cab4.feb2b6","type":"subflow:f985a78b.017a88","z":"2ea254e1.57525c","name":"","env":[],"x":210,"y":140,"wires":[]},{"id":"20da697f.4ef406","type":"function","z":"a4068e80.92d37","name":"","func":"\nreturn msg;","outputs":1,"noerr":0,"x":200,"y":80,"wires":[[]]},{"id":"8d1d5013.f6ce","type":"subflow:a4068e80.92d37","z":"2ea254e1.57525c","name":"","env":[],"x":230,"y":200,"wires":[]},{"id":"d968a72b.65a878","type":"function","z":"2dd42cc4.5050d4","name":"","func":"\nreturn msg;","outputs":1,"noerr":0,"x":200,"y":80,"wires":[[]]},{"id":"4638c165.c228f","type":"subflow:2dd42cc4.5050d4","z":"2ea254e1.57525c","name":"","env":[],"x":180,"y":260,"wires":[]}]
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
