### PR TITLE
bump https-proxy-agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "fs-extra": "8.1.0",
         "fs.notify": "0.0.4",
         "hash-sum": "2.0.0",
-        "https-proxy-agent": "2.2.4",
+        "https-proxy-agent": "5.0.0",
         "i18next": "15.1.2",
         "iconv-lite": "0.5.0",
         "is-utf8": "0.2.1",

--- a/packages/node_modules/@node-red/nodes/package.json
+++ b/packages/node_modules/@node-red/nodes/package.json
@@ -27,7 +27,7 @@
         "fs-extra": "8.1.0",
         "fs.notify": "0.0.4",
         "hash-sum": "2.0.0",
-        "https-proxy-agent": "2.2.4",
+        "https-proxy-agent": "5.0.0",
         "is-utf8": "0.2.1",
         "js-yaml": "3.13.1",
         "media-typer": "1.1.0",


### PR DESCRIPTION
fixes #2469

this is a major version bump of https-proxy-agent, because they set engine to >6 and did some refactoring, which is ok for node-red.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

version bump, because dependency has bug

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
