### PR TITLE
Fix invalid JSON data in template node

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/de/function/80-template.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/function/80-template.html
@@ -35,10 +35,12 @@
   <p> Beispiel: Wenn eine Vorlage von:
   <pre> Hallo {{payload.name}}. Heute ist {{date}} </pre>
   <p> eine Nachricht empfangt, die folgendes enthält:
-  <pre> {
-Datum: "Montag"
-Payload: { Name: "Fred"}
-} </pre>
+  <pre>{
+  date: "Montag",
+  payload: {
+    name: "Fred"
+  }
+}</pre>
   <p> wird die resultierende Nachrich wie folgt sein:
   <pre> Hallo Fred. Heute ist Montag </pre>
   <p> Es ist möglich, eine Eigenschaft aus dem Flowkontext oder dem globalen Kontext zu verwenden. 

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/80-template.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/80-template.html
@@ -36,7 +36,7 @@
     <pre>Hello {{payload.name}}. Today is {{date}}</pre>
     <p>receives a message containing:
     <pre>{
-  date: "Monday"
+  date: "Monday",
   payload: {
     name: "Fred"
   }

--- a/packages/node_modules/@node-red/nodes/locales/ja/function/80-template.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/function/80-template.html
@@ -34,9 +34,9 @@
     <pre>こんにちは{{payload.name}}さん。今日は{{date}}です。</pre>
     <p>というテンプレートに対して、
     <pre>{
-  date: "月曜日"
+  date: "月曜日",
   payload: {
-    name: "山田",
+    name: "山田"
   }
 }</pre>
     <p>というメッセージを受信した場合、</p>

--- a/packages/node_modules/@node-red/nodes/locales/ko/function/80-template.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/function/80-template.html
@@ -34,9 +34,9 @@
     <pre>안녕하세요, {{payload.name}}씨. 오늘은 {{date}}입니다.</pre>
     <p>라는 템플릿에 대해,
     <pre>{
-  date: "월요일"
+  date: "월요일",
   payload: {
-    name: "홍길동",
+    name: "홍길동"
   }
 }</pre>
     <p>이라는 메세지를 수신한 경우,</p>


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Current examples in the information tab of the template node don't work correctly because the JSON is not valid. Therefore, I fixed them in this pull request.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality