### PR TITLE
Fix: Remove nodejs deprecation warning in 21-httpin node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/21-httpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httpin.js
@@ -228,7 +228,7 @@ module.exports = function(RED) {
                             var diff = process.hrtime(startAt);
                             var ms = diff[0] * 1e3 + diff[1] * 1e-6;
                             var metricResponseTime = ms.toFixed(3);
-                            var metricContentLength = res._headers["content-length"];
+                            var metricContentLength = res.getHeader("content-length");
                             //assuming that _id has been set for res._metrics in HttpOut node!
                             node.metric("response.time.millis", {_msgid:res._msgid} , metricResponseTime);
                             node.metric("response.content-length.bytes", {_msgid:res._msgid} , metricContentLength);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
There is a deprecation warning during http requests when metrics enabled:
`(node:87599) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated` 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
