### PR TITLE
Support BrowserStack in UI testing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,6 +26,10 @@ module.exports = function(grunt) {
         nodemonArgs.push(flowFile);
     }
 
+    var browserstack = grunt.option('browserstack');
+    if (browserstack) {
+        process.env.BROWSERSTACK = true;
+    }
     var nonHeadless = grunt.option('non-headless');
     if (nonHeadless) {
         process.env.NODE_RED_NON_HEADLESS = true;

--- a/scripts/install-ui-test-dependencies.sh
+++ b/scripts/install-ui-test-dependencies.sh
@@ -3,5 +3,7 @@ npm install --no-save \
  wdio-chromedriver-service@^0.1.5 \
  wdio-mocha-framework@^0.6.4 \
  wdio-spec-reporter@^0.1.5 \
- webdriverio@^4.14.1 \
- chromedriver@^78.0.1
+ webdriverio@^4.14.4 \
+ chromedriver@^79.0.0 \
+ wdio-browserstack-service@^0.1.19 \
+ browserstack-local@^1.4.4

--- a/test/editor/pageobjects/util/key_page.js
+++ b/test/editor/pageobjects/util/key_page.js
@@ -27,6 +27,12 @@ var shortCutKeyMapForMac = {
 };
 
 function getShortCutKey(type) {
+    if (process.env.BROWSERSTACK) {
+        if (browser.desiredCapabilities.os === 'OS X') {
+            return shortCutKeyMapForMac[type];
+        }
+        return shortCutKeyMap[type];
+    }
     if (os.type() === 'Darwin') {
         return shortCutKeyMapForMac[type];
     }


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes
In this pull request, I added code to execute UI testing on BrowserStack.
The discussion slides about the BrowserStack support are as follows (page 12-17). 
https://github.com/node-red-hitachi/node-red-notes/blob/master/Meeting/20200127/02-Testing.pdf

[Procedures to execute UI testing]
(1) Set BrowserStack credentials to environment variables 
    BROWSERSTACK_USERNAME=\<user name\>
    BROWSERSTACK_ACCESS_KEY=\<accesss key\>
(2) npm install
(3) scripts/install-ui-test-dependencies.sh
(4) grunt --browserstack

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality