### PR TITLE
Remove Node.js v8 from Travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,3 @@ matrix:
         - ./node_modules/.bin/grunt && istanbul report text && ( cat coverage/lcov.info | $(npm get prefix)/bin/coveralls || true ) && rm -rf coverage
       before_script:
         - npm install -g istanbul coveralls
-    - node_js: "8"


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Because Node v8 became EOL at the end of December, I removed it from Travis settings.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
