### PR TITLE
Add Japanese translation for join node

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -892,7 +892,8 @@
             "fixup": "最終調整式"
         },
         "errors": {
-            "invalid-expr": "JSONata式が不正: __error__"
+            "invalid-expr": "JSONata式が不正: __error__",
+            "invalid-type": "__error__ をバッファに連結できません"
         }
     },
     "sort": {

--- a/packages/node_modules/@node-red/nodes/locales/ja/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/sequence/17-split.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 
-<script type="text/x-red" data-help-name="split">
+<script type="text/html" data-help-name="split">
     <p>メッセージをメッセージ列に分割します。</p>
 
     <h3>入力</h3>
@@ -52,8 +52,7 @@
     <p>このモードで処理する際には、メッセージ数を予め知ることができないため、<code>msg.parts.count</code>プロパティは設定されません。従って、<b>join</b>ノードの「自動モード」と組み合わせることはできません。</p>
 </script>
 
-
-<script type="text/x-red" data-help-name="join">
+<script type="text/html" data-help-name="join">
     <p>メッセージ列を結合して一つのメッセージにします。</p>
     <p>メッセージの結合には次の3つのモードが利用できます。</p>
     <dl>
@@ -79,7 +78,7 @@
         </ul>
         </dd>
         <dt class="optional">complete</dt>
-        <dd>設定されている場合、保持しているメッセージを結合して送信します。</dd>
+        <dd>設定されている場合、本ノードはペイロードを追加し、保持しているメッセージを送信します。ペイロードを追加したくない場合は、msgから削除してください。</dd>
     </dl>
     <h3>詳細</h3>
 


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Because English messages of the join node was updated in the commit, https://github.com/node-red/node-red/commit/85a1f59a93664e317934b3beac7f9de60f00b1c9, I added translation of that in this commit.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality