### PR TITLE
Add icons and support i18n in typedInput of JSON editor

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/json.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/json.js
@@ -301,9 +301,9 @@
             var val = $('<input type="text" class="red-ui-editor-type-json-editor-value">').css({width:w+"px"}).val(""+valValue).insertAfter(valueLabel).typedInput({
                 types:[
                     'str','num','bool',
-                    {value:"null",label:"null",hasValue:false},
-                    {value:"array",label:RED._("common.type.array"),hasValue:false},
-                    {value:"object",label:RED._("common.type.object"),hasValue:false}
+                    {value:"null",label:RED._("common.type.null"),hasValue:false},
+                    {value:"array",label:RED._("common.type.array"),hasValue:false,icon:"red/images/typedInput/json.png"},
+                    {value:"object",label:RED._("common.type.object"),hasValue:false,icon:"red/images/typedInput/json.png"}
                 ],
                 default: valType
             });


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I found that there're menus that don't support internationalization and have no icons in JSON editor. Therefore, I fixed them.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality