### PR TITLE
Remove old leagcy wording from file node info (Japanese and Chinese)

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/ja/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/storage/10-file.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="file">
+<script type="text/html" data-help-name="file">
     <p><code>msg.payload</code>をファイルに書き出します。書き出しは、ファイルの最後に追記もしくは既存の内容の置き換えを選択できます。この他、ファイルの削除を行うことも可能です。</p>
     <h3>入力</h3>
     <dl class="message-properties">
@@ -31,7 +31,7 @@
     <p>この他、ファイルの削除を行うことも可能です。</p>
 </script>
 
-<script type="text/x-red" data-help-name="file in">
+<script type="text/html" data-help-name="file in">
     <p>ファイルの内容を文字列もしくはバイナリバッファとして読み出します。</p>
     <h3>入力</h3>
     <dl class="message-properties">
@@ -44,8 +44,6 @@
         <dd>ファイルの内容を文字列もしくはバッファで表現します</dd>
         <dt class="optional">filename <span class="property-type">文字列</span></dt>
         <dd>読み出し対象のファイル名をノードに設定していない場合、このプロパティでファイルを指定します</dd>
-        <dt class="optional">error <span class="property-type">オブジェクト</span></dt>
-        <dd><i>非推奨</i>: 設定で有効にした場合、ファイルの読み込み時にエラーが発生すると<code>payload</code>を持たず<code>error</code>プロパティにエラーの詳細情報を設定したメッセージを送信します。この動作モードは非推奨であり、新しいノード実装ではデフォルトでは無効としています。詳細については、以下を参照してください。</dd>
     </dl>
     <h3>詳細</h3>
     <p>ファイルネームは絶対パスでの指定を推奨します。絶対パスを指定しない場合は、Node-REDプロセスのワーキングディレクトリからの相対パスとして扱います。</p>
@@ -53,7 +51,5 @@
     <p>テキストファイルの場合、行毎に分割して各々メッセージを送信することができます。また、バイナリファイルの場合、小さな塊のバッファに分割して送信できます。バッファの分割単位はオペレーティングシステム依存ですが、一般に64k(Linux/Mac)もしくは41k(Windows)です。</p>
     <p>複数のメッセージに分割する場合、各メッセージには<code>parts</code>プロパティが設定され、メッセージ列を構成します。</p>
     <p>出力形式が文字列の場合、入力データのエンコーディングをエンコーディングリストから選択できます。</p>
-    <h4>旧式のエラー処理</h4>
-    <p>Node-RED 0.17より前の版では、ファイルの読み込み時にエラーが発生すると<code>payload</code>を持たず<code>error</code>プロパティにエラーの詳細情報を設定したメッセージを送信します。この動作モードは非推奨であり、新しいノード実装ではデフォルトでは無効としています。ノードの設定により、必要に応じてこのモードを有効にできます。</p>
     <p>エラーはcatchノードで補足して処理することを推奨します。</p>
 </script>

--- a/packages/node_modules/@node-red/nodes/locales/zh-CN/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/locales/zh-CN/storage/10-file.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="file">
+<script type="text/html" data-help-name="file">
     <p>将<code>msg.payload</code>写入文件，添加到末尾或替换现有内容。或者，它也可以删除文件。</p>
     <h3>输入</h3>
     <dl class="message-properties">
@@ -31,7 +31,7 @@
     <p>您可以将此节点配置为删除文件。</p>
 </script>
 
-<script type="text/x-red" data-help-name="file in">
+<script type="text/html" data-help-name="file in">
     <p>以字符串或二进制缓冲区的形式读取文件的内容。</p>
     <h3>输入</h3>
     <dl class="message-properties">
@@ -44,8 +44,6 @@
         <dd>文件的内容可以是字符串，也可以是二进制的buffer。</dd>
         <dt class="optional">filename <span class="property-type">字符串</span></dt>
         <dd>如果未在节点配置中设置，该属性可以选择要读取的文件名。</dd>
-        <dt class="optional">error <span class="property-type">object</span></dt>
-        <dd><i>已不推荐使用</i>: 如果在节点中启用，则当节点在读取文件时遇到错误时，它将发送一条没有<code>有效荷载</code>的消息，且将消息的<code>error</code>属性设置为错误的详细信息。在默认情况下，此行为模式已弃用且未启用。 请参阅下面的详细信息。</dd>
     </dl>
     <h3>详细</h3>
     <p>文件名应该是绝对路径，否则将相对于Node-RED进程的工作目录。</p>
@@ -53,7 +51,5 @@
     <p>可以选择将文本文件拆分为几行，每行输出一条消息，或者将二进制文件拆分为较小的buffer块-块大小取决于操作系统，但通常为64k（Linux/Mac）或41k（Windows）。</p>
     <p>当拆分为多条消息时，每条消息将具有<code>parts</code>属性集，从而形成完整的消息序列。</p>
     <p>如果输出格式为字符串，则可以从编码列表中指定输入数据的编码。</p>
-    <h4>旧版的错误处理</h4>
-    <p>在Node-RED 0.17之前，如果此节点在读取文件时遇到错误，它将发送一条不包含<code>msg.payload</code>，但包含<code>msg.error</code>的消息。在<code>msg.error</code>中记录详细的错误内容。但这是模式已被弃用，默认未启用。如有需要，您可以在节点配置中重新启用该模式。</p>
     <p>应该使用Catch节点来捕获并处理错误。</p>
 </script>

--- a/packages/node_modules/@node-red/nodes/locales/zh-TW/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/locales/zh-TW/storage/10-file.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="file">
+<script type="text/html" data-help-name="file">
     <p>將<code>msg.payload</code>寫入文件，添加到末尾或替換現有內容。或者，它也可以刪除文件。</p>
     <h3>輸入</h3>
     <dl class="message-properties">
@@ -31,7 +31,7 @@
     <p>您可以將此節點配置爲刪除文件。</p>
 </script>
 
-<script type="text/x-red" data-help-name="file in">
+<script type="text/html" data-help-name="file in">
     <p>以字符串或二進制緩衝區的形式讀取文件的內容。</p>
     <h3>輸入</h3>
     <dl class="message-properties">
@@ -44,8 +44,6 @@
         <dd>文件的內容可以是字符串，也可以是二進制的buffer。</dd>
         <dt class="optional">filename <span class="property-type">字符串</span></dt>
         <dd>如果未在節點配置中設置，該屬性可以選擇要讀取的文件名。</dd>
-        <dt class="optional">error <span class="property-type">object</span></dt>
-        <dd><i>已不推薦使用</i>: 如果在節點中啓用，則當節點在讀取文件時遇到錯誤時，它將發送一條沒有<code>有效荷載</code>的消息，且將消息的<code>error</code>屬性設置爲錯誤的詳細信息。在默認情況下，此行爲模式已棄用且未啓用。 請參閱下面的詳細信息。</dd>
     </dl>
     <h3>詳細</h3>
     <p>文件名應該是絕對路徑，否則將相對于Node-RED進程的工作目錄。</p>
@@ -53,7 +51,5 @@
     <p>可以選擇將文本文件拆分爲幾行，每行輸出一條消息，或者將二進制文件拆分爲較小的buffer塊-塊大小取決于操作系統，但通常爲64k（Linux/Mac）或41k（Windows）。</p>
     <p>當拆分爲多條消息時，每條消息將具有<code>parts</code>屬性集，從而形成完整的消息序列。</p>
     <p>如果輸出格式爲字符串，則可以從編碼列表中指定輸入數據的編碼。</p>
-    <h4>舊版的錯誤處理</h4>
-    <p>在Node-RED 0.17之前，如果此節點在讀取文件時遇到錯誤，它將發送一條不包含<code>msg.payload</code>，但包含<code>msg.error</code>的消息。在<code>msg.error</code>中記錄詳細的錯誤內容。但這是模式已被棄用，默認未啓用。如有需要，您可以在節點配置中重新啓用該模式。</p>
     <p>應該使用Catch節點來捕獲並處理錯誤。</p>
 </script>


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I applied updates (https://github.com/node-red/node-red/commit/b165129388f37f2f8b873016c1cc346b9aaf0185 and https://github.com/node-red/node-red/commit/09d55a0cbdff545f59138c232163283dfe0fde65) of English messages on file node property to Japanese and Chinese ones.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality