### PR TITLE
Update inject node error handling

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.js
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.js
@@ -45,6 +45,19 @@ module.exports = function(RED) {
         this.cronjob = null;
         var node = this;
 
+        node.props.forEach(function (prop) {
+            if (prop.vt === "jsonata") {
+                try {
+                    var val = prop.v ? prop.v : "";
+                    prop.exp = RED.util.prepareJSONataExpression(val, node);
+                }
+                catch (err) {
+                    node.error(RED._("inject.errors.invalid-expr", {error:err.message}));
+                    prop.exp = null;
+                }
+            }
+        });
+
         if (node.repeat > 2147483) {
             node.error(RED._("inject.errors.toolong", this));
             delete node.repeat;
@@ -86,10 +99,22 @@ module.exports = function(RED) {
 
                 if (!property) return;
 
+                if (valueType === "jsonata") {
+                    if (p.exp) {
+                        try {
+                            var val = RED.util.evaluateJSONataExpression(p.exp, msg);
+                            RED.util.setMessageProperty(msg, property, val, true);
+                        }
+                        catch  (err) {
+                            errors.push(err.message);
+                        }
+                    }
+                    return;
+                }
                 try {
                     RED.util.setMessageProperty(msg,property,RED.util.evaluateNodeProperty(value, valueType, this, msg),true);
                 } catch (err) {
-                    errors.push(err);
+                    errors.push(err.toString());
                 }
             });
 

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -83,7 +83,8 @@
         "success": "Successfully injected: __label__",
         "errors": {
             "failed": "inject failed, see log for details",
-            "toolong": "Interval too large"
+            "toolong": "Interval too large",
+            "invalid-expr": "Invalid JSONata expression: __error__"
         }
     },
     "catch": {

--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -83,7 +83,8 @@
         "success": "inject処理を実行しました: __label__",
         "errors": {
             "failed": "inject処理が失敗しました。詳細はログを確認してください。",
-            "toolong": "時間間隔が大き過ぎます"
+            "toolong": "時間間隔が大き過ぎます",
+            "invalid-expr": "JSONata式が不正: __error__"
         }
     },
     "catch": {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
New properties definition interface of inject node allow use of JSONata expression that is useful for creating values using logics.  

However, in the current implementation, if an error occurs in a JSONata expression, the node's error output become "[object Object]" at runtime.  On the other hand, in change node, an error of JSONata expression is reported at deployment time.

This fix ensures that the message is output correctly and change the behavior in line with the current change node.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
