### PR TITLE
i18n support in tooltips

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/de/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/de/editor.json
@@ -444,8 +444,8 @@
       "none" : "keine",
       "subflows" : "Subflows",
       "flows" : "Flows",
-      "filterUnused" : "Nicht verwendet",
       "filterAll" : "alle",
+      "filterUnused" : "Nicht verwendet",
       "filtered" : "__count__ verdeckt"
     },
     "context" : {

--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -315,6 +315,7 @@
         "labelInputs": "Inputs",
         "labelOutputs": "Outputs",
         "settingIcon": "Icon",
+        "default": "default",
         "noDefaultLabel": "none",
         "defaultLabel": "use default label",
         "searchIcons": "Search icons",
@@ -557,8 +558,10 @@
             "none": "none",
             "subflows": "subflows",
             "flows": "flows",
-            "filterUnused":"unused",
-            "filterAll":"all",
+            "filterAll": "all",
+            "showAllConfigNodes": "Show all config nodes",
+            "filterUnused": "unused",
+            "showAllUnusedConfigNodes": "Show all unused config nodes",
             "filtered": "__count__ hidden"
         },
         "context": {

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -315,6 +315,7 @@
         "labelInputs": "入力",
         "labelOutputs": "出力",
         "settingIcon": "アイコン",
+        "default": "デフォルト",
         "noDefaultLabel": "なし",
         "defaultLabel": "既定のラベルを使用",
         "searchIcons": "アイコンを検索",
@@ -557,8 +558,10 @@
             "none": "なし",
             "subflows": "サブフロー",
             "flows": "フロー",
-            "filterUnused": "未使用",
             "filterAll": "全て",
+            "showAllConfigNodes": "全設定ノードを表示",
+            "filterUnused": "未使用",
+            "showAllUnusedConfigNodes": "未使用の全設定ノードを表示",
             "filtered": "__count__ 個が無効"
         },
         "context": {

--- a/packages/node_modules/@node-red/editor-client/locales/ko/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ko/editor.json
@@ -494,8 +494,8 @@
       "none": "없음",
       "subflows": "보조 플로우",
       "flows": "플로우",
-      "filterUnused": "미사용",
       "filterAll": "전체",
+      "filterUnused": "미사용",
       "filtered": "__count__ 개 숨김"
     },
     "context": {

--- a/packages/node_modules/@node-red/editor-client/locales/zh-CN/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/zh-CN/editor.json
@@ -385,8 +385,8 @@
             "none": "无",
             "subflows": "子流程",
             "flows": "流程",
-            "filterUnused": "未使用",
             "filterAll": "所有",
+            "filterUnused": "未使用",
             "filtered": "__count__ 个隐藏"
         },
         "palette": {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1034,7 +1034,7 @@ RED.editor = (function() {
             });
 
             RED.popover.tooltip(iconButton, function() {
-                return $("#red-ui-editor-node-icon").val()||"default";
+                return $("#red-ui-editor-node-icon").val() || RED._("editor.default");
             })
             $('<input type="hidden" id="red-ui-editor-node-icon">').val(node.icon).appendTo(iconRow);
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
@@ -346,8 +346,8 @@ RED.sidebar.config = (function() {
                 refreshConfigNodeList();
             }
         });
-        RED.popover.tooltip($('#red-ui-sidebar-config-filter-all'),"Show all config nodes");
-        RED.popover.tooltip($('#red-ui-sidebar-config-filter-unused'),"Show all unused config nodes");
+        RED.popover.tooltip($('#red-ui-sidebar-config-filter-all'), RED._("sidebar.config.showAllUnusedConfigNodes"));
+        RED.popover.tooltip($('#red-ui-sidebar-config-filter-unused'), RED._("sidebar.config.showAllUnusedConfigNodes"));
 
     }
     function show(id) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Because some tooltips don't support i18n, I modified them to support i18n.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
