### PR TITLE
Allow credentials to be provided as part of /flows api

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/api/flows.js
+++ b/packages/node_modules/@node-red/runtime/lib/api/flows.js
@@ -57,6 +57,8 @@ var api = module.exports = {
     * Sets the current flow configuration
     * @param {Object} opts
     * @param {User} opts.user - the user calling the api
+    * @param {Object} opts.flows - the flow configuration: `{flows: [..], credentials: {}}`
+    * @param {Object} opts.deploymentType - the type of deployment - "full", "nodes", "flows", "reload"
     * @param {Object} opts.req - the request to log (optional)
     * @return {Promise<Flows>} - the active flow configuration
     * @memberof @node-red/runtime_flows
@@ -83,7 +85,7 @@ var api = module.exports = {
                         return reject(err);
                     }
                 }
-                apiPromise = runtime.nodes.setFlows(flows.flows,deploymentType);
+                apiPromise = runtime.nodes.setFlows(flows.flows,flows.credentials,deploymentType);
             }
             apiPromise.then(function(flowId) {
                 return resolve({rev:flowId});

--- a/packages/node_modules/@node-red/runtime/lib/nodes/flows/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/flows/index.js
@@ -106,15 +106,20 @@ function load(forceStart) {
         // This is a force reload from the API - disable safeMode
         delete settings.safeMode;
     }
-    return setFlows(null,"load",false,forceStart);
+    return setFlows(null,null,"load",false,forceStart);
 }
 
 /*
  * _config - new node array configuration
+ * _credentials - new credentials configuration (optional)
  * type - full/nodes/flows/load (default full)
  * muteLog - don't emit the standard log messages (used for individual flow api)
  */
-function setFlows(_config,type,muteLog,forceStart) {
+function setFlows(_config,_credentials,type,muteLog,forceStart) {
+    if (typeof _credentials === "string") {
+        type = _credentials;
+        _credentials = null;
+    }
     type = type||"full";
     if (settings.safeMode) {
         if (type !== "load") {
@@ -155,16 +160,27 @@ function setFlows(_config,type,muteLog,forceStart) {
                 delete newFlowConfig.allNodes[id].credentials;
             }
         }
+        var credsDirty;
 
-        // Allow the credential store to remove anything no longer needed
-        credentials.clean(config);
+        if (_credentials) {
+            // A full set of credentials have been provided. Use those instead
+            configSavePromise = credentials.load(_credentials);
+            credsDirty = true;
+        } else {
+            // Allow the credential store to remove anything no longer needed
+            credentials.clean(config);
 
-        // Remember whether credentials need saving or not
-        var credsDirty = credentials.dirty();
+            // Remember whether credentials need saving or not
+            var credsDirty = credentials.dirty();
+
+            configSavePromise = Promise.resolve();
+        }
 
         // Get the latest credentials and ask storage to save them (if needed)
         // as well as the new flow configuration.
-        configSavePromise = credentials.export().then(function(creds) {
+        configSavePromise = configSavePromise.then(function() {
+            return credentials.export()
+        }).then(function(creds) {
             var saveConfig = {
                 flows: config,
                 credentialsDirty:credsDirty,
@@ -515,7 +531,7 @@ function addFlow(flow) {
     var newConfig = clone(activeConfig.flows);
     newConfig = newConfig.concat(nodes);
 
-    return setFlows(newConfig,'flows',true).then(function() {
+    return setFlows(newConfig,null,'flows',true).then(function() {
         log.info(log._("nodes.flows.added-flow",{label:(flow.label?flow.label+" ":"")+"["+flow.id+"]"}));
         return flow.id;
     });
@@ -646,7 +662,7 @@ function updateFlow(id,newFlow) {
     }
 
     newConfig = newConfig.concat(nodes);
-    return setFlows(newConfig,'flows',true).then(function() {
+    return setFlows(newConfig,null,'flows',true).then(function() {
         log.info(log._("nodes.flows.updated-flow",{label:(label?label+" ":"")+"["+id+"]"}));
     })
 }
@@ -668,7 +684,7 @@ function removeFlow(id) {
         return node.z !== id && node.id !== id;
     });
 
-    return setFlows(newConfig,'flows',true).then(function() {
+    return setFlows(newConfig,null,'flows',true).then(function() {
         log.info(log._("nodes.flows.removed-flow",{label:(flow.label?flow.label+" ":"")+"["+flow.id+"]"}));
     });
 }

--- a/test/unit/@node-red/runtime/lib/api/flows_spec.js
+++ b/test/unit/@node-red/runtime/lib/api/flows_spec.js
@@ -53,7 +53,7 @@ describe("runtime-api/flows", function() {
         var loadFlows;
         var reloadError = false;
         beforeEach(function() {
-            setFlows = sinon.spy(function(flows,type) {
+            setFlows = sinon.spy(function(flows,credentials,type) {
                 if (flows[0] === "error") {
                     var err = new Error("error");
                     err.code = "error";
@@ -91,7 +91,19 @@ describe("runtime-api/flows", function() {
                 result.should.eql({rev:"newRev"});
                 setFlows.called.should.be.true();
                 setFlows.lastCall.args[0].should.eql([4,5,6]);
-                setFlows.lastCall.args[1].should.eql("full");
+                setFlows.lastCall.args[2].should.eql("full");
+                done();
+            }).catch(done);
+        });
+        it("includes credentials when part of the request", function(done) {
+            flows.setFlows({
+                flows: {flows:[4,5,6], credentials: {$:"creds"}},
+            }).then(function(result) {
+                result.should.eql({rev:"newRev"});
+                setFlows.called.should.be.true();
+                setFlows.lastCall.args[0].should.eql([4,5,6]);
+                setFlows.lastCall.args[1].should.eql({$:"creds"});
+                setFlows.lastCall.args[2].should.eql("full");
                 done();
             }).catch(done);
         });
@@ -103,7 +115,7 @@ describe("runtime-api/flows", function() {
                 result.should.eql({rev:"newRev"});
                 setFlows.called.should.be.true();
                 setFlows.lastCall.args[0].should.eql([4,5,6]);
-                setFlows.lastCall.args[1].should.eql("nodes");
+                setFlows.lastCall.args[2].should.eql("nodes");
                 done();
             }).catch(done);
         });
@@ -125,7 +137,7 @@ describe("runtime-api/flows", function() {
                 result.should.eql({rev:"newRev"});
                 setFlows.called.should.be.true();
                 setFlows.lastCall.args[0].should.eql([4,5,6]);
-                setFlows.lastCall.args[1].should.eql("nodes");
+                setFlows.lastCall.args[2].should.eql("nodes");
                 done();
             }).catch(done);
         });


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

This PR allows credentials to be included as part of the `/flows` end point.

For example:

```
curl --header "Node-RED-API-Version: v2" \
     --header "Content-Type: application/json" \
     --request POST \
     --data '{"flows":[{"id":"12e1febf.0d0201","type":"tab","label":"Flow 1","disabled":false,"info":""},{"id":"6a4f931.ab6016c","type":"http request","z":"12e1febf.0d0201","name":"","method":"GET","ret":"txt","paytoqs":false,"url":"","tls":"","persist":false,"proxy":"","authType":"basic","x":430,"y":120,"wires":[[]]}],"credentials":{"6a4f931.ab6016c":{"user":"foo","password":"bar"}}}' http://localhost:1880/flows
```

This does a complete replacement of the credentials in the runtime - it cannot be used to incrementally update only some of the credentials. That will come in a future update.

This is an alternative implement to #2414  which addresses an issue with that implement where it would save the credentials *after* restarting the flow configuration.
