### PR TITLE
Activate project menu after initial clone

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/projects/projects.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/projects/projects.js
@@ -685,6 +685,8 @@ RED.projects = (function() {
                                             }
                                         }
                                     },projectData).then(function() {
+                                        RED.menu.setDisabled('menu-item-projects-open',false);
+                                        RED.menu.setDisabled('menu-item-projects-settings',false);
                                         RED.events.emit("project:change", {name:name});
                                     }).always(function() {
                                         setTimeout(function() {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
In the `Projects` menu, the `Open` and `Project Settings` are disabled after enabling project feature and initial cloning of a project from a remote repository.
This PR fixes this problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
