### PR TITLE
Fix issue where subflow color did not update when not on a flow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -2238,6 +2238,12 @@ RED.editor = (function() {
                             changes.color = newColor;
                             changed = true;
                             RED.utils.clearNodeColorCache();
+                            if (editing_node.type === "subflow") {
+                                var nodeDefinition = RED.nodes.getType(
+                                    "subflow:" + editing_node.id
+                                );
+                                nodeDefinition["color"] = newColor;
+                            }
                         }
 
                         var old_env = editing_node.env;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
This PR fixes #2298.  I investigated the issue and the reproduction steps are much simpler than originally described in the ticket.  This bug seems to occur when a subflow color is changed from the initial load and the subflow node does not exist on any flows.  

I'm guessing when the `RED.nodes.eachNode` loop happens and the subflow exists on a flow it gets updated (but I'm not sure).  

From my logging it seems like if the subflow doesn't exist on a flow the registry's `nodeDefinitions` contains a stale version of the subflow with the old color.

This PR adds some logic to update the nodeDefinition of the subflow with the new color when there is a color change.

Repro:
Add a new subflow
Change the color of it
Drag it onto a flow tab and observe the color

Not sure if this is the best way to fix this so any guidance would be appreciated (pretty new to node-red and this repo)
<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
