### PR TITLE
Complete zh-CN translation for Editor-client/Nodes/Runtime

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/zh-CN/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/zh-CN/editor.json
@@ -10,7 +10,22 @@
             "load": "读取",
             "save": "保存",
             "import": "导入",
-            "export": "导出"
+            "export": "导出",
+            "back": "后退",
+            "next": "下一个",
+            "clone": "克隆项目",
+            "cont": "继续"
+        },
+        "type": {
+            "string": "字符串",
+            "number": "数字",
+            "boolean": "布尔值",
+            "array": "数组",
+            "buffer": "buffer",
+            "object": "对象",
+            "jsonString": "JSON字符串",
+            "undefined": "为定义",
+            "null": "空"
         }
     },
     "workspace": {
@@ -19,10 +34,13 @@
         "confirmDelete": "确认删除",
         "delete": "你确定想删除 '__label__'?",
         "dropFlowHere": "把流程放到这里",
+        "addFlow": "添加流程",
+        "listFlows": "流程一览",
         "status": "状态",
         "enabled": "有效",
         "disabled": "无效",
-        "info": "详细描述"
+        "info": "详细描述",
+        "selectNodes": "点击节点来选择"
     },
     "menu": {
         "label": {
@@ -36,10 +54,15 @@
                 "defaultDir": "默认方向",
                 "ltr": "从左到右",
                 "rtl": "从右到左",
-                "auto": "上下文"
+                "auto": "上下文",
+                "language": "语言",
+                "browserDefault": "浏览器默认"
             },
             "sidebar": {
                 "show": "显示侧边栏"
+            },
+            "palette": {
+                "show": "显示控制板"
             },
             "settings": "设置",
             "userSettings": "用户设置",
@@ -60,10 +83,22 @@
             "keyboardShortcuts": "键盘快捷方式",
             "login": "登陆",
             "logout": "退出",
-            "editPalette":"节点管理",
+            "editPalette": "节点管理",
             "other": "其他",
-            "showTips": "显示小提示"
+            "showTips": "显示小提示",
+            "help": "Node-RED网页",
+            "projects": "项目",
+            "projects-new": "新建",
+            "projects-open": "打开",
+            "projects-settings": "项目设定",
+            "showNodeLabelDefault": "显示新添加的节点的标签"
         }
+    },
+    "actions": {
+        "toggle-navigator": "切换导航器",
+        "zoom-out": "缩小",
+        "zoom-reset": "重设缩放",
+        "zoom-in": "放大"
     },
     "user": {
         "loggedInAs": "作为__name__登陆",
@@ -82,29 +117,73 @@
         "warning": "<strong>警告</strong>: __message__",
         "warnings": {
             "undeployedChanges": "节点中存在未部署的更改",
+            "nodeActionDisabled": "节点操作已禁用",
             "nodeActionDisabledSubflow": "节点动作在子流程中被禁用",
             "missing-types": "流程由于缺少节点类型而停止。请检查日志的详细信息",
-            "restartRequired": "Node-RED必须重新启动，以启用升级的模块"
+            "safe-mode": "<p>流程以安全模式停止。</p><p>您可以修改流程并部署更改以重新启动。</p>",
+            "restartRequired": "Node-RED必须重新启动，以启用升级的模块",
+            "credentials_load_failed": "<p>由于无法解密凭据，因此流程停止。</p><p>流程凭据文件已加密，但是项目的加密密钥丢失或无效。</p>",
+            "credentials_load_failed_reset": "<p>凭据无法解密</p><p>流凭据文件已加密，但是项目的加密密钥丢失或无效。</p><p>流凭据文件将在下一次部署时重置。任何现有的流凭证将被清除。</p>",
+            "missing_flow_file": "<p>找不到项目流程文件。</p><p>该项目未配置流程文件。</p>",
+            "missing_package_file": "<p>找不到项目包文件。</p><p>项目缺少package.json文件。</p>",
+            "project_empty": "<p>该项目为空。</p><p>是否要创建一组默认的项目文件？<br/>否则，您将必须在编辑器外部手动将文件添加到项目中。</p>",
+            "project_not_found": "<p>未找到项目'__project__'。</p>",
+            "git_merge_conflict": "<p>自动合并更改失败。</p><p>修复未合并的冲突，然后提交结果。</p>"
         },
-        "error": "<strong>Error</strong>: __message__",
+        "error": "<strong>错误</strong>: __message__",
         "errors": {
             "lostConnection": "丢失与服务器的连接，重新连接...",
             "lostConnectionReconnect": "丢失与服务器的连接，__time__秒后重新连接",
             "lostConnectionTry": "现在尝试",
             "cannotAddSubflowToItself": "无法向其自身添加子流程",
             "cannotAddCircularReference": "无法添加子流程 - 循环引用",
-            "unsupportedVersion": "您正在使用不受支持的Node.js版本<br/>请升级到最新版本的Node.js LTS"
+            "unsupportedVersion": "您正在使用不受支持的Node.js版本<br/>请升级到最新版本的Node.js LTS",
+            "failedToAppendNode": "<p>'__module__'加载失败</p><p>__error__</p>"
+        },
+        "project": {
+            "change-branch": "转到本地分支'__project__'",
+            "merge-abort": "Git合并中止",
+            "loaded": "项目'__project__'已加载",
+            "updated": "项目'__project__'已更新",
+            "pull": "项目'__project__'已重新加载",
+            "revert": "项目 '__project__'已还原",
+            "merge-complete": "Git合并完成",
+            "setupCredentials": "设定证书",
+            "setupProjectFiles": "设置项目文件",
+            "no": "不了，谢谢",
+            "createDefault": "创建默认项目文件",
+            "mergeConflict": "显示合并冲突"
+        },
+        "label": {
+            "manage-project-dep": "管理项目依赖性",
+            "setup-cred": "设定证书",
+            "setup-project": "设置项目文件",
+            "create-default-package": "创建默认的包文件",
+            "no-thanks": "不了，谢谢",
+            "create-default-project": "创建默认项目文件",
+            "show-merge-conflicts": "显示合并冲突"
         }
     },
     "clipboard": {
         "clipboard": "剪贴板",
         "nodes": "节点",
+        "node": "__count__节点",
+        "node_plural": "__count__节点",
+        "configNode": "__count__配置节点",
+        "configNode_plural": "__count__配置节点",
+        "flow": "__count__流程",
+        "flow_plural": "__count__流程",
+        "subflow": "__count__子流程",
+        "subflow_plural": "__count__子流程",
         "pasteNodes": "在这里粘贴节点",
+        "selectFile": "选择要导入的文件",
         "importNodes": "导入节点",
         "exportNodes": "导出节点至剪贴板",
+        "download": "下载",
         "importUnrecognised": "导入了无法识别的类型:",
         "importUnrecognised_plural": "导入了无法识别的类型:",
         "nodesExported": "节点导出到了剪贴板",
+        "nodesImported": "导入：",
         "nodeCopied": "已复制__count__个节点",
         "nodeCopied_plural": "已复制__count__个节点",
         "invalidFlow": "无效的流程: __message__",
@@ -114,11 +193,21 @@
             "all": "所有流程",
             "compact": "紧凑",
             "formatted": "已格式化",
-            "copy": "导出到剪贴板"
+            "copy": "导出到剪贴板",
+            "export": "到处到库",
+            "exportAs": "导出为",
+            "overwrite": "替换",
+            "exists": "<p><b>\"__file__\"</b>已存在</p><p>是否要替换它？</p>"
         },
         "import": {
             "import": "导入到",
-            "newFlow": "新流程"
+            "newFlow": "新流程",
+            "errors": {
+                "notArray": "输入的不是JSON数组",
+                "itemNotObject": "输入的流无效 - 项目__index__不是节点对象",
+                "missingId": "输入的流无效-项 __index__ 缺少'id'属性",
+                "missingType": "输入的流程无效-项__index__缺少'类型'属性"
+            }
         },
         "copyMessagePath": "已复制路径",
         "copyMessageValue": "已复制数值",
@@ -132,7 +221,10 @@
         "modifiedFlowsDesc": "只部署包含已更改节点的流",
         "modifiedNodes": "已更改的节点",
         "modifiedNodesDesc": "只部署已经更改的节点",
+        "restartFlows": "重启流程",
+        "restartFlowsDesc": "重新启动当前部署的流程",
         "successfulDeploy": "部署成功",
+        "successfulRestart": "成功重启流程",
         "deployFailed": "部署失败: __message__",
         "unusedConfigNodes": "您有一些未使用的配置节点",
         "unusedConfigNodesLink": "点击此处查看它们",
@@ -152,16 +244,24 @@
             "improperlyConfigured": "工作区包含一些未正确配置的节点:",
             "unknown": "工作区包含一些未知的节点类型:",
             "confirm": "你确定要部署吗?",
+            "doNotWarn": "不要再对此发出警告",
             "conflict": "服务器正在运行较新的一组流程。",
             "backgroundUpdate": "服务器上的流程已更新。",
             "conflictChecking": "检查是否可以自动合并更改",
             "conflictAutoMerge": "此更改不包括冲突，可以自动合并",
-            "conflictManualMerge": "这些更改包括了在部署之前必须解决的冲突。"
+            "conflictManualMerge": "这些更改包括了在部署之前必须解决的冲突。",
+            "plusNMore": "+ __count__更多"
         }
+    },
+    "eventLog": {
+        "title": "事件记录日志",
+        "view": "查看日志"
     },
     "diff": {
         "unresolvedCount": "__count__个未解决的冲突",
         "unresolvedCount_plural": "__count__个未解决的冲突",
+        "globalNodes": "全局节点",
+        "flowProperties": "流程属性",
         "type": {
             "added": "已添加",
             "changed": "已更改",
@@ -175,9 +275,19 @@
         "nodeCount": "__count__个节点",
         "nodeCount_plural": "__count__个节点",
         "local": "本地",
-        "remote": "远程"
+        "remote": "远程",
+        "reviewChanges": "查看变更",
+        "noBinaryFileShowed": "无法显示二进制文件内容",
+        "viewCommitDiff": "查看提交更改",
+        "compareChanges": "比较变更",
+        "saveConflict": "保存冲突解决",
+        "conflictHeader": "已解决<span>__unresolved__</span>中的<span>__resolved__</span>个冲突",
+        "commonVersionError": "通用版本不包含有效的JSON：",
+        "oldVersionError": "旧版本不包含有效的JSON：",
+        "newVersionError": "新版本不包含有效的JSON："
     },
     "subflow": {
+        "editSubflowInstance": "编辑子流实例：__name__",
         "editSubflow": "编辑流程模板: __name__",
         "edit": "编辑流程模板",
         "subflowInstances": "这个子流程模板有__count__个实例",
@@ -185,8 +295,14 @@
         "editSubflowProperties": "编辑属性",
         "input": "输入:",
         "output": "输出:",
+        "status": "状态节点",
         "deleteSubflow": "删除子流程",
         "info": "详细描述",
+        "category": "类别",
+        "env": {
+            "restore": "恢复为默认子流",
+            "remove": "删除环境变量"
+        },
         "errors": {
             "noNodesSelected": "<strong>无法创建子流程</strong>: 未选择节点",
             "multipleInputsToSelection": "<strong>无法创建子流程</strong>: 多个输入到了选择"
@@ -204,18 +320,68 @@
         "editConfig": "编辑__type__配置",
         "addNewType": "添加新的__type__节点",
         "nodeProperties": "节点属性",
+        "label": "标签",
+        "color": "颜色",
         "portLabels": "端口标签",
         "labelInputs": "输入",
         "labelOutputs": "输出",
+        "settingIcon": "图标",
+        "default": "默认",
         "noDefaultLabel": "无",
         "defaultLabel": "使用默认标签",
+        "searchIcons": "搜索图标",
+        "useDefault": "使用默认",
+        "description": "描述",
+        "show": "显示",
+        "hide": "隐藏",
+        "locale": "选择界面语言",
+        "icon": "图标",
+        "inputType": "输入类型",
+        "inputs": {
+            "input": "输入",
+            "select": "选择",
+            "checkbox": "复选框",
+            "spinner": "微调器",
+            "none": "空",
+            "hidden": "隐藏属性"
+        },
+        "types": {
+            "str": "字符串",
+            "num": "数字",
+            "bool": "布尔",
+            "json": "JSON",
+            "bin": "buffer",
+            "env": "环境变量"
+        },
+        "menu": {
+            "input": "输入",
+            "select": "选择",
+            "checkbox": "复选框",
+            "spinner": "微调器",
+            "hidden": "仅标签"
+        },
+        "select": {
+            "label": "标签",
+            "value": "值"
+        },
+        "spinner": {
+            "min": "最小值",
+            "max": "最大值"
+        },
         "errors": {
-            "scopeChange": "更改范围将使其他流中的节点无法使用"
+            "scopeChange": "更改范围将使其他流中的节点无法使用",
+            "invalidProperties": "无效的属性："
         }
     },
     "keyboard": {
         "title": "键盘快捷键",
+        "keyboard": "键盘",
+        "filterActions": "筛选动作",
+        "shortcut": "快捷键",
+        "scope": "范围",
         "unassigned": "未分配",
+        "global": "全局",
+        "workspace": "工作组",
         "selectAll": "选择所有节点",
         "selectAllConnected": "选择所有连接的节点",
         "addRemoveNode": "从选择中添加/删除节点",
@@ -226,12 +392,14 @@
         "nudgeNode": "移动所选节点(1px)",
         "moveNode": "移动所选节点(20px)",
         "toggleSidebar": "切换侧边栏",
+        "togglePalette": "切换控制板",
         "copyNode": "复制所选节点",
         "cutNode": "剪切所选节点",
         "pasteNode": "粘贴节点",
         "undoChange": "撤消上次执行的更改",
         "searchBox": "打开搜索框",
-        "managePalette": "管理面板"
+        "managePalette": "管理面板",
+        "actionList": "动作列表"
     },
     "library": {
         "library": "库",
@@ -239,29 +407,41 @@
         "saveToLibrary": "保存到库...",
         "typeLibrary": "__type__类型库",
         "unnamedType": "无名__type__",
-        "exportToLibrary": "将节点导出到库",
+        "exportedToLibrary": "节点导出到库",
         "dialogSaveOverwrite": "一个叫做__libraryName__的__libraryType__已经存在，您需要覆盖么？",
         "invalidFilename": "无效的文件名",
         "savedNodes": "保存的节点",
         "savedType": "已保存__type__",
         "saveFailed": "保存失败: __message__",
+        "newFolder": "新文件夹",
         "types": {
+            "local": "本地的",
             "examples": "例子"
-        }
+        },
+        "exportToLibrary": "将节点导出到库"
     },
     "palette": {
         "noInfo": "无可用信息",
         "filter": "过滤节点",
         "search": "搜索模块",
+        "addCategory": "添加新的...",
         "label": {
             "subflows": "子流程",
+            "network": "网络",
+            "common": "共通",
             "input": "输入",
             "output": "输出",
             "function": "功能",
+            "sequence": "序列",
+            "parser": "解析",
             "social": "社交",
             "storage": "存储",
             "analysis": "分析",
             "advanced": "高级"
+        },
+        "actions": {
+            "collapse-all": "收起所有类别",
+            "expand-all": "展开所有类别"
         },
         "event": {
             "nodeAdded": "添加到面板中的节点:",
@@ -276,6 +456,7 @@
         },
         "editor": {
             "title": "面板管理",
+            "palette": "控制板",
             "times": {
                 "seconds": "秒前",
                 "minutes": "分前",
@@ -309,6 +490,8 @@
             "updated": "已更新",
             "install": "安装",
             "installed": "已安装",
+            "conflict": "冲突",
+            "conflictTip": "<p>无法安装此模块，因为它包含已安装的<br/>节点类型</p><p>与<code>__module__</code>冲突</p>",
             "loading": "加载目录...",
             "tab-nodes": "节点",
             "tab-install": "安装",
@@ -356,6 +539,7 @@
             "label": "信息",
             "node": "节点",
             "type": "类型",
+            "module": "模组",
             "id": "ID",
             "status": "状态",
             "enabled": "启用",
@@ -364,17 +548,18 @@
             "instances": "实例",
             "properties": "属性",
             "info": "信息",
+            "desc": "描述",
             "blank": "空白",
             "null": "空",
             "showMore": "展开",
             "showLess": "收起",
             "flow": "流程",
-            "selection":"选择",
-            "nodes":"__count__ 个节点",
+            "selection": "选择",
+            "nodes": "__count__ 个节点",
             "flowDesc": "流程描述",
             "subflowDesc": "子流程描述",
             "nodeHelp": "节点帮助",
-            "none":"无",
+            "none": "无",
             "arrayItems": "__count__个项目",
             "showTips": "您可以从设置面板启用提示信息"
         },
@@ -386,8 +571,24 @@
             "subflows": "子流程",
             "flows": "流程",
             "filterAll": "所有",
+            "showAllConfigNodes": "显示所有配置节点",
             "filterUnused": "未使用",
+            "showAllUnusedConfigNodes": "显示所有未使用的配置节点",
             "filtered": "__count__ 个隐藏"
+        },
+        "context": {
+            "name": "上下文数据",
+            "label": "上下午",
+            "none": "未选择",
+            "refresh": "刷新以加载",
+            "empty": "空",
+            "node": "节点",
+            "flow": "流程",
+            "global": "全局",
+            "deleteConfirm": "你确定要删除这个项目吗？",
+            "autoRefresh": "刷新选择更改",
+            "refrsh": "刷新",
+            "delete": "删除"
         },
         "palette": {
             "name": "节点管理",
@@ -399,8 +600,151 @@
             "description": "描述",
             "dependencies": "依赖",
             "settings": "设置",
+            "noSummaryAvailable": "无可用摘要",
             "editDescription": "编辑项目描述",
-            "editDependencies": "编辑项目依赖"
+            "editDependencies": "编辑项目依赖",
+            "noDescriptionAvailable": "没有可用的描述",
+            "editReadme": "编辑README.md",
+            "showProjectSettings": "显示项目设置",
+            "projectSettings": {
+                "title": "项目设置",
+                "edit": "编辑",
+                "none": "空",
+                "install": "安装",
+                "removeFromProject": "从项目中删除",
+                "addToProject": "添加到项目",
+                "files": "文件",
+                "package": "包",
+                "flow": "流程",
+                "credentials": "证书",
+                "packageCreate": "保存更改后将创建文件",
+                "fileNotExist": "文件不存在",
+                "selectFile": "选择文件",
+                "invalidEncryptionKey": "无效的加密密钥",
+                "encryptionEnabled": "启用加密",
+                "encryptionDisabled": "加密已禁用",
+                "setTheEncryptionKey": "设置加密密钥",
+                "resetTheEncryptionKey": "重置加密密钥",
+                "changeTheEncryptionKey": "更改加密密钥",
+                "currentKey": "当前密钥",
+                "newKey": "新密钥",
+                "credentialsAlert": "这将删除所有现有凭证",
+                "versionControl": "版本控制",
+                "branches": "分支",
+                "noBranches": "没有分支",
+                "deleteConfirm": "您确定要删除本地分支'__name__'吗？ 这不能被撤消。",
+                "unmergedConfirm": "本地分支'__name__'具有未合并的更改，这些更改将丢失。你确定要删除吗？",
+                "deleteUnmergedBranch": "删除未合并的分支",
+                "gitRemotes": "Git远程仓库",
+                "addRemote": "添加远程仓库",
+                "addRemote2": "添加远程仓库",
+                "remoteName": "远程仓库名",
+                "nameRule": "只能包含A-Z 0-9 _ -",
+                "url": "URL",
+                "urlRule": "https://, ssh:// or file://",
+                "urlRule2": "网址中不能包含用户名/密码",
+                "noRemotes": "没有远程仓库",
+                "deleteRemoteConfrim": "您确定要删除远程仓库'__name__'吗？",
+                "deleteRemote": "删除远程仓库"
+            },
+            "userSettings": {
+                "committerDetail": "提交者详细信息",
+                "committerTip": "保留空白以使用系统默认值",
+                "userName": "用户名",
+                "email": "电子邮件",
+                "sshKeys": "SSH密钥",
+                "sshKeysTip": "允许您创建到远程git存储库的安全连接。",
+                "add": "添加密钥",
+                "addSshKey": "添加SSH密钥",
+                "addSshKeyTip": "生成新的公钥/私钥对",
+                "name": "名字",
+                "nameRule": "只能包含A-Z 0-9 _ -",
+                "passphrase": "密码短语",
+                "passphraseShort": "密码短语过短",
+                "optional": "可选的",
+                "cancel": "取消",
+                "generate": "生成密钥",
+                "noSshKeys": "没有SSH密钥",
+                "copyPublicKey": "将公钥复制到剪贴板",
+                "delete": "删除密钥",
+                "gitConfig": "Git配置",
+                "deleteConfirm": "您确定要删除SSH密钥__name__吗？这不能被撤消。"
+            },
+            "versionControl": {
+                "unstagedChanges": "未暂存的变更",
+                "stagedChanges": "暂存的变更",
+                "unstageChange": "取消变更的暂存",
+                "stageChange": "暂存变更",
+                "unstageAllChange": "取消所有变更的暂存",
+                "stageAllChange": "暂存所有变更",
+                "commitChanges": "提交变更",
+                "resolveConflicts": "解决冲突",
+                "head": "HEAD",
+                "staged": "暂存的",
+                "unstaged": "未暂存的",
+                "local": "本地的",
+                "remote": "远程的",
+                "revert": "您确定要将更改恢复为'__file__'吗？这不能被撤消。",
+                "revertChanges": "还原变更",
+                "localChanges": "本地变更",
+                "none": "None",
+                "conflictResolve": "解决所有冲突。提交更改以完成合并。",
+                "localFiles": "本地文件",
+                "all": "所有的",
+                "unmergedChanges": "未合并的更改",
+                "abortMerge": "中止合并",
+                "commit": "提交",
+                "changeToCommit": "提交变更",
+                "commitPlaceholder": "输入您的提交信息",
+                "cancelCapital": "取消",
+                "commitCapital": "提交",
+                "commitHistory": "提交历史",
+                "branch": "分支:",
+                "moreCommits": "更多提交",
+                "changeLocalBranch": "变更本地分支",
+                "createBranchPlaceholder": "查找或创建分支",
+                "upstream": "上游",
+                "localOverwrite": "切换分支会覆盖您现有的本地更改。您必须先提交或撤消那些更改。",
+                "manageRemoteBranch": "管理远程分支",
+                "unableToAccess": "无法访问远程存储库",
+                "retry": "重试",
+                "setUpstreamBranch": "设置为上游分支",
+                "createRemoteBranchPlaceholder": "查找或创建远程分支",
+                "trackedUpstreamBranch": "创建的分支将被设置为跟踪的上游分支。",
+                "selectUpstreamBranch": "分支将被创建。 在下面选择以将其设置为被跟踪的上游分支。",
+                "pushFailed": "推送失败，因为远程具有更多的最新提交。请先拉取并合并，然后再尝试推送。",
+                "push": "推送",
+                "pull": "拉取",
+                "unablePull": "<p>无法提取远程更改；您未暂存的本地更改将被覆盖。</p><p>请先提交更改，然后重试。</p>",
+                "showUnstagedChanges": "显示未暂存的更改",
+                "connectionFailed": "无法连接到远程存储库：",
+                "pullUnrelatedHistory": "<p>远程有无关的提交历史</p><p>您确定要将这些更改拉入本地仓库吗？</p>",
+                "pullChanges": "拉取更改",
+                "history": "历史",
+                "projectHistory": "项目历史",
+                "daysAgo": "__count__天前",
+                "daysAgo_plural": "__count__天前",
+                "hoursAgo": "__count__小时前",
+                "hoursAgo_plural": "__count__小时前",
+                "minsAgo": "__count__分钟前",
+                "minsAgo_plural": "__count__分钟前",
+                "secondsAgo": "秒前",
+                "notTracking": "您的本地分支当前未跟踪一个远程分支。",
+                "statusUnmergedChanged": "您的仓库中有未合并的更改。您需要解决冲突并提交结果。",
+                "repositoryUpToDate": "您的仓库是最新的。",
+                "commitsAhead": "您的存储库领先远程仓库__count__次提交。您现在可以推送这些提交。",
+                "commitsAhead_plural": "您的存储库领先远程仓库__count__次提交。您现在可以推送这些提交。",
+                "commitsBehind": "您的存储库落后远程仓库__count__次提交。您现在可以拉取这些提交。",
+                "commitsBehind_plural": "您的存储库落后远程仓库__count__次提交。您现在可以拉取这些提交。",
+                "commitsAheadAndBehind1": "您的存储库落后远程仓库__count__次提交",
+                "commitsAheadAndBehind1_plural": "您的存储库落后远程仓库__count__次提交",
+                "commitsAheadAndBehind2": "领先远程仓库__count__次提交。",
+                "commitsAheadAndBehind2_plural": "领先远程仓库__count__次提交。",
+                "commitsAheadAndBehind3": "您必须先拉取远程提交，然后才能进行推送。",
+                "commitsAheadAndBehind3_plural": "您必须先拉取远程提交，然后才能进行推送。",
+                "refreshCommitHistory": "刷新提交历史",
+                "refreshChanges": "刷新更改"
+            }
         }
     },
     "typedInput": {
@@ -408,10 +752,12 @@
             "str": "文字列",
             "num": "数字",
             "re": "正则表达式",
-            "bool": "布尔",
+            "bool": "布尔值",
             "json": "JSON",
             "bin": "二进制流",
-            "date": "时间戳"
+            "date": "时间戳",
+            "jsonata": "表达式",
+            "env": "环境变量"
         }
     },
     "editableList": {
@@ -423,8 +769,10 @@
     },
     "expressionEditor": {
         "functions": "功能",
+        "functionReference": "功能reference",
         "insert": "插入",
         "title": "JSONata表达式编辑器",
+        "test": "测试",
         "data": "示例消息",
         "result": "结果",
         "format": "格式表达方法",
@@ -438,14 +786,228 @@
             "eval": "评估表达式错误:\n  __message__"
         }
     },
+    "jsEditor": {
+        "title": "JavaScript编辑器"
+    },
+    "textEditor": {
+        "title": "文本编辑器"
+    },
     "jsonEditor": {
         "title": "JSON编辑器",
-        "format": "格式化JSON"
+        "format": "格式化JSON",
+        "rawMode": "编辑 JSON",
+        "uiMode": "Visual编辑器",
+        "insertAbove": "在上方插入",
+        "insertBelow": "在下方插入",
+        "addItem": "添加项目",
+        "copyPath": "复制路径到项目",
+        "expandItems": "展开项目",
+        "collapseItems": "收合项目",
+        "duplicate": "重复",
+        "error": {
+            "invalidJSON": "无效的JSON: "
+        }
+    },
+    "markdownEditor": {
+        "title": "Markdown编辑器",
+        "expand": "展开",
+        "format": "格式化为markdown",
+        "heading1": "标题 1",
+        "heading2": "标题 2",
+        "heading3": "标题 3",
+        "bold": "粗体",
+        "italic": "斜体",
+        "code": "代码",
+        "ordered-list": "排序的列表",
+        "unordered-list": "非排序的列表",
+        "quote": "引用",
+        "link": "链接",
+        "horizontal-rule": "水平线",
+        "toggle-preview": "切换预览"
     },
     "bufferEditor": {
         "title": "缓冲区编辑器",
         "modeString": "作为UTF-8字符串处理",
         "modeArray": "作为JSON数组处理",
         "modeDesc": "<h3>缓冲区编辑器</h3><p>缓冲区类型被存储为字节值的JSON数组。编辑器将尝试将输入的数值解析为JSON数组。如果它不是有效的JSON，它将被视为UTF-8字符串，并被转换为单个字符代码点的数组。</p><p>例如，<code>Hello World</code>的值会被转换为JSON数组：<pre>[72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]</pre></p>"
+    },
+    "projects": {
+        "config-git": "配置Git客户端",
+        "welcome": {
+            "hello": "你好！ 我们已经将“项目”引入了Node-RED。",
+            "desc0": "这是一种用于管理流程文件的新方法，并且包括对流程的版本控制。",
+            "desc1": "首先，您可以创建您的第一个项目或从git存储库克隆现有项目。",
+            "desc2": "如果不确定，可以暂时跳过此步骤。您仍然可以随时通过“项目”菜单创建第一个项目。",
+            "create": "建立专案",
+            "clone": "克隆仓库",
+            "openExistingProject": "打开现有项目",
+            "not-right-now": "不是现在"
+        },
+        "git-config": {
+            "setup": "设置您的版本控制客户端",
+            "desc0": "Node-RED使用开源工具Git进行版本控制。它跟踪对项目文件的更改，并允许您将其推送到远程存储库。",
+            "desc1": "提交一组更改时，Git会使用用户名和电子邮件地址记录谁进行了更改。用户名可以是您想要的任何名称-不必是您的真实姓名。",
+            "desc2": "您的Git客户端已经配置了以下详细信息。",
+            "desc3": "您可以稍后在设置对话框的'Git config'标签下更改这些设置。",
+            "username": "用户名",
+            "email": "电子邮件"
+        },
+        "project-details": {
+            "create": "创建你的项目",
+            "desc0": "项目被维护为Git仓库。与他人一起共享您的流程",
+            "desc1": "您可以创建多个项目，并通过编辑器在它们之间快速切换。",
+            "desc2": "首先，您的项目需要一个名称和一个可选的描述。",
+            "already-exists": "项目已存在",
+            "must-contain": "只能包含A-Z 0-9 _ -",
+            "project-name": "项目名",
+            "desc": "描述",
+            "opt": "可选的"
+        },
+        "clone-project": {
+            "clone": "克隆一个项目",
+            "desc0": "如果您已经有一个包含项目的git仓库，则可以对其进行克隆以开始使用。",
+            "already-exists": "项目已存在",
+            "must-contain": "只能包含A-Z 0-9 _ -",
+            "project-name": "项目名",
+            "no-info-in-url": "网址中不要包含用户名/密码",
+            "git-url": "Git仓库的url",
+            "protocols": "https://, ssh:// or file://",
+            "auth-failed": "认证失败",
+            "username": "用户名",
+            "passwd": "秘密啊",
+            "ssh-key": "SSH密钥",
+            "passphrase": "密码短语",
+            "ssh-key-desc": "在通过ssh克隆仓库之前，必须添加SSH密钥才能访问它。",
+            "ssh-key-add": "添加一个ssh密钥",
+            "credential-key": "证书加密密钥",
+            "cant-get-ssh-key": "错误！ 无法获取所选的SSH密钥路径。",
+            "already-exists2": "已存在",
+            "git-error": "git错误",
+            "connection-failed": "连接失败",
+            "not-git-repo": "不是一个git仓库",
+            "repo-not-found": "未发现仓库"
+        },
+        "default-files": {
+            "create": "创建您的项目文件",
+            "desc0": "一个包含您的流程文件，Readme文件和package.json文件的项目。",
+            "desc1": "它可以包含您要在Git仓库中维护的任何其他文件。",
+            "desc2": "您现有的流程和凭证文件将被复制到项目中。",
+            "flow-file": "流程文件",
+            "credentials-file": "证书文件"
+        },
+        "encryption-config": {
+            "setup": "设置证书文件的加密",
+            "desc0": "您的流程证书文件可以被加密以确保其内容安全。",
+            "desc1": "如果要将这些证书存储在公共Git存储库中，则必须通过提供密钥短语来对它们进行加密。",
+            "desc2": "您的流程证书文件当前未加密。",
+            "desc3": "这意味着任何有权访问该文件的人都可以读取其内容，例如密码和访问令牌。",
+            "desc4": "如果要将这些证书存储在公共Git仓库中，则必须通过提供密钥短语来对它们进行加密。",
+            "desc5": "当前，使用设置文件中的credentialSecret属性作为密钥来加密流程证书文件。",
+            "desc6": "您的流程证书文件当前使用系统生成的密钥加密。您应该为此项目提供一个新的密钥。",
+            "desc7": "密钥将与项目文件分开存储。您将需要提供在另一个Node-RED实例中使用该项目的密钥。",
+            "credentials": "证书",
+            "enable": "启用加密",
+            "disable": "禁用加密",
+            "disabled": "禁用的",
+            "copy": "复制现有密钥",
+            "use-custom": "使用自定义密钥",
+            "desc8": "证书文件不会被加密，其内容很容易阅读",
+            "create-project-files": "创建项目文件",
+            "create-project": "创建项目",
+            "already-exists": "已存在",
+            "git-error": "git错误",
+            "git-auth-error": "git认证错误"
+        },
+        "create-success": {
+            "success": "您已经成功创建了第一个项目！",
+            "desc0": "现在，您可以像往常一样继续使用Node-RED。",
+            "desc1": "侧栏中的“信息”标签显示了您当前的活动项目。名称旁边的按钮可用于访问项目设置视图。",
+            "desc2": "侧栏中的“历史记录”标签可用于查看项目中已更改的文件并提交。它向您显示了提交的完整历史记录，并允许您将更改推送到远程存储库。"
+        },
+        "create": {
+            "projects": "项目",
+            "already-exists": "项目已存在",
+            "must-contain": "只能包含A-Z 0-9 _ -",
+            "no-info-in-url": "网址中不要包含用户名/密码",
+            "open": "打开项目",
+            "create": "创建项目",
+            "clone": "克隆仓库",
+            "project-name": "项目名",
+            "desc": "描述",
+            "opt": "可选的",
+            "flow-file": "流程文件",
+            "credentials": "证书",
+            "enable-encryption": "启用加密",
+            "disable-encryption": "禁用加密",
+            "encryption-key": "加密密钥",
+            "desc0": "用来保护您的凭证的短语",
+            "desc1": "凭证文件不会被加密，其内容很容易阅读",
+            "git-url": "Git存储库URL",
+            "protocols": "https://, ssh:// or file://",
+            "auth-failed": "验证失败",
+            "username": "用户名",
+            "password": "密码",
+            "ssh-key": "SSH密钥",
+            "passphrase": "密码短语",
+            "desc2": "在通过ssh克隆存储库之前，必须添加SSH密钥才能访问它。",
+            "add-ssh-key": "添加一个ssh密钥",
+            "credentials-encryption-key": "证书加密密钥",
+            "already-exists-2": "已存在",
+            "git-error": "git错误",
+            "con-failed": "连接失败",
+            "not-git": "不是git仓库",
+            "no-resource": "找不到存储库",
+            "cant-get-ssh-key-path": "错误！无法获取所选的SSH密钥路径。",
+            "unexpected_error": "意外的错误"
+        },
+        "delete": {
+            "confirm": "您确定要删除此项目吗？"
+        },
+        "create-project-list": {
+            "search": "搜索您的项目",
+            "current": "当前的"
+        },
+        "require-clean": {
+            "confirm": "<p>您有未部署的更改，这些更改将丢失。</p><p>您要继续吗？</p>"
+        },
+        "send-req": {
+            "auth-req": "存储库需要认证",
+            "username": "用户名",
+            "password": "秘密",
+            "passphrase": "密码短语",
+            "retry": "重试",
+            "update-failed": "无法更新身份验证",
+            "unhandled": "未处理的错误响应"
+        },
+        "create-branch-list": {
+            "invalid": "无效的分支",
+            "create": "创建分支",
+            "current": "当前的"
+        },
+        "create-default-file-set": {
+            "no-active": "没有活动项目就无法创建默认文件集",
+            "no-empty": "无法在非空项目上创建默认文件集",
+            "git-error": "git错误"
+        },
+        "errors": {
+            "no-username-email": "您的Git客户端未配置用户名/电子邮件。",
+            "unexpected": "发生了一个意料之外的问题",
+            "code": "代码"
+        }
+    },
+    "editor-tab": {
+        "properties": "属性",
+        "envProperties": "环境变量",
+        "description": "描述",
+        "appearance": "外观",
+        "preview": "UI预览",
+        "defaultValue": "默认值"
+    },
+    "languages": {
+        "de": "德语",
+        "en-US": "英文",
+        "ja": "日语",
+        "ko": "韩文",
+        "zh-CN": "简体中文"
     }
 }

--- a/packages/node_modules/@node-red/editor-client/locales/zh-CN/jsonata.json
+++ b/packages/node_modules/@node-red/editor-client/locales/zh-CN/jsonata.json
@@ -214,5 +214,53 @@
     "$toMillis": {
         "args": "timestamp",
         "desc": "将ISO 8601格式的字符串`timestamp`转换为从UNIX时间 (1970年1月1日 UTC/GMT的午夜）开始到现在的毫秒数。如果该字符串的格式不正确，则抛出错误。"
+    },
+    "$env": {
+        "args": "arg",
+        "desc": "返回环境变量的值。\n\n这是Node-RED定义的函数。"
+    },
+    "$eval": {
+        "args": "expr [, context]",
+        "desc": "使用当前上下文来作为评估依据，分析并评估字符串`expr`，其中包含文字JSON或JSONata表达式。"
+    },
+    "$formatInteger": {
+        "args": "number, picture",
+        "desc": "将“数字”转换为字符串，并将其格式化为“图片”字符串指定的整数表示形式。图片字符串参数定义了数字的格式，并具有与XPath F&O 3.1 规范中的fn：format-integer相同的语法。"
+    },
+    "$parseInteger": {
+        "args": "string, picture",
+        "desc": "使用“图片”字符串指定的格式将“字符串”参数的内容解析为整数（作为JSON数字）。图片字符串参数与$formatInteger格式相同。."
+    },
+    "$error": {
+        "args": "[str]",
+        "desc": "引发错误并显示一条消息。 可选的`str`将替代$error()函数评估的默认消息。"
+    },
+    "$assert": {
+        "args": "arg, str",
+        "desc": "如果`arg`为真，则该函数返回。 如果arg为假，则抛出带有str的异常作为异常消息。"
+    },
+    "$single": {
+        "args": "array, function",
+        "desc": "返回满足参数function谓语的array参数中的唯一值 (比如：传递值时，函数返回布尔值“true”)。如果匹配值的数量不唯一时，则抛出异常。\n\n应在以下签名中提供函数：`function（value [，index [，array []]]）`其中value是数组的每个输入，index是该值的位置，整个数组作为第三个参数传递。"
+    },
+    "$encodeUrl": {
+        "args": "str",
+        "desc": "通过用表示字符的UTF-8编码的一个，两个，三个或四个转义序列替换某些字符的每个实例，对统一资源定位符（URL）组件进行编码。\n\n示例：`$encodeUrlComponent(\"?x=test\")` => `\"%3Fx%3Dtest\"`"
+    },
+    "$encodeUrlComponent": {
+        "args": "str",
+        "desc": "通过用表示字符的UTF-8编码的一个，两个，三个或四个转义序列替换某些字符的每个实例，对统一资源定位符（URL）进行编码。\n\n示例： `$encodeUrl(\"https://mozilla.org/?x=шеллы\")` => `\"https://mozilla.org/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B\"`"
+    },
+    "$decodeUrl": {
+        "args": "str",
+        "desc": "解码以前由encodeUrlComponent创建的统一资源定位器（URL）组件。 \n\n示例： `$decodeUrlComponent(\"%3Fx%3Dtest\")` => `\"?x=test\"`"
+    },
+    "$decodeUrlComponent": {
+        "args": "str",
+        "desc": "解码先前由encodeUrl创建的统一资源定位符（URL）。 \n\n示例： `$decodeUrl(\"https://mozilla.org/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B\")` => `\"https://mozilla.org/?x=шеллы\"`"
+    },
+    "$distinct": {
+        "args": "array",
+        "desc": "返回一个数组，其中重复的值已从`数组`中删除"
     }
 }

--- a/packages/node_modules/@node-red/nodes/locales/zh-CN/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/zh-CN/messages.json
@@ -6,7 +6,9 @@
             "name": "名称",
             "username": "用户名",
             "password": "密码",
-            "property": "属性"
+            "property": "属性",
+            "selectNodes": "选择节点...",
+            "expand": "扩展"
         },
         "status": {
             "connected": "已连接",
@@ -35,7 +37,22 @@
         "stopped": "停止",
         "failed": "注入失败: __error__",
         "label": {
-            "repeat": "重复"
+            "repeat": "重复",
+            "flow": "流上下午",
+            "global": "全局上下文",
+            "str": "字符串",
+            "num": "数值",
+            "bool": "布尔值",
+            "json": "JSON对象",
+            "bin": "buffer",
+            "date": "时间戳",
+            "env": "环境变量",
+            "object": "对象",
+            "string": "字符串",
+            "boolean": "布尔值",
+            "number": "数值",
+            "Array": "数组",
+            "invalid": "无效的JSON对象"
         },
         "timestamp": "时间戳",
         "none": "无",
@@ -70,15 +87,13 @@
         }
     },
     "catch": {
-        "catch": "监测所有节点",
-        "catchNodes": "监测__number__个节点",
+        "catch": "捕获：所有节点",
+        "catchNodes": "捕获：__number__个节点",
+        "catchUncaught": "捕获：未捕获",
         "label": {
-            "source": "监测范围",
-            "node": "节点",
-            "type": "类型",
+            "source": "捕获范围",
             "selectAll": "全选",
-            "sortByLabel": "按名称排序",
-            "sortByType": "按类型排序"
+            "uncaught": "忽略其他捕获节点处理的错误"
         },
         "scope": {
             "all": "所有节点",
@@ -90,10 +105,6 @@
         "statusNodes": "报告__number__个节点状态",
         "label": {
             "source": "报告状态范围",
-            "node": "节点",
-            "type": "类型",
-            "selectAll": "全选",
-            "sortByLabel": "按名称排序",
             "sortByType": "按类型排序"
         },
         "scope": {
@@ -101,8 +112,13 @@
             "selected": "指定节点"
         }
     },
+    "complete": {
+        "completeNodes": "完成: __number__个节点"
+    },
     "debug": {
         "output": "输出",
+        "none": "None",
+        "invalid-exp": "无效的JSONata表达式: __error__",
         "msgprop": "信息属性",
         "msgobj": "完整信息",
         "to": "目标",
@@ -124,7 +140,11 @@
             "filterCurrent": "当前流程",
             "debugNodes": "调试节点",
             "clearLog": "清空日志",
-            "openWindow": "在新窗口打开"
+            "filterLog": "过滤日志",
+            "openWindow": "在新窗口打开",
+            "copyPath": "复制路径",
+            "copyPayload": "复制值",
+            "pinPath": "固定展开"
         },
         "messageMenu": {
             "collapseAll": "折叠所有路径",
@@ -146,26 +166,33 @@
             "key": "私钥",
             "passphrase": "密码",
             "ca": "CA证书",
-            "verify-server-cert":"验证服务器证书"
+            "verify-server-cert":"验证服务器证书",
+            "servername": "服务器名"
         },
         "placeholder": {
             "cert":"证书路径 (PEM 格式)",
             "key":"私钥路径 (PEM 格式)",
             "ca":"CA证书路径 (PEM 格式)",
-            "passphrase":"私钥密码 (可选)"
+            "passphrase":"私钥密码 (可选)",
+            "servername":"用于SNI"
         },
         "error": {
             "missing-file": "未提供证书/密钥文件"
         }
     },
     "exec": {
+        "exec": "exec",
+        "spawn": "spawn",
         "label": {
             "command": "命令",
             "append": "追加",
             "timeout": "超时",
             "timeoutplace": "可选填",
             "return": "输出",
-            "seconds": "秒"
+            "seconds": "秒",
+            "stdout": "标准输出",
+            "stderr": "标准错误输出",
+            "retcode": "返回码"
         },
         "placeholder": {
             "extraparams": "额外的输入参数"
@@ -177,6 +204,7 @@
         "oldrc": "使用旧式输出 (兼容模式)"
     },
     "function": {
+        "function": "函数",
         "label": {
             "function": "函数",
             "outputs": "输出"
@@ -187,6 +215,7 @@
         }
     },
     "template": {
+        "template": "模板",
         "label": {
             "template": "模版",
             "property": "属性",
@@ -199,7 +228,7 @@
             "yaml": "YAML",
             "none": "无"
         },
-        "templatevalue": "This is the payload: {{payload}} !"
+        "templatevalue": "这是有效载荷: {{payload}} !"
     },
     "delay": {
         "action": "行为设置",
@@ -272,6 +301,9 @@
         "wait-reset": "等待被重置",
         "wait-for": "等待",
         "wait-loop": "周期性重发",
+        "for": "处理",
+        "bytopics": "每个msg.topic",
+        "alltopics": "所有消息",
         "duration": {
             "ms": "毫秒",
             "s": "秒",
@@ -290,6 +322,7 @@
         }
     },
     "comment": {
+        "comment": "注释"
     },
     "unknown": {
         "label": {
@@ -300,9 +333,10 @@
     "mqtt": {
         "label": {
             "broker": "服务端",
-            "example": "e.g. localhost",
+            "example": "比如：本地主机",
             "output": "输出",
             "qos": "QoS",
+            "retain": "保持",
             "clientid": "客户端ID",
             "port": "端口",
             "keepalive": "Keepalive计时(秒)",
@@ -312,17 +346,22 @@
             "verify-server-cert":"验证服务器证书",
             "compatmode": "使用旧式MQTT 3.1支持"
         },
+        "sections-label":{
+            "birth-message": "连接时发送的消息（出生消息）",
+            "will-message":"意外断开连接时的发送消息（Will消息）",
+            "close-message":"断开连接前发送的消息（关闭消息）"
+        },
         "tabs-label": {
             "connection": "连接",
             "security": "安全",
-            "will": "Will信息",
-            "birth": "Birth信息"
+            "messages": "消息"
         },
         "placeholder": {
             "clientid": "留白则自动生成",
             "clientid-nonclean":"如非新会话，必须设置客户端ID",
             "will-topic": "留白将禁止Will信息",
-            "birth-topic": "留白将禁止Birth信息"
+            "birth-topic": "留白将禁止Birth信息",
+            "close-topic": "留白以禁用关闭消息"
         },
         "state": {
             "connected": "已连接到服务端: __broker__",
@@ -333,7 +372,9 @@
         "output": {
             "buffer": "Buffer",
             "string": "字符串",
-            "base64": "Base64编码字符串"
+            "base64": "Base64编码字符串",
+            "auto": "自动检测 (字符串或buffer)",
+            "json": "解析的JSON对象"
         },
         "true": "是",
         "false": "否",
@@ -342,7 +383,9 @@
             "not-defined": "主题未设置",
             "missing-config": "未设置服务端",
             "invalid-topic": "主题无效",
-            "nonclean-missingclientid": "客户端ID未设定，使用新会话"
+            "nonclean-missingclientid": "客户端ID未设定，使用新会话",
+            "invalid-json-string": "无效的JSON字符串",
+            "invalid-json-parse": "无法解析JSON字符串"
         }
     },
     "httpin": {
@@ -353,13 +396,27 @@
             "return": "返回",
             "upload": "接受文件上传?",
             "status": "状态码",
-            "headers": "Header",
-            "other": "其他"
+            "headers": "头",
+            "other": "其他",
+            "paytoqs" : "将msg.payload附加为查询字符串参数",
+            "utf8String": "UTF8格式的字符串",
+            "binaryBuffer": "二进制buffer",
+            "jsonObject": "解析的JSON对象",
+            "authType": "类型",
+            "bearerToken": "Token"
         },
         "setby": "- 用 msg.method 设定 -",
         "basicauth": "基本认证",
         "use-tls": "使用安全连接 (SSL/TLS) ",
         "tls-config":"TLS 设置",
+        "basic": "基本认证",
+        "digest": "摘要认证",
+        "bearer": "bearer认证",
+        "use-proxy": "使用代理服务器",
+        "persist": "对连接启用keep-alive",
+        "proxy-config": "代理服务器设置",
+        "use-proxyauth": "使用代理身份验证",
+        "noproxy-hosts": "代理例外",
         "utf8": "UTF-8 字符串",
         "binary": "二进制数据",
         "json": "JSON对象",
@@ -376,7 +433,10 @@
             "json-error": "JSON 解析错误",
             "no-url": "未设定 URL",
             "deprecated-call":"__method__方法已弃用",
-            "invalid-transport":"非HTTP传输请求"
+            "invalid-transport":"非HTTP传输请求",
+            "timeout-isnan": "超时值不是有效数字，忽略",
+            "timeout-isnegative": "超时值为负，忽略",
+            "invalid-payload": "无效的有效载荷"
         },
         "status": {
             "requesting": "请求中"
@@ -399,13 +459,19 @@
             "url1": "URL 应该使用ws:&#47;&#47;或者wss:&#47;&#47;方案并指向现有的websocket侦听器.",
             "url2": "默认情况下，<code>payload</code> 将包含要发送或从Websocket接收的数据。可以将客户端配置为以JSON格式的字符串发送或接收整个消息对象."
         },
+        "status": {
+            "connected": "连接数 __count__",
+            "connected_plural": "连接数 __count__"
+        },
         "errors": {
             "connect-error": "ws连接发生了错误: ",
             "send-error": "发送时发生了错误: ",
-            "missing-conf": "未设置服务器"
+            "missing-conf": "未设置服务器",
+            "duplicate-path": "同一路径上不能有两个WebSocket侦听器: __path__"
         }
     },
     "watch": {
+        "watch": "watch",
         "label": {
             "files": "文件",
             "recursive": "递归所有子文件夹"
@@ -421,7 +487,7 @@
             "output": "输出",
             "port": "端口",
             "host": "主机地址",
-            "payload": "的有效载荷",
+            "payload": "有效载荷",
             "delimited": "分隔符号",
             "close-connection": "是否在成功发送每条信息后断开连接?",
             "decode-base64": "用 Base64 解码信息?",
@@ -480,7 +546,6 @@
             "output": "输出",
             "group": "组",
             "interface": "本地IP",
-            "interfaceprompt": "（可选）本地 IP 绑定到",
             "send": "发送一个",
             "toport": "到端口",
             "address": "地址",
@@ -488,6 +553,7 @@
         },
         "placeholder": {
             "interface": "（可选）eth0的IP地址",
+            "interfaceprompt": "(可选) 要绑定的本地接口或地址",
             "address": "目标IP地址"
         },
         "udpmsgs": "udp信息",
@@ -529,15 +595,18 @@
             "ip-notset": "udp: IP地址未设定",
             "port-notset": "udp: 端口未设定",
             "port-invalid": "udp: 无效端口号码",
-            "alreadyused": "udp: 端口已被占用"
+            "alreadyused": "udp: 端口已被占用",
+            "ifnotfound": "udp: 接口 __iface__ 未发现"
         }
     },
     "switch": {
+        "switch": "switch",
         "label": {
             "property": "属性",
             "rule": "规则",
             "repair" : "重建信息队列"
         },
+        "previous": "先前值",
         "and": "与",
         "checkall": "全选所有规则",
         "stopfirst": "接受第一条匹配信息后停止",
@@ -550,11 +619,15 @@
             "false":"为假",
             "null":"为空",
             "nnull":"非空",
-            "head":"head",
-            "tail":"tail",
-            "index":"index between",
+            "istype": "类型是",
+            "empty": "为空",
+            "nempty": "非空",
+            "head":"头",
+            "tail":"尾",
+            "index":"索引在..中间",
             "exp":"JSONata表达式",
-            "else":"除此以外"
+            "else":"除此以外",
+            "hask": "拥有键"
         },
         "errors": {
             "invalid-expr": "无效的JSONata表达式: __error__",
@@ -588,6 +661,7 @@
         }
     },
     "range": {
+        "range": "range",
         "label": {
             "action": "操作",
             "inputrange": "映射输入数据",
@@ -623,7 +697,8 @@
             "firstrow": "第一行包含列名",
             "output": "输出",
             "includerow": "包含列名行",
-            "newline": "换行符"
+            "newline": "换行符",
+            "usestrings": "parse numerical values"
         },
         "placeholder": {
             "columns": "用逗号分割列名"
@@ -654,7 +729,8 @@
     "html": {
         "label": {
             "select": "选取项",
-            "output": "输出"
+            "output": "输出",
+            "in": "in"
         },
         "output": {
             "html": "选定元素的html内容",
@@ -670,7 +746,9 @@
         "errors": {
             "dropped-object": "忽略非对象格式的有效负载",
             "dropped": "忽略不支持格式的有效负载类型",
-            "dropped-error": "转换有效负载失败"
+            "dropped-error": "转换有效负载失败",
+            "schema-error": "JSON架构错误",
+            "schema-error-compile": "JSON架构错误: 未能编译架构"
         },
         "label": {
             "o2j": "对象至JSON",
@@ -713,7 +791,10 @@
             "breaklines": "分拆成行",
             "filelabel": "文件",
             "sendError": "发生错误时发送消息（传统模式）",
-            "deletelabel": "删除 __file__"
+            "deletelabel": "删除 __file__",
+            "encoding": "编码",
+            "utf8String": "UTF8字符串",
+            "binaryBuffer": "二进制buffer"
         },
         "action": {
             "append": "追加至文件",
@@ -731,6 +812,21 @@
             "deletedfile": "删除文件: __file__",
             "appendedfile": "追加至文件: __file__"
         },
+        "encoding": {
+            "none": "默认",
+            "native": "Native",
+            "unicode": "Unicode",
+            "japanese": "日本",
+            "chinese": "中国",
+            "korean": "韩国",
+            "taiwan": "台湾/香港",
+            "windows": "Windows代码页",
+            "iso": "ISO代码页",
+            "ibm": "IBM代码页",
+            "mac": "Mac代码页",
+            "koi8": "KOI8代码页",
+            "misc": "其它"
+        },
         "errors": {
             "nofilename": "未指定文件名",
             "invaliddelete": "警告：无效删除。请在配置对话框中使用特定的删除选项",
@@ -742,6 +838,7 @@
         "tip": "提示: 文件名应该是绝对路径，否则它将相对于Node-RED进程的工作目录。"
     },
     "split": {
+        "split": "split",
         "intro":"基于以下类型拆分<code>msg.payload</code>:",
         "object":"<b>对象</b>",
         "objectSend":"每个键值对作为单个消息发送",
@@ -753,6 +850,7 @@
         "addname":" 复制键到 "
     },
     "join":{
+        "join": "join",
         "mode":{
             "mode":"模式",
             "auto":"自动",
@@ -761,6 +859,7 @@
             "custom":"手动"
         },
         "combine":"合并每个",
+        "completeMessage": "完整的消息",
         "create":"输出为",
         "type":{
             "string":"字符串",
@@ -799,6 +898,7 @@
         }
     },
     "sort" : {
+        "sort": "sort",
         "target" : "排序属性",
         "seq" : "信息队列",
         "key" : "键值",
@@ -812,6 +912,7 @@
         "clear" : "清空sort节点中的待定信息"
     },
     "batch" : {
+        "batch": "batch",
         "mode": {
             "label" : "模式",
             "num-msgs" : "按指定数量分组",

--- a/packages/node_modules/@node-red/runtime/locales/zh-CN/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/zh-CN/runtime.json
@@ -1,0 +1,174 @@
+{
+    "runtime": {
+        "welcome": "欢迎使用Node-RED",
+        "version": "__component__ 版本： __version__",
+        "unsupported_version": "__component__的不受支持的版本。要求: __requires__ 找到: __version__",
+        "paths": {
+            "settings": "设置文件  : __path__",
+            "httpStatic": "HTTP Static    : __path__"
+        }
+    },
+
+    "server": {
+        "loading": "加载控制板节点",
+        "palette-editor": {
+            "disabled": "控制板编辑器已禁用：用户设置",
+            "npm-not-found": "控制板编辑器已禁用：找不到npm命令",
+            "npm-too-old": "控制板编辑器已禁用： npm版本太旧。需要版本npm >= 3.x"
+        },
+        "errors": "无法注册__count__节点类型",
+        "errors_plural": "无法注册__count__个节点类型",
+        "errors-help": "使用-v运行以获取详细信息",
+        "missing-modules": "缺少节点模块：",
+        "node-version-mismatch": "无法在此版本上加载节点模块。要求：__ version__",
+        "type-already-registered": "'__type__'已由模块__module__注册",
+        "removing-modules": "从配置中删除模块",
+        "added-types": "添加的节点类型：",
+        "removed-types": "删除的节点类型：",
+        "install": {
+            "invalid": "无效的模块名称",
+            "installing": "安装模块：__ name__，版本：__ version__",
+            "installed": "已安装的模块：__ name__",
+            "install-failed": "安装失败",
+            "install-failed-long": "模块__name__安装失败：",
+            "install-failed-not-found": "$t(server.install.install-failed-long) 模块未发现",
+            "upgrading": "更新模块: __name__ 至版本: __version__",
+            "upgraded": "更新模块: __name__。 重新启动Node-RED以使用新版本",
+            "upgrade-failed-not-found": "$t(server.install.install-failed-long) 未发现版本",
+            "uninstalling": "卸载模块: __name__",
+            "uninstall-failed": "卸载失败",
+            "uninstall-failed-long": "卸载模块__name__失败:",
+            "uninstalled": "卸载模块: __name__"
+        },
+        "unable-to-listen": "无法在__listenpath__上收听",
+        "port-in-use": "错误: 端口正在使用中",
+        "uncaught-exception": "未捕获的异常：",
+        "admin-ui-disabled": "管理员界面已禁用",
+        "now-running": "服务器现在在__listenpath__上运行",
+        "failed-to-start": "无法启动服务器：",
+        "headless-mode": "在headless模式下运行",
+        "httpadminauth-deprecated": "不建议使用httpAdminAuth。请改用adminAuth"
+    },
+
+    "api": {
+        "flows": {
+            "error-save": "保存流程错误: __message__",
+            "error-reload": "重载流程错误: __message__"
+        },
+        "library": {
+            "error-load-entry": "加载库条目'__path__'时出错：__message__",
+            "error-save-entry": "保存库条目'__path__'时出错：__ message__",
+            "error-load-flow": "加载流程'__path__'时出错：__ message__",
+            "error-save-flow": "保存流'__path__'时出错：__ message__"
+        },
+        "nodes": {
+            "enabled": "启用的节点类型:",
+            "disabled": "禁用的节点类型:",
+            "error-enable": "无法启用节点:"
+        }
+    },
+
+    "comms": {
+        "error": "通讯渠道错误：__ message__",
+        "error-server": "通信服务器错误：__ message__",
+        "error-send": "通讯发送错误：__ message__"
+    },
+
+    "settings": {
+        "user-not-available": "无法保存用户设置：__ message__",
+        "not-available": "设置不可用",
+        "property-read-only": "属性“ __prop__”是只读的"
+    },
+
+    "nodes": {
+        "credentials": {
+            "error":"加载证书时出错：__ message__",
+            "error-saving":"保存证书时出错：__ message__",
+            "not-registered": "证书类型'__type__'未注册",
+            "system-key-warning": "\n\n---------------------------------------------------------------------\n您的流程证书文件是使用系统生成的密钥加密的。\n\n如果系统生成的密钥由于任何原因丢失，则您的证书文件将无法恢复，您将必须删除它并重新输入您的证书。\n\n您应该使用您的设置文件中的'credentialSecret'选项设置自己的密钥。然后，下次部署更改时，Node-RED将使用选择的密钥重新加密您的证书文件。\n---------------------------------------------------------------------\n"
+        },
+        "flows": {
+            "safe-mode": "流程在安全模式下停止。部署开始。",
+            "registered-missing": "缺少注册的类型：__ type__",
+            "error": "错误加载流程：__ message__",
+            "starting-modified-nodes": "启动修改的节点",
+            "starting-modified-flows": "启动修改的流程",
+            "starting-flows": "启动流程",
+            "started-modified-nodes": "修改的节点已启动",
+            "started-modified-flows": "修改的流程已启动",
+            "started-flows": "流程已启动",
+            "stopping-modified-nodes": "停止修改的节点",
+            "stopping-modified-flows": "停止修改的流程",
+            "stopping-flows": "停止流程",
+            "stopped-modified-nodes": "修改的节点已停止",
+            "stopped-modified-flows": "修改的流程已停止",
+            "stopped-flows": "流程已停止",
+            "stopped": "已停止",
+            "stopping-error": "错误停止节点：__ message__",
+            "added-flow": "流程已添加: __label__",
+            "updated-flow": "流程已更新: __label__",
+            "removed-flow": "流程已移除: __label__",
+            "missing-types": "等待缺少的类型被注册：",
+            "missing-type-provided": " - __type__ (由npm模块__module__提供)",
+            "missing-type-install-1": "要安装所有缺少的模块，请运行：",
+            "missing-type-install-2": "在目录中："
+        },
+        "flow": {
+            "unknown-type": "未知类型: __type__",
+            "missing-types": "缺少类型",
+            "error-loop": "邮件已超过最大捕获数"
+        },
+        "index": {
+            "unrecognised-id": "无法识别的ID: __id__",
+            "type-in-use": "使用中的类型: __msg__",
+            "unrecognised-module": "无法识别的模块: __module__"
+        },
+        "registry": {
+            "localfilesystem": {
+                "module-not-found": "找不到模块:'__module__'"
+            }
+        }
+    },
+
+    "storage": {
+        "index": {
+            "forbidden-flow-name": "禁止流程名称"
+        },
+        "localfilesystem": {
+            "user-dir": "用户目录: __path__",
+            "flows-file": "流程文件: __path__",
+            "create": "创建新__type__文件",
+            "empty": "现有__type__文件为空",
+            "invalid": "现有__type__文件为无效json",
+            "restore": "恢复__type__文件备份：__path__",
+            "restore-fail": "恢复__type__文件备份失败：__ message__",
+            "fsync-fail": "将文件__path__刷新到磁盘失败：__message__",
+            "projects": {
+                "changing-project": "设置活动项目：__ project__",
+                "active-project": "活动项目：__ project__",
+                "project-not-found": "找不到项目：__ project__",
+                "no-active-project": "没有活动的项目：使用默认流文件",
+                "disabled": "项目已禁用：editorTheme.projects.enabled = false",
+                "disabledNoFlag": "项目已禁用：设置editorTheme.projects.enabled = true来启用",
+                "git-not-found": "项目已禁用：找不到git命令",
+                "git-version-old": "项目已禁用：不支持的git __version__。 需要的git版本为2.x",
+                "summary": "一个Node-RED项目",
+                "readme": "### 关于\n\n这是您项目的README.md文件。它可以帮助用户了解您的项目，如何使用它以及他们可能需要知道的其他任何信息。"
+            }
+        }
+    },
+
+    "context": {
+        "log-store-init": "上下文储存: '__name__' [__info__]",
+        "error-loading-module": "加载上下文存储时出错： __message__",
+        "error-loading-module2": "加载上下文存储时出错 '__module__': __message__",
+        "error-module-not-defined": "上下文存储库'__storage__'缺少“模块”选项",
+        "error-invalid-module-name": "无效的上下文存储名称：'__ name__'",
+        "error-invalid-default-module": "无效的默认的上下文存储库： '__storage__'",
+        "unknown-store": "指定了未知的上下文存储库'__name__'。 使用默认存储库。",
+        "localfilesystem": {
+            "error-circular": "上下文__scope__包含无法保留的循环引用",
+            "error-write": "编写上下文时出错：__ message__"
+        }
+    }
+}


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

1. Add zh-CN translation for runtime.json
2. Update zh-CN translation for editor-client
3. Update zh-CN translation for nodes messages.json

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
