### PR TITLE
Support for context stores using JSONata and evaluateNodeProperty()

### DIFF
--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -558,11 +558,11 @@ function evaluateNodeProperty(value, type, node, msg, callback) {
  */
 function prepareJSONataExpression(value,node) {
     var expr = jsonata(value);
-    expr.assign('flowContext',function(val) {
-        return node.context().flow.get(val);
+    expr.assign('flowContext',function(val, store) {
+        return node.context().flow.get(val, store);
     });
-    expr.assign('globalContext',function(val) {
-        return node.context().global.get(val);
+    expr.assign('globalContext',function(val, store) {
+        return node.context().global.get(val, store);
     });
     expr.assign('env', function(name) {
         var val = getSetting(node, name);


### PR DESCRIPTION
The function prepareJSONataExpression() does not take context store into account.
This causes problems when using typedInput fields and getting the value of a property based on its type using evaluateNodeProperty()

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
The function `prepareJSONataExpression()` does not take context store into account.
This causes problems when using `typedInput` fields and getting the value of a property based on its type using`evaluateNodeProperty()`. 

So far the only option was to check first if the type of the property is `"jsonata"`, then call `prepareJSONataExpression()` and then `evaluateJSONataExpression()` with a callback so that the context stores are taken into account.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
