### PR TITLE
Fix problem with multi-byte character when reading library

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/library.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/library.js
@@ -57,41 +57,17 @@ function getFileMeta(root,path) {
 function getFileBody(root,path) {
     var body = "";
     var fn = fspath.join(root,path);
-    var fd = fs.openSync(fn,"r");
-    var size = fs.fstatSync(fd).size;
-    var scanning = true;
-    var read = 0;
-    var length = 50;
-    var remaining = "";
-    var buffer = Buffer.alloc(length);
-    while(read < size) {
-        var thisRead = fs.readSync(fd,buffer,0,length);
-        if (scanning) {
-            var data = remaining+buffer.slice(0,thisRead).toString();
-            read += thisRead;
-            var parts = data.split("\n");
-            if (read < size) {
-                remaining = parts.splice(-1)[0];
-            } else {
-                remaining = "";
-            }
-            for (var i=0;i<parts.length;i+=1) {
-                if (! /^\/\/ \w+: /.test(parts[i])) {
-                    scanning = false;
-                    body += (body.length > 0?"\n":"")+parts[i];
-                }
-            }
-            if (!scanning) {
-                body += remaining;
-            }
-        } else {
-            read += thisRead;
-            body += buffer.slice(0,thisRead).toString();
+    var data = fs.readFileSync(fn,'utf8');
+    var parts = data.split("\n");
+
+    parts.forEach((part) => {
+        if (! /^\/\/ \w+: /.test(part)) {
+            body += (body.length > 0?"\n":"")+ part;
         }
-    }
-    fs.closeSync(fd);
+    });
     return body;
 }
+
 function getLibraryEntry(type,path) {
     var root = fspath.join(libDir,type);
     var rootPath = fspath.join(libDir,type,path);

--- a/test/unit/@node-red/runtime/lib/storage/localfilesystem/library_spec.js
+++ b/test/unit/@node-red/runtime/lib/storage/localfilesystem/library_spec.js
@@ -203,4 +203,35 @@ describe('storage/localfilesystem/library', function() {
             done(err);
         });
     });
+
+    it('should return a newly saved multi-byte character library flow',function(done) {
+        localfilesystemLibrary.init({userDir:userDir}).then(function() {
+            createObjectLibrary("flows");
+            localfilesystemLibrary.getLibraryEntry('flows','B').then(function(flows) {
+                flows.should.eql([ 'C', {fn:'flow.json'} ]);
+                var ft = path.join("B","D","file4");
+                localfilesystemLibrary.saveLibraryEntry('flows',ft,{mno:'pqr'},"こんにちわこんにちわこんにちわ").then(function() {
+                    setTimeout(function() {
+                        localfilesystemLibrary.getLibraryEntry('flows',path.join("B","D")).then(function(flows) {
+                            flows.should.eql([ { mno: 'pqr', fn: 'file4.json' } ]);
+                            localfilesystemLibrary.getLibraryEntry('flows',ft+".json").then(function(body) {
+                                body.should.eql("こんにちわこんにちわこんにちわ");
+                                done();
+                            }).catch(function(err) {
+                                done(err);
+                            });
+                        }).catch(function(err) {
+                            done(err);
+                        })
+                    }, 50);
+                }).catch(function(err) {
+                    done(err);
+                });
+            }).catch(function(err) {
+                done(err);
+            });
+        }).catch(function(err) {
+            done(err);
+        });
+    });
 });

--- a/test/unit/@node-red/runtime/lib/storage/localfilesystem/library_spec.js
+++ b/test/unit/@node-red/runtime/lib/storage/localfilesystem/library_spec.js
@@ -204,7 +204,7 @@ describe('storage/localfilesystem/library', function() {
         });
     });
 
-    it('should return a newly saved multi-byte character library flow',function(done) {
+    it('should return a newly saved library flow (multi-byte character)',function(done) {
         localfilesystemLibrary.init({userDir:userDir}).then(function() {
             createObjectLibrary("flows");
             localfilesystemLibrary.getLibraryEntry('flows','B').then(function(flows) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

#2391 is because the library file is read separately and cannot be encoded well.

https://github.com/node-red/node-red/blob/a4c351fd4f4114d11f516b40c5c0d770b7c087e5/packages/node_modules/%40node-red/runtime/lib/storage/localfilesystem/library.js#L57-L94

Encoding errors do not occur when files are read in batch.

```js
function getFileBody(root,path) {
    var body = "";
    var fn = fspath.join(root,path);
    var data = fs.readFileSync(fn,'utf8');
    var parts = data.split("\n");

    parts.forEach((part) => {
        if (! /^\/\/ \w+: /.test(part)) {
            body += (body.length > 0?"\n":"")+ part;
        }
    });
    return body;
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
