### PR TITLE
Change types from text/x-red to text/html in node html files

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="inject">
+<script type="text/html" data-template-name="inject">
     <div class="form-row">
         <label for="node-input-payload"><i class="fa fa-envelope"></i> <span data-i18n="common.label.payload"></span></label>
         <input type="text" id="node-input-payload" style="width:70%">

--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.html
@@ -1,5 +1,5 @@
 
-<script type="text/x-red" data-template-name="debug">
+<script type="text/html" data-template-name="debug">
     <div class="form-row">
         <label for="node-input-typed-complete"><i class="fa fa-list"></i> <span data-i18n="debug.output"></span></label>
         <input id="node-input-typed-complete" type="text" style="width: 70%">

--- a/packages/node_modules/@node-red/nodes/core/common/24-complete.html
+++ b/packages/node_modules/@node-red/nodes/core/common/24-complete.html
@@ -1,4 +1,4 @@
-<script type="text/x-red" data-template-name="complete">
+<script type="text/html" data-template-name="complete">
     <div class="form-row node-input-target-row">
         <button id="node-input-complete-target-select" class="red-ui-button" data-i18n="common.label.selectNodes"></button>
     </div>

--- a/packages/node_modules/@node-red/nodes/core/common/25-catch.html
+++ b/packages/node_modules/@node-red/nodes/core/common/25-catch.html
@@ -1,5 +1,5 @@
 
-<script type="text/x-red" data-template-name="catch">
+<script type="text/html" data-template-name="catch">
     <div class="form-row">
         <label style="width: auto" for="node-input-scope" data-i18n="catch.label.source"></label>
         <select id="node-input-scope-select">

--- a/packages/node_modules/@node-red/nodes/core/common/25-status.html
+++ b/packages/node_modules/@node-red/nodes/core/common/25-status.html
@@ -1,5 +1,5 @@
 
-<script type="text/x-red" data-template-name="status">
+<script type="text/html" data-template-name="status">
     <div class="form-row">
         <label style="width: auto" for="node-input-scope" data-i18n="status.label.source"></label>
         <select id="node-input-scope-select">

--- a/packages/node_modules/@node-red/nodes/core/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.html
@@ -1,12 +1,12 @@
 
-<script type="text/x-red" data-template-name="link in">
+<script type="text/html" data-template-name="link in">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
     </div>
     <div class="form-row node-input-link-row"></div>
 </script>
-<script type="text/x-red" data-template-name="link out">
+<script type="text/html" data-template-name="link out">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">

--- a/packages/node_modules/@node-red/nodes/core/common/90-comment.html
+++ b/packages/node_modules/@node-red/nodes/core/common/90-comment.html
@@ -1,5 +1,5 @@
 
-<script type="text/x-red" data-template-name="comment">
+<script type="text/html" data-template-name="comment">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">

--- a/packages/node_modules/@node-red/nodes/core/common/98-unknown.html
+++ b/packages/node_modules/@node-red/nodes/core/common/98-unknown.html
@@ -1,5 +1,5 @@
 
-<script type="text/x-red" data-template-name="unknown">
+<script type="text/html" data-template-name="unknown">
     <div class="form-tips"><span data-i18n="[html]unknown.tip"></span></div>
 </script>
 

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.html
@@ -1,5 +1,5 @@
 
-<script type="text/x-red" data-template-name="function">
+<script type="text/html" data-template-name="function">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
         <div style="display: inline-block; width: calc(100% - 105px)"><input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name"></div>

--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="switch">
+<script type="text/html" data-template-name="switch">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">

--- a/packages/node_modules/@node-red/nodes/core/function/15-change.html
+++ b/packages/node_modules/@node-red/nodes/core/function/15-change.html
@@ -1,5 +1,5 @@
 
-<script type="text/x-red" data-template-name="change">
+<script type="text/html" data-template-name="change">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">

--- a/packages/node_modules/@node-red/nodes/core/function/16-range.html
+++ b/packages/node_modules/@node-red/nodes/core/function/16-range.html
@@ -1,5 +1,5 @@
 
-<script type="text/x-red" data-template-name="range">
+<script type="text/html" data-template-name="range">
     <div class="form-row">
         <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> <span data-i18n="common.label.property"></span></label>
         <input type="text" id="node-input-property" style="width:calc(70% - 1px)"/>

--- a/packages/node_modules/@node-red/nodes/core/function/80-template.html
+++ b/packages/node_modules/@node-red/nodes/core/function/80-template.html
@@ -1,5 +1,5 @@
 
-<script type="text/x-red" data-template-name="template">
+<script type="text/html" data-template-name="template">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
         <div style="display: inline-block; width: calc(100% - 105px)"><input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name"></div>

--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.html
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="delay">
+<script type="text/html" data-template-name="delay">
     <div class="form-row">
         <label for="node-input-delay-action"><i class="fa fa-tasks"></i> <span data-i18n="delay.action"></span></label>
         <select id="node-input-delay-action" style="width:270px !important">

--- a/packages/node_modules/@node-red/nodes/core/function/89-trigger.html
+++ b/packages/node_modules/@node-red/nodes/core/function/89-trigger.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="trigger">
+<script type="text/html" data-template-name="trigger">
     <div class="form-row">
         <label data-i18n="trigger.send" for="node-input-op1"></label>
         <input type="hidden" id="node-input-op1type">

--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.html
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="exec">
+<script type="text/html" data-template-name="exec">
     <div class="form-row">
         <label for="node-input-command"><i class="fa fa-file"></i> <span data-i18n="exec.label.command"></span></label>
         <input type="text" id="node-input-command" data-i18n="[placeholder]exec.label.command">

--- a/packages/node_modules/@node-red/nodes/core/network/05-tls.html
+++ b/packages/node_modules/@node-red/nodes/core/network/05-tls.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="tls-config">
+<script type="text/html" data-template-name="tls-config">
     <div class="form-row" class="hide" id="node-config-row-uselocalfiles">
         <input type="checkbox" id="node-config-input-uselocalfiles" style="display: inline-block; width: auto; vertical-align: top;">
         <label for="node-config-input-uselocalfiles" style="width: 70%;"><span data-i18n="tls.label.use-local-files"></label>

--- a/packages/node_modules/@node-red/nodes/core/network/06-httpproxy.html
+++ b/packages/node_modules/@node-red/nodes/core/network/06-httpproxy.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="http proxy">
+<script type="text/html" data-template-name="http proxy">
     <div class="form-row">
         <label for="node-config-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
         <input type="text" id="node-config-input-name">

--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
@@ -11,7 +11,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="mqtt in">
+<script type="text/html" data-template-name="mqtt in">
     <div class="form-row">
         <label for="node-input-broker"><i class="fa fa-globe"></i> <span data-i18n="mqtt.label.broker"></span></label>
         <input type="text" id="node-input-broker">
@@ -75,7 +75,7 @@
     });
 </script>
 
-<script type="text/x-red" data-template-name="mqtt out">
+<script type="text/html" data-template-name="mqtt out">
     <div class="form-row">
         <label for="node-input-broker"><i class="fa fa-globe"></i> <span data-i18n="mqtt.label.broker"></span></label>
         <input type="text" id="node-input-broker">
@@ -129,7 +129,7 @@
     });
 </script>
 
-<script type="text/x-red" data-template-name="mqtt-broker">
+<script type="text/html" data-template-name="mqtt-broker">
     <div class="form-row">
         <label for="node-config-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
         <input type="text" id="node-config-input-name" data-i18n="[placeholder]common.label.name">

--- a/packages/node_modules/@node-red/nodes/core/network/21-httpin.html
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httpin.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="http in">
+<script type="text/html" data-template-name="http in">
     <div class="form-row">
         <label for="node-input-method"><i class="fa fa-tasks"></i> <span data-i18n="httpin.label.method"></span></label>
         <select type="text" id="node-input-method" style="width:70%;">
@@ -45,7 +45,7 @@
     <div id="node-input-tip" class="form-tips"><span data-i18n="httpin.tip.in"></span><code><span id="node-input-path"></span></code>.</div>
 </script>
 
-<script type="text/x-red" data-template-name="http response">
+<script type="text/html" data-template-name="http response">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">

--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="http request">
+<script type="text/html" data-template-name="http request">
     <div class="form-row">
         <label for="node-input-method"><i class="fa fa-tasks"></i> <span data-i18n="httpin.label.method"></span></label>
         <select type="text" id="node-input-method" style="width:70%;">

--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.html
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 <!-- WebSocket Input Node -->
-<script type="text/x-red" data-template-name="websocket in">
+<script type="text/html" data-template-name="websocket in">
     <div class="form-row">
         <label for="node-input-mode"><i class="fa fa-dot-circle-o"></i> <span data-i18n="websocket.label.type"></span></label>
         <select id="node-input-mode">
@@ -198,7 +198,7 @@
 </script>
 
 <!-- WebSocket out Node -->
-<script type="text/x-red" data-template-name="websocket out">
+<script type="text/html" data-template-name="websocket out">
     <div class="form-row">
         <label for="node-input-mode"><i class="fa fa-dot-circle-o"></i> <span data-i18n="websocket.label.type"></span></label>
         <select id="node-input-mode">
@@ -221,7 +221,7 @@
 </script>
 
 <!-- WebSocket Server configuration node -->
-<script type="text/x-red" data-template-name="websocket-listener">
+<script type="text/html" data-template-name="websocket-listener">
     <div class="form-row">
         <label for="node-config-input-path"><i class="fa fa-bookmark"></i> <span data-i18n="websocket.label.path"></span></label>
         <input id="node-config-input-path" type="text" placeholder="/ws/example">
@@ -240,7 +240,7 @@
 </script>
 
 <!-- WebSocket Client configuration node -->
-<script type="text/x-red" data-template-name="websocket-client">
+<script type="text/html" data-template-name="websocket-client">
     <div class="form-row">
         <label for="node-config-input-path"><i class="fa fa-bookmark"></i> <span data-i18n="websocket.label.url"></span></label>
         <input id="node-config-input-path" type="text" placeholder="ws://example.com/ws">

--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="tcp in">
+<script type="text/html" data-template-name="tcp in">
     <div class="form-row">
         <label for="node-input-server"><i class="fa fa-dot-circle-o"></i> <span data-i18n="tcpin.label.type"></span></label>
         <select id="node-input-server" style="width:120px; margin-right:5px;">
@@ -108,7 +108,7 @@
 </script>
 
 
-<script type="text/x-red" data-template-name="tcp out">
+<script type="text/html" data-template-name="tcp out">
     <div class="form-row">
         <label for="node-input-beserver"><i class="fa fa-dot-circle-o"></i> <span data-i18n="tcpin.label.type"></span></label>
         <select id="node-input-beserver" style="width:150px; margin-right:5px;">
@@ -188,7 +188,7 @@
 </script>
 
 
-<script type="text/x-red" data-template-name="tcp request">
+<script type="text/html" data-template-name="tcp request">
     <div class="form-row">
         <label for="node-input-server"><i class="fa fa-globe"></i> <span data-i18n="tcpin.label.server"></span></label>
         <input type="text" id="node-input-server" placeholder="ip.address" style="width:45%">

--- a/packages/node_modules/@node-red/nodes/core/network/32-udp.html
+++ b/packages/node_modules/@node-red/nodes/core/network/32-udp.html
@@ -15,7 +15,7 @@
 -->
 
 <!--  The Input Node  -->
-<script type="text/x-red" data-template-name="udp in">
+<script type="text/html" data-template-name="udp in">
     <div class="form-row">
         <label for="node-input-port"><i class="fa fa-sign-in"></i> <span data-i18n="udp.label.listen"></span></label>
         <select id="node-input-multicast" style='width:70%'>
@@ -115,7 +115,7 @@
 
 
 <!--  The Output Node  -->
-<script type="text/x-red" data-template-name="udp out">
+<script type="text/html" data-template-name="udp out">
     <div class="form-row">
         <label for="node-input-port"><i class="fa fa-envelope"></i> <span data-i18n="udp.label.send"></span></label>
         <select id="node-input-multicast" style="width:40%">

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-CSV.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-CSV.html
@@ -1,5 +1,5 @@
 
-<script type="text/x-red" data-template-name="csv">
+<script type="text/html" data-template-name="csv">
     <div class="form-row">
         <label for="node-input-temp"><i class="fa fa-list"></i> <span data-i18n="csv.label.columns"></span></label>
         <input type="text" id="node-input-temp" data-i18n="[placeholder]csv.placeholder.columns">

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-HTML.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-HTML.html
@@ -1,5 +1,5 @@
 
-<script type="text/x-red" data-template-name="html">
+<script type="text/html" data-template-name="html">
     <div class="form-row">
         <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> <span data-i18n="node-red:common.label.property"></span></label>
         <input type="text" id="node-input-property" style="width:70%">

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-JSON.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-JSON.html
@@ -1,5 +1,5 @@
 
-<script type="text/x-red" data-template-name="json">
+<script type="text/html" data-template-name="json">
     <div class="form-row">
         <label for="node-input-action"><i class="fa fa-dot-circle-o"></i> <span data-i18n="json.label.action"></span></label>
         <select style="width:70%" id="node-input-action">

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-XML.html
@@ -1,5 +1,5 @@
 
-<script type="text/x-red" data-template-name="xml">
+<script type="text/html" data-template-name="xml">
     <div class="form-row">
         <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> <span data-i18n="node-red:common.label.property"></span></label>
         <input type="text" id="node-input-property" style="width:70%;"/>

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-YAML.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-YAML.html
@@ -1,5 +1,5 @@
 
-<script type="text/x-red" data-template-name="yaml">
+<script type="text/html" data-template-name="yaml">
     <div class="form-row">
         <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> <span data-i18n="node-red:common.label.property"></span></label>
         <input type="text" id="node-input-property" style="width:70%;"/>

--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="split">
+<script type="text/html" data-template-name="split">
     <div class="form-row"><span data-i18n="[html]split.intro"></span></div>
     <div class="form-row"><span data-i18n="[html]split.strBuff"></span></div>
     <div class="form-row">
@@ -113,7 +113,7 @@
 </script>
 
 
-<script type="text/x-red" data-template-name="join">
+<script type="text/html" data-template-name="join">
     <div class="form-row">
         <label data-i18n="join.mode.mode"></label>
         <select id="node-input-mode" style="width:200px;">

--- a/packages/node_modules/@node-red/nodes/core/sequence/18-sort.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/18-sort.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="sort">
+<script type="text/html" data-template-name="sort">
 
     <div class="form-row">
         <label for="node-input-target"><i class="fa fa-dot-circle-o"></i> <span data-i18n="sort.target"></span></label>

--- a/packages/node_modules/@node-red/nodes/core/sequence/19-batch.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/19-batch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="batch">
+<script type="text/html" data-template-name="batch">
     <div class="form-row">
         <label for="node-input-mode"><span data-i18n="batch.mode.label"></span></label>
         <select type="text" id="node-input-mode" style="width: 300px;">

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.html
@@ -1,5 +1,5 @@
 
-<script type="text/x-red" data-template-name="file">
+<script type="text/html" data-template-name="file">
     <div class="form-row node-input-filename">
          <label for="node-input-filename"><i class="fa fa-file"></i> <span data-i18n="file.label.filename"></span></label>
          <input id="node-input-filename" type="text">
@@ -34,7 +34,7 @@
     <div class="form-tips"><span data-i18n="file.tip"></span></div>
 </script>
 
-<script type="text/x-red" data-template-name="file in">
+<script type="text/html" data-template-name="file in">
     <div class="form-row">
          <label for="node-input-filename"><i class="fa fa-file"></i> <span data-i18n="file.label.filename"></span></label>
          <input id="node-input-filename" type="text" data-i18n="[placeholder]file.label.filename">

--- a/packages/node_modules/@node-red/nodes/core/storage/23-watch.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/23-watch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-template-name="watch">
+<script type="text/html" data-template-name="watch">
     <div class="form-row node-input-filename">
          <label for="node-input-files"><i class="fa fa-file"></i> <span data-i18n="watch.label.files"></span></label>
          <input id="node-input-files" type="text" tabindex="1" data-i18n="[placeholder]watch.placeholder.files">

--- a/packages/node_modules/@node-red/nodes/locales/de/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/common/20-inject.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="inject">
+<script type="text/html" data-help-name="inject">
   <p> Injiziert eine Nachricht manuell oder in regelmäßigen Intervallen in einen Nachrichtenflow. 
     Bei den Nutzdaten kann es sich um eine Vielzahl von Typen handeln, einschließlich Zeichenfolgen, JavaScript-Objekte oder die aktuelle Zeit. </p>
     <h3> Ausgaben </h3>

--- a/packages/node_modules/@node-red/nodes/locales/de/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/common/21-debug.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="debug">
+<script type="text/html" data-help-name="debug">
   <p> Zeigt die ausgewählten Nachrichteneigenschaften auf der Registerkarte "Debug" und 
     optional im Laufzeitprotokoll an. Standardmäßig wird  <code>msg.payload</code> angezeigt. </p>
   <h3> Details </h3>

--- a/packages/node_modules/@node-red/nodes/locales/de/common/25-catch.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/common/25-catch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="catch">
+<script type="text/html" data-help-name="catch">
     <p> Fängt Fehler von Nodes auf derselben Registerkarte ab. </p>
     <h3> Ausgaben </h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/de/common/25-status.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/common/25-status.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="status">
+<script type="text/html" data-help-name="status">
     <p> Berichtet Statusnachrichten von anderen Node auf derselben Registerkarte. </p>
     <h3> Ausgaben </h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/de/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/common/60-link.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="link in">
+<script type="text/html" data-help-name="link in">
    <p> Erstellt virtuelle Verbindungen zwischen Flows. </p>
    <h3> Details </h3>
    <p> Der Node kann mit jedem beliebigen  <code>Link-out</code> Node auf einer beliebigen Registerkarte verbunden werden.
@@ -25,7 +25,7 @@
    <p> <b> Hinweis:  </b> Links können nicht in einem Subflow erstellt oder aus einem Subflow heraus erstellt werden. </p>
 </script>
 
-<script type="text/x-red" data-help-name="link out">
+<script type="text/html" data-help-name="link out">
    <p> Erstellt virtuelle Verbindungen zwischen Flows. </p>
    <h3> Details </h3>
    <p> Der Node kann mit jedem beliebigen  <code>Link-out</code> Node auf einer beliebigen Registerkarte verbunden werden.

--- a/packages/node_modules/@node-red/nodes/locales/de/common/90-comment.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/common/90-comment.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="comment">
+<script type="text/html" data-help-name="comment">
     <p>Ein Node, der zur Kommentierung der Flows verwendet werden kann.</p>
     <h3>Details</h3>
     <p>Das Textfeld des Node akzeptiert die Markdown Syntax. Der eingegebene Text wird dann in diesem Informations Panel angezeigt.

--- a/packages/node_modules/@node-red/nodes/locales/de/common/98-unknown.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/common/98-unknown.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="unknown">
+<script type="text/html" data-help-name="unknown">
     <p>Dieser Node ist von einem Typ, der in der aktuellen Node-RED Installation unbekannt ist.</p>
     <h3>Details</h3>
     <p><i>Wenn der Flow im aktuellen Zustand eingesetzt wird, bleibt die Konfiguration erhalten 

--- a/packages/node_modules/@node-red/nodes/locales/de/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/function/10-function.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="function">
+<script type="text/html" data-help-name="function">
   <p> Ein JavaScript-Funktionsblock, der für die Nachrichten ausgeführt werden soll, die vom Node empfangen werden. </p>
   <p> Die Nachrichten werden als JavaScript-Objekt mit dem Namen  <code>msg</code> übergeben. </p>
   <p> Er erwartet eine Eigenschaft  <code> msg.payload </code> , die den Hauptteil der Nachricht enthält. </p>

--- a/packages/node_modules/@node-red/nodes/locales/de/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/function/10-switch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="switch">
+<script type="text/html" data-help-name="switch">
     <p>Weiterleitung von Nachrichten basierend auf den Werten ihrer Eigenschaften oder der Position der Sequenz.</p>
     <h3>Details</h3>
     <p>Wenn eine Nachricht ankommt, wertet der Node jede der definierten Regeln aus

--- a/packages/node_modules/@node-red/nodes/locales/de/function/15-change.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/function/15-change.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="change">
+<script type="text/html" data-help-name="change">
     <p>Setzen, Ändern, Löschen oder Verschieben von Eigenschaften einer Nachricht, eines Flow-Kontextes oder eines globalen Kontextes.</p>
     <p>Der Node kann mehrere Regeln angeben, die in der Reihenfolge ihrer Definition angewendet werden.</p>
     <h3>Details</h3>

--- a/packages/node_modules/@node-red/nodes/locales/de/function/16-range.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/function/16-range.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="range">
+<script type="text/html" data-help-name="range">
     <p>Ordnet einen numerischen Wert einem anderen Bereich zu..</p>
     <h3>Eingaben</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/de/function/80-template.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/function/80-template.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="template">
+<script type="text/html" data-help-name="template">
   <p> Legt eine Eigenschaft fest, die auf der bereitgestellten Vorlage basiert. </p>
   <h3> Eingaben </h3>
   <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/de/function/89-delay.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/function/89-delay.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="delay">
+<script type="text/html" data-help-name="delay">
     <p> Verzögert jede Nachricht, die den Node durchläuft oder begrenzt die Geschwindigkeit, mit der sie übergeben werden können. </p>
     <h3> Eingaben </h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/de/function/89-trigger.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/function/89-trigger.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="trigger">
+<script type="text/html" data-help-name="trigger">
     <p> Wenn der Trigger ausgelöst wird, kann eine Nachricht gesendet werden und dann optional eine weitere Nachricht , 
         sofern der Trigger nicht verlängert oder zurückgesetzt wird. </p>
 

--- a/packages/node_modules/@node-red/nodes/locales/de/function/90-exec.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/function/90-exec.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="exec">
+<script type="text/html" data-help-name="exec">
     <p> Führt einen Systembefehl aus und gibt seine Ausgabe zurück. </p>
     <p> Der Node kann so konfiguriert werden, dass er entweder wartet, bis der Befehl abgeschlossen ist,
         oder die Ausgabe so sendet wie der Befehl sie generiert. </p>

--- a/packages/node_modules/@node-red/nodes/locales/de/network/05-tls.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/network/05-tls.html
@@ -14,6 +14,6 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="tls-config">
+<script type="text/html" data-help-name="tls-config">
     <p>Konfigurationsoptionen für TLS Verbindungen.</p>
 </script>

--- a/packages/node_modules/@node-red/nodes/locales/de/network/06-httpproxy.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/network/06-httpproxy.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="http proxy">
+<script type="text/html" data-help-name="http proxy">
     <p>Konfigurationsoptionen für den HTTP Proxy.</p>
 
     <h3>Details</h3>

--- a/packages/node_modules/@node-red/nodes/locales/de/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/network/10-mqtt.html
@@ -11,7 +11,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="mqtt in">
+<script type="text/html" data-help-name="mqtt in">
    <p> Stellt eine Verbindung zu einem MQTT-Broker her und subskribiert Nachrichten zu dem angegebenen Topic. </p>
    <h3> Ausgaben </h3>
    <dl class="message-properties">
@@ -31,7 +31,7 @@
    <p> Mehrere MQTT-Nodes (in oder out) können bei Bedarf dieselbe Brokerverbindung nutzen. </p>
 </script>
 
-<script type="text/x-red" data-help-name="mqtt out">
+<script type="text/html" data-help-name="mqtt out">
     <p>Stellt eine Verbindung zu einem MQTT-Broker her und publiziert Nachrichten.</p>
     <h3>Eingaben</h3>
     <dl class="message-properties">
@@ -61,7 +61,7 @@
     <p>Mehrere MQTT-Nodes (in oder out) können bei Bedarf dieselbe Brokerverbindung nutzen.</p>
 </script>
 
-<script type="text/x-red" data-help-name="mqtt-broker">
+<script type="text/html" data-help-name="mqtt-broker">
    <p> Konfiguration für eine Verbindung zu einem MQTT-Broker. </p>
    <p> Diese Konfiguration erstellt eine Verbindung zu einem Broker, die anschließend von den 
       Nodes <code>MQTT In</code> und <code>MQTT Out</code> verwendet werden. </p>

--- a/packages/node_modules/@node-red/nodes/locales/de/network/21-httpin.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/network/21-httpin.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="http in">
+<script type="text/html" data-help-name="http in">
     <p>Erstellt einen HTTP Endpunkt zur Erzeugung von Web Services.</p>
     <h3>Outputs</h3>
     <dl class="message-properties">
@@ -53,7 +53,7 @@
         muss einen code>HTTP Response</code> Node enthalten, um die Anforderung abzuschließen. </p>
 </script>
 
-<script type="text/x-red" data-help-name="http response">
+<script type="text/html" data-help-name="http response">
     <p>Sendet Antworten auf Anforderungen, die von einem code>HTTP In</code> Node empfangen wurden. </p>
     <h3>Eingaben</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/de/network/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/network/21-httprequest.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="http request">
+<script type="text/html" data-help-name="http request">
     <p>Sendet HTTP-Anforderungen und gibt die Antwort zurück.</p>
 
     <h3>Eingaben</h3>

--- a/packages/node_modules/@node-red/nodes/locales/de/network/22-websocket.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/network/22-websocket.html
@@ -14,14 +14,14 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="websocket in">
+<script type="text/html" data-help-name="websocket in">
     <p>WebSocket Eingangs-Node.</p>
     <p>Standardmäßig befinden sich die vom WebSocket empfangenen Daten in <code>msg.payload</code>.
         Der Socket kann konfiguriert werden, um einen korrekt gebildeten JSON-String zu erwarten,
         in diesem Fall wird er das JSON analysieren und das resultierende Objekt als gesamte Nachricht senden.</p>
 </script>
 
-<script type="text/x-red" data-help-name="websocket out">
+<script type="text/html" data-help-name="websocket out">
     <p>WebSocket Ausgabe-Node.</p>
     <p>Standardmäßig wird <code>msg.payload</code> über den WebSocket gesendet. 
        Der Socket kann so konfiguriert werden, dass er das gesamte <code>msg</code> Objekt als JSON-String kodiert und über den WebSocket sendet.</p>
@@ -33,12 +33,12 @@
         muss die Eigenschaft <code>msg._session</code> innerhalb des Flow gelöscht werden.</p>
 </script>
 
-<script type="text/x-red" data-help-name="websocket-listener">
+<script type="text/html" data-help-name="websocket-listener">
    <p>Dieser Konfigurations-Node erstellt einen WebSocket Server-Endpunkt unter Verwendung des angegebenen Pfades.</p>
 </script>
 
 <!-- WebSocket Client configuration node -->
-<script type="text/x-red" data-template-name="websocket-client">
+<script type="text/html" data-template-name="websocket-client">
     <div class="form-row">
         <label for="node-config-input-path"><i class="fa fa-bookmark"></i> <span data-i18n="websocket.label.url"></span></label>
         <input id="node-config-input-path" type="text" placeholder="ws://example.com/ws">
@@ -61,6 +61,6 @@
     </div>
 </script>
 
-<script type="text/x-red" data-help-name="websocket-client">
+<script type="text/html" data-help-name="websocket-client">
    <p>Dieser Konfigurations-Node verbindet einen WebSocket-Client mit der angegebenen URL.</p>
 </script>

--- a/packages/node_modules/@node-red/nodes/locales/de/network/31-tcpin.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/network/31-tcpin.html
@@ -14,13 +14,13 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="tcp in">
+<script type="text/html" data-help-name="tcp in">
     <p>Bietet eine Auswahl an TCP-Eingängen. Kann sich entweder mit einem entfernten TCP-Port verbinden oder eingehende Verbindungen akzeptieren.</p>
     <p><b>Note: </b>Auf einigen Systemen benötigen Sie möglicherweise Root- oder Administratorzugriff, um 
         Ports unter 1024 und/oder Broadcast nutzen zu können.</p>
 </script>
 
-<script type="text/x-red" data-help-name="tcp out">
+<script type="text/html" data-help-name="tcp out">
     <p>Bietet eine Auswahl an TCP-Ausgängen. Kann sich entweder mit einem entfernten TCP-Port verbinden,
        eingehende Verbindungen akzeptieren oder auf Nachrichten antworten, die von einem TCP-In-Node empfangen werden.</p>
        <p>Nur der Inhalt von <code>msg.payload</code> wird gesendet.</p>
@@ -32,7 +32,7 @@
         Ports unter 1024 und/oder Broadcast nutzen zu können.</p>
 </script>
  
-<script type="text/x-red" data-help-name="tcp request">
+<script type="text/html" data-help-name="tcp request">
     <p>Ein einfacher TCP-Anforderungs-Node - sendet die <code>msg.payload</code> an einen Server-TCP-Port und erwartet eine Antwort.</p>
     <p>Verbindet sich, sendet die "Anforderung" und liest die "Antwort". Der Node wartet entweder auf eine vorgegebene Anzahl von
         Zeichen in einen festen Buffer, auf ein bestimmtes Zeichen oder einen festen Timeout ab der ersten Antwort,

--- a/packages/node_modules/@node-red/nodes/locales/de/network/32-udp.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/network/32-udp.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="udp in">
+<script type="text/html" data-help-name="udp in">
     <p>Ein UDP-Eingangs-Node, der eine <code>msg.payload</code> erzeugt, die einen
         Buffer, Strings oder base64-kodierter String enthält. Multicast wird unterstützt.</p>
     <p>Über die Eigenschaften <code>msg.ip</code> und <code>msg.port</code> kann auf die Werte der 
@@ -23,7 +23,7 @@
         Ports unter 1024 und/oder Broadcast nutzen zu können.</p>
 </script>
 
-<script type="text/x-red" data-help-name="udp out">
+<script type="text/html" data-help-name="udp out">
     <p>Dieser Node sendet <code>msg.payload</code> an den angegebenen UDP-Host und Port. Multicast wird unterstützt.</p>
     <p>Sie können <code>msg.ip</code> und <code>msg.port</code> verwenden, um die Zielwerte festzulegen, 
         aber die statisch im Node konfigurierten Werte haben Vorrang.</p>

--- a/packages/node_modules/@node-red/nodes/locales/de/parsers/70-CSV.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/parsers/70-CSV.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="csv">
+<script type="text/html" data-help-name="csv">
     <p>Konvertiert zwischen einem CSV-formatierten String und ihrer JavaScript-Objektdarstellung in beide Richtungen.</p>
     <h3>Eingaben</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/de/parsers/70-HTML.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/parsers/70-HTML.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="html">
+<script type="text/html" data-help-name="html">
     <p>Extrahiert unter Verwendung eines CSS-Selektors Elemente aus einem HTML-Dokument, das sich in <code>msg.payload</code> befindet.</p>
     <h3>Eingaben</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/de/parsers/70-JSON.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/parsers/70-JSON.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="json">
+<script type="text/html" data-help-name="json">
     <p>Konvertiert zwischen einem JSON-String und seiner JavaScript-Objektdarstellung in beide Richtungen.</p>
     <h3>Eingaben</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/de/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/parsers/70-XML.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="xml">
+<script type="text/html" data-help-name="xml">
     <p>Konvertiert zwischen einem XML-String und seiner JavaScript-Objektdarstellung - in beiden Richtungen.</p>
     <h3>Eingaben</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/de/parsers/70-YAML.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/parsers/70-YAML.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="yaml">
+<script type="text/html" data-help-name="yaml">
     <p>Konvertiert zwischen einer YAML-formatierten String und ihrer JavaScript-Objektdarstellung in beide Richtungen.</p>
     <h3>Eingaben</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/de/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/sequence/17-split.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="split">
+<script type="text/html" data-help-name="split">
     <p>Teilt eine Nachricht in eine Folge von Nachrichten auf.</p>
 
     <h3>Eingaben</h3>
@@ -62,7 +62,7 @@
         Das bedeutet, dass er nicht mit dem <b>join</b> Node im Automatikmodus verwendet werden kann.</p>
 </script>
 
-<script type="text/x-red" data-help-name="join">
+<script type="text/html" data-help-name="join">
     <p>Verbindet Sequenzen von Nachrichten zu einer einzigen Nachricht.</p>
     <p>Es sind drei Modi verfügbar:</p>
     <dl>

--- a/packages/node_modules/@node-red/nodes/locales/de/sequence/18-sort.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/sequence/18-sort.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="sort">
+<script type="text/html" data-help-name="sort">
     <p>Eine Funktion, die die Nachrichteneigenschaft oder eine Folge von Nachrichten sortiert.</p>
     <p>Wenn der Node konfiguriert ist, um die Nachrichteneigenschaft zu sortieren,
         sortiert er Array-Daten, auf die von der angegebenen Nachrichteneigenschaft verwiesen wird.</p>

--- a/packages/node_modules/@node-red/nodes/locales/de/sequence/19-batch.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/sequence/19-batch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="batch">
+<script type="text/html" data-help-name="batch">
     <p>Erstellt Sequenzen von Nachrichten nach verschiedenen Regeln.</p>
     <h3>Details</h3>
     <p>Es gibt drei Modi für die Erstellung von Nachrichtensequenzen:</p>

--- a/packages/node_modules/@node-red/nodes/locales/de/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/storage/10-file.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="file">
+<script type="text/html" data-help-name="file">
     <p>Schreibt <code>msg.payload</code> in eine Datei, wobei entweder der vorhandene Inhalt hinzugefügt oder ersetzt wird.
         Alternativ kann die Datei auch gelöscht werden.</p>
     <h3>Eingaben</h3>
@@ -34,7 +34,7 @@
     <p>Alternativ kann dieser Node konfiguriert werden, um die Datei zu löschen.</p>
 </script>
 
-<script type="text/x-red" data-help-name="file in">
+<script type="text/html" data-help-name="file in">
     <p>Reads the contents of a file as either a string or binary buffer.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/de/storage/23-watch.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/storage/23-watch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="watch">
+<script type="text/html" data-help-name="watch">
     <p>Überwacht ein Verzeichnis oder eine Datei auf Änderungen.</p>
     <p>Es kann eine kommagetrennte Liste von Verzeichnissen und/oder Dateien eingeben werden. 
       Es müssen Anführungszeichen "...." um alle Einträge gesetzt werden, die Leerzeichen enthalten.</p>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/common/20-inject.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="inject">
+<script type="text/html" data-help-name="inject">
 <p>Injects a message into a flow either manually or at regular intervals. The message
 payload can be a variety of types, including strings, JavaScript objects or the current time.</p>
 <h3>Outputs</h3>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/common/21-debug.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="debug">
+<script type="text/html" data-help-name="debug">
     <p>Displays selected message properties in the debug sidebar tab and optionally the runtime log. By default it displays <code>msg.payload</code>, but can be configured to display any property, the full message or the result of a JSONata expression.</p>
     <h3>Details</h3>
     <p>The debug sidebar provides a structured view of the messages it is sent, making it easier to understand their structure.</p>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/common/24-complete.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/common/24-complete.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="complete">
+<script type="text/html" data-help-name="complete">
     <p>Trigger a flow when another node completes its handling of a message.</p>
     <h3>Details</h3>
     <p>If a node tells the runtime when it has finished handling a message,

--- a/packages/node_modules/@node-red/nodes/locales/en-US/common/25-catch.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/common/25-catch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="catch">
+<script type="text/html" data-help-name="catch">
     <p>Catch errors thrown by nodes on the same tab.</p>
     <h3>Outputs</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/en-US/common/25-status.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/common/25-status.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="status">
+<script type="text/html" data-help-name="status">
     <p>Report status messages from other nodes on the same tab.</p>
     <h3>Outputs</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/en-US/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/common/60-link.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="link in">
+<script type="text/html" data-help-name="link in">
     <p>Create virtual wires between flows.</p>
     <h3>Details</h3>
     <p>The node can be connected to any <code>link out</code> node that exists on any tab.
@@ -25,7 +25,7 @@
     <p><b>Note: </b>Links cannot be created going into, or out of, a subflow.</p>
 </script>
 
-<script type="text/x-red" data-help-name="link out">
+<script type="text/html" data-help-name="link out">
     <p>Create virtual wires between flows.</p>
     <h3>Details</h3>
     <p>The node can be connected to any <code>link in</code> node that exists on any tab.

--- a/packages/node_modules/@node-red/nodes/locales/en-US/common/90-comment.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/common/90-comment.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="comment">
+<script type="text/html" data-help-name="comment">
     <p>A node you can use to add comments to your flows.</p>
     <h3>Details</h3>
     <p>The edit panel will accept Markdown syntax. The text will be rendered into

--- a/packages/node_modules/@node-red/nodes/locales/en-US/common/98-unknown.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/common/98-unknown.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="unknown">
+<script type="text/html" data-help-name="unknown">
     <p>This node is a type unknown to your installation of Node-RED.</p>
     <h3>Details</h3>
     <p><i>If you deploy with the node in this state, its configuration will be preserved, but

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/10-function.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="function">
+<script type="text/html" data-help-name="function">
     <p>A JavaScript function block to run against the messages being received by the node.</p>
     <p>The messages are passed in as a JavaScript object called <code>msg</code>.</p>
     <p>By convention it will have a <code>msg.payload</code> property containing

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/10-switch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="switch">
+<script type="text/html" data-help-name="switch">
     <p>Route messages based on their property values or sequence position.</p>
     <h3>Details</h3>
     <p>When a message arrives, the node will evaluate each of the defined rules

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/15-change.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/15-change.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="change">
+<script type="text/html" data-help-name="change">
     <p>Set, change, delete or move properties of a message, flow context or global context.</p>
     <p>The node can specify multiple rules that will be applied in the order they are defined.</p>
     <h3>Details</h3>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/16-range.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/16-range.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="range">
+<script type="text/html" data-help-name="range">
     <p>Maps a numeric value to a different range.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/80-template.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/80-template.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="template">
+<script type="text/html" data-help-name="template">
     <p>Sets a property based on the provided template.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/89-delay.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/89-delay.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="delay">
+<script type="text/html" data-help-name="delay">
     <p>Delays each message passing through the node or limits the rate at which they can pass.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/89-trigger.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/89-trigger.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="trigger">
+<script type="text/html" data-help-name="trigger">
     <p>When triggered, can send a message, and then optionally a second message, unless extended or reset.</p>
 
     <h3>Inputs</h3>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/90-exec.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/90-exec.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="exec">
+<script type="text/html" data-help-name="exec">
     <p>Runs a system command and returns its output.</p>
     <p>The node can be configured to either wait until the command completes, or to
     send its output as the command generates it.</p>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/network/05-tls.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/network/05-tls.html
@@ -14,6 +14,6 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="tls-config">
+<script type="text/html" data-help-name="tls-config">
     <p>Configuration options for TLS connections.</p>
 </script>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/network/06-httpproxy.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/network/06-httpproxy.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="http proxy">
+<script type="text/html" data-help-name="http proxy">
     <p>Configuration options for HTTP proxy.</p>
 
     <h3>Details</h3>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/network/10-mqtt.html
@@ -11,7 +11,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="mqtt in">
+<script type="text/html" data-help-name="mqtt in">
 <p>Connects to a MQTT broker and subscribes to messages from the specified topic.</p>
     <h3>Outputs</h3>
     <dl class="message-properties">
@@ -31,7 +31,7 @@
     <p>Several MQTT nodes (in or out) can share the same broker connection if required.</p>
 </script>
 
-<script type="text/x-red" data-help-name="mqtt out">
+<script type="text/html" data-help-name="mqtt out">
     <p>Connects to a MQTT broker and publishes messages.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">
@@ -60,7 +60,7 @@
     <p>Several MQTT nodes (in or out) can share the same broker connection if required.</p>
 </script>
 
-<script type="text/x-red" data-help-name="mqtt-broker">
+<script type="text/html" data-help-name="mqtt-broker">
     <p>Configuration for a connection to an MQTT broker.</p>
     <p>This configuration will create a single connection to the broker which can
        then be reused by <code>MQTT In</code> and <code>MQTT Out</code> nodes.</p>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/network/21-httpin.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/network/21-httpin.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="http in">
+<script type="text/html" data-help-name="http in">
     <p>Creates an HTTP end-point for creating web services.</p>
     <h3>Outputs</h3>
     <dl class="message-properties">
@@ -54,7 +54,7 @@
        must include an HTTP Response node to complete the request.</p>
 </script>
 
-<script type="text/x-red" data-help-name="http response">
+<script type="text/html" data-help-name="http response">
     <p>Sends responses back to requests received from an HTTP Input node.</p>
 
     <h3>Inputs</h3>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/network/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/network/21-httprequest.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="http request">
+<script type="text/html" data-help-name="http request">
     <p>Sends HTTP requests and returns the response.</p>
 
     <h3>Inputs</h3>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/network/22-websocket.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/network/22-websocket.html
@@ -14,14 +14,14 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="websocket in">
+<script type="text/html" data-help-name="websocket in">
     <p>WebSocket input node.</p>
     <p>By default, the data received from the WebSocket will be in <code>msg.payload</code>.
     The socket can be configured to expect a properly formed JSON string, in which
     case it will parse the JSON and send on the resulting object as the entire message.</p>
 </script>
 
-<script type="text/x-red" data-help-name="websocket out">
+<script type="text/html" data-help-name="websocket out">
     <p>WebSocket out node.</p>
     <p>By default, <code>msg.payload</code> will be sent over the WebSocket. The socket
     can be configured to encode the entire <code>msg</code> object as a JSON string and send that
@@ -34,10 +34,10 @@
     should delete the <code>msg._session</code> property within the flow.</p>
 </script>
 
-<script type="text/x-red" data-help-name="websocket-listener">
+<script type="text/html" data-help-name="websocket-listener">
    <p>This configuration node creates a WebSocket Server endpoint using the specified path.</p>
 </script>
 
-<script type="text/x-red" data-help-name="websocket-client">
+<script type="text/html" data-help-name="websocket-client">
    <p>This configuration node connects a WebSocket client to the specified URL.</p>
 </script>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/network/31-tcpin.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/network/31-tcpin.html
@@ -14,14 +14,14 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="tcp in">
+<script type="text/html" data-help-name="tcp in">
     <p>Provides a choice of TCP inputs. Can either connect to a remote TCP port,
        or accept incoming connections.</p>
     <p><b>Note: </b>On some systems you may need root or administrator access
     to access ports below 1024.</p>
 </script>
 
-<script type="text/x-red" data-help-name="tcp out">
+<script type="text/html" data-help-name="tcp out">
     <p>Provides a choice of TCP outputs. Can either connect to a remote TCP port,
     accept incoming connections, or reply to messages received from a TCP In node.</p>
     <p>Only the <code>msg.payload</code> is sent.</p>
@@ -34,7 +34,7 @@
     to access ports below 1024.</p>
 </script>
 
-<script type="text/x-red" data-help-name="tcp request">
+<script type="text/html" data-help-name="tcp request">
     <p>A simple TCP request node - sends the <code>msg.payload</code> to a server tcp port and expects a response.</p>
     <p>Connects, sends the "request", and reads the "response". It can either count a number of
     returned characters into a fixed buffer, match a specified character before returning,

--- a/packages/node_modules/@node-red/nodes/locales/en-US/network/32-udp.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/network/32-udp.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="udp in">
+<script type="text/html" data-help-name="udp in">
     <p>A UDP input node, that produces a <code>msg.payload</code> containing a
     Buffer, string, or base64 encoded string. Supports multicast.</p>
     <p>It also provides <code>msg.ip</code> and <code>msg.port</code> set to the
@@ -23,7 +23,7 @@
     ports below 1024 and/or broadcast.</p>
 </script>
 
-<script type="text/x-red" data-help-name="udp out">
+<script type="text/html" data-help-name="udp out">
     <p>This node sends <code>msg.payload</code> to the designated UDP host and port. Supports multicast.</p>
     <p>You may also use <code>msg.ip</code> and <code>msg.port</code> to set the destination values, but the statically configured values have precedence.</p>
     <p>If you select broadcast either set the address to the local broadcast ip address, or maybe try 255.255.255.255, which is the global broadcast address.</p>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-CSV.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-CSV.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="csv">
+<script type="text/html" data-help-name="csv">
     <p>Converts between a CSV formatted string and its JavaScript object representation, in either direction.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-HTML.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-HTML.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="html">
+<script type="text/html" data-help-name="html">
     <p>Extracts elements from an html document held in <code>msg.payload</code> using a CSS selector.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-JSON.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-JSON.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="json">
+<script type="text/html" data-help-name="json">
     <p>Converts between a JSON string and its JavaScript object representation, in either direction.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-XML.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="xml">
+<script type="text/html" data-help-name="xml">
     <p>Converts between an XML string and its JavaScript object representation, in either direction.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-YAML.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-YAML.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="yaml">
+<script type="text/html" data-help-name="yaml">
     <p>Converts between a YAML formatted string and its JavaScript object representation, in either direction.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/en-US/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/sequence/17-split.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="split">
+<script type="text/html" data-help-name="split">
     <p>Splits a message into a sequence of messages.</p>
 
     <h3>Inputs</h3>
@@ -63,7 +63,7 @@
     means it cannot be used with the <b>join</b> node in its automatic mode</p>
 </script>
 
-<script type="text/x-red" data-help-name="join">
+<script type="text/html" data-help-name="join">
     <p>Joins sequences of messages into a single message.</p>
     <p>There are three modes available:</p>
     <dl>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/sequence/18-sort.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/sequence/18-sort.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="sort">
+<script type="text/html" data-help-name="sort">
     <p>A function that sorts message property or a sequence of messages.</p>
     <p>When configured to sort message property, the node sorts array data pointed to by specified message property.</p>
     <p>When configured to sort a sequence of messages, it will reorder the messages.</p>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/sequence/19-batch.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/sequence/19-batch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="batch">
+<script type="text/html" data-help-name="batch">
     <p>Creates sequences of messages based on various rules.</p>
     <h3>Details</h3>
     <p>There are three modes for creating message sequences:</p>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/storage/10-file.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="file">
+<script type="text/html" data-help-name="file">
     <p>Writes <code>msg.payload</code> to a file, either adding to the end or replacing the existing content.
        Alternatively, it can delete the file.</p>
     <h3>Inputs</h3>
@@ -36,7 +36,7 @@
     <p>Alternatively, this node can be configured to delete the file.</p>
 </script>
 
-<script type="text/x-red" data-help-name="file in">
+<script type="text/html" data-help-name="file in">
     <p>Reads the contents of a file as either a string or binary buffer.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/en-US/storage/23-watch.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/storage/23-watch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="watch">
+<script type="text/html" data-help-name="watch">
     <p>Watches a directory or file for changes.</p>
     <p>You can enter a list of comma separated directories and/or files. You will
     need to put quotes "..." around any that have spaces in.</p>

--- a/packages/node_modules/@node-red/nodes/locales/ja/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/common/20-inject.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="inject">
+<script type="text/html" data-help-name="inject">
 <p>手動もしくは一定間隔でメッセージをフローに注入します。メッセージのペイロードには、文字列、JavaScriptオブジェクト、現在の時刻など、さまざまな値を指定できます。</p>
 <h3>出力</h3>
 <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ja/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/common/21-debug.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="debug">
+<script type="text/html" data-help-name="debug">
     <p>サイドバーの「デバッグ」タブに、選択したメッセージプロパティの値を表示します。設定により、ランタイムログへの出力も可能です。デフォルトの表示対象は<code>msg.payload</code>ですが、設定により、指定したプロパティ、メッセージ全体、もしくは、JSONata式の評価結果を出力できます。</p>
     <h3>詳細</h3>
     <p>「デバッグ」サイドバーは受け取ったメッセージの階層構造を表示する機能を備えます。この機能によりメッセージの構造を容易に理解できます。</p>

--- a/packages/node_modules/@node-red/nodes/locales/ja/common/24-complete.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/common/24-complete.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="complete">
+<script type="text/html" data-help-name="complete">
     <p>他のノードにおけるメッセージ処理の完了を受けてフローを開始します。</p>
     <h3>詳細</h3>
     <p>ノードからランタイムに対してメッセージ処理の完了が通知されると、本ノードによって次のフローを開始できます。</p>

--- a/packages/node_modules/@node-red/nodes/locales/ja/common/25-catch.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/common/25-catch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="catch">
+<script type="text/html" data-help-name="catch">
     <p>同じタブ内のノードが送出したエラーをキャッチします。</p>
     <h3>出力</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ja/common/25-status.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/common/25-status.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="status">
+<script type="text/html" data-help-name="status">
     <p>同じタブ内のノードのステータスメッセージを取得します。</p>
     <h3>出力</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ja/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/common/60-link.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="link in">
+<script type="text/html" data-help-name="link in">
     <p>フロー間に仮想的なリンクを作成します。</p>
     <h3>詳細</h3>
     <p>任意のタブ上に存在する<code>link out</code>ノードに接続できます。この接続はあたかも直接リンクしたかのように動作します。</p>
@@ -22,7 +22,7 @@
     <p><b>注: </b>サブフローの外から中、もしくは、中から外へのリンクを作成することはできません。</p>
 </script>
 
-<script type="text/x-red" data-help-name="link out">
+<script type="text/html" data-help-name="link out">
     <p>フロー間に仮想的なリンクを作成します。</p>
     <h3>詳細</h3>
     <p>任意のタブ上に存在する<code>link in</code>ノードに接続できます。この接続はあたかも直接リンクしたかのように動作します。</p>

--- a/packages/node_modules/@node-red/nodes/locales/ja/common/90-comment.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/common/90-comment.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="comment">
+<script type="text/html" data-help-name="comment">
     <p>フローにコメントを記述するために利用します。</p>
     <h3>詳細</h3>
     <p>編集パネルはMarkdown形式を記入可能です。入力したテキストは、「情報」サイドパネルに表示されます。</p>

--- a/packages/node_modules/@node-red/nodes/locales/ja/common/98-unknown.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/common/98-unknown.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="unknown">
+<script type="text/html" data-help-name="unknown">
     <p>インストールされたNode-REDが認識できない種別のノードです。</p>
     <h3>詳細</h3>
     <p><i>この種別のノードをデプロイした場合、設定は保持されますが、足りないノードをインストールするまでフローを開始することはできません。</i></p>

--- a/packages/node_modules/@node-red/nodes/locales/ja/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/function/10-function.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="function">
+<script type="text/html" data-help-name="function">
     <p>受信メッセージに対して処理を行うJavaScriptコード(関数の本体)を定義します。</p>
     <p>入力メッセージは<code>msg</code>という名称のJavaScriptオブジェクトで受け渡されます。</p>
     <p><code>msg</code>オブジェクトは<code>msg.payload</code>プロパティにメッセージ本体を保持するのが慣例です。</p>

--- a/packages/node_modules/@node-red/nodes/locales/ja/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/function/10-switch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="switch">
+<script type="text/html" data-help-name="switch">
     <p>プロパティの値によってメッセージの振り分けを行います。</p>
     <h3>詳細</h3>
     <p>受信したメッセージに対し、指定されたルールを順に評価し、マッチしたルールに対応する出力ポートにメッセージを送出します。</p>

--- a/packages/node_modules/@node-red/nodes/locales/ja/function/15-change.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/function/15-change.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="change">
+<script type="text/html" data-help-name="change">
     <p>メッセージ、フローコンテキスト、グローバルコンテキストのプロパティを変更、削除、移動します。</p>
     <p>ルールを複数指定した場合、定義した順に適用します。</p>
     <h3>詳細</h3>

--- a/packages/node_modules/@node-red/nodes/locales/ja/function/16-range.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/function/16-range.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="range">
+<script type="text/html" data-help-name="range">
     <p>数値を異なる範囲の値に変換します。</p>
     <h3>入力</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ja/function/80-template.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/function/80-template.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="template">
+<script type="text/html" data-help-name="template">
     <p>テンプレートに基づいてプロパティを設定します。</p>
     <h3>入力</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ja/function/89-delay.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/function/89-delay.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="delay">
+<script type="text/html" data-help-name="delay">
     <p>ノードを通過するメッセージを遅延もしくは流量を制限します。</p>
     <h3>入力</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ja/function/89-trigger.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/function/89-trigger.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="trigger">
+<script type="text/html" data-help-name="trigger">
     <p>メッセージを受信すると、別のメッセージの送信を行います。延長もしくは初期化が指定されていない場合には、2つ目のメッセージを送信することもできます。</p>
 
     <h3>入力</h3>

--- a/packages/node_modules/@node-red/nodes/locales/ja/function/90-exec.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/function/90-exec.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="exec">
+<script type="text/html" data-help-name="exec">
     <p>システムのコマンドを実行し出力を返します。</p>
     <p>コマンドの完了まで待つか、コマンドが出力を行う毎にメッセージを出力するかを指定できます。</p>
     <p>実行対象のコマンドは、ノードの設定もしくは受信メッセージで指定します。</p>

--- a/packages/node_modules/@node-red/nodes/locales/ja/network/05-tls.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/network/05-tls.html
@@ -14,6 +14,6 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="tls-config">
+<script type="text/html" data-help-name="tls-config">
     <p>TLS接続のためのオプション設定</p>
 </script>

--- a/packages/node_modules/@node-red/nodes/locales/ja/network/06-httpproxy.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/network/06-httpproxy.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="http proxy">
+<script type="text/html" data-help-name="http proxy">
     <p>プロキシのためのオプション設定</p>
 
     <h3>詳細</h3>

--- a/packages/node_modules/@node-red/nodes/locales/ja/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/network/10-mqtt.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="mqtt in">
+<script type="text/html" data-help-name="mqtt in">
 <p>MQTTブローカに接続し、指定したトピックのメッセージをサブスクライブ(購読)します。</p>
     <h3>出力</h3>
     <dl class="message-properties">
@@ -33,7 +33,7 @@
     <p>MQTT(inおよびout)ノードはブローカへの接続設定を必要に応じて共有できます。</p>
 </script>
 
-<script type="text/x-red" data-help-name="mqtt out">
+<script type="text/html" data-help-name="mqtt out">
     <p>MQTTブローカに接続し、メッセージをパブリッシュ(発行)します。</p>
     <h3>入力</h3>
     <dl class="message-properties">
@@ -57,7 +57,7 @@
     <p>MQTT(inおよびout)ノードはブローカへの接続設定を必要に応じて共有できます。</p>
 </script>
 
-<script type="text/x-red" data-help-name="mqtt-broker">
+<script type="text/html" data-help-name="mqtt-broker">
     <p>MQTTブローカへの接続設定</p>
     <p>ブローカへの接続設定を作成します。設定は<code>MQTT In</code>および<code>MQTT Out</code>ノードで再利用できます。</p>
     <p>ノードにクライアントIDを設定しておらずセッションの初期化を設定している場合、ランダムなクライアントIDを生成します。クライアントIDを設定する場合、接続先のブローカで一意となるようにしてください。</p>

--- a/packages/node_modules/@node-red/nodes/locales/ja/network/21-httpin.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/network/21-httpin.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="http in">
+<script type="text/html" data-help-name="http in">
     <p>HTTPエンドポイントを作成し、Webサービスを構成します。</p>
     <h3>出力</h3>
     <dl class="message-properties">
@@ -41,7 +41,7 @@
     <p><b>注:</b> このノードはリクエストに対するレスポンスの送信は行いません。リクエストを処理するにはフローにHTTP Responseノードを含めてください。</p>
 </script>
 
-<script type="text/x-red" data-help-name="http response">
+<script type="text/html" data-help-name="http response">
     <p>HTTP Inノードで受け付けたリクエストに対するレスポンスを送り返します。</p>
 
     <h3>入力</h3>

--- a/packages/node_modules/@node-red/nodes/locales/ja/network/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/network/21-httprequest.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="http request">
+<script type="text/html" data-help-name="http request">
     <p>HTTPリクエストを送信し、レスポンスを返します。</p>
 
     <h3>入力</h3>

--- a/packages/node_modules/@node-red/nodes/locales/ja/network/22-websocket.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/network/22-websocket.html
@@ -14,12 +14,12 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="websocket in">
+<script type="text/html" data-help-name="websocket in">
     <p>WebSocket入力ノード</p>
     <p>デフォルトでは、WebSocketにより受信したデータは<code>msg.payload</code>に格納します。ソケットはJSON形式の文字列を待ち受けるように設定することができます。JSON形式の文字列を受け付けると、オブジェクトへの変換を行い、メッセージ全体として送信します。</p>
 </script>
 
-<script type="text/x-red" data-help-name="websocket out">
+<script type="text/html" data-help-name="websocket out">
     <p>WebSocket出力ノード</p>
     <p>デフォルトでは、<code>msg.payload</code>をWebSocket経由で送信します。ソケットは<code>msg</code>全体をJSON文字列にエンコードしてWebSocketを介して送信することもできます。</p>
 
@@ -27,10 +27,10 @@
     <p>WebSocket Inノードが生成したメッセージをブロードキャストしたい場合には、フロー中で<code>msg._session</code>プロパティを削除します。</p>
 </script>
 
-<script type="text/x-red" data-help-name="websocket-listener">
+<script type="text/html" data-help-name="websocket-listener">
     <p>この設定ノードはパスを指定してWebSocketサーバのエンドポイントを作成します。</p>
 </script>
 
-<script type="text/x-red" data-help-name="websocket-client">
+<script type="text/html" data-help-name="websocket-client">
     <p>この設定ノードは指定したURLにWebSocketクライアントを接続します。</p>
 </script>

--- a/packages/node_modules/@node-red/nodes/locales/ja/network/31-tcpin.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/network/31-tcpin.html
@@ -14,12 +14,12 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="tcp in">
+<script type="text/html" data-help-name="tcp in">
     <p>TCPからの入力を行います。リモートTCPポートに接続するか、外部からのコネクションを受け付けます。</p>
     <p><b>注: </b>1024番より小さな番号のポートをアクセスするにはrootもしくはadministrator権限が必要なシステムもあります。</p>
 </script>
 
-<script type="text/x-red" data-help-name="tcp out">
+<script type="text/html" data-help-name="tcp out">
     <p>TCPへの出力を行います。リモートTCPポートへ接続、外部からのコネクションの受け付け、もしくは、TCP Inノードで受け付けたメッセージへのリプライを行います。</p>
     <p><code>msg.payload</code>のみが送信対象となります。</p>
     <p><code>msg.payload</code>がバイナリデータをBase64エンコーディングの文字列に変換したものの場合、Base64デコードオプションを指定するとデータをバイナリに変換して送信します。</p>
@@ -27,7 +27,7 @@
     <p><b>注: </b>1024番より小さな番号のポートをアクセスするにはrootもしくはadministrator権限が必要なシステムもあります。</p>
 </script>
 
-<script type="text/x-red" data-help-name="tcp request">
+<script type="text/html" data-help-name="tcp request">
     <p>シンプルなTCPリクエストノード。<code>msg.payload</code>をサーバのTCPポートに送信し、レスポンスを待ちます。</p>
     <p>サーバに接続、"リクエスト"送信、"レスポンス"受信を行います。固定長の文字数、指定文字へのマッチ、最初のリプライの到着から指定した時間待つ、データの到着待ち、データ送信を行いリプライを待たず接続を即時解除、などから動作を選択できます。</p>
     <p>レスポンスはバッファ形式で<code>msg.payload</code>に出力されます。文字列として扱いには、.toString()を使用してください。</p>

--- a/packages/node_modules/@node-red/nodes/locales/ja/network/32-udp.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/network/32-udp.html
@@ -14,13 +14,13 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="udp in">
+<script type="text/html" data-help-name="udp in">
     <p>UDP入力ノード。<code>msg.payload</code>にバッファ、文字列、もしくは、Base64エンコーディング文字列を生成します。マルチキャストをサポートしています。</p>
     <p><code>msg.ip</code>と<code>msg.port</code>に受信したメッセージのIPアドレスとポートを設定します。</p>
     <p><b>注</b>: 1024番より小さな番号のポートへのアクセス、ブロードキャストを行うにはrootもしくはadministrator権限が必要なシステムもあります。</p>
 </script>
 
-<script type="text/x-red" data-help-name="udp out">
+<script type="text/html" data-help-name="udp out">
     <p><code>msg.payload</code>を指定したUDPのホストとポートに送信します。マルチキャストをサポートします。</p>
     <p><code>msg.ip</code>と<code>msg.port</code>に接続先を設定できますが、ノード設定の方が優先されます。</p>
     <p>ブロードキャストを行うには、アドレスをローカルブロードキャストIPアドレスに設定するか、グローバルブロードキャストアドレスである255.255.255.255を試してください。</p>

--- a/packages/node_modules/@node-red/nodes/locales/ja/parsers/70-CSV.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/parsers/70-CSV.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="csv">
+<script type="text/html" data-help-name="csv">
     <p>CSV形式の文字列とそのJavaScriptオブジェクト表現の間で双方向の変換を行います。</p>
     <h3>入力</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ja/parsers/70-HTML.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/parsers/70-HTML.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="html">
+<script type="text/html" data-help-name="html">
     <p><code>msg.payload</code>に格納したHTMLドキュメントからCSSセレクタを使用して要素を取り出します。</p>
     <h3>入力</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ja/parsers/70-JSON.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/parsers/70-JSON.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="json">
+<script type="text/html" data-help-name="json">
     <p>JSON文字列とJavaScriptオブジェクトとの間で相互変換を行います。</p>
     <h3>入力</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ja/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/parsers/70-XML.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="xml">
+<script type="text/html" data-help-name="xml">
     <p>XML文字列とJavaScriptオブジェクトとの間で相互変換を行います。</p>
     <h3>入力</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ja/parsers/70-YAML.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/parsers/70-YAML.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="yaml">
+<script type="text/html" data-help-name="yaml">
     <p>YAML形式の文字列とJavaScriptオブジェクトの間で相互変換を行います。</p>
     <h3>入力</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ja/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/sequence/17-split.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="split">
+<script type="text/html" data-help-name="split">
     <p>メッセージをメッセージ列に分割します。</p>
 
     <h3>入力</h3>
@@ -53,7 +53,7 @@
 </script>
 
 
-<script type="text/x-red" data-help-name="join">
+<script type="text/html" data-help-name="join">
     <p>メッセージ列を結合して一つのメッセージにします。</p>
     <p>メッセージの結合には次の3つのモードが利用できます。</p>
     <dl>

--- a/packages/node_modules/@node-red/nodes/locales/ja/sequence/18-sort.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/sequence/18-sort.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="sort">
+<script type="text/html" data-help-name="sort">
     <p>メッセージ列もしくは配列型のペイロードをソートします。</p>
     <p><b>split</b>ノードと組み合わせてメッセージの並べ替えを行うことができます。</p>
     <p>ソート順序は以下が指定可能です。</p>

--- a/packages/node_modules/@node-red/nodes/locales/ja/sequence/19-batch.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/sequence/19-batch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="batch">
+<script type="text/html" data-help-name="batch">
     <p>指定したルールによりメッセージ列を生成します。</p>
     <h3>詳細</h3>
     <p>メッセージ列の生成には以下の3つのモードが利用できます。</p>

--- a/packages/node_modules/@node-red/nodes/locales/ja/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/storage/10-file.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="file">
+<script type="text/html" data-help-name="file">
     <p><code>msg.payload</code>をファイルに書き出します。書き出しは、ファイルの最後に追記もしくは既存の内容の置き換えを選択できます。この他、ファイルの削除を行うことも可能です。</p>
     <h3>入力</h3>
     <dl class="message-properties">
@@ -31,7 +31,7 @@
     <p>この他、ファイルの削除を行うことも可能です。</p>
 </script>
 
-<script type="text/x-red" data-help-name="file in">
+<script type="text/html" data-help-name="file in">
     <p>ファイルの内容を文字列もしくはバイナリバッファとして読み出します。</p>
     <h3>入力</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ja/storage/23-watch.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/storage/23-watch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="watch">
+<script type="text/html" data-help-name="watch">
     <p>ディレクトリもしくはファイルの変化を検知します。</p>
     <p>カンマ区切りでディレクトリおよびファイルのリストを指定します。空白を含む場合は、引用符で"..."のように囲んでください。</p>
     <p>Windowsでは、2重バックスラッシュ\\をディレクトリ名に使用します。</p>

--- a/packages/node_modules/@node-red/nodes/locales/ko/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/common/20-inject.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="inject">
+<script type="text/html" data-help-name="inject">
 <p>수동, 혹은 일정간격으로 메세지를 플로우에 주입합니다. 메세지의 페이로드에는 문자열, JavaScript오브젝트, 현재시각 등 다양한 값을 지정할 수 있습니다.</p>
 <h3>출력</h3>
 <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ko/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/common/21-debug.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="debug">
+<script type="text/html" data-help-name="debug">
     <p>사이브바의 '디버그'탭에 선택한 메세지 프로퍼티의 값을 표시합니다. 설정에 의해, 랜덤로그로 출력도 가능합니다. 기본값의 표시대상은 <code>msg.payload</code>이지만, 설정에 의해 지정한 프로퍼티, 메세지 전체, 혹은 JSONata식의 평가결과를 출력할 수 있습니다.</p>
     <h3>상세</h3>
     <p>'디버그'사이드바는 받은 메시지의 계층구조를 표시하는 기능을 갖추고 있습니다. 이 기능으로 메시지의 구조를 쉽게 이해할 수 있습니다.</p>

--- a/packages/node_modules/@node-red/nodes/locales/ko/common/25-catch.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/common/25-catch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="catch">
+<script type="text/html" data-help-name="catch">
     <p>같은 탭내의 노드가 송출한 에러를 캐치합니다.</p>
     <h3>출력</h3>
     <dl class=message-properties>

--- a/packages/node_modules/@node-red/nodes/locales/ko/common/25-status.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/common/25-status.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="status">
+<script type="text/html" data-help-name="status">
     <p>같은 탭내 노드의 스테이터스 메시지를 취득합니다.</p>
     <h3>출력</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ko/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/common/60-link.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="link in">
+<script type="text/html" data-help-name="link in">
     <p>플로우간에 가상의 링크를 작성합니다.</p>
     <h3>상세</h3>
     <p>임의의 탭상에 존재하는 <code>link out</code>노드에 접속할 수 있습니다. 이 접속은 마치 직접 링크한 것 처럼 작동합니다.</p>

--- a/packages/node_modules/@node-red/nodes/locales/ko/common/90-comment.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/common/90-comment.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="comment">
+<script type="text/html" data-help-name="comment">
     <p>플로우에 코멘트를 기술하기 위해 이용합니다.</p>
     <h3>상세</h3>
     <p>편집패널은 Markdown형식으로 기입가능 합니다. 입력한 텍스트는 '정보'사이드패널에 표시됩니다.</p>

--- a/packages/node_modules/@node-red/nodes/locales/ko/common/98-unknown.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/common/98-unknown.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="unknown">
+<script type="text/html" data-help-name="unknown">
     <p>설치된 Node-RED가 인식할 수 없는 종류의 노드입니다.</p>
     <h3>상세</h3>
     <p><i>이 종류의 노드를 배포한 경우, 설정은 유지되지만 부족한 노드를 설치할 때 까지 플로우를 시작할 수 없습니다.</i></p>

--- a/packages/node_modules/@node-red/nodes/locales/ko/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/function/10-function.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="function">
+<script type="text/html" data-help-name="function">
     <p>수신 메시지에 대해서 처리를 실시하는 JavaScript코드(함수의 본체)를 정의합니다.</p>
     <p>입력 메시지는 <code>msg</code>라는 명칭의 JavaScript 객체로 전달됩니다.</p>
     <p><code>msg</code>오브젝트는<code>msg.payload</code>프로퍼티에 메시지 본체를 유지하는 것이 관례입니다.</p>

--- a/packages/node_modules/@node-red/nodes/locales/ko/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/function/10-switch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="switch">
+<script type="text/html" data-help-name="switch">
     <p>프로퍼티 값에 의해 메세지를 분류합니다.</p>
     <h3>상세</h3>
     <p>수신한 메세지에 대해, 지정된 룰을 순서대로 평가하여 매치된 룰에 대응하는 출력포트에 메세지를 송출합니다.</p>

--- a/packages/node_modules/@node-red/nodes/locales/ko/function/15-change.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/function/15-change.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="change">
+<script type="text/html" data-help-name="change">
     <p>메세지, 플로우컨텍스트, 글로벌컨텍스트의 프로퍼티를 변경, 삭제, 이동합니다.</p>
     <p>룰을 여러개 지정한 경우, 정의된 순으로 적용됩니다.</p>
     <h3>상세</h3>

--- a/packages/node_modules/@node-red/nodes/locales/ko/function/16-range.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/function/16-range.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="range">
+<script type="text/html" data-help-name="range">
     <p>수치를 다른 범위 값으로 변환합니다.</p>
     <h3>입력</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ko/function/80-template.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/function/80-template.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="template">
+<script type="text/html" data-help-name="template">
     <p>템플릿에 기초하여 프로퍼티를 설정합니다.</p>
     <h3>입력</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ko/function/89-delay.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/function/89-delay.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="delay">
+<script type="text/html" data-help-name="delay">
     <p>노드를 통과하는 메세지를 지연, 혹은 유량을 제한합니다.</p>
     <h3>입력</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ko/function/89-trigger.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/function/89-trigger.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="trigger">
+<script type="text/html" data-help-name="trigger">
     <p>메세지를 송신하면, 다른 메세지를 송신합니다. 지연 혹은 초기화가 지정되있지 않은 경우에는, 다음 2번째 메세지를 송신할 수 도 있습니다.</p>
 
     <h3>입력</h3>

--- a/packages/node_modules/@node-red/nodes/locales/ko/function/90-exec.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/function/90-exec.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="exec">
+<script type="text/html" data-help-name="exec">
     <p>시스템 커맨드를 실행하여 출력을 반환합니다.</p>
     <p>커맨드 완료까지 기다릴지, 커맨드가 출력을 실행할 때 마다 메세지를 출력할지 지정할 수 있습니다.</p>
     <p>실행대상의 커맨드는, 노드의 설정 혹은 수신메세지에서 지정합니다.</p>

--- a/packages/node_modules/@node-red/nodes/locales/ko/network/05-tls.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/network/05-tls.html
@@ -14,6 +14,6 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="tls-config">
+<script type="text/html" data-help-name="tls-config">
     <p>TLS접속을 위한 옵션 설정</p>
 </script>

--- a/packages/node_modules/@node-red/nodes/locales/ko/network/06-httpproxy.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/network/06-httpproxy.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="http proxy">
+<script type="text/html" data-help-name="http proxy">
     <p>프록시를 위한 옵션 설정</p>
 
     <h3>상세</h3>

--- a/packages/node_modules/@node-red/nodes/locales/ko/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/network/10-mqtt.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="mqtt in">
+<script type="text/html" data-help-name="mqtt in">
 <p>MQTT브로커에 접속하여, 지정한 토픽의 메세지를 서브스크랩(구독)합니다.</p>
     <h3>출력</h3>
     <dl class="message-properties">
@@ -33,7 +33,7 @@
     <p>MQTT(in 및 out)노드는 브로커로의 접속설정을 필요에 따라 공유할 수 있습니다.</p>
 </script>
 
-<script type="text/x-red" data-help-name="mqtt out">
+<script type="text/html" data-help-name="mqtt out">
     <p>MQTT브로커에 접속하여, 메세지를 퍼블리쉬(발행) 합니다.</p>
     <h3>입력</h3>
     <dl class="message-properties">
@@ -57,7 +57,7 @@
     <p>MQTT(in 및 out)노드는 브로커로의 접속설정을 필요에 따라 공유할 수 있습니다.</p>
 </script>
 
-<script type="text/x-red" data-help-name="mqtt-broker">
+<script type="text/html" data-help-name="mqtt-broker">
     <p>MQTT브로커로의 접속설정</p>
     <p>브로커로의 접속설정을 작성합니다. 설정은 <code>MQTT In</code> 및 <code>MQTT Out</code>노드로 재이용할 수 있습니다.</p>
     <p>노드에 클라이언트 ID를 설정하지 않고 세션의 초기화를 설정하고 있는 경우, 랜덤한 클라이언트 ID를 생성합니다. 클라이언트 ID를 설정할 경우, 접속처의 브로커로 통일되게 해주세요.</p>

--- a/packages/node_modules/@node-red/nodes/locales/ko/network/21-httpin.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/network/21-httpin.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="http in">
+<script type="text/html" data-help-name="http in">
     <p>HTTP 엔드 포인트를 작성하여 Web 서비스를 구성합니다.</p>
     <h3>출력</h3>
     <dl class="message-properties">
@@ -41,7 +41,7 @@
     <p><b>주:</b> 이 노드는 리퀘스트에 대한 레스폰스 송신을 하지 않습니다. 리퀘스트를 처리하기 위해서는 플로우에 HTTP Response노드를 포함해 주십시오.</p>
 </script>
 
-<script type="text/x-red" data-help-name="http response">
+<script type="text/html" data-help-name="http response">
     <p>HTTP In노드에서 받은 리퀘스트에 대한 레스폰스를 반환합니다.</p>
 
     <h3>입력</h3>

--- a/packages/node_modules/@node-red/nodes/locales/ko/network/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/network/21-httprequest.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="http request">
+<script type="text/html" data-help-name="http request">
     <p>HTTP리퀘스트를 송신하여, 리스폰스를 반환합니다.</p>
 
     <h3>입력</h3>

--- a/packages/node_modules/@node-red/nodes/locales/ko/network/22-websocket.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/network/22-websocket.html
@@ -14,12 +14,12 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="websocket in">
+<script type="text/html" data-help-name="websocket in">
     <p>WebSocket입력 노드</p>
     <p>기본값으로는, WebSocket에 의해 수신한 데이터는 <code>msg.payload</code>에 격납됩니다. 소켓은 JSON형식의 문자열을 대기하도록 설정할 수 있습니다. JSON형식의 문자열을 받으면, 오브젝트로 변환하여 메세지 전체로서 송신합니다.</p>
 </script>
 
-<script type="text/x-red" data-help-name="websocket out">
+<script type="text/html" data-help-name="websocket out">
     <p>WebSocket출력 노드</p>
     <p>기본값으로는, <code>msg.payload</code>를 WebSocket경유로 송신합니다. 소켓은 <code>msg</code>전체를 JSON문자열로 인코딩하여 WebSocket을 통해 송신할 수 있습니다.</p>
 
@@ -27,10 +27,10 @@
     <p>WebSocket In노드가 생성한 메세지를 브로드캐스트하고 싶은 경우에는, 플로우 안에서 <code>msg._session</code>프로퍼티를 삭제합니다.</p>
 </script>
 
-<script type="text/x-red" data-help-name="websocket-listener">
+<script type="text/html" data-help-name="websocket-listener">
     <p>이 설정노드는 패스를 지정하여 WebSocket서버의 엔드포인트를 작성합니다.</p>
 </script>
 
-<script type="text/x-red" data-help-name="websocket-client">
+<script type="text/html" data-help-name="websocket-client">
     <p>이 설정노드는 지정한 URL에 WebSocket클라이언트를 접속합니다.</p>
 </script>

--- a/packages/node_modules/@node-red/nodes/locales/ko/network/31-tcpin.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/network/31-tcpin.html
@@ -14,12 +14,12 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="tcp in">
+<script type="text/html" data-help-name="tcp in">
     <p>TCP로 부터의 입력을 수행합니다. 리모트 TCP포트에 접속하거나, 외부로부터의 접속을 접수합니다.</p>
     <p><b>주: </b>1024번 보다 작은 번호의 포트를 액세스 하기 위해서는 root 혹은 administrator권한이 필요한 시스템도 있습니다.</p>
 </script>
 
-<script type="text/x-red" data-help-name="tcp out">
+<script type="text/html" data-help-name="tcp out">
     <p>TCP로의 출력을 수행합니다. 리모트 TCP포트로 접속, 외부로부터의 접속을 접수, 혹은 TCP In노드에서 받은 메세지로의 리플라이를 수행합니다.</p>
     <p><code>msg.payload</code>만이 송신대상입니다.</p>
     <p><code>msg.payload</code>가 바이너리데이터를 Base64인코딩의 문자열로 변환한 것일 경우, Base64디코딩 옵션을 지정하면 데이터를 바이너리로 변환하여 송신합니다.</p>
@@ -27,7 +27,7 @@
     <p><b>주: </b>1024번 보다 작은 번호의 포트를 액세스 하기 위해서는 root 혹은 administrator권한이 필요한 시스템도 있습니다.</p>
 </script>
 
-<script type="text/x-red" data-help-name="tcp request">
+<script type="text/html" data-help-name="tcp request">
     <p>간단한 TCP리퀘스트 노드. <code>msg.payload</code>를 서버의 TCP포트에 송신하여, 리스폰스를 기다립니다.</p>
     <p>서버접속, "리퀘스트"송신, "리스폰스"수신을 수행합니다. 고정장의 문자수나 지정문자로의 매치, 첫 리플라이의 도착으로 부터 지정된 시간동안 대기, 데이터 도착 대기, 데이터 송신을 수행하여 리플라이를 기다리지 않고 접속을 즉시 삭제, 등의 동작을 선택할 수 있습니다.</p>
     <p>리스폰스는 버퍼형식으로 <code>msg.payload</code>에 출력됩니다. 문자열로서 취급하기 위해서는, .toString()을 사용해 주세요.</p>

--- a/packages/node_modules/@node-red/nodes/locales/ko/network/32-udp.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/network/32-udp.html
@@ -14,13 +14,13 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="udp in">
+<script type="text/html" data-help-name="udp in">
     <p>UDP입력 노드. <code>msg.payload</code>에 버퍼, 문자열, 혹은 Base64인코딩 문자열을 생성합니다. 멀티캐스트를 지원합니다.</p>
     <p><code>msg.ip</code>와 <code>msg.port</code>에 수신된 메세지의 IP주소와 포트를 설정합니다.</p>
     <p><b>주: </b>1024번 보다 작은 번호의 포트를 액세스, 브로드캐스트 하기 위해서는 root 혹은 administrator권한이 필요한 시스템도 있습니다.</p>
 </script>
 
-<script type="text/x-red" data-help-name="udp out">
+<script type="text/html" data-help-name="udp out">
     <p><code>msg.payload</code>를 지정된 UDP 호스트와 포트에 송신합니다. 멀티캐스트를 지원합니다.</p>
     <p><code>msg.ip</code>와 <code>msg.port</code>에 접속처를 설정할수 있지만, 노드설정이 우선시 됩니다.</p>
     <p>브로드캐스트를 수행하기 위해서는, 주소를 로컬 브로드캐스트 IP주소로 설정하거나, 글로벌 브로드캐스트인 255.255.255.255를 시험해 주세요.</p>

--- a/packages/node_modules/@node-red/nodes/locales/ko/parsers/70-CSV.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/parsers/70-CSV.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="csv">
+<script type="text/html" data-help-name="csv">
     <p>CSV형식의 문자열과 그 JavaScript오브젝트 표현의 사이에서 쌍방향의 변환을 수행합니다.</p>
     <h3>입력</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ko/parsers/70-HTML.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/parsers/70-HTML.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="html">
+<script type="text/html" data-help-name="html">
     <p><code>msg.payload</code>에 격납한 HTML다큐멘트에서 CSS셀렉터를 사용하여 요소를 추출합니다.</p>
     <h3>입력</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ko/parsers/70-JSON.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/parsers/70-JSON.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="json">
+<script type="text/html" data-help-name="json">
     <p>JSON문자열과 JavaScript오브젝트과의 사이에서 상호변환을 수행합니다.</p>
     <h3>입력</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ko/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/parsers/70-XML.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="xml">
+<script type="text/html" data-help-name="xml">
     <p>XML문자열과 JavaScript오브젝트와의 사이에서 상호변환을 수행합니다.</p>
     <h3>입력</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ko/parsers/70-YAML.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/parsers/70-YAML.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="yaml">
+<script type="text/html" data-help-name="yaml">
     <p>YAML형식의 문자열과 JavaScript오브젝트 사이에서 상호변환을 수행합니다.</p>
     <h3>입력</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ko/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/sequence/17-split.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="split">
+<script type="text/html" data-help-name="split">
     <p>메세지를 메세지열로 분할합니다.</p>
 
     <h3>입력</h3>
@@ -53,7 +53,7 @@
 </script>
 
 
-<script type="text/x-red" data-help-name="join">
+<script type="text/html" data-help-name="join">
     <p>메세지열를 결합하여 하나의 메세지로 만듭니다.</p>
     <p>메세지의 결합에는 다음 3개의 모드를 이용할 수 있습니다.</p>
     <dl>

--- a/packages/node_modules/@node-red/nodes/locales/ko/sequence/18-sort.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/sequence/18-sort.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="sort">
+<script type="text/html" data-help-name="sort">
     <p>메세지 열 혹은 배열형의 페이로드를 정렬합니다.</p>
     <p><b>split</b>노드와 조합하여 메세지의 순서를 정렬할 수 있습니다.</p>
     <p>아래의 정렬순서를 지정할 수 있습니다.</p>

--- a/packages/node_modules/@node-red/nodes/locales/ko/sequence/19-batch.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/sequence/19-batch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="batch">
+<script type="text/html" data-help-name="batch">
     <p>지정한 룰에 의해 메세지열을 생성합니다.</p>
     <h3>상세</h3>
     <p>메세지열의 생성에는 아래의 3가지 모드를 이용할 수 있습니다.</p>

--- a/packages/node_modules/@node-red/nodes/locales/ko/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/storage/10-file.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="file">
+<script type="text/html" data-help-name="file">
     <p><code>msg.payload</code>를 파일로 내보냅니다. 내보내기는, 파일의 마지막에 추기 혹은 기존 내용의 치환을 선택할 수 있습니다. 또한, 파일을 삭제하는 것도 가능합니다.</p>
     <h3>입력</h3>
     <dl class="message-properties">
@@ -31,7 +31,7 @@
     <p>또한, 파일을 삭제할 수도 있습니다.</p>
 </script>
 
-<script type="text/x-red" data-help-name="file in">
+<script type="text/html" data-help-name="file in">
     <p>파일 내용을 문자열 혹은 바이너리버퍼로 불러옵니다.</p>
     <h3>입력</h3>
     <dl class="message-properties">

--- a/packages/node_modules/@node-red/nodes/locales/ko/storage/23-watch.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/storage/23-watch.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="watch">
+<script type="text/html" data-help-name="watch">
     <p>디렉토리 혹은 파일의 변화를 감지합니다.</p>
     <p>콤마로 나누어 디렉토리 및 파일 리스트를 지정합니다. 공백을 포함하는 경우, 인용부를 이용해 "..." 형태로 만들어 주세요.</p>
     <p>Windows에서는, 2중 백슬래쉬\\를 디렉토리 이름으로 사용합니다.</p>


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
As we updated the document about creating nodes ( https://github.com/node-red/node-red.github.io/pull/146 ), I modified types in core nodes. Because node developers tend to refer to the files of core nodes when they create their custom nodes, this fix will be useful for them.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
