### PR TITLE
Fix width on inject node property

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.html
@@ -138,11 +138,11 @@
         width: 100px;
     }
     .inject-time-days input {
-        width: auto;
-        vertical-align: baseline;
+        width: auto !important;
+        vertical-align: baseline !important;
     }
     .inject-time-times {
-        width: 90px;
+        width: 90px !important;
     }
     #inject-time-time {
         width: 75px;


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
On the inject node property UI, the pull-down menu and checkboxes are wider than specified values. This problem seemed to occur because the order of the styles to apply was changed in Node-RED  v1.0.0. Therefore, I added `!important` to set higher priority.

![image](https://user-images.githubusercontent.com/20310935/66186271-d303ea00-e6bc-11e9-97e6-7f70796b62bc.png)

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
