### PR TITLE
Fix UI testing on the latest Google Chrome

### DIFF
--- a/scripts/install-ui-test-dependencies.sh
+++ b/scripts/install-ui-test-dependencies.sh
@@ -4,4 +4,5 @@ npm install --no-save \
  wdio-mocha-framework@^0.6.4 \
  wdio-spec-reporter@^0.1.5 \
  webdriverio@^4.14.1 \
- chromedriver@2
+ chromedriver@^78.0.1 \
+ @wdio/cli@^5.15.6

--- a/scripts/install-ui-test-dependencies.sh
+++ b/scripts/install-ui-test-dependencies.sh
@@ -4,5 +4,4 @@ npm install --no-save \
  wdio-mocha-framework@^0.6.4 \
  wdio-spec-reporter@^0.1.5 \
  webdriverio@^4.14.1 \
- chromedriver@^78.0.1 \
- @wdio/cli@^5.15.6
+ chromedriver@^78.0.1

--- a/test/editor/wdio.conf.js
+++ b/test/editor/wdio.conf.js
@@ -61,7 +61,7 @@ exports.config = {
         maxInstances: 2,
         //
         browserName: 'chrome',
-        chromeOptions: {
+        'goog:chromeOptions': {
             args: process.env.NODE_RED_NON_HEADLESS
                 // Runs tests with opening a browser.
                 ? ['--disable-gpu']
@@ -134,7 +134,7 @@ exports.config = {
     // Services take over a specific job you don't want to take care of. They enhance
     // your test setup with almost no effort. Unlike plugins, they don't add new
     // commands. Instead, they hook themselves up into the test process.
-    port: '9515',
+    port: 9515,
     path: '/',
     services: ['chromedriver'],
     //


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Currently, UI testing doesn't work because the handling of the latest Google Chrome seems to have been changed. To work correctly, I updated the modules and modified the settings of the Webdriver IO.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality