### PR TITLE
Move receive metric position to better reflect async changes

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
@@ -193,6 +193,7 @@ Node.prototype.emit = function(event, ...args) {
  */
 Node.prototype._emitInput = function(arg) {
     var node = this;
+    this.metric("receive", arg);
     if (node._inputCallback) {
         // Just one callback registered.
         try {
@@ -448,7 +449,6 @@ Node.prototype.receive = function(msg) {
     if (!msg._msgid) {
         msg._msgid = redUtil.generateId();
     }
-    this.metric("receive",msg);
     this.emit("input",msg);
 };
 


### PR DESCRIPTION
Fixes #2444


- [x] Bugfix (non-breaking change which fixes an issue)

## Proposed changes

Moves the point where we log the `receive` metric event so it is *after* the async break. This will mean the gap between the `receive` and subsequent `send` metric events better reflect the actual processing time.

@HiroyasuNishiyama this is a very simple change, but would appreciate if you could verify the metrics look better with this change in place.