### PR TITLE
Fix for unexpected abort of Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "js-yaml": "3.13.1",
         "json-stringify-safe": "5.0.1",
         "jsonata": "1.8.0",
+        "lodash": "4.17.15",
         "media-typer": "1.1.0",
         "memorystore": "1.6.1",
         "mime": "2.4.4",

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -20,7 +20,7 @@
  */
 
 
-const clone = require("clone");
+const clone = require("lodash/cloneDeep");
 const jsonata = require("jsonata");
 const safeJSONStringify = require("json-stringify-safe");
 const util = require("util");

--- a/test/unit/@node-red/util/lib/util_spec.js
+++ b/test/unit/@node-red/util/lib/util_spec.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  **/
 var should = require("should");
+var spawn = require("child_process").spawn;
 
 var NR_TEST_UTILS = require("nr-test-utils");
 
@@ -146,7 +147,12 @@ describe("@node-red/util/util", function() {
         it('handles undefined values without throwing an error', function() {
             var result = util.cloneMessage(undefined);
             should.not.exist(result);
-        })
+        });
+        it('handles wrapped object', function() {
+            var msg = spawn("ls", []);;
+            var result = util.cloneMessage(msg);
+            msg.should.equal(msg);
+        });
     });
     describe('getObjectProperty', function() {
         it('gets a property beginning with "msg."', function() {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
As discussed [here](https://discourse.nodered.org/t/warning-about-clone-node-crash-fatal-error-v8-setinternalfield-internal-field-out-of-bounds/16705)
Node.js runtime crashes when a message containing wrapped object  is passed.
This is caused by use of [`clone` library](https://github.com/pvorb/clone).
This PR changes to use [`lodash/cloneDeep`](https://github.com/lodash/lodash)  instead of `clone`.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
