### PR TITLE
Add Japanese translations for i18n

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -1008,6 +1008,7 @@
         "en-US": "English",
         "ja": "Japanese",
         "ko": "Korean",
-        "zh-CN": "Chinese(Simplified)"
+        "zh-CN": "Chinese(Simplified)",
+        "zh-TW": "Chinese(Traditional)"
     }
 }

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -803,9 +803,9 @@
         "expandItems": "要素を展開",
         "collapseItems": "要素を折り畳む",
         "duplicate": "複製",
-	"error": {
-	    "invalidJSON": "不正なJSON: "
-	}
+        "error": {
+            "invalidJSON": "不正なJSON: "
+        }
     },
     "markdownEditor": {
         "title": "マークダウンエディタ",
@@ -1007,6 +1007,7 @@
         "en-US": "英語",
         "ja": "日本語",
         "ko": "韓国語",
-        "zh-CN": "中国語(簡体)"
+        "zh-CN": "中国語(簡体)",
+        "zh-TW": "中国語(繁体)"
     }
 }

--- a/packages/node_modules/@node-red/editor-client/locales/ja/jsonata.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/jsonata.json
@@ -245,11 +245,11 @@
     },
     "$encodeUrl": {
         "args": "str",
-        "desc": "Uniform Resource Locator (URL)を構成する文字を1、２、3、もしくは、4文字エスケープシーケンスのUTF-8文字エンコーディングで置換します。\n\n例: `$encodeUrlComponent(\"?x=test\")` => `\"%3Fx%3Dtest\"`"
+        "desc": "Uniform Resource Locator (URL)を構成する文字を1、2、3、もしくは、4文字エスケープシーケンスのUTF-8文字エンコーディングで置換します。\n\n例: `$encodeUrlComponent(\"?x=test\")` => `\"%3Fx%3Dtest\"`"
     },
     "$encodeUrlComponent": {
         "args": "str",
-        "desc": "Uniform Resource Locator (URL)要素を構成する文字を1、２、３、もしくは、4文字エスケープシーケンスのUTF-8文字エンコーディングで置換します。\n\n例: `$encodeUrl(\"https://mozilla.org/?x=шеллы\")` => `\"https://mozilla.org/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B\"`"
+        "desc": "Uniform Resource Locator (URL)要素を構成する文字を1、2、3、もしくは、4文字エスケープシーケンスのUTF-8文字エンコーディングで置換します。\n\n例: `$encodeUrl(\"https://mozilla.org/?x=шеллы\")` => `\"https://mozilla.org/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B\"`"
     },
     "$decodeUrl": {
         "args": "str",
@@ -262,5 +262,9 @@
     "$distinct": {
         "args": "array",
         "desc": "配列`array`から重複要素を削除した配列を返します。"
+    },
+    "$type": {
+        "args": "value",
+        "desc": "`value` の型を文字列として返します。もし `value` が未定義の場合、 `undefined` が返されます。"
     }
 }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I added translations for the JSONata expression editor and language menu. At the same time, I fixed typos.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
