### PR TITLE
Add Japanese translation to node property of websocket node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.html
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.html
@@ -163,7 +163,7 @@
             if (root === "") {
                 $("#node-config-ws-tip").hide();
             } else {
-                $("#node-config-ws-path").html(root);
+                $("#node-config-ws-path").html(RED._("node-red:websocket.tip.path2", { path: root }));
                 $("#node-config-ws-tip").show();
             }
         }
@@ -235,7 +235,7 @@
     </div>
     <div class="form-tips">
         <span data-i18n="[html]websocket.tip.path1"></span>
-        <p id="node-config-ws-tip"><span data-i18n="[html]websocket.tip.path2"></span><code><span id="node-config-ws-path"></span></code>.</p>
+        <p id="node-config-ws-tip"><span id="node-config-ws-path"></span></p>
     </div>
 </script>
 

--- a/packages/node_modules/@node-red/nodes/locales/de/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/de/messages.json
@@ -397,7 +397,7 @@
     "message" : "gesamte Nachricht",
     "tip" : {
       "path1" : "Standardmäßig enthält  <code> Nutzdaten </code>  die Daten, die über einen Websocket gesendet oder von einem Websocket empfangen werden. Der Listener kann so konfiguriert werden, dass er das gesamte Nachrichtenobjekt als eine JSON-formatierte Zeichenfolge sendet oder empfängt.",
-      "path2" : "Dieser Pfad ist relativ zu ",
+      "path2" : "Dieser Pfad ist relativ zu <code>__path__</code>.",
       "url1" : "URL sollte ws: &#47; & #47; oder wss: &#47; & #47; Schema verwenden und auf einen vorhandenen Websocket-Listener verweisen.",
       "url2" : "Standardmäßig enthält  <code> Nutzdaten </code>  die Daten, die über einen Websocket gesendet oder von einem Websocket empfangen werden. Der Client kann so konfiguriert werden, dass er das gesamte Nachrichtenobjekt als eine JSON-formatierte Zeichenfolge sendet oder empfängt."
     },

--- a/packages/node_modules/@node-red/nodes/locales/de/network/22-websocket.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/network/22-websocket.html
@@ -37,30 +37,6 @@
    <p>Dieser Konfigurations-Node erstellt einen WebSocket Server-Endpunkt unter Verwendung des angegebenen Pfades.</p>
 </script>
 
-<!-- WebSocket Client configuration node -->
-<script type="text/x-red" data-template-name="websocket-client">
-    <div class="form-row">
-        <label for="node-config-input-path"><i class="fa fa-bookmark"></i> <span data-i18n="websocket.label.url"></span></label>
-        <input id="node-config-input-path" type="text" placeholder="ws://example.com/ws">
-    </div>
-    <div class="form-row node-config-row-tls hide">
-        <label for="node-config-input-tls" data-i18n="httpin.tls-config"></label>
-        <input type="text" id="node-config-input-tls">
-    </div>
-
-    <div class="form-row">
-        <label for="node-config-input-wholemsg" data-i18n="websocket.sendrec"></label>
-        <select type="text" id="node-config-input-wholemsg" style="width: 70%;">
-            <option value="false" data-i18n="websocket.payload"></option>
-            <option value="true" data-i18n="websocket.message"></option>
-        </select>
-    </div>
-    <div class="form-tips">
-        <p><span data-i18n="[html]websocket.tip.url1"></span></p>
-        <span data-i18n="[html]websocket.tip.url2"></span>
-    </div>
-</script>
-
 <script type="text/x-red" data-help-name="websocket-client">
    <p>Dieser Konfigurations-Node verbindet einen WebSocket-Client mit der angegebenen URL.</p>
 </script>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -455,7 +455,7 @@
         "message": "entire message",
         "tip": {
             "path1": "By default, <code>payload</code> will contain the data to be sent over, or received from a websocket. The listener can be configured to send or receive the entire message object as a JSON formatted string.",
-            "path2": "This path will be relative to ",
+            "path2": "This path will be relative to <code>__path__</code>.",
             "url1": "URL should use ws:&#47;&#47; or wss:&#47;&#47; scheme and point to an existing websocket listener.",
             "url2": "By default, <code>payload</code> will contain the data to be sent over, or received from a websocket. The client can be configured to send or receive the entire message object as a JSON formatted string."
         },

--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -455,7 +455,7 @@
         "message": "メッセージ全体を送信/受信",
         "tip": {
             "path1": "標準では <code>payload</code> がwebsocketから送信、受信されるデータを持ちます。クライアントはJSON形式の文字列としてメッセージ全体を送信、受信するよう設定できます。",
-            "path2": "This path will be relative to ",
+            "path2": "このパスは <code>__path__</code> の相対パスになります。",
             "url1": "URLには ws:&#47;&#47; または wss:&#47;&#47; スキーマを使用して、存在するwebsocketリスナを設定してください。",
             "url2": "標準では <code>payload</code> がwebsocketから送信、受信されるデータを持ちます。クライアントはJSON形式の文字列としてメッセージ全体を送信、受信するよう設定できます。"
         },

--- a/packages/node_modules/@node-red/nodes/locales/ko/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ko/messages.json
@@ -446,7 +446,7 @@
         "message": "메세지 전체를 송신/수신",
         "tip": {
             "path1": "표준으로는 <code>payload</code> 가 websocket에서 송신, 수신된 데이터를 기다립니다. 클라이언트는 JSON형식의 문자열로 메세지전체를 송신, 수신하도록 설정할 수 있습니다.",
-            "path2": "This path will be relative to ",
+            "path2": "This path will be relative to <code>__path__</code>.",
             "url1": "URL에는 ws:&#47;&#47; 또는 wss:&#47;&#47; 스키마를 사용하여, 존재하는 websocket리스너를 설정해 주세요.",
             "url2": "표준으로는 <code>payload</code> 가 websocket에서 송신,수신될 데이터를 기다립니다.클라이언트는 JSON형식의 문자열로 메세지전체를 송신, 수신하도록 설정할 수 있습니다."
         },

--- a/packages/node_modules/@node-red/nodes/locales/zh-CN/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/zh-CN/messages.json
@@ -455,7 +455,7 @@
         "message": "完整信息",
         "tip": {
             "path1": "默认情况下，<code>payload</code>将包含要发送或从Websocket接收的数据。侦听器可以配置为以JSON格式的字符串发送或接收整个消息对象.",
-            "path2": "这条路径将相对于 ",
+            "path2": "这条路径将相对于 <code>__path__</code>.",
             "url1": "URL 应该使用ws:&#47;&#47;或者wss:&#47;&#47;方案并指向现有的websocket侦听器.",
             "url2": "默认情况下，<code>payload</code> 将包含要发送或从Websocket接收的数据。可以将客户端配置为以JSON格式的字符串发送或接收整个消息对象."
         },

--- a/packages/node_modules/@node-red/nodes/locales/zh-TW/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/zh-TW/messages.json
@@ -455,7 +455,7 @@
         "message": "完整資訊",
         "tip": {
             "path1": "預設情況下，<code>payload</code>將包含要發送或從Websocket接收的資料。偵聽器可以配置為以JSON格式的字串發送或接收整個消息物件.",
-            "path2": "這條路徑將相對於 ",
+            "path2": "這條路徑將相對於 <code>__path__</code>.",
             "url1": "URL 應該使用ws:&#47;&#47;或者wss:&#47;&#47;方案並指向現有的websocket監聽器.",
             "url2": "預設情況下，<code>payload</code> 將包含要發送或從Websocket接收的資料。可以將使用者端配置為以JSON格式的字串發送或接收整個消息物件."
         },


### PR DESCRIPTION
## Proposed changes
Because I found that the English message remains on the WebSocket node property in my Japanese browser environment, I added Japanese translations. To support the same change in other languages, I also modified other message catalogs.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
