### PR TITLE
noproxy support in mqtt, Proxy & noproxy support in websocket

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -129,7 +129,7 @@ module.exports = function(RED) {
                     // check if proxy is set in env
                     var noproxy;
                     if (noprox) {
-                        for (var i in noprox) {
+                        for (var i = 0; i < noprox.length; i += 1) {
                             if (this.brokerurl.indexOf(noprox[i].trim()) !== -1) { noproxy=true; }
                         }
                     }

--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -111,9 +111,13 @@ module.exports = function(RED) {
         if (typeof this.cleansession === 'undefined') {
             this.cleansession = true;
         }
-        var prox;
-        if (process.env.http_proxy != null) { prox = process.env.http_proxy; }
-        if (process.env.HTTP_PROXY != null) { prox = process.env.HTTP_PROXY; }
+
+        var prox, noprox;
+        if (process.env.http_proxy) { prox = process.env.http_proxy; }
+        if (process.env.HTTP_PROXY) { prox = process.env.HTTP_PROXY; }
+        if (process.env.no_proxy) { noprox = process.env.no_proxy.split(","); }
+        if (process.env.NO_PROXY) { noprox = process.env.NO_PROXY.split(","); }
+
 
         // Create the URL to pass in to the MQTT.js library
         if (this.brokerurl === "") {
@@ -121,9 +125,15 @@ module.exports = function(RED) {
             if (this.broker.indexOf("://") > -1) {
                 this.brokerurl = this.broker;
                 // Only for ws or wss, check if proxy env var for additional configuration
-                if (this.brokerurl.indexOf("wss://") > -1 || this.brokerurl.indexOf("ws://") > -1 )
-                // check if proxy is set in env
-                    if (prox) {
+                if (this.brokerurl.indexOf("wss://") > -1 || this.brokerurl.indexOf("ws://") > -1 ) {
+                    // check if proxy is set in env
+                    var noproxy;
+                    if (noprox) {
+                        for (var i in noprox) {
+                            if (this.brokerurl.indexOf(noprox[i].trim()) !== -1) { noproxy=true; }
+                        }
+                    }
+                    if (prox && !noproxy) {
                         var parsedUrl = url.parse(this.brokerurl);
                         var proxyOpts = url.parse(prox);
                         // true for wss
@@ -134,6 +144,7 @@ module.exports = function(RED) {
                             agent: agent
                         }
                     }
+                }
             } else {
                 // construct the std mqtt:// url
                 if (this.usetls) {

--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
@@ -89,7 +89,7 @@ module.exports = function(RED) {
                 method = msg.method.toUpperCase();          // use the msg parameter
             }
 
-            var isHttps = (/^https/.test(url));
+            var isHttps = (/^https/i.test(url));
 
             var opts = {};
             opts.url = url;

--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
@@ -39,10 +39,10 @@ module.exports = function(RED) {
         else { this.reqTimeout = 120000; }
 
         var prox, noprox;
-        if (process.env.http_proxy != null) { prox = process.env.http_proxy; }
-        if (process.env.HTTP_PROXY != null) { prox = process.env.HTTP_PROXY; }
-        if (process.env.no_proxy != null) { noprox = process.env.no_proxy.split(","); }
-        if (process.env.NO_PROXY != null) { noprox = process.env.NO_PROXY.split(","); }
+        if (process.env.http_proxy) { prox = process.env.http_proxy; }
+        if (process.env.HTTP_PROXY) { prox = process.env.HTTP_PROXY; }
+        if (process.env.no_proxy) { noprox = process.env.no_proxy.split(","); }
+        if (process.env.NO_PROXY) { noprox = process.env.NO_PROXY.split(","); }
 
         var proxyConfig = null;
         if (n.proxy) {

--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
@@ -88,8 +88,13 @@ module.exports = function(RED) {
             if (msg.method && n.method && (n.method === "use")) {
                 method = msg.method.toUpperCase();          // use the msg parameter
             }
+
+            var isHttps = (/^https/.test(url));
+
             var opts = {};
             opts.url = url;
+            // set defaultport, else when using HttpsProxyAgent, it's defaultPort of 443 will be used :(.
+            opts.defaultPort = isHttps?443:80;
             opts.timeout = node.reqTimeout;
             opts.method = method;
             opts.headers = {};
@@ -284,6 +289,7 @@ module.exports = function(RED) {
                 opts.headers[clSet] = opts.headers['content-length'];
                 delete opts.headers['content-length'];
             }
+            
             var noproxy;
             if (noprox) {
                 for (var i in noprox) {

--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
@@ -292,7 +292,7 @@ module.exports = function(RED) {
             
             var noproxy;
             if (noprox) {
-                for (var i in noprox) {
+                for (var i = 0; i < noprox.length; i += 1) {
                     if (url.indexOf(noprox[i]) !== -1) { noproxy=true; }
                 }
             }

--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
@@ -19,6 +19,8 @@ module.exports = function(RED) {
     var ws = require("ws");
     var inspect = require("util").inspect;
     var url = require("url");
+    var HttpsProxyAgent = require('https-proxy-agent');
+
 
     var serverUpgradeAdded = false;
     function handleServerUpgrade(request, socket, head) {
@@ -55,7 +57,28 @@ module.exports = function(RED) {
 
         function startconn() {    // Connect to remote endpoint
             node.tout = null;
+            var prox, noprox;
+            if (process.env.http_proxy) { prox = process.env.http_proxy; }
+            if (process.env.HTTP_PROXY) { prox = process.env.HTTP_PROXY; }
+            if (process.env.no_proxy) { noprox = process.env.no_proxy.split(","); }
+            if (process.env.NO_PROXY) { noprox = process.env.NO_PROXY.split(","); }
+            
+            var noproxy = false;
+            if (noprox) {
+                for (var i in noprox) {
+                    if (node.path.indexOf(noprox[i].trim()) !== -1) { noproxy=true; }
+                }
+            }
+            
+            var agent = undefined;
+            if (prox && !noproxy) {
+                agent = new HttpsProxyAgent(prox);
+            }
+
             var options = {};
+            if (agent) {
+                options.agent = agent;
+            }
             if (node.tls) {
                 var tlsNode = RED.nodes.getNode(node.tls);
                 if (tlsNode) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Bugfix: Fixes comparison of proxy and noproxy against null, now just looks for non-falsy.
1/ The existing comparison encourages people to set the env variable to null, which ends up with it equalling the string 'null'.
2/ if (process.env.no_proxy === undefined), then process.env.no_proxy.split will fail.

Extends proxy use in mqtt by adding noproxy support.

Adds proxy/noproxy support to websocket.

ToDo:
really, proxy configuration node selection should also be added to mqtt and websocket?

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
