### PR TITLE
Add credential type to TypedInput

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -757,7 +757,8 @@
             "bin": "buffer",
             "date": "timestamp",
             "jsonata": "expression",
-            "env": "env variable"
+            "env": "env variable",
+            "cred": "credential"
         }
     },
     "editableList": {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -164,6 +164,77 @@
                     }
                 })
             }
+        },
+        cred:{
+            value:"cred",
+            label:"credential",
+            icon:"fa fa-lock",
+            inputType: "password",
+            valueLabel: function(container,value) {
+                var that = this;
+                container.css("pointer-events","none");
+                var buttons = $('<div>').css({
+                    position: "absolute",
+                    right:"6px",
+                    top: "6px",
+                    "pointer-events":"all"
+                }).appendTo(container);
+                var eyeButton = $('<button type="button" class="red-ui-button red-ui-button-small"></button>').css({
+                    width:"20px"
+                }).appendTo(buttons).on("click", function(evt) {
+                    evt.preventDefault();
+                    var currentType = that.input.attr("type");
+                    if (currentType === "text") {
+                        that.input.attr("type","password");
+                        eyeCon.removeClass("fa-eye-slash").addClass("fa-eye");
+                    } else {
+                        that.input.attr("type","text");
+                        eyeCon.removeClass("fa-eye").addClass("fa-eye-slash");
+                    }
+                }).hide();
+                var eyeCon = $('<i class="fa fa-eye"></i>').css("margin-left","-1px").appendTo(eyeButton);
+
+                if (value === "__PWRD__") {
+                    var innerContainer = $('<div><i class="fa fa-asterisk"></i><i class="fa fa-asterisk"></i><i class="fa fa-asterisk"></i><i class="fa fa-asterisk"></i><i class="fa fa-asterisk"></i></div>').css({
+                        padding:"6px 6px",
+                        borderRadius:"4px"
+                    }).addClass("red-ui-typedInput-value-label-inactive").appendTo(container);
+                    var editButton = $('<button type="button" class="red-ui-button red-ui-button-small"><i class="fa fa-pencil"></i></button>').appendTo(buttons).on("click", function(evt) {
+                        evt.preventDefault();
+                        innerContainer.hide();
+                        container.css("background","none");
+                        container.css("pointer-events","none");
+                        that.input.val("");
+                        that.element.val("");
+                        that.elementDiv.show();
+                        editButton.hide();
+                        cancelButton.show();
+                        eyeButton.show();
+                        setTimeout(function() {
+                            that.input.focus();
+                        },50);
+                    });
+                    var cancelButton = $('<button type="button" class="red-ui-button red-ui-button-small"><i class="fa fa-times"></i></button>').css("margin-left","3px").appendTo(buttons).on("click", function(evt) {
+                        evt.preventDefault();
+                        innerContainer.show();
+                        container.css("background","");
+                        that.input.val("__PWRD__");
+                        that.element.val("__PWRD__");
+                        that.elementDiv.hide();
+                        editButton.show();
+                        cancelButton.hide();
+                        eyeButton.hide();
+                        that.input.attr("type","password");
+                        eyeCon.removeClass("fa-eye-slash").addClass("fa-eye");
+
+                    }).hide();
+                } else {
+                    container.css("background","none");
+                    container.css("pointer-events","none");
+                    this.elementDiv.show();
+                    eyeButton.show();
+                }
+            }
         }
     };
     var nlsd = false;
@@ -219,6 +290,8 @@
                 var m = that.element.attr(d);
                 that.input.attr(d,m);
             });
+
+            this.defaultInputType = this.input.attr('type');
 
             this.uiSelect.addClass("red-ui-typedInput-container");
 
@@ -687,7 +760,7 @@
                             $('<img>',{src:mapDeprecatedIcon(opt.icon),style:"margin-right: 4px;height: 18px;"}).prependTo(this.selectLabel);
                         }
                         else {
-                            $('<i>',{class:"red-ui-typedInput-icon "+opt.icon}).prependTo(this.selectLabel);
+                            $('<i>',{class:"red-ui-typedInput-icon "+opt.icon,style:"min-width: 13px; margin-right: 4px;"}).prependTo(this.selectLabel);
                         }
                     }
                     if (opt.hasValue === false || (opt.showLabel !== false && !opt.icon)) {
@@ -822,6 +895,11 @@
                         if (this.optionSelectTrigger) {
                             this.optionSelectTrigger.hide();
                         }
+                        if (opt.inputType) {
+                            this.input.attr('type',opt.inputType)
+                        } else {
+                            this.input.attr('type',this.defaultInputType)
+                        }
                         if (opt.hasValue === false) {
                             this.oldValue = this.input.val();
                             this.input.val("");
@@ -830,8 +908,8 @@
                         } else if (opt.valueLabel) {
                             this.valueLabelContainer.show();
                             this.valueLabelContainer.empty();
-                            opt.valueLabel.call(this,this.valueLabelContainer,this.input.val());
                             this.elementDiv.hide();
+                            opt.valueLabel.call(this,this.valueLabelContainer,this.input.val());
                         } else {
                             if (this.oldValue !== undefined) {
                                 this.input.val(this.oldValue);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -173,6 +173,7 @@
             valueLabel: function(container,value) {
                 var that = this;
                 container.css("pointer-events","none");
+                this.elementDiv.hide();
                 var buttons = $('<div>').css({
                     position: "absolute",
                     right:"6px",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -188,9 +188,15 @@
                     if (currentType === "text") {
                         that.input.attr("type","password");
                         eyeCon.removeClass("fa-eye-slash").addClass("fa-eye");
+                        setTimeout(function() {
+                            that.input.focus();
+                        },50);
                     } else {
                         that.input.attr("type","text");
                         eyeCon.removeClass("fa-eye").addClass("fa-eye-slash");
+                        setTimeout(function() {
+                            that.input.focus();
+                        },50);
                     }
                 }).hide();
                 var eyeCon = $('<i class="fa fa-eye"></i>').css("margin-left","-1px").appendTo(eyeButton);

--- a/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
@@ -57,7 +57,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
         .red-ui-typedInput-value-label-inactive {
-            backgroundColor: $secondary-background-disabled;
+            background: $secondary-background-disabled;
             color: $secondary-text-color-disabled;
         }
     }

--- a/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
@@ -56,7 +56,10 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-
+        .red-ui-typedInput-value-label-inactive {
+            backgroundColor: $secondary-background-disabled;
+            color: $secondary-text-color-disabled;
+        }
     }
 }
 .red-ui-typedInput-options {
@@ -123,7 +126,7 @@ button.red-ui-typedInput-option-trigger
     }
     &.disabled {
         cursor: default;
-        i.red-ui-typedInput-icon {
+        > i.red-ui-typedInput-icon {
             color: $secondary-text-color-disabled;
         }
     }


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)
## Proposed changes

Introduces a new `cred` built-in type for the TypedInput widget.

This is intended as an alternative to the plain `<input type="password">` element, providing a more intuitive user experience for the way the editor already handles credentials.

When a node is edited, the editor doesn't know the true value of any password-credential properties. It only knows if the runtime has a value or not.

With a plain password input, we use the placeholder `__PWRD__` so we can tell if the user has edited the value or not. But that can lead to confusion:

1. the placeholder dots for `__PWRD__` may be a different length to the value a user knows they have set. That makes the user uncertain if the value has been stored properly or truncated.
2. if the user knows what value they entered previously and wants to edit it, they may edit the text in the field believing they are editing the original value - but they are actually editing the text `__PWRD__`

Here's what the new type looks like:

<img width="253" alt="Node-RED" src="https://user-images.githubusercontent.com/51083/68033836-6fb7a880-fcb8-11e9-8e1e-2b32a39fe7bf.png">

The first example is an instance that didn't have an existing value, the user has typed something in. The eye icon on the right can be used to show the password in clear text (and hide it again).

The second example is an instance that has an existing value (ie the editor knows there is a value, but not what it actually is). The input is disabled. To change the value, the user must click on the pencil icon on the right.

The third example is what it looks like after the user clicks the pencil - the input is enabled and blanked out. This makes it clear you aren't editing the existing value, but instead providing a new one. The eye icon again can be used to toggle the visibility. The back arrow reverts to the existing value (example 2).

In action:

![](http://g.recordit.co/nkk7USBEaT.gif)

