### PR TITLE
Replace <br> to space in filterChange function

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -475,7 +475,7 @@ RED.palette = (function() {
     function filterChange(val) {
         var re = new RegExp(val.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'),'i');
         $("#red-ui-palette-container .red-ui-palette-node").each(function(i,el) {
-            var currentLabel = $(el).find(".red-ui-palette-label").text();
+            var currentLabel = $(el).find(".red-ui-palette-label").html().replace(/<br\s*\/?>/gi,' ');
             var type = $(el).attr("data-palette-type");
             if (val === "" || re.test(type) || re.test(currentLabel)) {
                 $(this).show();


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

When filtering nodes in the palette, there was a problem that the node names were formatted and could not be searched properly.

`Demo for subflow in subflow` is recognized as `Demo forsubflow insubflow` .

<img width="1680" alt="スクリーンショット 2019-12-21 9 02 47" src="https://user-images.githubusercontent.com/23309/71299560-45898980-23d1-11ea-8e0d-fcae4d8677f5.png">

Discussion: https://github.com/node-red/node-red/issues/2409

I found that a small change in the formatting part gave the expected result.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
