### PR TITLE
Support ctrl key to select tabs for Windows

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
@@ -218,7 +218,7 @@ RED.tabs = (function() {
             var thisTab = $(this).parent();
             var fireSelectionChanged = false;
             if (options.onselect) {
-                if (evt.metaKey) {
+                if (evt.metaKey || evt.ctrlKey) {
                     if (thisTab.hasClass("selected")) {
                         thisTab.removeClass("selected");
                         if (thisTab[0] !== currentTab[0]) {


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes
Quick wiring supports both meta and ctrl keys but selecting tab supports meta key only. It is difficult for Windows users to select tabs using the meta key (Windows key) because the Windows taskbar is opened when the key is used. I think that the ctrl key is needed for Windows users.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
