### PR TITLE
Interval of inject node should be 596 hours or less.

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -79,7 +79,7 @@
         "on": "on",
         "onstart": "Inject once after",
         "onceDelay": "seconds, then",
-        "tip": "<b>Note:</b> \"interval between times\" and \"at a specific time\" will use cron.<br/>\"interval\" should be less than 596 hours.<br/>See info box for details.",
+        "tip": "<b>Note:</b> \"interval between times\" and \"at a specific time\" will use cron.<br/>\"interval\" should be 596 hours or less.<br/>See info box for details.",
         "success": "Successfully injected: __label__",
         "errors": {
             "failed": "inject failed, see log for details",


### PR DESCRIPTION

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Changed tip of inject node dialog.
Interval of inject node should be "596 hours or less", not "less than 596 hours".

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
