### PR TITLE
Fix draggable handling in palette

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -298,7 +298,8 @@ RED.palette = (function() {
                 },
                 stop: function() { d3.select('.red-ui-flow-link-splice').classed('red-ui-flow-link-splice',false); if (spliceTimer) { clearTimeout(spliceTimer); spliceTimer = null;}},
                 drag: function(e,ui) {
-                    ui.originalPosition.left = $('#' + e.target.id).offset().left;
+                    var paletteNode = getPaletteNode(nt);
+                    ui.originalPosition.left = paletteNode.offset().left;
 
                     if (def.inputs > 0 && def.outputs > 0) {
                         mouseX = ui.position.left - paletteWidth + (ui.helper.width()/2) + chart.scrollLeft();


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
There's a draggable handling problem in the 1.0-beta version of Node-RED. When users drag a node to the outside central workspace, the node will return to the incorrect location (left edge of the palette) because `$('#' + e.target.id).offset().left;` always has 0 as the value currently. Therefore, I replaced the code with `getPaletteNode(nt)` to get the appropriate location.

![draggable](https://user-images.githubusercontent.com/20310935/65654990-7fa6f180-e055-11e9-91b3-32b0b6ee79f8.gif)

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
