### PR TITLE
Fix XPath in page objects for UI tests

### DIFF
--- a/test/editor/pageobjects/nodes/core/function/15-change_page.js
+++ b/test/editor/pageobjects/nodes/core/function/15-change_page.js
@@ -85,7 +85,7 @@ changeNode.prototype.ruleMove = function (p, to, index) {
 }
 
 changeNode.prototype.addRule = function () {
-    browser.clickWithWait('//*[@id="dialog-form"]/div[5]/div/a');
+    browser.clickWithWait('//div[contains(@class, "red-ui-editableList")]/a');
 }
 
 module.exports = changeNode;

--- a/test/editor/pageobjects/nodes/core/parsers/70-JSON_page.js
+++ b/test/editor/pageobjects/nodes/core/parsers/70-JSON_page.js
@@ -29,7 +29,7 @@ jsonNode.prototype.setAction = function (action) {
 }
 
 jsonNode.prototype.setProperty = function (property) {
-    browser.setValue('//*[@id="dialog-form"]/div[4]/div/div[1]/input', property);
+    browser.setValue('//*[contains(@class, "red-ui-typedInput-container")]/div[1]/input', property);
 }
 
 module.exports = jsonNode;

--- a/test/editor/pageobjects/nodes/core/parsers/70-XML_page.js
+++ b/test/editor/pageobjects/nodes/core/parsers/70-XML_page.js
@@ -29,7 +29,7 @@ xmlNode.prototype.setAction = function (action) {
 }
 
 xmlNode.prototype.setProperty = function (property) {
-    browser.setValue('//*[@id="dialog-form"]/div[3]/div/div[1]/input', property);
+    browser.setValue('//*[contains(@class, "red-ui-typedInput-container")]/div[1]/input', property);
 }
 
 module.exports = xmlNode;

--- a/test/editor/pageobjects/nodes/core/parsers/70-YAML_page.js
+++ b/test/editor/pageobjects/nodes/core/parsers/70-YAML_page.js
@@ -29,7 +29,7 @@ yamlNode.prototype.setAction = function (action) {
 }
 
 yamlNode.prototype.setProperty = function (property) {
-    browser.setValue('//*[@id="dialog-form"]/div[3]/div/div[1]/input', property);
+    browser.setValue('//*[contains(@class, "red-ui-typedInput-container")]/div[1]/input', property);
 }
 
 module.exports = yamlNode;


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Because XPath was changed in the commit(https://github.com/node-red/node-red/commit/cc5fdd984459f74bb022bfc4f34d7a4f95eb8b7a),  the UI test fails. Therefore, I fixed the XPath in the page objects.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
