### PR TITLE
fix tab appearance of subflow template panel

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -2423,15 +2423,16 @@ RED.editor = (function() {
                 buildAppearanceForm(appearanceTab.content,editing_node);
                 editorTabs.addTab(appearanceTab);
 
+                buildEditForm(nodePropertiesTab.content,"dialog-form","subflow-template", undefined, editing_node);
+                trayBody.i18n();
+
                 $.getJSON(getCredentialsURL("subflow", subflow.id), function (data) {
                     subflow.credentials = data;
                     subflow.credentials._ = $.extend(true,{},data);
 
-                    buildEditForm(nodePropertiesTab.content,"dialog-form","subflow-template", undefined, editing_node);
                     $("#subflow-input-name").val(subflow.name);
                     RED.text.bidi.prepareInput($("#subflow-input-name"));
 
-                    trayBody.i18n();
                     finishedBuilding = true;
                     done();
                 });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Subflow template editing panel has three configuration tabs.  But, when opening the panel, only one icon is shown as below.

<!-- Describe the nature of this change. What problem does it address? -->
<img width="527" alt="スクリーンショット 2020-03-15 8 17 39" src="https://user-images.githubusercontent.com/30289092/76692221-bc63b500-6696-11ea-8192-51dd1d93292b.png">

After clicking the appearance icon, properties icon is shown.

<img width="527" alt="スクリーンショット 2020-03-15 8 17 49" src="https://user-images.githubusercontent.com/30289092/76692222-cdacc180-6696-11ea-86e1-c3e16fc748a4.png">

Then after clicking icon, descriptions icon is shown.

<img width="527" alt="スクリーンショット 2020-03-15 8 18 06" src="https://user-images.githubusercontent.com/30289092/76692234-faf96f80-6696-11ea-8c65-18ad2559c5e7.png">

This seems to be caused by a move of tab construction code into callback function.
This PR fixes this problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
