### PR TITLE
I18n - language fallback behaviour

### DIFF
--- a/packages/node_modules/@node-red/util/lib/i18n.js
+++ b/packages/node_modules/@node-red/util/lib/i18n.js
@@ -125,7 +125,7 @@ var MessageFileLoader = {
         // read base language (e. g. 'de'), then actual language (e. g. 'de-DE') 
         readFile(baseLng, ns).then(
             baseData => {
-                // scenario 2: reading base language was successful -> read actual language -> if this fails, return base language data
+                // scenario 1: reading base language was successful -> read actual language -> if this fails, return base language data
                 readFile(lng, ns).then(data => callback(null, data), () => callback(null, baseData))
             },
             () => {

--- a/packages/node_modules/@node-red/util/lib/i18n.js
+++ b/packages/node_modules/@node-red/util/lib/i18n.js
@@ -81,35 +81,58 @@ function mergeCatalog(fallback,catalog) {
     }
 }
 
-var MessageFileLoader = {
-    type: "backend",
-    init: function(services, backendOptions, i18nextOptions) {},
-    read: function(lng, ns, callback) {
-        if (resourceMap[ns]) {
-            var file = path.join(resourceMap[ns].basedir,lng,resourceMap[ns].file);
-            //console.log(file);
-            fs.readFile(file,"utf8",function(err,content) {
+
+function readFile(lng, ns) {
+    return new Promise((resolve, reject) => {
+        if (resourceCache[ns] && resourceCache[ns][lng]) {
+            resolve(resourceCache[ns][lng]);
+        } else if (resourceMap[ns]) {
+            var file = path.join(resourceMap[ns].basedir, lng, resourceMap[ns].file);
+            fs.readFile(file, "utf8", function (err, content) {
                 if (err) {
-                    callback(err);
+                    reject(err);
                 } else {
                     try {
-                        resourceCache[ns] = resourceCache[ns]||{};
+                        resourceCache[ns] = resourceCache[ns] || {};
                         resourceCache[ns][lng] = JSON.parse(content.replace(/^\uFEFF/, ''));
-                        //console.log(resourceCache[ns][lng]);
-                        if (lng !== defaultLang) {
-                            mergeCatalog(resourceCache[ns][defaultLang],resourceCache[ns][lng]);
+                        var baseLng = lng.split('-')[0];
+                        if (baseLng !== lng && resourceCache[ns][baseLng]) {
+                            mergeCatalog(resourceCache[ns][baseLng], resourceCache[ns][lng]);
                         }
-                        callback(null, resourceCache[ns][lng]);
-                    } catch(e) {
-                        callback(e);
+                        if (lng !== defaultLang) {
+                            mergeCatalog(resourceCache[ns][defaultLang], resourceCache[ns][lng]);
+                        }
+                        resolve(resourceCache[ns][lng]);
+                    } catch (e) {
+                        reject(e);
                     }
                 }
             });
         } else {
-            callback(new Error("Unrecognised namespace"));
+            reject(new Error("Unrecognised namespace"));
         }
-    }
+    });
+}
 
+var MessageFileLoader = {
+    type: "backend",
+    init: function (services, backendOptions, i18nextOptions) { },
+    read: function (lng, ns, callback) {
+        // there are two languages to consider:
+        // 1) the actual language lng (e. g. 'en-US' or 'de-DE', 'fr-FR',...)
+        // 2) the base language (e. g. 'en', 'de', 'fr',...)
+        var baseLng = lng.split('-')[0];
+        // read base language (e. g. 'de'), then actual language (e. g. 'de-DE') 
+        readFile(baseLng, ns).then(
+            baseData => {
+                // scenario 2: reading base language was successful -> read actual language -> if this fails, return base language data
+                readFile(lng, ns).then(data => callback(null, data), () => callback(null, baseData))
+            },
+            () => {
+                // scenario 2: reading base language failed -> read actual language -> if this fails too, return error
+                readFile(lng, ns).then(data => callback(null, data), err => callback(err))
+            });
+    }
 }
 
 function getCurrentLocale() {

--- a/packages/node_modules/@node-red/util/lib/i18n.js
+++ b/packages/node_modules/@node-red/util/lib/i18n.js
@@ -118,19 +118,12 @@ var MessageFileLoader = {
     type: "backend",
     init: function (services, backendOptions, i18nextOptions) { },
     read: function (lng, ns, callback) {
-        // there are two languages to consider:
-        // 1) the actual language lng (e. g. 'en-US' or 'de-DE', 'fr-FR',...)
-        // 2) the base language (e. g. 'en', 'de', 'fr',...)
-        var baseLng = lng.split('-')[0];
-        // read base language (e. g. 'de'), then actual language (e. g. 'de-DE') 
-        readFile(baseLng, ns).then(
-            baseData => {
-                // scenario 1: reading base language was successful -> read actual language -> if this fails, return base language data
-                readFile(lng, ns).then(data => callback(null, data), () => callback(null, baseData))
-            },
-            () => {
-                // scenario 2: reading base language failed -> read actual language -> if this fails too, return error
-                readFile(lng, ns).then(data => callback(null, data), err => callback(err))
+        readFile(lng, ns)
+            .then(data => callback(null, data))
+            .catch(() => {
+                // if reading language file fails -> try reading base language (e. g. 'fr' instead of 'fr-FR' or 'de' for 'de-DE')
+                var baseLng = lng.split('-')[0];
+                readFile(baseLng, ns).then(baseData => callback(null, baseData)).catch(err => callback(err));
             });
     }
 }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

As discussed in the [forum](https://discourse.nodered.org/t/i18n-language-fallback-behaviour/13039):
The i18n language fallback behaviour is currently not following the [fallback principles](https://www.i18next.com/principles/fallback) of the i18next framework.

E. g. if the browser language is set to "de-DE" and there are no "de-DE" files, it should(!) look for "de" files first. Instead Node-RED falls back to "en-US" immediately.

This PR should fix that issue.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
