### PR TITLE
Fix handling to avoid invalid nested subflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -845,7 +845,7 @@ RED.nodes = (function() {
             var m = /^subflow:(.+)$/.exec(newNodes[i].type);
             if (m) {
                 var subflowId = m[1];
-                var parent = getSubflow(newNodes[i].z || activeWorkspace);
+                var parent = getSubflow(activeWorkspace);
                 if (parent) {
                     var err;
                     if (subflowId === parent.id) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
On the latest Node-RED flow editor, users can mistakenly create a nested subflow using keyboard shortcuts.

![subflowcopy](https://user-images.githubusercontent.com/20310935/66917190-e36e7a00-f057-11e9-9816-8f528cefa149.gif)

To avoid the nested subflow, there's the handling to show an error in the current implementation but it doesn't work correctly because `getSubflow(newNodes[i].z || activeWorkspace)` returns `null`. I think that `getSubflow(activeWorkspace)` is enough to the handling. Because I cannot imagine the situation to use `newNodes[i].z`, I tried to submit this pull request as a draft pull request.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
