### PR TITLE
add support for exporting subflow template

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -168,6 +168,7 @@
         "selectFile": "select a file to import",
         "importNodes": "Import nodes",
         "exportNodes": "Export nodes",
+        "exportSubflow": "Export subflow",
         "download": "Download",
         "importUnrecognised": "Imported unrecognised type:",
         "importUnrecognised_plural": "Imported unrecognised types:",
@@ -286,6 +287,7 @@
         "output": "outputs:",
         "status": "status node",
         "deleteSubflow": "delete subflow",
+        "exportSubflow": "export subflow",
         "info": "Description",
         "category": "Category",
         "env": {

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -168,6 +168,7 @@
         "selectFile": "読み込むファイルを選択してください",
         "importNodes": "フローをクリップボートから読み込み",
         "exportNodes": "フローをクリップボードへ書き出し",
+        "exportSubflow": "サブフローをクリップボードへ書き出し",
         "download": "ダウンロード",
         "importUnrecognised": "認識できない型が読み込まれました:",
         "importUnrecognised_plural": "認識できない型が読み込まれました:",
@@ -286,6 +287,7 @@
         "output": "出力:",
         "status": "ステータスノード",
         "deleteSubflow": "サブフローを削除",
+        "exportSubflow": "サブフローを書き出し",
         "info": "詳細",
         "category": "カテゴリ",
         "env": {

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -568,8 +568,25 @@ RED.nodes = (function() {
         return node;
     }
 
+    function collectNodesInSubflow(n) {
+        var nodes = RED.nodes.filterNodes({z:n.id});
+        return createExportableNodeSet(nodes);
+    }
+    
     function convertSubflow(n) {
         var node = {};
+        var id = n.id;
+        if (n.flow) {
+            var flow = collectNodesInSubflow(n);
+            node.flow = flow;
+            node.sealded = n.sealed;
+            node.hidden = n.hidden;
+            node.version = n.version;
+            node.author = n.author;
+            node.license = n.license;
+            node.keywords = n.keywords;
+            node.description = n.description;
+        }
         node.id = n.id;
         node.type = n.type;
         node.name = n.name;
@@ -796,6 +813,17 @@ RED.nodes = (function() {
         if (!$.isArray(newNodes)) {
             newNodes = [newNodes];
         }
+
+        // Flatten nodes within exported subflow
+        var tmp = [];
+        newNodes.forEach(function (n) {
+            tmp.push(n);
+            if ((n.type === "subflow") && n.hasOwnProperty("flow")) {
+                var flow = n.flow;
+                tmp = tmp.concat(flow);
+            }
+        });
+        newNodes = tmp;
 
         // Scan for any duplicate nodes and remove them. This is a temporary
         // fix to help resolve corrupted flows caused by 0.20.0 where multiple

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -28,6 +28,11 @@ RED.clipboard = (function() {
     var libraryBrowser;
     var examplesBrowser;
 
+    function cloneObject(obj) {
+        var newObj = Object.assign({}, obj);
+        return newObj;
+    }
+    
     function setupDialogs() {
         dialog = $('<div id="red-ui-clipboard-dialog" class="hide"><form class="dialog-form form-horizontal"></form></div>')
             .appendTo("#red-ui-editor")
@@ -170,7 +175,7 @@ RED.clipboard = (function() {
         dialogContainer = dialog.children(".dialog-form");
 
         exportNodesDialog =
-            '<div class="form-row">'+
+            '<div class="form-row" id="red-ui-clipboard-dialog-export-nodes">'+
                 '<label style="width:auto;margin-right: 10px;" data-i18n="common.label.export"></label>'+
                 '<span id="red-ui-clipboard-dialog-export-rng-group" class="button-group">'+
                     '<a id="red-ui-clipboard-dialog-export-rng-selected" class="red-ui-button toggle" href="#" data-i18n="clipboard.export.selected"></a>'+
@@ -484,7 +489,7 @@ RED.clipboard = (function() {
         });
     }
 
-    function exportNodes(mode) {
+    function exportNodes(mode, subflow) {
         if (disabled) {
             return;
         }
@@ -577,7 +582,19 @@ RED.clipboard = (function() {
             var type = $(this).attr('id');
             var flow = "";
             var nodes = null;
-            if (type === 'red-ui-clipboard-dialog-export-rng-selected') {
+            if (subflow) {
+                var sf = cloneObject(subflow);
+                sf.flow = [];
+                sf.sealed = false;
+                sf.hidden = false;
+                sf.version = "0.0.0";
+                sf.author = "";
+                sf.license = "";
+                sf.keywords = [];
+                sf.description = "";
+                nodes = RED.nodes.createExportableNodeSet([sf]);
+            }
+            else if (type === 'red-ui-clipboard-dialog-export-rng-selected') {
                 var selection = RED.workspaces.selection();
                 if (selection.length > 0) {
                     nodes = [];
@@ -637,13 +654,23 @@ RED.clipboard = (function() {
             $("#red-ui-clipboard-dialog-export-fmt-mini").trigger("click");
         }
         tabs.activateTab("red-ui-clipboard-dialog-export-tab-"+mode);
-        dialog.dialog("option","title",RED._("clipboard.exportNodes")).dialog( "open" );
+        dialog.dialog("option","title",RED._(subflow ? "clipboard.exportSubflow" : "clipboard.exportNodes")).dialog( "open" );
 
         $("#red-ui-clipboard-dialog-export-text").trigger("focus");
         $("#red-ui-clipboard-dialog-cancel").show();
         $("#red-ui-clipboard-dialog-export").show();
         $("#red-ui-clipboard-dialog-download").show();
 
+        if (subflow) {
+            $("#red-ui-clipboard-dialog-export-nodes").hide();
+        }
+        else {
+            $("#red-ui-clipboard-dialog-export-export-nodes").show();
+        }
+    }
+
+    function exportSubflow(mode, subflow) {
+        exportNodes(mode, subflow);
     }
 
     function loadFlowLibrary(browser,library,label) {
@@ -791,6 +818,7 @@ RED.clipboard = (function() {
         },
         import: importNodes,
         export: exportNodes,
+        exportSubflow: exportSubflow,
         copyText: copyText
     }
 })();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -2404,6 +2404,10 @@ RED.editor = (function() {
         RED.tray.show(trayOptions);
     }
 
+    function showExportSubflowDialog(subflow) {
+        RED.clipboard.exportSubflow(null, subflow);
+    }
+
     function showTypeEditor(type, options) {
         if (customEditTypes.hasOwnProperty(type)) {
             if (editStack.length > 0) {
@@ -2527,6 +2531,7 @@ RED.editor = (function() {
         edit: showEditDialog,
         editConfig: showEditConfigNodeDialog,
         editSubflow: showEditSubflowDialog,
+        exportSubflow: showExportSubflowDialog,
         editJavaScript: function(options) { showTypeEditor("_js",options) },
         editExpression: function(options) { showTypeEditor("_expression", options) },
         editJSON: function(options) { showTypeEditor("_json", options) },

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -334,6 +334,9 @@ RED.subflow = (function() {
         // Delete
         $('<a class="button" id="red-ui-subflow-delete" href="#" data-i18n="[append]subflow.deleteSubflow"><i class="fa fa-trash"></i> </a>').appendTo(toolbar);
 
+        // Export
+        $('<a class="button" id="red-ui-subflow-export" href="#" data-i18n="[append]subflow.exportSubflow"><i class="fa fa-share"></i> </a>').appendTo(toolbar);
+
         toolbar.i18n();
 
 
@@ -438,6 +441,11 @@ RED.subflow = (function() {
 
         });
 
+        $("#red-ui-subflow-export").on("click", function(event) {
+            event.preventDefault();
+            RED.editor.exportSubflow(RED.nodes.subflow(RED.workspaces.active()));
+        });
+        
         refreshToolbar(activeSubflow);
 
         $("#red-ui-workspace-chart").css({"margin-top": "40px"});


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This draft PR add initial support (phase1) of subflow export feature
described in [Exportable SUBFLOW](https://github.com/node-red/designs/blob/master/designs/exportable-subflow/README.md) design note.

This adds **export subflow** button on subflow template edit tab, support for new subflow format that embeds nodes within it using **flow** property, and importing new subflow format.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
