### PR TITLE
Add env vars to enable safe mode and projects

### DIFF
--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -133,13 +133,13 @@ try {
 if (parsedArgs.verbose) {
     settings.verbose = true;
 }
-if (parsedArgs.safe || process.env.NODE_RED_ENABLE_SAFE_MODE) {
+if (parsedArgs.safe || (process.env.NODE_RED_ENABLE_SAFE_MODE && !/^false$/i.test(process.env.NODE_RED_ENABLE_SAFE_MODE) )) {
     settings.safeMode = true;
 }
 if (process.env.NODE_RED_ENABLE_PROJECTS) {
     settings.editorTheme = settings.editorTheme || {};
     settings.editorTheme.projects = settings.editorTheme.projects || {};
-    settings.editorTheme.projects.enabled = true;
+    settings.editorTheme.projects.enabled = !/^false$/i.test(process.env.NODE_RED_ENABLE_PROJECTS);
 }
 
 if (settings.https) {

--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -133,8 +133,13 @@ try {
 if (parsedArgs.verbose) {
     settings.verbose = true;
 }
-if (parsedArgs.safe) {
+if (parsedArgs.safe || process.env.NODE_RED_ENABLE_SAFE_MODE) {
     settings.safeMode = true;
+}
+if (process.env.NODE_RED_ENABLE_PROJECTS) {
+    settings.editorTheme = settings.editorTheme || {};
+    settings.editorTheme.projects = settings.editorTheme.projects || {};
+    settings.editorTheme.projects.enabled = true;
 }
 
 if (settings.https) {


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)


## Proposed changes

This PR introduces two new environment variables that can be used to modify Node-RED behaviour.

 - `NODE_RED_ENABLE_SAFE_MODE` : enables safe mode. Equivalent to `--safe` argument
 - `NODE_RED_ENABLE_PROJECTS` : enables projects. Equivalent to `editorTheme.projects.enabled=true`

The benefit of adding these env vars is it makes it easier to enable these features in the docker container for two reasons:

1. you don't have to change the start command to add `--safe`
2. you don't have to edit the settings file to enable projects

Rather than add these things as docker specific features, it seems sensible to add them to the core of node-red as I'm sure they will be useful in other scenarios.

