### PR TITLE
Filein cloning

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,6 +16,7 @@
 
 var path = require("path");
 var fs = require("fs-extra");
+var sass = require("node-sass");
 
 module.exports = function(grunt) {
 
@@ -220,6 +221,7 @@ module.exports = function(grunt) {
         sass: {
             build: {
                 options: {
+                    implementation: sass,
                     outputStyle: 'compressed'
                 },
                 files: [{

--- a/package.json
+++ b/package.json
@@ -93,19 +93,20 @@
         "grunt-mocha-istanbul": "5.0.2",
         "grunt-nodemon": "~0.4.2",
         "grunt-npm-command": "~0.1.2",
-        "grunt-sass": "~2.0.0",
+        "grunt-sass": "~3.1.0",
         "grunt-simple-mocha": "~0.4.1",
         "http-proxy": "^1.16.2",
         "istanbul": "0.4.5",
+        "jsdoc-nr-template": "github:node-red/jsdoc-nr-template",
         "minami": "1.2.3",
         "mocha": "^5.2.0",
         "mosca": "^2.8.3",
+        "node-red-node-test-helper": "^0.2.3",
+        "node-sass": "^4.13.0",
         "should": "^8.4.0",
         "sinon": "1.17.7",
         "stoppable": "^1.1.0",
-        "supertest": "3.4.2",
-        "node-red-node-test-helper": "^0.2.3",
-        "jsdoc-nr-template": "node-red/jsdoc-nr-template"
+        "supertest": "3.4.2"
     },
     "engines": {
         "node": ">=8"

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.js
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.js
@@ -140,8 +140,8 @@ module.exports = function(RED) {
                             try {
                                 var stat = fs.statSync(filename);
                                 node.wstreamIno = stat.ino;
-                            } catch(err) {
-                            }
+                            } 
+                            catch(err) { }
                         });
                         node.wstream.on("error", function(err) {
                             node.error(RED._("file.errors.appendfail",{error:err.toString()}),msg);
@@ -276,7 +276,6 @@ module.exports = function(RED) {
                     ch = "\n";
                     type = "string";
                 }
-                var hwm;
                 var getout = false;
 
                 var rs = fs.createReadStream(filename)
@@ -290,30 +289,24 @@ module.exports = function(RED) {
                                     spare += decode(chunk, node.encoding);
                                     var bits = spare.split("\n");
                                     for (var i=0; i < bits.length - 1; i++) {
-                                        var m = {
-                                            payload:bits[i],
-                                            topic:msg.topic,
-                                            filename:msg.filename,
-                                            parts:{index:count, ch:ch, type:type, id:msg._msgid}
-                                        }
+                                        var sendMessage = RED.util.cloneMessage(msg);
+                                        sendMessage.payload = bits[i];
+                                        sendMessage.parts = {index:count, ch:ch, type:type, id:msg._msgid};
                                         count += 1;
-                                        nodeSend(m);
+                                        nodeSend(sendMessage);
                                     }
                                     spare = bits[i];
                                 }
                                 if (node.format === "stream") {
-                                    var m = {
-                                        payload:chunk,
-                                        topic:msg.topic,
-                                        filename:msg.filename,
-                                        parts:{index:count, ch:ch, type:type, id:msg._msgid}
-                                    }
+                                    var sendMessage = RED.util.cloneMessage(msg);
+                                    sendMessage.payload = chunk;
+                                    sendMessage.parts = {index:count, ch:ch, type:type, id:msg._msgid};
                                     count += 1;
                                     if (chunk.length < hwm) { // last chunk is smaller that high water mark = eof
                                         getout = false;
-                                        m.parts.count = count;
+                                        sendMessage.parts.count = count;
                                     }
-                                    nodeSend(m);
+                                    nodeSend(sendMessage);
                                 }
                             }
                             else {
@@ -332,28 +325,23 @@ module.exports = function(RED) {
                         nodeDone();
                     })
                     .on('end', function() {
+                        var sendMessage = RED.util.cloneMessage(msg);
                         if (node.chunk === false) {
                             if (node.format === "utf8") {
-                                msg.payload = decode(lines, node.encoding);
+                                sendMessage.payload = decode(lines, node.encoding);
                             }
-                            else { msg.payload = lines; }
-                            nodeSend(msg);
+                            else { sendMessage.payload = lines; }
+                            nodeSend(sendMessage);
                         }
                         else if (node.format === "lines") {
-                            var m = { payload: spare,
-                                      parts: {
-                                          index: count,
-                                          count: count+1,
-                                          ch: ch,
-                                          type: type,
-                                          id: msg._msgid
-                                      }
-                                    };
-                            nodeSend(m);
+                            sendMessage.payload = spare;
+                            sendMessage.parts = { index:count, count:count+1, ch:ch, type:type, id:msg._msgid };
+                            nodeSend(sendMessage);
                         }
                         else if (getout) { // last chunk same size as high water mark - have to send empty extra packet.
-                            var m = { parts:{index:count, count:count, ch:ch, type:type, id:msg._msgid} };
-                            nodeSend(m);
+                            delete sendMessage.payload;
+                            sendMessage.parts = { parts:{index:count, count:count, ch:ch, type:type, id:msg._msgid} };
+                            nodeSend(sendMessage);
                         }
                         nodeDone();
                     });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Currently when in multi-line modes the the file-in node creates new messages for each line/buffer it outputs... - this doesn't pass though any existing properties of the incoming msg - which is our "normal" behaviour.

This PR fixes that but does mean we clone the original msg for every line/buffer we output...
Questions then are 
 - [ ] is this overhead desirable ?
 - [ ] is there a better way of cloning for this case that may be faster 
 - [ ] is there extra cloning going on on the .send that means we don't need to worry about this here ?

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
