### PR TITLE
Prohibit line break in type menu of typedInput

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
@@ -70,6 +70,7 @@
     border: 1px solid $primary-border-color;
     box-sizing: border-box;
     background: $secondary-background;
+    white-space: nowrap;
     z-index: 2000;
     a {
         padding: 6px 18px 6px 6px;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
For typedInput with long list of types, unexpected line break is inserted after menu icon of type items as shown below:

- Change node[Japanese]
![スクリーンショット 2019-10-28 23 50 37](https://user-images.githubusercontent.com/30289092/67689721-15c89180-f9df-11e9-8b85-05378d7f2080.png)

- Change node[English with narrow browser window]
![スクリーンショット 2019-10-28 23 51 16](https://user-images.githubusercontent.com/30289092/67689740-1e20cc80-f9df-11e9-920f-15774b904a9e.png)

This PR prohibits insertion of line break in menu items.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
