### PR TITLE
Add placeholders to name fields

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -19,12 +19,18 @@ RED.subflow = (function() {
     var currentLocale = "en-US";
 
     var _subflowEditTemplate = '<script type="text/x-red" data-template-name="subflow">'+
-        '<div class="form-row"><label for="node-input-name" data-i18n="[append]editor:common.label.name"><i class="fa fa-tag"></i> </label><input type="text" id="node-input-name"></div>'+
+        '<div class="form-row">'+
+            '<label for="node-input-name" data-i18n="[append]editor:common.label.name"><i class="fa fa-tag"></i> </label>'+
+            '<input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">'+
+        '</div>'+
         '<div id="subflow-input-ui"></div>'+
         '</script>';
 
     var _subflowTemplateEditTemplate = '<script type="text/x-red" data-template-name="subflow-template">'+
-        '<div class="form-row"><label for="subflow-input-name" data-i18n="[append]common.label.name"><i class="fa fa-tag"></i>  </label><input type="text" id="subflow-input-name"></div>'+
+        '<div class="form-row">'+
+            '<label for="subflow-input-name" data-i18n="[append]common.label.name"><i class="fa fa-tag"></i>  </label>'+
+            '<input type="text" id="subflow-input-name" data-i18n="[placeholder]common.label.name">'+
+        '</div>'+
         '<div class="form-row">'+
             '<ul style="margin-bottom: 20px;" id="subflow-env-tabs"></ul>'+
         '</div>'+

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -164,7 +164,7 @@ RED.workspaces = (function() {
                 var dialogForm = $('<form id="dialog-form" class="form-horizontal"></form>').appendTo(trayBody);
                 $('<div class="form-row">'+
                     '<label for="node-input-name" data-i18n="[append]editor:common.label.name"><i class="fa fa-tag"></i> </label>'+
-                    '<input type="text" id="node-input-name">'+
+                    '<input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">'+
                 '</div>').appendTo(dialogForm);
 
 

--- a/packages/node_modules/@node-red/nodes/99-sample.html.demo
+++ b/packages/node_modules/@node-red/nodes/99-sample.html.demo
@@ -38,8 +38,8 @@
     <!-- By convention, most nodes have a 'name' property. The following div -->
     <!-- provides the necessary field. Should always be the last option      -->
     <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
-        <input type="text" id="node-input-name" placeholder="Name">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
     </div>
 </script>
 

--- a/packages/node_modules/@node-red/nodes/99-sample.html.demo
+++ b/packages/node_modules/@node-red/nodes/99-sample.html.demo
@@ -30,8 +30,8 @@
    <!-- (with the 'node-input-' prefix).                                     -->
    <!-- The available icon classes are defined Font Awesome Icons (FA Icons) -->
     <div class="form-row">
-        <label for="node-input-topic"><i class="fa fa-tasks"></i> Topic</label>
-        <input type="text" id="node-input-topic" placeholder="Topic">
+        <label for="node-input-topic"><i class="fa fa-tasks"></i> <span data-i18n="common.label.topic"></span></label>
+        <input type="text" id="node-input-topic" data-i18n="[placeholder]common.label.topic">
     </div>
 
     <br/>

--- a/packages/node_modules/@node-red/nodes/core/common/90-comment.html
+++ b/packages/node_modules/@node-red/nodes/core/common/90-comment.html
@@ -2,7 +2,7 @@
 <script type="text/x-red" data-template-name="comment">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
-        <input type="text" id="node-input-name">
+        <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
     </div>
     <div class="form-row node-text-editor-row">
         <input type="hidden" id="node-input-info" autofocus="autofocus">


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Because I found that there are name fields which have no placeholders in subflow node, tab, comment node, and 99-sample node, I added them.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality