### PR TITLE
Support i18n for typedInput in join and switch nodes

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -15,6 +15,17 @@
             "next": "Next",
             "clone": "Clone project",
             "cont": "Continue"
+        },
+        "type": {
+            "string": "string",
+            "number": "number",
+            "boolean": "boolean",
+            "array": "array",
+            "buffer": "buffer",
+            "object": "object",
+            "jsonString": "JSON string",
+            "undefined": "undefined",
+            "null": "null"
         }
     },
     "workspace": {

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -15,6 +15,17 @@
             "next": "進む",
             "clone": "プロジェクトをクローン",
             "cont": "続ける"
+        },
+        "type": {
+            "string": "文字列",
+            "number": "数値",
+            "boolean": "真偽値",
+            "array": "配列",
+            "buffer": "バッファ",
+            "object": "オブジェクト",
+            "jsonString": "JSON文字列",
+            "undefined": "undefined",
+            "null": "null"
         }
     },
     "workspace": {

--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.html
@@ -237,15 +237,15 @@
 
                     function createTypeValueField(){
                         return $('<input/>',{class:"node-input-rule-type-value",type:"text",style:"margin-left: 5px;"}).appendTo(row).typedInput({default:'string',types:[
-                            {value:"string",label:RED._("node-red:switch.label.string"),hasValue:false,icon:"red/images/typedInput/az.png"},
-                            {value:"number",label:RED._("node-red:switch.label.number"),hasValue:false,icon:"red/images/typedInput/09.png"},
-                            {value:"boolean",label:RED._("node-red:switch.label.boolean"),hasValue:false,icon:"red/images/typedInput/bool.png"},
-                            {value:"array",label:RED._("node-red:switch.label.array"),hasValue:false,icon:"red/images/typedInput/json.png"},
-                            {value:"buffer",label:RED._("node-red:switch.label.buffer"),hasValue:false,icon:"red/images/typedInput/bin.png"},
-                            {value:"object",label:RED._("node-red:switch.label.object"),hasValue:false,icon:"red/images/typedInput/json.png"},
-                            {value:"json",label:RED._("node-red:switch.label.jsonString"),hasValue:false,icon:"red/images/typedInput/json.png"},
-                            {value:"undefined",label:RED._("node-red:switch.label.undefined"),hasValue:false},
-                            {value:"null",label:RED._("node-red:switch.label.null"),hasValue:false}
+                            {value:"string",label:RED._("common.type.string"),hasValue:false,icon:"red/images/typedInput/az.png"},
+                            {value:"number",label:RED._("common.type.number"),hasValue:false,icon:"red/images/typedInput/09.png"},
+                            {value:"boolean",label:RED._("common.type.boolean"),hasValue:false,icon:"red/images/typedInput/bool.png"},
+                            {value:"array",label:RED._("common.type.array"),hasValue:false,icon:"red/images/typedInput/json.png"},
+                            {value:"buffer",label:RED._("common.type.buffer"),hasValue:false,icon:"red/images/typedInput/bin.png"},
+                            {value:"object",label:RED._("common.type.object"),hasValue:false,icon:"red/images/typedInput/json.png"},
+                            {value:"json",label:RED._("common.type.jsonString"),hasValue:false,icon:"red/images/typedInput/json.png"},
+                            {value:"undefined",label:RED._("common.type.undefined"),hasValue:false},
+                            {value:"null",label:RED._("common.type.null"),hasValue:false}
                         ]});
                     }
 

--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.html
@@ -127,7 +127,7 @@
         },
         oneditprepare: function() {
             var node = this;
-            var previousValueType = {value:"prev",label:this._("inject.previous"),hasValue:false};
+            var previousValueType = {value:"prev",label:this._("switch.previous"),hasValue:false};
 
             $("#node-input-property").typedInput({default:this.propertyType||'msg',types:['msg','flow','global','jsonata','env']});
             var outputCount = $("#node-input-outputs").val("{}");
@@ -237,15 +237,15 @@
 
                     function createTypeValueField(){
                         return $('<input/>',{class:"node-input-rule-type-value",type:"text",style:"margin-left: 5px;"}).appendTo(row).typedInput({default:'string',types:[
-                            {value:"string",label:"string",hasValue:false},
-                            {value:"number",label:"number",hasValue:false},
-                            {value:"boolean",label:"boolean",hasValue:false},
-                            {value:"array",label:"array",hasValue:false},
-                            {value:"buffer",label:"buffer",hasValue:false},
-                            {value:"object",label:"object",hasValue:false},
-                            {value:"json",label:"JSON string",hasValue:false},
-                            {value:"undefined",label:"undefined",hasValue:false},
-                            {value:"null",label:"null",hasValue:false}
+                            {value:"string",label:RED._("node-red:switch.label.string"),hasValue:false},
+                            {value:"number",label:RED._("node-red:switch.label.number"),hasValue:false},
+                            {value:"boolean",label:RED._("node-red:switch.label.boolean"),hasValue:false},
+                            {value:"array",label:RED._("node-red:switch.label.array"),hasValue:false},
+                            {value:"buffer",label:RED._("node-red:switch.label.buffer"),hasValue:false},
+                            {value:"object",label:RED._("node-red:switch.label.object"),hasValue:false},
+                            {value:"json",label:RED._("node-red:switch.label.jsonString"),hasValue:false},
+                            {value:"undefined",label:RED._("node-red:switch.label.undefined"),hasValue:false},
+                            {value:"null",label:RED._("node-red:switch.label.null"),hasValue:false}
                         ]});
                     }
 

--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.html
@@ -237,13 +237,13 @@
 
                     function createTypeValueField(){
                         return $('<input/>',{class:"node-input-rule-type-value",type:"text",style:"margin-left: 5px;"}).appendTo(row).typedInput({default:'string',types:[
-                            {value:"string",label:RED._("node-red:switch.label.string"),hasValue:false},
-                            {value:"number",label:RED._("node-red:switch.label.number"),hasValue:false},
-                            {value:"boolean",label:RED._("node-red:switch.label.boolean"),hasValue:false},
-                            {value:"array",label:RED._("node-red:switch.label.array"),hasValue:false},
-                            {value:"buffer",label:RED._("node-red:switch.label.buffer"),hasValue:false},
-                            {value:"object",label:RED._("node-red:switch.label.object"),hasValue:false},
-                            {value:"json",label:RED._("node-red:switch.label.jsonString"),hasValue:false},
+                            {value:"string",label:RED._("node-red:switch.label.string"),hasValue:false,icon:"red/images/typedInput/az.png"},
+                            {value:"number",label:RED._("node-red:switch.label.number"),hasValue:false,icon:"red/images/typedInput/09.png"},
+                            {value:"boolean",label:RED._("node-red:switch.label.boolean"),hasValue:false,icon:"red/images/typedInput/bool.png"},
+                            {value:"array",label:RED._("node-red:switch.label.array"),hasValue:false,icon:"red/images/typedInput/json.png"},
+                            {value:"buffer",label:RED._("node-red:switch.label.buffer"),hasValue:false,icon:"red/images/typedInput/bin.png"},
+                            {value:"object",label:RED._("node-red:switch.label.object"),hasValue:false,icon:"red/images/typedInput/json.png"},
+                            {value:"json",label:RED._("node-red:switch.label.jsonString"),hasValue:false,icon:"red/images/typedInput/json.png"},
                             {value:"undefined",label:RED._("node-red:switch.label.undefined"),hasValue:false},
                             {value:"null",label:RED._("node-red:switch.label.null"),hasValue:false}
                         ]});

--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
@@ -285,7 +285,11 @@
                     $("#node-input-property").typedInput('types',['msg']);
                     $("#node-input-joiner").typedInput("show");
                 } else {
-                    $("#node-input-property").typedInput('types',['msg', {value:"full",label:"complete message",hasValue:false}]);
+                    $("#node-input-property").typedInput('types', ['msg', {
+                        value: "full",
+                        label: RED._("node-red:join.completeMessage"),
+                        hasValue: false
+                    }]);
                 }
             });
 
@@ -297,7 +301,11 @@
 
             $("#node-input-property").typedInput({
                 typeField: $("#node-input-propertyType"),
-                types:['msg', {value:"full", label:"complete message", hasValue:false}]
+                types: ['msg', {
+                    value: "full",
+                    label: RED._("node-red:join.completeMessage"),
+                    hasValue: false
+                }]
             });
 
             $("#node-input-key").typedInput({

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -604,15 +604,6 @@
         "label": {
             "property": "Property",
             "rule": "rule",
-            "string": "string",
-            "number": "number",
-            "boolean": "boolean",
-            "array": "array",
-            "buffer": "buffer",
-            "object": "object",
-            "jsonString": "JSON string",
-            "undefined": "undefined",
-            "null": "null",
             "repair": "recreate message sequences"
         },
         "previous": "previous value",

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -604,33 +604,43 @@
         "label": {
             "property": "Property",
             "rule": "rule",
-            "repair" :  "recreate message sequences"
+            "string": "string",
+            "number": "number",
+            "boolean": "boolean",
+            "array": "array",
+            "buffer": "buffer",
+            "object": "object",
+            "jsonString": "JSON string",
+            "undefined": "undefined",
+            "null": "null",
+            "repair": "recreate message sequences"
         },
+        "previous": "previous value",
         "and": "and",
         "checkall": "checking all rules",
         "stopfirst": "stopping after first match",
         "ignorecase": "ignore case",
         "rules": {
-            "btwn":"is between",
-            "cont":"contains",
-            "regex":"matches regex",
-            "true":"is true",
-            "false":"is false",
-            "null":"is null",
-            "nnull":"is not null",
-            "istype":"is of type",
-            "empty":"is empty",
-            "nempty":"is not empty",
-            "head":"head",
-            "tail":"tail",
-            "index":"index between",
-            "exp":"JSONata exp",
-            "else":"otherwise",
-            "hask":"has key"
+            "btwn": "is between",
+            "cont": "contains",
+            "regex": "matches regex",
+            "true": "is true",
+            "false": "is false",
+            "null": "is null",
+            "nnull": "is not null",
+            "istype": "is of type",
+            "empty": "is empty",
+            "nempty": "is not empty",
+            "head": "head",
+            "tail": "tail",
+            "index": "index between",
+            "exp": "JSONata exp",
+            "else": "otherwise",
+            "hask": "has key"
         },
         "errors": {
             "invalid-expr": "Invalid JSONata expression: __error__",
-            "too-many" : "too many pending messages in switch node"
+            "too-many": "too many pending messages in switch node"
         }
     },
     "change": {
@@ -848,41 +858,42 @@
         "stream":"Handle as a stream of messages",
         "addname":" Copy key to "
     },
-    "join":{
+    "join": {
         "join": "join",
-        "mode":{
-            "mode":"Mode",
-            "auto":"automatic",
-            "merge":"merge sequences",
-            "reduce":"reduce sequence",
-            "custom":"manual"
+        "mode": {
+            "mode": "Mode",
+            "auto": "automatic",
+            "merge": "merge sequences",
+            "reduce": "reduce sequence",
+            "custom": "manual"
         },
-        "combine":"Combine each",
-        "create":"to create",
-        "type":{
-            "string":"a String",
-            "array":"an Array",
-            "buffer":"a Buffer",
-            "object":"a key/value Object",
-            "merged":"a merged Object"
+        "combine": "Combine each",
+        "completeMessage": "complete message",
+        "create": "to create",
+        "type": {
+            "string": "a String",
+            "array": "an Array",
+            "buffer": "a Buffer",
+            "object": "a key/value Object",
+            "merged": "a merged Object"
         },
-        "using":"using the value of",
-        "key":"as the key",
-        "joinedUsing":"joined using",
-        "send":"Send the message:",
-        "afterCount":"After a number of message parts",
-        "count":"count",
-        "subsequent":"and every subsequent message.",
-        "afterTimeout":"After a timeout following the first message",
-        "seconds":"seconds",
-        "complete":"After a message with the <code>msg.complete</code> property set",
-        "tip":"This mode assumes this node is either paired with a <i>split</i> node or the received messages will have a properly configured <code>msg.parts</code> property.",
-        "too-many" : "too many pending messages in join node",
+        "using": "using the value of",
+        "key": "as the key",
+        "joinedUsing": "joined using",
+        "send": "Send the message:",
+        "afterCount": "After a number of message parts",
+        "count": "count",
+        "subsequent": "and every subsequent message.",
+        "afterTimeout": "After a timeout following the first message",
+        "seconds": "seconds",
+        "complete": "After a message with the <code>msg.complete</code> property set",
+        "tip": "This mode assumes this node is either paired with a <i>split</i> node or the received messages will have a properly configured <code>msg.parts</code> property.",
+        "too-many": "too many pending messages in join node",
         "merge": {
-            "topics-label":"Merged Topics",
-            "topics":"topics",
-            "topic" : "topic",
-            "on-change":"Send merged message on arrival of a new topic"
+            "topics-label": "Merged Topics",
+            "topics": "topics",
+            "topic": "topic",
+            "on-change": "Send merged message on arrival of a new topic"
         },
         "reduce": {
             "exp": "Reduce exp",

--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -602,15 +602,6 @@
         "label": {
             "property": "プロパティ",
             "rule": "条件",
-            "string": "文字列",
-            "number": "数値",
-            "boolean": "真偽値",
-            "array": "配列",
-            "buffer": "バッファ",
-            "object": "オブジェクト",
-            "jsonString": "JSON文字列",
-            "undefined": "undefined",
-            "null": "null",
             "repair": "メッセージ列の補正"
         },
         "previous": "前回の値",

--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -602,8 +602,18 @@
         "label": {
             "property": "プロパティ",
             "rule": "条件",
+            "string": "文字列",
+            "number": "数値",
+            "boolean": "真偽値",
+            "array": "配列",
+            "buffer": "バッファ",
+            "object": "オブジェクト",
+            "jsonString": "JSON文字列",
+            "undefined": "undefined",
+            "null": "null",
             "repair": "メッセージ列の補正"
         },
+        "previous": "前回の値",
         "and": "～",
         "checkall": "全ての条件を適用",
         "stopfirst": "最初に合致した条件で終了",
@@ -856,6 +866,7 @@
             "custom": "手動"
         },
         "combine": "結合",
+        "completeMessage": "メッセージ全体",
         "create": "出力",
         "type": {
             "string": "文字列",


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I found that there're typedInput menus that don't support i18n in join and switch nodes. Therefore, I modified the code.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality