### PR TITLE
Refresh https settings

### DIFF
--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -143,7 +143,46 @@ if (process.env.NODE_RED_ENABLE_PROJECTS) {
 }
 
 if (settings.https) {
-    server = https.createServer(settings.https,function(req,res) {app(req,res);});
+    var startupHttps = settings.https;
+    
+    if (typeof startupHttps === "function") {
+        // Get the result of the function, because createServer doesn't accept functions as input
+        startupHttps = startupHttps(); 
+    }  
+
+    server = https.createServer(startupHttps,function(req,res) {app(req,res);});
+    
+    // Refresh https settings at intervals for NodeJs version 11 and above
+    if (settings.httpsRefreshInterval) {
+        if (typeof startupHttps === "function") {        
+            if (server.setSecureContext) {
+                console.log("Refreshing https settings every " + parseInt(settings.credentialRenewalTime) + " seconds.");
+                setInterval(function () {
+                    try {
+                        // Get the result of the function, because createServer doesn't accept functions as input
+                        var refreshedHttps = settings.https();
+                        
+                        if (!refreshedHttps.key || !refreshedHttps.cert) {
+                            console.log("Cannot refresh the https settings when the https property function doesn't return a 'key' and 'cert'.");
+                            return;
+                        }
+                            
+                        // Only update the credentials in the server when key or cert has changed
+                        if(!server.key || !server.cert || !server.key.equals(refreshedHttps.key) || !server.cert.equals(refreshedHttps.cert)) {
+                            server.setSecureContext(refreshedHttps);
+                            console.log("The https settings have been refreshed.");
+                        }
+                    } catch(err) {
+                        console.log("Failed to refresh the https settings: " + err);
+                    }
+                }, parseInt(settings.credentialRenewalTime) * 1000);
+            } else {
+                console.log("Cannot refresh the https settings automatically, because NodeJs version 11 or above is required.");
+            }
+        } else {
+            console.log("Cannot refresh the https settings automatically (at httpsRefreshInterval), because the https property needs to be a function.");
+        } 
+    }
 } else {
     server = http.createServer(function(req,res) {app(req,res);});
 }

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -139,13 +139,24 @@ module.exports = {
     // The following property can be used to enable HTTPS
     // See http://nodejs.org/api/https.html#https_https_createserver_options_requestlistener
     // for details on its contents.
-    // See the comment at the top of this file on how to load the `fs` module used by
-    // this setting.
-    //
+    // See the comment at the top of this file on how to load the `fs` module used by this setting.
+    // This property can be an object, containing both a (private) key and a (public) certificate:
     //https: {
-    //    key: fs.readFileSync('privatekey.pem'),
-    //    cert: fs.readFileSync('certificate.pem')
+    //  key: fs.readFileSync('privkey.pem'),
+    //  cert: fs.readFileSync('cert.pem')
     //},
+    // This property can also be a function (e.g. to automatic refresh the https settings):
+    //https: function() {
+    //     return {
+    //         key: fs.readFileSync('privkey.pem'),
+    //         cert: fs.readFileSync('cert.pem')
+    //     }
+    //},
+
+    // The following property can be used to refresh the https settings at regular time intervals (seconds).
+    // Prerequisite: the 'https' property should be enabled (based on a function)!
+    // Caution: NodeJs version 11 or above is required to use this option!
+    //httpsRefreshInterval : 3600,
 
     // The following property can be used to cause insecure HTTP connections to
     // be redirected to HTTPS.


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

When the content of the cert.pem or privkey.pem file has been updated, the server should be able to use those renewed keypairs without having to restart it.  Currently both files are only being read at startup, so it is required to restart Node-RED every time the files are updated.

This pull request contains following major changes:
+ The existing ```https``` setting in the settings.js file can now also be a function, which is required to make sure that the readFileSync function result isn't cached.
+ A new ```httpsRefreshInterval``` setting has been added to the settings.js file, to determine the refresh interval (in seconds).
+ The red.js file will start a timer when the interval has been specified.

This pull request has been discussed on [Discourse](https://discourse.nodered.org/t/pull-request-proposal-automatic-certificate-renewal/21282).  I think that all changes - that Nick has requested so far - are  implemented, except from this one:

> if https is a function, it should be able to return either the Object itself, or a Promise that resolves to the object. This will allow the function to perform asynchronous actions, such as re-reading files etc.

Not sure I understand this request correctly: currently I return a function, which which allows me to re-read the files over and over again without any problems.   The content of both files are not cached anymore.  Would be nice if you could clarify this a bit, because I'm not using promises that much ...

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
