### PR TITLE
Fix language handling in subflow node

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -802,8 +802,8 @@ RED.subflow = (function() {
             }
             $("<option/>", opt).text(item.text).appendTo(locales);
         });
-        currentLocale = RED.i18n.lang();
-        locales.val(currentLocale);
+        var locale = RED.i18n.lang();
+        locales.val(locale);
 
         locales.on("change", function() {
             currentLocale = $(this).val();
@@ -1371,7 +1371,8 @@ RED.subflow = (function() {
         }
 
         var labels = ui.label || {};
-        var labelText = lookupLabel(labels, labels["en-US"]||tenv.name, currentLocale);
+        var locale = RED.i18n.lang();
+        var labelText = lookupLabel(labels, labels["en-US"]||tenv.name, locale);
         var label = $('<label>').appendTo(row);
         var labelContainer = $('<span></span>').appendTo(label);
         if (ui.icon) {
@@ -1423,7 +1424,7 @@ RED.subflow = (function() {
                 input = $('<select>').css('width','70%').appendTo(row);
                 if (ui.opts.opts) {
                     ui.opts.opts.forEach(function(o) {
-                        $('<option>').val(o.v).text(lookupLabel(o.l, o.l['en-US']||o.v, currentLocale)).appendTo(input);
+                        $('<option>').val(o.v).text(lookupLabel(o.l, o.l['en-US']||o.v, locale)).appendTo(input);
                     })
                 }
                 input.val(val.value);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -806,12 +806,12 @@ RED.subflow = (function() {
         locales.val(currentLocale);
 
         locales.on("change", function() {
-            var locale = $(this).val();
+            currentLocale = $(this).val();
             var items = $("#node-input-env-container").editableList("items");
             items.each(function (i, item) {
                 var entry = $(this).data('data');
                 var labelField = entry.ui.labelField;
-                labelField.val(lookupLabel(entry.ui.label, "", locale));
+                labelField.val(lookupLabel(entry.ui.label, "", currentLocale));
                 if (labelField.timeout) {
                     clearTimeout(labelField.timeout);
                     delete labelField.timeout;


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I found that the previous pull request (#2328) didn't solve the problem. I have misunderstood the usage of `currentLocale`. In this pull request, the modified code simply uses `RED.i18n.lang()` when the editor needs the language which was specified in user settings UI.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
