### PR TITLE
let setMessageProperty return success flag

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/15-change.js
+++ b/packages/node_modules/@node-red/nodes/core/function/15-change.js
@@ -215,7 +215,9 @@ module.exports = function(RED) {
                                         if (rule.t === 'delete') {
                                             RED.util.setMessageProperty(msg,property,undefined);
                                         } else if (rule.t === 'set') {
-                                            RED.util.setMessageProperty(msg,property,value);
+                                            if (!RED.util.setMessageProperty(msg,property,value)) {
+                                                node.warn(RED._("change.errors.no-override",{prop:property}));
+                                            }
                                         } else if (rule.t === 'change') {
                                             current = RED.util.getMessageProperty(msg,property);
                                             if (typeof current === 'string') {

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -657,7 +657,8 @@
         "errors": {
             "invalid-from": "Invalid 'from' property: __error__",
             "invalid-json": "Invalid 'to' JSON property",
-            "invalid-expr": "Invalid JSONata expression: __error__"
+            "invalid-expr": "Invalid JSONata expression: __error__",
+            "no-override": "Can't overwrite primitive type with object __prop__."
         }
     },
     "range": {

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -368,10 +368,15 @@ function setObjectProperty(msg,prop,value,createMissing) {
     var length = msgPropParts.length;
     var obj = msg;
     var key;
+    var flag = true;
     for (var i=0;i<length-1;i++) {
         key = msgPropParts[i];
         if (typeof key === 'string' || (typeof key === 'number' && !Array.isArray(obj))) {
             if (obj.hasOwnProperty(key)) {
+                if (length > 1 && ((typeof obj[key] !== "object" && typeof obj[key] !== "function") || obj[key] === null)) {
+                    //console.log("Can't override primitive type with object.");
+                    flag = false;
+                }
                 obj = obj[key];
             } else if (createMissing) {
                 if (typeof msgPropParts[i+1] === 'string') {
@@ -409,8 +414,14 @@ function setObjectProperty(msg,prop,value,createMissing) {
             delete obj[key]
         }
     } else {
-        obj[key] = value;
+        if (typeof obj === "object" && obj !== null) {
+            obj[key] = value;
+        } else {
+            //console.log("Can't override primitive type with object.");
+            flag = false;
+        }  
     }
+    return flag;
 }
 
 /*!


### PR DESCRIPTION


<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
adds a return flag to RED.utils.setMessageProperty that returns true if ok and false if the call tries to overwrite an existing primitive type.
This can then be used in change node to create a warning to the user.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [X] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
