### PR TITLE
fix read property when node.op2type is pay/payl ( #2399 )

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/89-trigger.js
+++ b/packages/node_modules/@node-red/nodes/core/function/89-trigger.js
@@ -124,7 +124,7 @@ module.exports = function(RED) {
             else {
                 if (((!node.topics[topic].tout) && (node.topics[topic].tout !== 0)) || (node.loop === true)) {
                     promise = Promise.resolve();
-                    if (node.op2type === "pay" || node.op2type === "payl") { node.topics[topic].m2 = RED.util.cloneMessage(msg.payload); }
+                    if (node.op2type === "pay" || node.op2type === "payl") { node.topics[topic].m2 = RED.util.cloneMessage(msg); }
                     else if (node.op2Templated) { node.topics[topic].m2 = mustache.render(node.op2,msg); }
                     else if (node.op2type !== "nul") {
                         promise = new Promise((resolve,reject) => {
@@ -186,7 +186,11 @@ module.exports = function(RED) {
                                                 });
                                             }
                                             promise.then(() => {
-                                                msg2.payload = node.topics[topic].m2;
+                                                if(node.op2type === "payl" || node.op2type === "pay"){
+                                                    msg2 = node.topics[topic].m2;
+                                                }else{
+                                                    msg2.payload = node.topics[topic].m2;
+                                                }
                                                 delete node.topics[topic];
                                                 node.send(msg2);
                                                 node.status({});
@@ -208,7 +212,7 @@ module.exports = function(RED) {
                 }
                 else if ((node.extend === "true" || node.extend === true) && (node.duration > 0)) {
                     /* istanbul ignore else  */
-                    if (node.op2type === "payl") { node.topics[topic].m2 = RED.util.cloneMessage(msg.payload); }
+                    if (node.op2type === "payl") { node.topics[topic].m2 = RED.util.cloneMessage(msg); }
                     /* istanbul ignore else  */
                     if (node.topics[topic].tout) { clearTimeout(node.topics[topic].tout); }
                     node.topics[topic].tout = setTimeout(function() {
@@ -233,7 +237,9 @@ module.exports = function(RED) {
                             if (node.op2type !== "nul") {
                                 if (node.topics[topic] !== undefined) {
                                     msg2 = RED.util.cloneMessage(msg);
-                                    msg2.payload = node.topics[topic].m2;
+                                    if(node.op2type !== "payl" && node.op2type !== "pay"){
+                                        msg2.payload = node.topics[topic].m2;
+                                    }
                                 }
                             }
                             delete node.topics[topic];
@@ -245,7 +251,9 @@ module.exports = function(RED) {
                     }, node.duration);
                 }
                 else {
-                    if (node.op2type === "payl") { node.topics[topic].m2 = RED.util.cloneMessage(msg.payload); }
+                    if (node.op2type === "payl") {
+                        node.topics[topic].m2 = RED.util.cloneMessage(msg); 
+                    }
                 }
             }
             return Promise.resolve();


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

This PR is a fix of #2399.

In TriggerNode, when the following option is selected, msg object is handled instead of msg.payload.

- the original msg object
- the latest msg object

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
