### PR TITLE
Add httpAdminMiddleware to allow custom headers on admin routes

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/index.js
@@ -59,6 +59,12 @@ function init(settings,_server,storage,runtimeAPI) {
         });
         adminApp.use(corsHandler);
 
+        if (settings.httpAdminMiddleware) {
+            if (typeof settings.httpAdminMiddleware === "function") {
+                adminApp.use(settings.httpAdminMiddleware)
+            }
+        }
+
         auth.init(settings,storage);
 
         var maxApiRequestSize = settings.apiMaxLength || '5mb';

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -182,6 +182,17 @@ module.exports = {
     //    next();
     //},
 
+
+    // The following property can be used to add a custom middleware function
+    // in front of all admin http routes. For example, to set custom http
+    // headers
+    // httpAdminMiddleware: function(req,res,next) {
+    //    // Set the X-Frame-Options header to limit where the editor
+    //    // can be embedded
+    //    //res.set('X-Frame-Options', 'sameorigin');
+    //    next();
+    // },
+
     // The following property can be used to pass custom options to the Express.js
     // server used by Node-RED. For a full list of available options, refer
     // to http://expressjs.com/en/api.html#app.settings.table


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Adds `httpAdminMiddleware` as a new optional setting that works in the same way as the existing `httpNodeMiddleware` setting, but is applied to the HTTP Admin routes.

This will allow, for example, for custom http headers to be added to all admin routes. 

The example in the settings file does this:

```
     httpAdminMiddleware: function(req,res,next) {
        // Set the X-Frame-Options header to limit where the editor
        // can be embedded
        res.set('X-Frame-Options', 'sameorigin');
        next();
     },
```

which can be used to restrict how the editor is iframed into other pages.

