### PR TITLE
Remove unnecessary namespaces for i18n

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -803,9 +803,9 @@
         "expandItems": "要素を展開",
         "collapseItems": "要素を折り畳む",
         "duplicate": "複製",
-	"error": {
-	    "invalidJSON": "不正なJSON: "
-	}
+        "error": {
+            "invalidJSON": "不正なJSON: "
+        }
     },
     "markdownEditor": {
         "title": "マークダウンエディタ",

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-HTML.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-HTML.html
@@ -1,7 +1,7 @@
 
 <script type="text/x-red" data-template-name="html">
     <div class="form-row">
-        <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> <span data-i18n="node-red:common.label.property"></span></label>
+        <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> <span data-i18n="common.label.property"></span></label>
         <input type="text" id="node-input-property" style="width:70%">
     </div>
     <div class="form-row">

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-XML.html
@@ -1,7 +1,7 @@
 
 <script type="text/x-red" data-template-name="xml">
     <div class="form-row">
-        <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> <span data-i18n="node-red:common.label.property"></span></label>
+        <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> <span data-i18n="common.label.property"></span></label>
         <input type="text" id="node-input-property" style="width:70%;"/>
     </div>
     <div class="form-row">

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-YAML.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-YAML.html
@@ -1,7 +1,7 @@
 
 <script type="text/x-red" data-template-name="yaml">
     <div class="form-row">
-        <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> <span data-i18n="node-red:common.label.property"></span></label>
+        <label for="node-input-property"><i class="fa fa-ellipsis-h"></i> <span data-i18n="common.label.property"></span></label>
         <input type="text" id="node-input-property" style="width:70%;"/>
     </div>
     <div class="form-row">

--- a/packages/node_modules/@node-red/nodes/core/sequence/18-sort.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/18-sort.html
@@ -53,8 +53,8 @@
     </div>
 
     <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
     </div>
 </script>
 

--- a/packages/node_modules/@node-red/nodes/core/sequence/19-batch.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/19-batch.html
@@ -60,8 +60,8 @@
     </div>
 
     <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
     </div>
 
 </script>


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
While checking the messages catalog, I found that some node files have unnecessary namespaces for i18n. To match namespace rules with other nodes, I removed the namespaces.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality