### PR TITLE
Fix IME bug in text editor

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/ace.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/ace.scss
@@ -52,6 +52,10 @@
         @include component-shadow;
         border-color: $popover-background;
     }
+    textarea.ace_text-input {
+        overflow: hidden;
+        padding: 0px 1px !important;
+    }
 
     #red-ui-event-log-editor {
         .ace_scroller {

--- a/packages/node_modules/@node-red/editor-client/src/sass/forms.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/forms.scss
@@ -78,8 +78,7 @@
     }
 
     textarea {
-        overflow: hidden;
-        padding: 0px 1px !important;
+        overflow: auto;
         vertical-align: top;
     }
 

--- a/packages/node_modules/@node-red/editor-client/src/sass/forms.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/forms.scss
@@ -78,7 +78,8 @@
     }
 
     textarea {
-        overflow: auto;
+        overflow: hidden;
+        padding: 0px 1px !important;
         vertical-align: top;
     }
 


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
When Japanese users input Japanese words on the ace editor, an unknown horizontal object which interferes with reading input text emerges.


![editorbug](https://user-images.githubusercontent.com/20310935/71053085-b726c500-2190-11ea-9452-039b0531cf64.gif)
Discussion: https://discourse.nodered.org/t/since-version-1-0-japanese-inline-input-has-become-difficult-to-use/19009

I found that this problem came from CSS restructuring. Therefore, I modified it (I checked it on the latest Chrome and Firefox on both Windows 10 and macOS in addition to IE and Safari).

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
