### PR TITLE
Add tooltip to the expand button in markdown editor

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -796,6 +796,7 @@
     },
     "markdownEditor": {
         "title": "Markdown editor",
+        "expand": "Expand",
         "format": "Formatted with markdown",
         "heading1": "Heading 1",
         "heading2": "Heading 2",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -795,6 +795,7 @@
     },
     "markdownEditor": {
         "title": "マークダウンエディタ",
+        "expand": "拡大",
         "format": "マークダウン形式で記述",
         "heading1": "見出しレベル1",
         "heading2": "見出しレベル2",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -2484,7 +2484,7 @@ RED.editor = (function() {
             editor.toolbar = customEditTypes['_markdown'].buildToolbar(toolbarRow,editor);
             if (options.expandable !== false) {
                 var expandButton = $('<button type="button" class="red-ui-button" style="float: right;"><i class="fa fa-expand"></i></button>').appendTo(editor.toolbar);
-
+                RED.popover.tooltip(expandButton, RED._("markdownEditor.expand"));
                 expandButton.on("click", function(e) {
                     e.preventDefault();
                     var value = editor.getValue();


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I added a tooltip to the expand button in the markdown editor.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
