### PR TITLE
Make JSONata help initially shown

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/expression.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/expression.js
@@ -207,6 +207,7 @@
                         }
                         expressionEditor.getSession().setValue(v||"",-1);
                     });
+                    funcSelect.change();
 
                     var tabs = RED.tabs.create({
                         element: $("#red-ui-editor-type-expression-tabs"),


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Function help text of JSONata expression editor is initially blank.

![スクリーンショット 2019-10-29 10 28 25](https://user-images.githubusercontent.com/30289092/67730041-eba2be00-fa36-11e9-877d-3caacbc8d387.png)

This PR fixes it to be shown initially.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
