### PR TITLE
Allow to know particular session from status node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
@@ -74,7 +74,7 @@ module.exports = function(RED) {
                     buffer = (node.datatype == 'buffer') ? Buffer.alloc(0) : "";
                     node.connected = true;
                     node.log(RED._("tcpin.status.connected",{host:node.host,port:node.port}));
-                    node.status({fill:"green",shape:"dot",text:"common.status.connected"});
+                    node.status({fill:"green",shape:"dot",text:"common.status.connected",_session:{type:"tcp",id:id}});
                 });
                 client.setKeepAlive(true,120000);
                 connectionPool[id] = client;
@@ -121,7 +121,7 @@ module.exports = function(RED) {
                 client.on('close', function() {
                     delete connectionPool[id];
                     node.connected = false;
-                    node.status({fill:"red",shape:"ring",text:"common.status.disconnected"});
+                    node.status({fill:"red",shape:"ring",text:"common.status.disconnected",_session:{type:"tcp",id:id}});
                     if (!node.closing) {
                         if (end) { // if we were asked to close then try to reconnect once very quick.
                             end = false;


### PR DESCRIPTION
The rationale is to collect (via status changes) own list of active sessions for particular tcp-in nodes to allow to pass an external message to those sessions only.
Proposed as a workaround for https://discourse.nodered.org/t/tcp-connection-pool-better-separation/19432.
Please consider applying.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
