### PR TITLE
Remove undefined loadFlowLibrary call

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -418,8 +418,6 @@ var RED = (function() {
                 RED.notify(RED._("palette.event.nodeUpgraded", {module:msg.module,version:msg.version}),"success");
                 RED.nodes.registry.setModulePendingUpdated(msg.module,msg.version);
             }
-            // Refresh flow library to ensure any examples are updated
-            RED.library.loadFlowLibrary();
         });
         RED.comms.subscribe("event-log/#", function(topic,payload) {
             var id = topic.substring(9);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Installing new node from editor *Manage Palette* interface causes following error:
```
Uncaught TypeError: RED.library.loadFlowLibrary is not a function
```
It seems that  the `loadFlowLibrary` function become useless in current Node-RED version.  Thus, this PR removes call of the `loadFlowLibrary` call.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
