### PR TITLE
Add Japanese translations for grouping nodes

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -15,8 +15,10 @@
             "next": "Next",
             "clone": "Clone project",
             "cont": "Continue",
+            "style": "Style",
             "line": "Outline",
             "fill": "Fill",
+            "label": "Label",
             "color": "Color",
             "position": "Position"
         },
@@ -1001,7 +1003,7 @@
             "retry": "Retry",
             "update-failed": "Failed to update auth",
             "unhandled": "Unhandled error response",
-            "host-key-verify-failed": "<p>Host key verification failed.</p><p>The repository host key could not be verified. Please update your <code>known_hosts</code> file and try again."
+            "host-key-verify-failed": "<p>Host key verification failed.</p><p>The repository host key could not be verified. Please update your <code>known_hosts</code> file and try again.</p>"
         },
         "create-branch-list": {
             "invalid": "Invalid branch",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -14,7 +14,13 @@
             "back": "戻る",
             "next": "進む",
             "clone": "プロジェクトをクローン",
-            "cont": "続ける"
+            "cont": "続ける",
+            "style": "形式",
+            "line": "線",
+            "fill": "塗りつぶし",
+            "label": "ラベル",
+            "color": "色",
+            "position": "配置"
         },
         "type": {
             "string": "文字列",
@@ -91,7 +97,12 @@
             "projects-new": "新規",
             "projects-open": "開く",
             "projects-settings": "設定",
-            "showNodeLabelDefault": "追加したノードのラベルを表示"
+            "showNodeLabelDefault": "追加したノードのラベルを表示",
+            "groups": "グループ",
+            "groupSelection": "選択部分をグループ化",
+            "ungroupSelection": "選択部分をグループ解除",
+            "groupMergeSelection": "選択部分をマージ",
+            "groupRemoveSelection": "グループから削除"
         }
     },
     "actions": {
@@ -171,6 +182,8 @@
         "node_plural": "__count__ 個のノード",
         "configNode": "__count__ 個の設定ノード",
         "configNode_plural": "__count__ 個の設定ノード",
+        "group": "__count__ 個のグループ",
+        "group_plural": "__count__ 個のグループ",
         "flow": "__count__ 個のフロー",
         "flow_plural": "__count__ 個のフロー",
         "subflow": "__count__ 個のサブフロー",
@@ -186,6 +199,9 @@
         "nodesImported": "読み込みました:",
         "nodeCopied": "__count__ 個のノードをコピーしました",
         "nodeCopied_plural": "__count__ 個のノードをコピーしました",
+        "groupCopied": "__count__ 個のグループをコピーしました",
+        "groupCopied_plural": "__count__ 個のグループをコピーしました",
+        "groupStyleCopied": "グループの形式をコピーしました",
         "invalidFlow": "不正なフロー: __message__",
         "export": {
             "selected": "選択したフロー",
@@ -306,6 +322,13 @@
         "errors": {
             "noNodesSelected": "<strong>サブフローを作成できません</strong>: ノードが選択されていません",
             "multipleInputsToSelection": "<strong>サブフローを作成できません</strong>: 複数の入力が選択されています"
+        }
+    },
+    "group": {
+        "editGroup": "__name__ グループを編集",
+        "errors": {
+            "cannotCreateDiffGroups": "異なるグループのノードを使用してグループを作成することはできません",
+            "cannotAddSubflowPorts": "グループにサブフローの端子を追加できません"
         }
     },
     "editor": {
@@ -539,6 +562,7 @@
             "label": "情報",
             "node": "ノード",
             "type": "型",
+            "group": "グループ",
             "module": "モジュール",
             "id": "ID",
             "status": "状態",
@@ -614,9 +638,9 @@
                 "removeFromProject": "プロジェクトから削除",
                 "addToProject": "プロジェクトへ追加",
                 "files": "ファイル",
-                "package": "パッケージ",
                 "flow": "フロー",
                 "credentials": "認証情報",
+                "package": "パッケージ",
                 "packageCreate": "変更が保存された時にファイルが作成されます",
                 "fileNotExist": "ファイルが存在しません",
                 "selectFile": "ファイルを選択",
@@ -757,7 +781,8 @@
             "bin": "バッファ",
             "date": "日時",
             "jsonata": "JSONata式",
-            "env": "環境変数"
+            "env": "環境変数",
+            "cred": "認証情報"
         }
     },
     "editableList": {
@@ -977,7 +1002,8 @@
             "passphrase": "パスフレーズ",
             "retry": "リトライ",
             "update-failed": "認証の更新に失敗しました",
-            "unhandled": "エラー応答が処理されませんでした"
+            "unhandled": "エラー応答が処理されませんでした",
+            "host-key-verify-failed": "<p>ホストキーの検証に失敗</p><p>リポジトリのホストキーを検証できませんでした。<code>known_hosts</code>ファイルを更新して、もう一度試してください。</p>"
         },
         "create-branch-list": {
             "invalid": "不正なブランチ",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
@@ -25,14 +25,14 @@ RED.group = (function() {
         // '<div class="node-input-group-style-tools"><span class="button-group"><button class="red-ui-button red-ui-button-small">Use default style</button><button class="red-ui-button red-ui-button-small">Set as default style</button></span></div>'+
 
         '<div class="form-row" id="node-input-row-style-stroke">'+
-            '<label>Style</label>'+
+            '<label data-i18n="editor:common.label.style"></label>'+
             '<label style="width: 70px;margin-right:10px" for="node-input-style-stroke" data-i18n="editor:common.label.line"></label>'+
         '</div>'+
         '<div class="form-row" style="padding-left: 100px;" id="node-input-row-style-fill">'+
             '<label style="width: 70px;margin-right: 10px "  for="node-input-style-fill" data-i18n="editor:common.label.fill"></label>'+
         '</div>'+
         '<div class="form-row">'+
-            '<label for="node-input-style-label">Label</label>'+
+            '<label for="node-input-style-label" data-i18n="editor:common.label.label"></label>'+
             '<input type="checkbox" id="node-input-style-label"/>'+
         '</div>'+
         '<div class="form-row" id="node-input-row-style-label-options">'+

--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -37,6 +37,7 @@
         "stopped": "stopped",
         "failed": "inject失敗: __error__",
         "label": {
+            "properties": "プロパティ",
             "repeat": "繰り返し",
             "flow": "フローコンテクスト",
             "global": "グローバルコンテクスト",
@@ -79,7 +80,6 @@
         "on": "曜日",
         "onstart": "Node-RED起動の",
         "onceDelay": "秒後、以下を行う",
-        "tip": "<b>注釈:</b> 「指定した時間間隔、日時」と「指定した日時」はcronを使用します。<br/>「時間間隔」には596時間より小さな値を指定します。<br/>詳細はノードの「情報」を確認してください。",
         "success": "inject処理を実行しました: __label__",
         "errors": {
             "failed": "inject処理が失敗しました。詳細はログを確認してください。",
@@ -310,7 +310,8 @@
             "m": "分",
             "h": "時間"
         },
-        "extend": " 新たなメッセージを受け取った時に遅延を延長",
+        "extend": "新たなメッセージを受け取った時に遅延を延長",
+        "second": "2つ目の出力端子に2番目のメッセージを送信",
         "label": {
             "trigger": "trigger",
             "trigger-block": "trigger & block",
@@ -696,7 +697,9 @@
             "output": "出力",
             "includerow": "1行目を列名とする",
             "newline": "改行コード",
-            "usestrings": "数値を変換する"
+            "usestrings": "数値を変換する",
+            "include_empty_strings": "空の文字を含む",
+            "include_null_values": "null値を含む"
         },
         "placeholder": {
             "columns": "コンマ区切りで列名を入力"


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
While I tried the functionality of grouping nodes, I translated English messages to Japanese.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality