### PR TITLE
Fix menu in visual JSON editor

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/json.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/json.js
@@ -141,6 +141,7 @@
                 })
             }});
             options.push({id:"red-ui-editor-type-json-menu-collapse-children",icon:"fa fa-angle-double-up", label:RED._('jsonEditor.collapseItems'),onselect:function(){
+                item.treeList.collapse();
                 item.children.forEach(function(child) {
                     child.treeList.collapse();
                 })


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Current "Collapse items" element in the menu on visual JSON editor collapses child JSON objects only. I think that it is natural to collapse both parent and child JSON objects (It is opposite handling of "Expand items"). Therefore, I added the handling to collapse the parent JSON object.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality