### PR TITLE
Check auth type on opening

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.html
@@ -170,6 +170,7 @@
             if (this.authType) {
                 $('#node-input-useAuth').prop('checked', true);
                 $("#node-input-authType-select").val(this.authType);
+                $("#node-input-authType-select").change();
             } else {
                 $('#node-input-useAuth').prop('checked', false);
             }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

When opening the config screen of a http-request node, the authentication type (digest, basic, bearer) will determine which fields (username, passworde, token) needs to be visible.  Since that ```change``` handler wasn't called, the incorrect authentication fields became visible.

I simply call the ```change()``` method of the authentication-type dropdown, to trigger the handler...

I have discussed the change (incl. animations) in this Discourse [post](https://discourse.nodered.org/t/odd-problem-with-bearer-authentication/12422/16?u=bartbutenaers).  

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
