### PR TITLE
Using the ‘a msg per line’ the last line does not get msg.topic passed

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.js
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.js
@@ -341,6 +341,7 @@ module.exports = function(RED) {
                         }
                         else if (node.format === "lines") {
                             var m = { payload: spare,
+                                      topic:msg.topic,
                                       parts: {
                                           index: count,
                                           count: count+1,


### PR DESCRIPTION
When using the file-in node and ‘a msg per line’ the last line does not get msg.topic passed. 

In the  
   .on(‘end’, function() { 
code (starting at line 334) the msg is created but no msg.topic is set. Adding 
   topic:msg.topic, 
after line 343 (var m = { payload: spare,) fixes the issue.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
