### PR TITLE
Fix description of grouping nodes

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -2635,6 +2635,7 @@ RED.editor = (function() {
                 if (RED.view.state() != RED.state.IMPORT_DRAGGING) {
                     RED.view.state(RED.state.DEFAULT);
                 }
+                RED.sidebar.info.refresh(editing_node);
                 nodeInfoEditor.destroy();
                 nodeInfoEditor = null;
                 editStack.pop();


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
The current dev version of the Node-RED flow editor doesn't show the description about a group on the info tab after users input the description. To show the description, they need to unselect the group and select it again.

![fixgrouping](https://user-images.githubusercontent.com/20310935/81768863-080bd100-9517-11ea-8dc7-1529a3d9938b.gif)

Therefore, I added the code to reflect the description on the info tab immediately after inputting the text.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality