### PR TITLE
Catches bad objects being encoded, returning instead the error.

### DIFF
--- a/packages/node_modules/@node-red/util/lib/log.js
+++ b/packages/node_modules/@node-red/util/lib/log.js
@@ -84,9 +84,14 @@ var consoleLogger = function(msg) {
             util.log("["+levelNames[msg.level]+"] "+(msg.type?"["+msg.type+":"+(msg.name||msg.id)+"] ":"")+msg.msg.stack);
         } else {
             var message = msg.msg;
-            if (typeof message === 'object' && message !== null && message.toString() === '[object Object]' && message.message) {
-                message = message.message;
+            try {
+                if (typeof message === 'object' && message !== null && message.toString() === '[object Object]' && message.message) {
+                    message = message.message;
+                }
+            } catch(e){
+                message = 'Exception trying to log: '+util.inspect(message);
             }
+            
             util.log("["+levelNames[msg.level]+"] "+(msg.type?"["+msg.type+":"+(msg.name||msg.id)+"] ":"")+message);
         }
     }

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -755,7 +755,7 @@ function encodeObject(msg,opts) {
                     }," ");
                 } else {
                     try { msg.msg = msg.msg.toString(); }
-                    catch(e) { msg.msg = "[Type not printable]"; }
+                    catch(e) { msg.msg = "[Type not printable]" + util.inspect(msg.msg); }
                 }
             }
         } else if (msgType === "function") {

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -784,9 +784,12 @@ function encodeObject(msg,opts) {
             errorMsg.name = e.name;
         }
         if (e.hasOwnProperty('message')) {
-            errorMsg.message = e.message;
+            errorMsg.message = 'encodeObject Error: ['+e.message + '] Value: '+util.inspect(msg.msg);
         } else {
-            errorMsg.message = e.toString();
+            errorMsg.message = 'encodeObject Error: ['+e.toString() + '] Value: '+util.inspect(msg.msg);
+        }
+        if (errorMsg.message.length > debuglength) {
+            errorMsg.message = errorMsg.message.substring(0,debuglength);
         }
         msg.msg = JSON.stringify(errorMsg);
         return msg;

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -652,130 +652,145 @@ function normaliseNodeTypeName(name) {
  * @memberof @node-red/util_util
  */
 function encodeObject(msg,opts) {
-    var debuglength = 1000;
-    if (opts && opts.hasOwnProperty('maxLength')) {
-        debuglength = opts.maxLength;
-    }
-    var msgType = typeof msg.msg;
-    if (msg.msg instanceof Error) {
-        msg.format = "error";
-        var errorMsg = {};
-        if (msg.msg.name) {
-            errorMsg.name = msg.msg.name;
+    try {
+        var debuglength = 1000;
+        if (opts && opts.hasOwnProperty('maxLength')) {
+            debuglength = opts.maxLength;
         }
-        if (msg.msg.hasOwnProperty('message')) {
-            errorMsg.message = msg.msg.message;
-        } else {
-            errorMsg.message = msg.msg.toString();
-        }
-        msg.msg = JSON.stringify(errorMsg);
-    } else if (msg.msg instanceof Buffer) {
-        msg.format = "buffer["+msg.msg.length+"]";
-        msg.msg = msg.msg.toString('hex');
-        if (msg.msg.length > debuglength) {
-            msg.msg = msg.msg.substring(0,debuglength);
-        }
-    } else if (msg.msg && msgType === 'object') {
-        try {
-            msg.format = msg.msg.constructor.name || "Object";
-            // Handle special case of msg.req/res objects from HTTP In node
-            if (msg.format === "IncomingMessage" || msg.format === "ServerResponse") {
+        var msgType = typeof msg.msg;
+        if (msg.msg instanceof Error) {
+            msg.format = "error";
+            var errorMsg = {};
+            if (msg.msg.name) {
+                errorMsg.name = msg.msg.name;
+            }
+            if (msg.msg.hasOwnProperty('message')) {
+                errorMsg.message = msg.msg.message;
+            } else {
+                errorMsg.message = msg.msg.toString();
+            }
+            msg.msg = JSON.stringify(errorMsg);
+        } else if (msg.msg instanceof Buffer) {
+            msg.format = "buffer["+msg.msg.length+"]";
+            msg.msg = msg.msg.toString('hex');
+            if (msg.msg.length > debuglength) {
+                msg.msg = msg.msg.substring(0,debuglength);
+            }
+        } else if (msg.msg && msgType === 'object') {
+            try {
+                msg.format = msg.msg.constructor.name || "Object";
+                // Handle special case of msg.req/res objects from HTTP In node
+                if (msg.format === "IncomingMessage" || msg.format === "ServerResponse") {
+                    msg.format = "Object";
+                }
+            } catch(err) {
                 msg.format = "Object";
             }
-        } catch(err) {
-            msg.format = "Object";
-        }
-        if (/error/i.test(msg.format)) {
-            msg.msg = JSON.stringify({
-                name: msg.msg.name,
-                message: msg.msg.message
-            });
-        } else {
-            var isArray = util.isArray(msg.msg);
-            if (isArray) {
-                msg.format = "array["+msg.msg.length+"]";
-                if (msg.msg.length > debuglength) {
-                    // msg.msg = msg.msg.slice(0,debuglength);
-                    msg.msg = {
-                        __enc__: true,
-                        type: "array",
-                        data: msg.msg.slice(0,debuglength),
-                        length: msg.msg.length
-                    }
-                }
-            }
-            if (isArray || (msg.format === "Object")) {
-                msg.msg = safeJSONStringify(msg.msg, function(key, value) {
-                    if (key === '_req' || key === '_res') {
-                        value = {
-                            __enc__: true,
-                            type: "internal"
-                        }
-                    } else if (value instanceof Error) {
-                        value = value.toString()
-                    } else if (util.isArray(value) && value.length > debuglength) {
-                        value = {
+            if (/error/i.test(msg.format)) {
+                msg.msg = JSON.stringify({
+                    name: msg.msg.name,
+                    message: msg.msg.message
+                });
+            } else {
+                var isArray = util.isArray(msg.msg);
+                if (isArray) {
+                    msg.format = "array["+msg.msg.length+"]";
+                    if (msg.msg.length > debuglength) {
+                        // msg.msg = msg.msg.slice(0,debuglength);
+                        msg.msg = {
                             __enc__: true,
                             type: "array",
-                            data: value.slice(0,debuglength),
-                            length: value.length
-                        }
-                    } else if (typeof value === 'string') {
-                        if (value.length > debuglength) {
-                            value = value.substring(0,debuglength)+"...";
-                        }
-                    } else if (typeof value === 'function') {
-                        value = {
-                            __enc__: true,
-                            type: "function"
-                        }
-                    } else if (typeof value === 'number') {
-                        if (isNaN(value) || value === Infinity || value === -Infinity) {
-                            value = {
-                                __enc__: true,
-                                type: "number",
-                                data: value.toString()
-                            }
-                        }
-                    } else if (value && value.constructor) {
-                        if (value.type === "Buffer") {
-                            value.__enc__ = true;
-                            value.length = value.data.length;
-                            if (value.length > debuglength) {
-                                value.data = value.data.slice(0,debuglength);
-                            }
-                        } else if (value.constructor.name === "ServerResponse") {
-                            value = "[internal]"
-                        } else if (value.constructor.name === "Socket") {
-                            value = "[internal]"
+                            data: msg.msg.slice(0,debuglength),
+                            length: msg.msg.length
                         }
                     }
-                    return value;
-                }," ");
-            } else {
-                try { msg.msg = msg.msg.toString(); }
-                catch(e) { msg.msg = "[Type not printable]"; }
+                }
+                if (isArray || (msg.format === "Object")) {
+                    msg.msg = safeJSONStringify(msg.msg, function(key, value) {
+                        if (key === '_req' || key === '_res') {
+                            value = {
+                                __enc__: true,
+                                type: "internal"
+                            }
+                        } else if (value instanceof Error) {
+                            value = value.toString()
+                        } else if (util.isArray(value) && value.length > debuglength) {
+                            value = {
+                                __enc__: true,
+                                type: "array",
+                                data: value.slice(0,debuglength),
+                                length: value.length
+                            }
+                        } else if (typeof value === 'string') {
+                            if (value.length > debuglength) {
+                                value = value.substring(0,debuglength)+"...";
+                            }
+                        } else if (typeof value === 'function') {
+                            value = {
+                                __enc__: true,
+                                type: "function"
+                            }
+                        } else if (typeof value === 'number') {
+                            if (isNaN(value) || value === Infinity || value === -Infinity) {
+                                value = {
+                                    __enc__: true,
+                                    type: "number",
+                                    data: value.toString()
+                                }
+                            }
+                        } else if (value && value.constructor) {
+                            if (value.type === "Buffer") {
+                                value.__enc__ = true;
+                                value.length = value.data.length;
+                                if (value.length > debuglength) {
+                                    value.data = value.data.slice(0,debuglength);
+                                }
+                            } else if (value.constructor.name === "ServerResponse") {
+                                value = "[internal]"
+                            } else if (value.constructor.name === "Socket") {
+                                value = "[internal]"
+                            }
+                        }
+                        return value;
+                    }," ");
+                } else {
+                    try { msg.msg = msg.msg.toString(); }
+                    catch(e) { msg.msg = "[Type not printable]"; }
+                }
+            }
+        } else if (msgType === "function") {
+            msg.format = "function";
+            msg.msg = "[function]"
+        } else if (msgType === "boolean") {
+            msg.format = "boolean";
+            msg.msg = msg.msg.toString();
+        } else if (msgType === "number") {
+            msg.format = "number";
+            msg.msg = msg.msg.toString();
+        } else if (msg.msg === null || msgType === "undefined") {
+            msg.format = (msg.msg === null)?"null":"undefined";
+            msg.msg = "(undefined)";
+        } else {
+            msg.format = "string["+msg.msg.length+"]";
+            if (msg.msg.length > debuglength) {
+                msg.msg = msg.msg.substring(0,debuglength)+"...";
             }
         }
-    } else if (msgType === "function") {
-        msg.format = "function";
-        msg.msg = "[function]"
-    } else if (msgType === "boolean") {
-        msg.format = "boolean";
-        msg.msg = msg.msg.toString();
-    } else if (msgType === "number") {
-        msg.format = "number";
-        msg.msg = msg.msg.toString();
-    } else if (msg.msg === null || msgType === "undefined") {
-        msg.format = (msg.msg === null)?"null":"undefined";
-        msg.msg = "(undefined)";
-    } else {
-        msg.format = "string["+msg.msg.length+"]";
-        if (msg.msg.length > debuglength) {
-            msg.msg = msg.msg.substring(0,debuglength)+"...";
+        return msg;
+    } catch(e) {
+        msg.format = "error";
+        var errorMsg = {};
+        if (e.name) {
+            errorMsg.name = e.name;
         }
+        if (e.hasOwnProperty('message')) {
+            errorMsg.message = e.message;
+        } else {
+            errorMsg.message = e.toString();
+        }
+        msg.msg = JSON.stringify(errorMsg);
+        return msg;
     }
-    return msg;
 }
 
 module.exports = {

--- a/test/unit/@node-red/util/lib/log_spec.js
+++ b/test/unit/@node-red/util/lib/log_spec.js
@@ -224,5 +224,19 @@ describe("@node-red/util/log", function() {
 
 
     });
+    it('it can log without exception', function() {
+        var msg = {
+            msg: {
+              mystrangeobj:"hello",
+            },
+        };
+        msg.msg.toString = function(){
+          throw new Error('Exception in toString - should have been caught');
+        }
+        msg.msg.constructor = { name: "strangeobj" };
+        var ret = log.info(msg.msg);
+    });
 
+    
+    
 });

--- a/test/unit/@node-red/util/lib/log_spec.js
+++ b/test/unit/@node-red/util/lib/log_spec.js
@@ -236,6 +236,16 @@ describe("@node-red/util/log", function() {
         msg.msg.constructor = { name: "strangeobj" };
         var ret = log.info(msg.msg);
     });
+    it('it can log an object but use .message', function() {
+        var msg = {
+            msg: {
+              message: "my special message",
+              mystrangeobj:"hello",
+            },
+        };
+        var ret = log.info(msg.msg);
+        sinon.assert.calledWithMatch(util.log,"my special message");
+    });
 
     
     

--- a/test/unit/@node-red/util/lib/util_spec.js
+++ b/test/unit/@node-red/util/lib/util_spec.js
@@ -822,6 +822,53 @@ describe("@node-red/util/util", function() {
                 success.should.eql(1);
                 done();
             });
+            it('very large object which fails to serialise should be truncated', function(done) {
+                var msg = {
+                    msg: {
+                        obj:{
+                            big:"",
+                            cantserialise:{
+                                message:'this will not be displayed',
+                                toJSON: function(val) {
+                                    throw new Error('this exception should have been caught');
+                                    return 'should not display because we threw first';
+                                },
+                            },
+                            canserialise:{
+                                message:'this should be displayed',
+                            }
+                        },
+                    }
+                };
+                
+                for (var i = 0; i < 1000; i++) {
+                  msg.msg.obj.big += 'some more string ';
+                }
+                
+                var result = util.encodeObject(msg);
+                result.format.should.eql("error");
+                var resultJson = JSON.parse(result.msg);
+                var success = (resultJson.message.length <= 1000);
+                success.should.eql(true);
+                done();
+            });
+            it('test bad toString', function(done) {
+                var msg = {
+                    msg: {
+                      mystrangeobj:"hello",
+                    },
+                };
+                msg.msg.toString = function(){
+                  throw new Error('Exception in toString - should have been caught');
+                }
+                msg.msg.constructor = { name: "strangeobj" };
+                
+                var result = util.encodeObject(msg);
+                var success = (result.msg.indexOf('[Type not printable]') >= 0);
+                success.should.eql(true);
+                done();
+            });
+
             
         });
     });

--- a/test/unit/@node-red/util/lib/util_spec.js
+++ b/test/unit/@node-red/util/lib/util_spec.js
@@ -772,6 +772,57 @@ describe("@node-red/util/util", function() {
                 var resultJson = JSON.parse(result.msg);
                 resultJson.socket.should.eql('[internal]');
             });
+            it('object which fails to serialise', function(done) {
+                var msg = {
+                    msg: {
+                        obj:{
+                            cantserialise:{
+                                message:'this will not be displayed',
+                                toJSON: function(val) {
+                                    throw 'this exception should have been caught';
+                                    return 'should not display because we threw first';
+                                },
+                            },
+                            canserialise:{
+                                message:'this should be displayed',
+                            }
+                        },
+                    }
+                };
+                var result = util.encodeObject(msg);
+                result.format.should.eql("error");
+                var success = (result.msg.indexOf('cantserialise') > 0);
+                success &= (result.msg.indexOf('this exception should have been caught') > 0);
+                success &= (result.msg.indexOf('canserialise') > 0);
+                success.should.eql(1);
+                done();
+            });
+            it('object which fails to serialise - different error type', function(done) {
+                var msg = {
+                    msg: {
+                        obj:{
+                            cantserialise:{
+                                message:'this will not be displayed',
+                                toJSON: function(val) {
+                                    throw new Error('this exception should have been caught');
+                                    return 'should not display because we threw first';
+                                },
+                            },
+                            canserialise:{
+                                message:'this should be displayed',
+                            }
+                        },
+                    }
+                };
+                var result = util.encodeObject(msg);
+                result.format.should.eql("error");
+                var success = (result.msg.indexOf('cantserialise') > 0);
+                success &= (result.msg.indexOf('this exception should have been caught') > 0);
+                success &= (result.msg.indexOf('canserialise') > 0);
+                success.should.eql(1);
+                done();
+            });
+            
         });
     });
 });

--- a/test/unit/@node-red/util/lib/util_spec.js
+++ b/test/unit/@node-red/util/lib/util_spec.js
@@ -842,7 +842,7 @@ describe("@node-red/util/util", function() {
                 };
                 
                 for (var i = 0; i < 1000; i++) {
-                  msg.msg.obj.big += 'some more string ';
+                    msg.msg.obj.big += 'some more string ';
                 }
                 
                 var result = util.encodeObject(msg);
@@ -855,11 +855,11 @@ describe("@node-red/util/util", function() {
             it('test bad toString', function(done) {
                 var msg = {
                     msg: {
-                      mystrangeobj:"hello",
+                        mystrangeobj:"hello",
                     },
                 };
                 msg.msg.toString = function(){
-                  throw new Error('Exception in toString - should have been caught');
+                    throw new Error('Exception in toString - should have been caught');
                 }
                 msg.msg.constructor = { name: "strangeobj" };
                 
@@ -868,8 +868,21 @@ describe("@node-red/util/util", function() {
                 success.should.eql(true);
                 done();
             });
+            it('test bad object constructor', function(done) {
+                var msg = {
+                    msg: {
+                        mystrangeobj:"hello",
+                        constructor: { 
+                            get name(){
+                                throw new Error('Exception in constructor name');
+                            }
+                        }                      
+                    },
+                };
+                var result = util.encodeObject(msg);
+                done();
+            });
 
-            
         });
     });
 });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Catches bad objects being encoded, returning instead the error.
Symptom- Observed that global context would not display in front end, the call returning 400.
Traced to an object in global which cause encodeObject to except.
This push catches that, and now global will display, but the object in question display as an error.

I considered catching around the call to encodeObject, but inside seems more appropriate as it fixes the issue globally.  However, please consider how this could impact any other code which uses encodeObject.

I assume this change will also affect all places where objects are converted for display on the UI.
e.g. 'bad things' in messages will display the result as an error.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
