### PR TITLE
[Draft] add support of exportable subflow phase2

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -303,6 +303,13 @@
             "restore": "Restore to subflow default",
             "remove": "Remove environment variable"
         },
+        "placeholder": {
+            "name": "export name",
+            "license": "license",
+            "keywords": "',' separated keywords",
+            "author": "author name",
+            "description": "description"
+        },
         "errors": {
             "noNodesSelected": "<strong>Cannot create subflow</strong>: no nodes selected",
             "multipleInputsToSelection": "<strong>Cannot create subflow</strong>: multiple inputs to selection"

--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -168,6 +168,7 @@
         "selectFile": "select a file to import",
         "importNodes": "Import nodes",
         "exportNodes": "Export nodes",
+        "exportSubflow": "Export subflow",
         "download": "Download",
         "importUnrecognised": "Imported unrecognised type:",
         "importUnrecognised_plural": "Imported unrecognised types:",
@@ -286,8 +287,18 @@
         "output": "outputs:",
         "status": "status node",
         "deleteSubflow": "delete subflow",
+        "exportSubflow": "export subflow",
         "info": "Description",
         "category": "Category",
+        "export-name": "Export As",
+        "no-prefix": "no prefix",
+        "license": "License",
+        "addLicense": "Add new...",
+        "version": "Version",
+        "keys": "Keywords",
+        "author": "Author",
+        "desc": "Description",
+        "export": "export",
         "env": {
             "restore": "Restore to subflow default",
             "remove": "Remove environment variable"
@@ -986,7 +997,8 @@
         "description": "Description",
         "appearance": "Appearance",
         "preview": "UI Preview",
-        "defaultValue": "Default value"
+        "defaultValue": "Default value",
+        "info": "Info" 
     },
     "languages" : {
         "de": "German",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -303,6 +303,13 @@
             "restore": "デフォルト値に戻す",
             "remove": "環境変数を削除"
         },
+        "placeholder": {
+            "name": "配布名",
+            "license": "ライセンス",
+            "keywords": "','で区切ったキーワード",
+            "author": "作者",
+            "description": "説明"
+        },
         "errors": {
             "noNodesSelected": "<strong>サブフローを作成できません</strong>: ノードが選択されていません",
             "multipleInputsToSelection": "<strong>サブフローを作成できません</strong>: 複数の入力が選択されています"

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -168,6 +168,7 @@
         "selectFile": "読み込むファイルを選択してください",
         "importNodes": "フローをクリップボートから読み込み",
         "exportNodes": "フローをクリップボードへ書き出し",
+        "exportSubflow": "サブフローをクリップボードへ書き出し",
         "download": "ダウンロード",
         "importUnrecognised": "認識できない型が読み込まれました:",
         "importUnrecognised_plural": "認識できない型が読み込まれました:",
@@ -285,9 +286,19 @@
         "input": "入力:",
         "output": "出力:",
         "status": "ステータスノード",
-        "deleteSubflow": "サブフローを削除",
+        "deleteSubflow": "削除",
+        "exportSubflow": "書出し",
         "info": "詳細",
         "category": "カテゴリ",
+        "export-name": "公開名",
+        "no-prefix": "無し",
+        "license": "ライセンス",
+        "addLicense": "新規...",
+        "version": "バージョン",
+        "keys": "キーワード",
+        "author": "作者",
+        "desc": "説明",
+        "export": "書出し",
         "env": {
             "restore": "デフォルト値に戻す",
             "remove": "環境変数を削除"
@@ -985,7 +996,8 @@
         "description": "説明",
         "appearance": "外観",
         "preview": "UIプレビュー",
-        "defaultValue": "デフォルト値"
+        "defaultValue": "デフォルト値",
+        "info": "情報"
     },
     "languages": {
         "de": "ドイツ語",

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -568,8 +568,24 @@ RED.nodes = (function() {
         return node;
     }
 
+    function collectNodesInSubflow(n) {
+        var nodes = RED.nodes.filterNodes({z:n.id});
+        return createExportableNodeSet(nodes);
+    }
+    
     function convertSubflow(n) {
         var node = {};
+        var id = n.id;
+        if (n.flow) {
+            var flow = collectNodesInSubflow(n);
+            node.flow = flow;
+            node.exportName = n.exportName;
+            node.version = n.version;
+            node.author = n.author;
+            node.license = n.license;
+            node.keywords = n.keywords;
+            node.description = n.description;
+        }
         node.id = n.id;
         node.type = n.type;
         node.name = n.name;
@@ -796,6 +812,17 @@ RED.nodes = (function() {
         if (!$.isArray(newNodes)) {
             newNodes = [newNodes];
         }
+
+        // Flatten nodes within exported subflow
+        var tmp = [];
+        newNodes.forEach(function (n) {
+            tmp.push(n);
+            if ((n.type === "subflow") && n.hasOwnProperty("flow")) {
+                var flow = n.flow;
+                tmp = tmp.concat(flow);
+            }
+        });
+        newNodes = tmp;
 
         // Scan for any duplicate nodes and remove them. This is a temporary
         // fix to help resolve corrupted flows caused by 0.20.0 where multiple

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -28,6 +28,11 @@ RED.clipboard = (function() {
     var libraryBrowser;
     var examplesBrowser;
 
+    function cloneObject(obj) {
+        var newObj = Object.assign({}, obj);
+        return newObj;
+    }
+    
     function setupDialogs() {
         dialog = $('<div id="red-ui-clipboard-dialog" class="hide"><form class="dialog-form form-horizontal"></form></div>')
             .appendTo("#red-ui-editor")
@@ -170,7 +175,7 @@ RED.clipboard = (function() {
         dialogContainer = dialog.children(".dialog-form");
 
         exportNodesDialog =
-            '<div class="form-row">'+
+            '<div class="form-row" id="red-ui-clipboard-dialog-export-nodes">'+
                 '<label style="width:auto;margin-right: 10px;" data-i18n="common.label.export"></label>'+
                 '<span id="red-ui-clipboard-dialog-export-rng-group" class="button-group">'+
                     '<a id="red-ui-clipboard-dialog-export-rng-selected" class="red-ui-button toggle" href="#" data-i18n="clipboard.export.selected"></a>'+
@@ -484,7 +489,8 @@ RED.clipboard = (function() {
         });
     }
 
-    function exportNodes(mode) {
+    function exportNodes(mode, subflow) {
+
         if (disabled) {
             return;
         }
@@ -577,7 +583,17 @@ RED.clipboard = (function() {
             var type = $(this).attr('id');
             var flow = "";
             var nodes = null;
-            if (type === 'red-ui-clipboard-dialog-export-rng-selected') {
+            if (subflow) {
+                var sf = cloneObject(subflow);
+                sf.flow = [];
+                sf.version = subflow.version;
+                sf.author = subflow.author;
+                sf.license = subflow.license;
+                sf.keywords = subflow.keywords;
+                sf.description = subflow.description;
+                nodes = RED.nodes.createExportableNodeSet([sf]);
+            }
+            else if (type === 'red-ui-clipboard-dialog-export-rng-selected') {
                 var selection = RED.workspaces.selection();
                 if (selection.length > 0) {
                     nodes = [];
@@ -637,13 +653,23 @@ RED.clipboard = (function() {
             $("#red-ui-clipboard-dialog-export-fmt-mini").trigger("click");
         }
         tabs.activateTab("red-ui-clipboard-dialog-export-tab-"+mode);
-        dialog.dialog("option","title",RED._("clipboard.exportNodes")).dialog( "open" );
+        dialog.dialog("option","title",RED._(subflow ? "clipboard.exportSubflow" : "clipboard.exportNodes")).dialog( "open" );
 
         $("#red-ui-clipboard-dialog-export-text").trigger("focus");
         $("#red-ui-clipboard-dialog-cancel").show();
         $("#red-ui-clipboard-dialog-export").show();
         $("#red-ui-clipboard-dialog-download").show();
 
+        if (subflow) {
+            $("#red-ui-clipboard-dialog-export-nodes").hide();
+        }
+        else {
+            $("#red-ui-clipboard-dialog-export-export-nodes").show();
+        }
+    }
+
+    function exportSubflow(mode, subflow) {
+        exportNodes(mode, subflow);
     }
 
     function loadFlowLibrary(browser,library,label) {
@@ -791,6 +817,7 @@ RED.clipboard = (function() {
         },
         import: importNodes,
         export: exportNodes,
+        exportSubflow: exportSubflow,
         copyText: copyText
     }
 })();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1155,7 +1155,8 @@ RED.editor = (function() {
         }).appendTo(nameRow);
         var name = $("<input/>", {
             type: "text",
-            id: "subflow-info-input-export-name"
+            id: "subflow-info-input-export-name",
+            "data-i18n": "[placeholder]editor:subflow.placeholder.name"
         }).css({
             "margin-left": "10px",
             width: "calc(100% - 292px)"
@@ -1200,7 +1201,8 @@ RED.editor = (function() {
         }).appendTo(licenceRow);
         var license = $("<input/>", {
             type: "text",
-            id: "subflow-info-input-custom-license"
+            id: "subflow-info-input-custom-license",
+            "data-i18n": "[placeholder]editor:subflow.placeholder.license"
         }).css({
             display: "none",
             "margin-left": "10px",
@@ -1281,7 +1283,8 @@ RED.editor = (function() {
         }).appendTo(keysRow);
         var keys = $("<input/>", {
             id: "subflow-info-input-keyword",
-            type: "text"
+            type: "text",
+            "data-i18n": "[placeholder]editor:subflow.placeholder.keywords"
         }).appendTo(keysRow);
         keys.val(node.keywords ? node.keywords.join(",") : node.keywords);
 
@@ -1294,7 +1297,8 @@ RED.editor = (function() {
         }).appendTo(authorRow);
         var author = $("<input/>", {
             id: "subflow-info-input-author",
-            type: "text"
+            type: "text",
+            "data-i18n": "[placeholder]editor:subflow.placeholder.author"
         }).appendTo(authorRow);
         author.val(node.author);
 
@@ -1307,7 +1311,8 @@ RED.editor = (function() {
         }).appendTo(descRow);
         var desc = $("<input/>", {
             id: "subflow-info-input-desc",
-            type: "text"
+            type: "text",
+            "data-i18n": "[placeholder]editor:subflow.placeholder.description"
         }).appendTo(descRow);
         desc.val(node.description);
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1134,6 +1134,206 @@ RED.editor = (function() {
         return nodeInfoEditor;
     }
 
+    function buildInfoForm(container, node, subflowEditor) {
+        var dialogForm = $('<form class="dialog-form form-horizontal" autocomplete="off"></form>').appendTo(container);
+
+        var nameRow = $("<div/>", {
+            class: "form-row"
+        }).appendTo(dialogForm);
+
+        var nameRow = $("<div/>", {
+            class: "form-row"
+        }).appendTo(dialogForm);
+        $("<label/>", {
+            for: "subflow-info-input-export-name",
+            "data-i18n": "editor:subflow.export-name"
+        }).appendTo(nameRow);
+        var prefixSelector = $("<select/>", {
+            id: "subflow-info-input-export-name-prefix"
+        }).css({
+            width: "140px"
+        }).appendTo(nameRow);
+        var name = $("<input/>", {
+            type: "text",
+            id: "subflow-info-input-export-name"
+        }).css({
+            "margin-left": "10px",
+            width: "calc(100% - 292px)"
+        }).appendTo(nameRow);
+        var prefixes = ["node-red-contrib-", "node-red-node-"];
+        prefixes.forEach(function(pre) {
+            prefixSelector.append($("<option/>").val(pre).text(pre));
+        })
+        prefixSelector.append($("<option/>", {
+            "disabled": true
+        }).text("---"));
+        prefixSelector.append($("<option/>").val("_none_").text(RED._("subflow.no-prefix")));
+
+        var exportName = node.exportName;
+        var prefix = "_none_";
+        if (exportName) {
+            prefixes.forEach(function(pre) {
+                if (exportName.indexOf(pre) === 0) {
+                    prefix = pre;
+                    exportName = exportName.substring(pre.length);
+                    return;
+                }
+            });
+        }
+        else {
+            exportName = node.name ? node.name.replace(/[^A-Za-z0-9_\-]/g, '_') : "";
+        }
+        prefixSelector.val(prefix);
+        name.val(exportName);
+
+        var licenceRow = $("<div/>", {
+            class: "form-row"
+        }).appendTo(dialogForm);
+        $("<label/>", {
+            for: "subflow-info-input-license",
+            "data-i18n": "editor:subflow.license"
+        }).appendTo(licenceRow);
+        var licenseSelector = $("<select/>", {
+            id: "subflow-info-input-license"
+        }).css({
+            width: "140px"
+        }).appendTo(licenceRow);
+        var license = $("<input/>", {
+            type: "text",
+            id: "subflow-info-input-custom-license"
+        }).css({
+            display: "none",
+            "margin-left": "10px",
+            width: "calc(100% - 292px)"
+        }).appendTo(licenceRow);
+        var licenses = ["Apache-2.0", "BSD-3-Clause", "BSD-2-Clause", "GPL-2.0", "GPL-3.0", "MIT", "MPL-2.0", "CDDL-1.0", "EPL-2.0"];
+        licenses.forEach(function(lic) {
+            licenseSelector.append($("<option/>").val(lic).text(lic));
+        })
+        licenseSelector.append($("<option/>", {
+            "disabled": true
+        }).text("---"));
+        licenseSelector.append($("<option/>").val("_custom_").text(RED._("subflow.addLicense")));
+
+        $("#subflow-info-input-license").on("change", function() {
+            var val = $(this).val();
+            if (val === "_custom_") {
+                $("#subflow-info-input-custom-license").show();
+            } else {
+                $("#subflow-info-input-custom-license").hide();
+                $("#subflow-info-input-custom-license").val(val);
+            }
+        })
+        license.val(node.license);
+        if (licenses.includes(node.license)) {
+            licenseSelector.val(node.license);
+        }
+        else {
+            licenseSelector.val("_custom_");
+        }
+        licenseSelector.change();
+        
+        var versionRow = $("<div/>", {
+            class: "form-row"
+        }).appendTo(dialogForm);
+        $("<label/>", {
+            for: "subflow-info-input-version",
+            "data-i18n": "editor:subflow.version"
+        }).appendTo(versionRow);
+        var major = $("<input/>", {
+            id: "subflow-info-input-version-major"
+        }).css({
+            width: "30px"
+        });
+        var minor = $("<input/>", {
+            id: "subflow-info-input-version-minor"
+        }).css({
+            width: "30px"
+        });
+        var patch = $("<input/>", {
+            id: "subflow-info-input-version-patch"
+        }).css({
+            width: "30px"
+        });
+        versionRow.append(major, " ", minor, " ", patch);
+        major.spinner({min: 0});
+        minor.spinner({min: 0});
+        patch.spinner({min: 0});
+        major.val(0);
+        minor.val(0);
+        patch.val(0);
+        var version = node.version;
+        if (version) {
+            var result = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+            if (result) {
+                $(major).val(result[1]);
+                $(minor).val(result[2]);
+                $(patch).val(result[3]);
+            }
+        }
+
+        var keysRow = $("<div/>", {
+            class: "form-row"
+        }).appendTo(dialogForm);
+        $("<label/>", {
+            for: "subflow-info-input-keyword",
+            "data-i18n": "editor:subflow.keys"
+        }).appendTo(keysRow);
+        var keys = $("<input/>", {
+            id: "subflow-info-input-keyword",
+            type: "text"
+        }).appendTo(keysRow);
+        keys.val(node.keywords ? node.keywords.join(",") : node.keywords);
+
+        var authorRow = $("<div/>", {
+            class: "form-row"
+        }).appendTo(dialogForm);
+        $("<label/>", {
+            for: "subflow-info-input-author",
+            "data-i18n": "editor:subflow.author"
+        }).appendTo(authorRow);
+        var author = $("<input/>", {
+            id: "subflow-info-input-author",
+            type: "text"
+        }).appendTo(authorRow);
+        author.val(node.author);
+
+        var descRow = $("<div/>", {
+            class: "form-row"
+        }).appendTo(dialogForm);
+        $("<label/>", {
+            for: "subflow-info-input-desc",
+            "data-i18n": "editor:subflow.desc"
+        }).appendTo(descRow);
+        var desc = $("<input/>", {
+            id: "subflow-info-input-desc",
+            type: "text"
+        }).appendTo(descRow);
+        desc.val(node.description);
+
+        var buttonRow = $("<div/>", {
+            class: "form-row"
+        }).appendTo(dialogForm);
+        var exportButton = $("<a/>", {
+            id: "subflow-info-export",
+            class: "red-ui-button"
+        }).css({
+            "margin-right": "30px",
+            "float": "right"
+        }).appendTo(buttonRow);
+        exportButton.append($("<i/>", {
+            class: "fa fa-share"
+        }), " ", RED._("subflow.export"));
+        exportButton.on("click", function (e) {
+            e.preventDefault();
+            commitSubflowEdit(node, subflowEditor, function() {
+                setTimeout(function() {
+                    showExportSubflowDialog(node);
+                }, 150);
+            });
+        });
+    }
+
     function showEditDialog(node) {
         var editing_node = node;
         var isDefaultIcon;
@@ -1794,7 +1994,6 @@ RED.editor = (function() {
                     nodeInfoEditor = buildDescriptionForm(descriptionTab.content,editing_config_node);
                 }
 
-
                 prepareEditDialog(editing_config_node,node_def,"node-config-input", function() {
                     if (editing_config_node._def.exclusive) {
                         $("#red-ui-editor-config-scope").hide();
@@ -2165,6 +2364,186 @@ RED.editor = (function() {
         }
     }
 
+    function arrayEq(a0, a1) {
+        if (a0 && a1 && (a0.length === a1.length)) {
+            for(var i = 0; i < a0.length; i++) {
+                if (a0[i] !== a1[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    function commitSubflowEdit(editing_node, subflowEditor, done) {
+        var changes = {};
+        var changed = false;
+        var wasDirty = RED.nodes.dirty();
+
+        var newName = $("#subflow-input-name").val();
+        if (newName != editing_node.name) {
+            changes['name'] = editing_node.name;
+            editing_node.name = newName;
+            changed = true;
+        }
+
+        var newDescription = subflowEditor.getValue();
+
+        if (newDescription != editing_node.info) {
+            changes['info'] = editing_node.info;
+            editing_node.info = newDescription;
+            changed = true;
+        }
+
+        if (updateLabels(editing_node, changes, null)) {
+            changed = true;
+        }
+
+        var icon = $("#red-ui-editor-node-icon").val()||"";
+        if ((editing_node.icon === undefined && icon !== "node-red/subflow.svg") ||
+            (editing_node.icon !== undefined && editing_node.icon !== icon)) {
+            changes.icon = editing_node.icon;
+            editing_node.icon = icon;
+            changed = true;
+        }
+
+        var newCategory = $("#subflow-appearance-input-category").val().trim();
+        if (newCategory === "_custom_") {
+            newCategory = $("#subflow-appearance-input-custom-category").val().trim();
+            if (newCategory === "") {
+                newCategory = editing_node.category;
+            }
+        }
+        if (newCategory === 'subflows') {
+            newCategory = '';
+        }
+        if (newCategory != editing_node.category) {
+            changes['category'] = editing_node.category;
+            editing_node.category = newCategory;
+            changed = true;
+        }
+
+        var oldColor = editing_node.color;
+        var newColor =  $("#red-ui-editor-node-color").val();
+        if (oldColor !== newColor) {
+            editing_node.color = newColor;
+            changes.color = newColor;
+            changed = true;
+            RED.utils.clearNodeColorCache();
+            if (editing_node.type === "subflow") {
+                var nodeDefinition = RED.nodes.getType(
+                    "subflow:" + editing_node.id
+                );
+                nodeDefinition["color"] = newColor;
+            }
+        }
+
+        var old_env = editing_node.env;
+        var new_env = RED.subflow.exportSubflowTemplateEnv($("#node-input-env-container").editableList("items"));
+        if (!isSameObj(old_env, new_env)) {
+            editing_node.env = new_env;
+            changes.env = editing_node.env;
+            changed = true;
+        }
+        RED.palette.refresh();
+
+        var old_exportName = editing_node.exportName;
+        var prefix = $("#subflow-info-input-export-name-prefix").val();
+        if (!prefix || (prefix === "_none_")) {
+            prefix = "";
+        }
+        var new_exportName = $("#subflow-info-input-export-name").val();
+        if (!new_exportName || (new_exportName === "")) {
+            new_exportName = editing_node.name;
+        }
+        new_exportName = prefix +new_exportName.replace(/[^A-Za-z0-9_\-]/g, '_');
+        if (old_exportName !== new_exportName) {
+            editing_node.exportName = new_exportName;
+            changes.exportName = new_exportName;
+            changed = true;
+        }
+
+        var old_license = editing_node.license;
+        var new_license = $("#subflow-info-input-custom-license").val();
+        if (old_license !== new_license) {
+            editing_node.license = new_license;
+            changes.license = new_license;
+            changed = true;
+        }
+
+        var old_version = editing_node.version;
+        var major = $("#subflow-info-input-version-major").val();
+        var minor = $("#subflow-info-input-version-minor").val();
+        var patch = $("#subflow-info-input-version-patch").val();
+        var new_version = major +"." +minor +"." +patch;
+        if (old_version !== new_version) {
+            editing_node.version = new_version;
+            changes.version = new_version;
+            changed = true;
+        }
+
+        var old_keywords  = editing_node.keywords;
+        var val = $("#subflow-info-input-keyword").val();
+        var new_keywords = (val ? val.split(",") : []);
+        if (!arrayEq(old_keywords, new_keywords)) {
+            editing_node.keywords = new_keywords;
+            changes.keywords = new_keywords;
+            changed = true;
+        }
+
+        var old_author  = editing_node.author;
+        var new_author = $("#subflow-info-input-author").val();
+        if (old_author !== new_author) {
+            editing_node.author = new_author;
+            changes.author = new_author;
+            changed = true;
+        }
+        
+        var old_desc  = editing_node.description;
+        var new_desc = $("#subflow-info-input-desc").val();
+        if (old_desc !== new_desc) {
+            editing_node.description = new_desc;
+            changes.description = new_desc;
+            changed = true;
+        }
+
+        if (changed) {
+            var wasChanged = editing_node.changed;
+            editing_node.changed = true;
+            validateNode(editing_node);
+            var subflowInstances = [];
+            RED.nodes.eachNode(function(n) {
+                if (n.type == "subflow:"+editing_node.id) {
+                    subflowInstances.push({
+                        id:n.id,
+                        changed:n.changed
+                    })
+                    n._def.color = editing_node.color;
+                    n.changed = true;
+                    n.dirty = true;
+                    updateNodeProperties(n);
+                    validateNode(n);
+                }
+            });
+            RED.nodes.dirty(true);
+            var historyEvent = {
+                t:'edit',
+                node:editing_node,
+                changes:changes,
+                dirty:wasDirty,
+                changed:wasChanged,
+                subflow: {
+                    instances:subflowInstances
+                }
+            };
+
+            RED.history.push(historyEvent);
+        }
+        editing_node.dirty = true;
+        RED.tray.close(null, done);
+    }
+    
     function showEditSubflowDialog(subflow) {
         var editing_node = subflow;
         editStack.push(subflow);
@@ -2186,110 +2565,7 @@ RED.editor = (function() {
                     class: "primary",
                     text: RED._("common.label.done"),
                     click: function() {
-                        var i;
-                        var changes = {};
-                        var changed = false;
-                        var wasDirty = RED.nodes.dirty();
-
-                        var newName = $("#subflow-input-name").val();
-
-                        if (newName != editing_node.name) {
-                            changes['name'] = editing_node.name;
-                            editing_node.name = newName;
-                            changed = true;
-                        }
-
-                        var newDescription = subflowEditor.getValue();
-
-                        if (newDescription != editing_node.info) {
-                            changes['info'] = editing_node.info;
-                            editing_node.info = newDescription;
-                            changed = true;
-                        }
-                        if (updateLabels(editing_node, changes, null)) {
-                            changed = true;
-                        }
-                        var icon = $("#red-ui-editor-node-icon").val()||"";
-                        if ((editing_node.icon === undefined && icon !== "node-red/subflow.svg") ||
-                            (editing_node.icon !== undefined && editing_node.icon !== icon)) {
-                            changes.icon = editing_node.icon;
-                            editing_node.icon = icon;
-                            changed = true;
-                        }
-                        var newCategory = $("#subflow-appearance-input-category").val().trim();
-                        if (newCategory === "_custom_") {
-                            newCategory = $("#subflow-appearance-input-custom-category").val().trim();
-                            if (newCategory === "") {
-                                newCategory = editing_node.category;
-                            }
-                        }
-                        if (newCategory === 'subflows') {
-                            newCategory = '';
-                        }
-                        if (newCategory != editing_node.category) {
-                            changes['category'] = editing_node.category;
-                            editing_node.category = newCategory;
-                            changed = true;
-                        }
-
-                        var oldColor = editing_node.color;
-                        var newColor =  $("#red-ui-editor-node-color").val();
-                        if (oldColor !== newColor) {
-                            editing_node.color = newColor;
-                            changes.color = newColor;
-                            changed = true;
-                            RED.utils.clearNodeColorCache();
-                            if (editing_node.type === "subflow") {
-                                var nodeDefinition = RED.nodes.getType(
-                                    "subflow:" + editing_node.id
-                                );
-                                nodeDefinition["color"] = newColor;
-                            }
-                        }
-
-                        var old_env = editing_node.env;
-                        var new_env = RED.subflow.exportSubflowTemplateEnv($("#node-input-env-container").editableList("items"));
-                        if (!isSameObj(old_env, new_env)) {
-                            editing_node.env = new_env;
-                            changes.env = editing_node.env;
-                            changed = true;
-                        }
-                        RED.palette.refresh();
-
-                        if (changed) {
-                            var wasChanged = editing_node.changed;
-                            editing_node.changed = true;
-                            validateNode(editing_node);
-                            var subflowInstances = [];
-                            RED.nodes.eachNode(function(n) {
-                                if (n.type == "subflow:"+editing_node.id) {
-                                    subflowInstances.push({
-                                        id:n.id,
-                                        changed:n.changed
-                                    })
-                                    n._def.color = editing_node.color;
-                                    n.changed = true;
-                                    n.dirty = true;
-                                    updateNodeProperties(n);
-                                    validateNode(n);
-                                }
-                            });
-                            RED.nodes.dirty(true);
-                            var historyEvent = {
-                                t:'edit',
-                                node:editing_node,
-                                changes:changes,
-                                dirty:wasDirty,
-                                changed:wasChanged,
-                                subflow: {
-                                    instances:subflowInstances
-                                }
-                            };
-
-                            RED.history.push(historyEvent);
-                        }
-                        editing_node.dirty = true;
-                        RED.tray.close();
+                        commitSubflowEdit(editing_node, subflowEditor, null);
                     }
                 }
             ],
@@ -2388,6 +2664,18 @@ RED.editor = (function() {
                 buildAppearanceForm(appearanceTab.content,editing_node);
                 editorTabs.addTab(appearanceTab);
 
+                var infoTab = {
+                    id: "editor-tab-info",
+                    label: RED._("editor-tab.info"),
+                    name: RED._("editor-tab.info"),
+                    content: $('<div>', {class:"red-ui-tray-content"}).appendTo(editorContent).hide(),
+                    iconClass: "fa fa-info-circle",
+                    onchange: function() {
+                    }
+                };
+                buildInfoForm(infoTab.content, editing_node, subflowEditor);
+                editorTabs.addTab(infoTab);
+
                 $("#subflow-input-name").val(subflow.name);
                 RED.text.bidi.prepareInput($("#subflow-input-name"));
 
@@ -2409,6 +2697,10 @@ RED.editor = (function() {
             }
         }
         RED.tray.show(trayOptions);
+    }
+
+    function showExportSubflowDialog(subflow) {
+        RED.clipboard.exportSubflow(null, subflow);
     }
 
     function showTypeEditor(type, options) {
@@ -2534,6 +2826,7 @@ RED.editor = (function() {
         edit: showEditDialog,
         editConfig: showEditConfigNodeDialog,
         editSubflow: showEditSubflowDialog,
+        exportSubflow: showExportSubflowDialog,
         editJavaScript: function(options) { showTypeEditor("_js",options) },
         editExpression: function(options) { showTypeEditor("_expression", options) },
         editJSON: function(options) { showTypeEditor("_json", options) },

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -334,6 +334,9 @@ RED.subflow = (function() {
         // Delete
         $('<a class="button" id="red-ui-subflow-delete" href="#" data-i18n="[append]subflow.deleteSubflow"><i class="fa fa-trash"></i> </a>').appendTo(toolbar);
 
+        // Export
+        $('<a class="button" id="red-ui-subflow-export" href="#" data-i18n="[append]subflow.exportSubflow"><i class="fa fa-share"></i> </a>').appendTo(toolbar);
+
         toolbar.i18n();
 
 
@@ -438,6 +441,11 @@ RED.subflow = (function() {
 
         });
 
+        $("#red-ui-subflow-export").on("click", function(event) {
+            event.preventDefault();
+            RED.editor.exportSubflow(RED.nodes.subflow(RED.workspaces.active()));
+        });
+        
         refreshToolbar(activeSubflow);
 
         $("#red-ui-workspace-chart").css({"margin-top": "40px"});

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tray.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tray.js
@@ -265,7 +265,7 @@ RED.tray = (function() {
             }
         },
         resize: handleWindowResize,
-        close: function close(done) {
+        close: function close(done, done1) {
             if (stack.length > 0) {
                 var tray = stack.pop();
                 tray.tray.css({
@@ -304,6 +304,9 @@ RED.tray = (function() {
                         $(".red-ui-sidebar-shade").hide();
                         RED.events.emit("editor:close");
                         RED.view.focus();
+                    }
+                    if (done1) {
+                        done1();
                     }
                 },250)
             }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.
-
-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

This draft PR add initial support (phase1+phase2) of subflow export feature
described in [Exportable SUBFLOW](https://github.com/node-red/designs/blob/master/designs/exportable-subflow/README.md) design note.

- Phase1

see https://github.com/node-red/node-red/pull/2309

- Phase2

Adds info tab to subflow edit panel.   This tab includes specifications for export name, license, version, keywords, author, and description.  

![スクリーンショット 2019-10-24 22 11 08](https://user-images.githubusercontent.com/30289092/67488708-39bc6800-f6ab-11e9-913f-1f8181343cf5.png)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
