### PR TITLE
Fix language handling in subflow node

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -806,12 +806,12 @@ RED.subflow = (function() {
         locales.val(currentLocale);
 
         locales.on("change", function() {
-            currentLocale = $(this).val();
+            var locale = $(this).val();
             var items = $("#node-input-env-container").editableList("items");
             items.each(function (i, item) {
                 var entry = $(this).data('data');
                 var labelField = entry.ui.labelField;
-                labelField.val(lookupLabel(entry.ui.label, "", currentLocale));
+                labelField.val(lookupLabel(entry.ui.label, "", locale));
                 if (labelField.timeout) {
                     clearTimeout(labelField.timeout);
                     delete labelField.timeout;


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
The current subflow cannot show messages in the node property according to language which is specified in user settings UI. The language used is the language that was specified in custom subflow UI. This problem occurred because custom subflow property UI overwrites the `currentLocale` value. Therefore, I changed the value name to avoid the conflict.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
