### PR TITLE
Let debug node show status indpendent of main output

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.html
@@ -377,12 +377,16 @@
                 }
             });
 
-
             $("#node-input-tostatus").on('change',function() {
                 if ($(this).is(":checked")) {
                     if (!that.hasOwnProperty("statusVal") || that.statusVal === "") {
-                        that.statusType = "msg";
-                        that.statusVal = (that.complete === "false") ? "payload" : ((that.complete === "true") ? "payload" : that.complete+"");  
+                        var type = $("#node-input-typed-complete").typedInput('type');
+                        var comp = "payload";
+                        if (type !== 'full') {
+                            comp = $("#node-input-typed-complete").typedInput('value');
+                        }
+                        that.statusType = (type !== "jsonata") ? "msg" : "jsonata";
+                        that.statusVal = comp;
                     }
                     $("#node-input-typed-status").typedInput('type',that.statusType);
                     $("#node-input-typed-status").typedInput('value',that.statusVal);

--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.html
@@ -52,7 +52,7 @@
             complete: {value:"false", required:true},
             targetType: {value:undefined},
             statusVal: {value:""},
-            statusType: {value:"msg"}
+            statusType: {value:"auto"}
         },
         label: function() {
             var suffix = "";
@@ -318,9 +318,14 @@
             delete RED._debug;
         },
         oneditprepare: function() {
+            var autoType = {
+                value: "auto",
+                label: RED._("node-red:debug.autostatus"),
+                hasValue: false
+            };
             $("#node-input-typed-status").typedInput({
-                default: "msg",
-                types:['msg',"jsonata"],
+                default: "auto",
+                types:[autoType, "msg", "jsonata"],
                 typeField: $("#node-input-statusType")
             });
             var that = this;
@@ -339,7 +344,7 @@
             }
             if (this.statusType === undefined) {
                 this.statusType = this.targetType;
-                $("#node-input-typed-status").typedInput('type',this.statusType || "msg");
+                $("#node-input-typed-status").typedInput('type',this.statusType || "auto");
             }
             if (typeof this.console === "string") {
                 this.console = (this.console == 'true');
@@ -385,7 +390,7 @@
                         if (type !== 'full') {
                             comp = $("#node-input-typed-complete").typedInput('value');
                         }
-                        that.statusType = (type !== "jsonata") ? "msg" : "jsonata";
+                        that.statusType = "auto";
                         that.statusVal = comp;
                     }
                     $("#node-input-typed-status").typedInput('type',that.statusType);
@@ -394,7 +399,7 @@
                 }
                 else {
                     $("#node-tostatus-line").hide();
-                    that.statusType = "msg";
+                    that.statusType = "auto";
                     that.statusVal = "";
                     $("#node-input-typed-status").typedInput('type',that.statusType);
                     $("#node-input-typed-status").typedInput('value',that.statusVal);

--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.html
@@ -6,24 +6,29 @@
         <input id="node-input-complete" type="hidden">
         <input id="node-input-targetType" type="hidden">
     </div>
-
     <div class="form-row">
         <label for="node-input-tosidebar"><i class="fa fa-random"></i> <span data-i18n="debug.to"></span></label>
         <label for="node-input-tosidebar" style="width:70%">
-        <input type="checkbox" id="node-input-tosidebar" style="display:inline-block; width:22px; vertical-align:baseline;"><span data-i18n="debug.toSidebar"></span>
+        <input type="checkbox" id="node-input-tosidebar" style="display:inline-block; width:22px; vertical-align:top;"><span data-i18n="debug.toSidebar"></span>
         </label>
     </div>
     <div class="form-row">
         <label for="node-input-console"> </label>
         <label for="node-input-console" style="width:70%">
-        <input type="checkbox" id="node-input-console" style="display:inline-block; width:22px; vertical-align:baseline;"><span data-i18n="debug.toConsole"></span>
+        <input type="checkbox" id="node-input-console" style="display:inline-block; width:22px; vertical-align:top;"><span data-i18n="debug.toConsole"></span>
         </label>
     </div>
-    <div class="form-row" id="node-tostatus-line">
+    <div class="form-row">
     <label for="node-input-tostatus"> </label>
     <label for="node-input-tostatus" style="width:70%">
-        <input type="checkbox" id="node-input-tostatus" style="display:inline-block; width:22px; vertical-align:baseline;"><span data-i18n="debug.toStatus"></span>
+        <input type="checkbox" id="node-input-tostatus" style="display:inline-block; width:22px; vertical-align:top;"><span data-i18n="debug.toStatus"></span>
     </label>
+    </div>
+    <div class="form-row" id="node-tostatus-line">
+        <label for="node-input-typed-status"><i class="fa fa-ellipsis-h"></i> <span data-i18n="debug.status"></span></label>
+        <input id="node-input-typed-status" type="text" style="width: 70%">
+        <input id="node-input-statusVal" type="hidden">
+        <input id="node-input-statusType" type="hidden">
     </div>
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
@@ -45,7 +50,9 @@
             console: {value:false},
             tostatus: {value:false},
             complete: {value:"false", required:true},
-            targetType: {value:undefined}
+            targetType: {value:undefined},
+            statusVal: {value:""},
+            statusType: {value:"msg"}
         },
         label: function() {
             var suffix = "";
@@ -308,7 +315,6 @@
             window.removeEventListener("message",this.handleWindowMessage);
             RED.actions.remove("core:show-debug-tab");
             RED.actions.remove("core:clear-debug-messages");
-
             delete RED._debug;
         },
         oneditprepare: function() {
@@ -331,6 +337,7 @@
                 label: RED._("node-red:debug.msgobj"),
                 hasValue: false
             };
+
             $("#node-input-typed-complete").typedInput({
                 default: "msg",
                 types:['msg', fullType, "jsonata"],
@@ -354,17 +361,30 @@
                 ) {
                     $("#node-input-typed-complete").typedInput('value','payload');
                 }
-                if ($("#node-input-typed-complete").typedInput('type') === 'full') {
-                    $("#node-tostatus-line").hide();
-                } else {
+            });
+
+            $("#node-input-typed-status").typedInput({
+                default: "msg",
+                types:['msg',"jsonata"],
+                typeField: $("#node-input-statusType")
+            });
+            var that = this;
+            $("#node-input-tostatus").on('change',function() {
+                if ($(this).is(":checked")) {
+                    if (!that.hasOwnProperty("statusVal") || that.statusVal === "") {
+                        that.statusType = "msg";
+                        that.statusVal = (that.complete === "false") ? "payload" : ((that.complete === "true") ? "payload" : that.complete+"");  
+                    }
+                    $("#node-input-typed-status").typedInput('type',that.statusType);
+                    $("#node-input-typed-status").typedInput('value',that.statusVal);
                     $("#node-tostatus-line").show();
                 }
-            });
-            $("#node-input-complete").on('change',function() {
-                if ($("#node-input-typed-complete").typedInput('type') === 'full') {
+                else {
                     $("#node-tostatus-line").hide();
-                } else {
-                    $("#node-tostatus-line").show();
+                    that.statusType = "msg";
+                    that.statusVal = "";
+                    $("#node-input-typed-status").typedInput('type',that.statusType);
+                    $("#node-input-typed-status").typedInput('value',that.statusVal);
                 }
             });
         },
@@ -375,6 +395,7 @@
             } else {
                 $("#node-input-complete").val($("#node-input-typed-complete").typedInput('value'));
             }
+            $("#node-input-statusVal").val($("#node-input-typed-status").typedInput('value'));
         }
     });
 })();

--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.html
@@ -318,6 +318,12 @@
             delete RED._debug;
         },
         oneditprepare: function() {
+            $("#node-input-typed-status").typedInput({
+                default: "msg",
+                types:['msg',"jsonata"],
+                typeField: $("#node-input-statusType")
+            });
+            var that = this;
             var none = {
                 value: "none",
                 label: RED._("node-red:debug.none"),
@@ -326,6 +332,14 @@
             if (this.tosidebar === undefined) {
                 this.tosidebar = true;
                 $("#node-input-tosidebar").prop('checked', true);
+            }
+            if (this.statusVal === undefined) {
+                this.statusVal = (this.complete === "false") ? "payload" : ((this.complete === "true") ? "payload" : this.complete+"");
+                $("#node-input-typed-status").typedInput('value',this.statusVal || "");
+            }
+            if (this.statusType === undefined) {
+                this.statusType = this.targetType;
+                $("#node-input-typed-status").typedInput('type',this.statusType || "msg");
             }
             if (typeof this.console === "string") {
                 this.console = (this.console == 'true');
@@ -363,12 +377,7 @@
                 }
             });
 
-            $("#node-input-typed-status").typedInput({
-                default: "msg",
-                types:['msg',"jsonata"],
-                typeField: $("#node-input-statusType")
-            });
-            var that = this;
+
             $("#node-input-tostatus").on('change',function() {
                 if ($(this).is(":checked")) {
                     if (!that.hasOwnProperty("statusVal") || that.statusVal === "") {

--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.js
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.js
@@ -15,13 +15,17 @@ module.exports = function(RED) {
         this.complete = hasEditExpression ? null : (n.complete||"payload").toString();
         if (this.complete === "false") { this.complete = "payload"; }
         this.console = ""+(n.console || false);
-        this.tostatus = (this.complete !== "true") && (n.tostatus || false);
+        this.tostatus = n.tostatus || false;
+        this.statusType = n.statusType || "msg";
+        this.statusVal = n.statusVal || this.complete;
         this.tosidebar = n.tosidebar;
         if (this.tosidebar === undefined) { this.tosidebar = true; }
         this.severity = n.severity || 40;
         this.active = (n.active === null || typeof n.active === "undefined") || n.active;
         if (this.tostatus) { this.status({fill:"grey", shape:"ring"}); }
         else { this.status({}); }
+        var hasStatExpression = (n.statusType === "jsonata");
+        var statExpression = hasStatExpression ? n.statusVal : null;
 
         var node = this;
         var levels = {
@@ -45,9 +49,19 @@ module.exports = function(RED) {
             "60": "blue"
         };
         var preparedEditExpression = null;
+        var preparedStatExpression = null;
         if (editExpression) {
             try {
                 preparedEditExpression = RED.util.prepareJSONataExpression(editExpression, this);
+            }
+            catch (e) {
+                node.error(RED._("debug.invalid-exp", {error: editExpression}));
+                return;
+            }
+        }
+        if (statExpression) {
+            try {
+                preparedStatExpression = RED.util.prepareJSONataExpression(statExpression, this);
             }
             catch (e) {
                 node.error(RED._("debug.invalid-exp", {error: editExpression}));
@@ -59,11 +73,8 @@ module.exports = function(RED) {
             // Either apply the jsonata expression or...
             if (preparedEditExpression) {
                 RED.util.evaluateJSONataExpression(preparedEditExpression, msg, (err, value) => {
-                    if (err) {
-                        done(RED._("debug.invalid-exp", {error: editExpression}));
-                    } else {
-                        done(null,{id:node.id, z:node.z, _alias: node._alias, path:node._flow.path, name:node.name, topic:msg.topic, msg:value});
-                    }
+                    if (err) { done(RED._("debug.invalid-exp", {error: editExpression})); } 
+                    else { done(null,{id:node.id, z:node.z, _alias: node._alias, path:node._flow.path, name:node.name, topic:msg.topic, msg:value}); }
                 });
             } else {
                 // Extract the required message property
@@ -71,17 +82,41 @@ module.exports = function(RED) {
                 var output = msg[property];
                 if (node.complete !== "false" && typeof node.complete !== "undefined") {
                     property = node.complete;
-                    try {
-                        output = RED.util.getMessageProperty(msg,node.complete);
-                    } catch(err) {
-                        output = undefined;
-                    }
+                    try { output = RED.util.getMessageProperty(msg,node.complete); } 
+                    catch(err) { output = undefined; }
                 }
                 done(null,{id:node.id, z:node.z, _alias: node._alias,  path:node._flow.path, name:node.name, topic:msg.topic, property:property, msg:output});
             }
         }
 
+        function prepareStatus(msg, done) {
+            // Either apply the jsonata expression or...
+            if (preparedStatExpression) {
+                RED.util.evaluateJSONataExpression(preparedStatExpression, msg, (err, value) => {
+                    if (err) { done(RED._("debug.invalid-exp", {error:editExpression})); } 
+                    else { done(null,{msg:value}); }
+                });
+            } else {
+                // Extract the required message property
+                var output;
+                try { output = RED.util.getMessageProperty(msg,node.statusVal); }
+                catch(err) { output = undefined; }
+                done(null,{msg:output});
+            }
+        }
+
         this.on("input", function(msg, send, done) {
+            if (node.tostatus === true) {
+                prepareStatus(msg,function(err,debugMsg) {
+                    if (err) { node.error(err); return; }
+                    var output = debugMsg.msg;
+                    var st = (typeof output === 'string') ? output : util.inspect(output);
+                    var severity = msg.errorlevel || node.severity;
+                    if (st.length > 32) { st = st.substr(0,32) + "..."; }
+                    node.status({fill:colors[severity] || "grey", shape:"dot", text:st});
+                });
+            }
+
             if (this.complete === "true") {
                 // debug complete msg object
                 if (this.console === "true") {
@@ -91,7 +126,8 @@ module.exports = function(RED) {
                     sendDebug({id:node.id, z:node.z, _alias: node._alias,  path:node._flow.path, name:node.name, topic:msg.topic, msg:msg});
                 }
                 done();
-            } else {
+            } 
+            else {
                 prepareValue(msg,function(err,debugMsg) {
                     if (err) {
                         node.error(err);
@@ -106,12 +142,6 @@ module.exports = function(RED) {
                         } else {
                             node.log(util.inspect(output, {colors:useColors}));
                         }
-                    }
-                    if (node.tostatus === true) {
-                        var st = (typeof output === 'string')?output:util.inspect(output);
-                        var severity = node.severity;
-                        if (st.length > 32) { st = st.substr(0,32) + "..."; }
-                        node.status({fill:colors[severity], shape:"dot", text:st});
                     }
                     if (node.active) {
                         if (node.tosidebar == true) {

--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.js
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.js
@@ -69,18 +69,32 @@ module.exports = function(RED) {
         }
 
         function prepareStatus(msg, done) {
-            // Either apply the jsonata expression or...
-            if (preparedStatExpression) {
-                RED.util.evaluateJSONataExpression(preparedStatExpression, msg, (err, value) => {
-                    if (err) { done(RED._("debug.invalid-exp", {error:editExpression})); } 
-                    else { done(null,{msg:value}); }
-                });
-            } else {
-                // Extract the required message property
-                var output;
-                try { output = RED.util.getMessageProperty(msg,node.statusVal); }
-                catch(err) { output = undefined; }
-                done(null,{msg:output});
+            if (node.statusType === "auto") {
+                if (node.complete === "true") {
+                    done(null,{msg:msg.payload});
+                }
+                else {
+                    prepareValue(msg,function(err,debugMsg) {
+                        if (err) { node.error(err); return; }
+                        done(null,{msg:debugMsg.msg});
+                    });
+                }
+            }
+            else {
+                // Either apply the jsonata expression or...
+                if (preparedStatExpression) {
+                    RED.util.evaluateJSONataExpression(preparedStatExpression, msg, (err, value) => {
+                        if (err) { done(RED._("debug.invalid-exp", {error:editExpression})); } 
+                        else { done(null,{msg:value}); }
+                    });
+                } 
+                else {
+                    // Extract the required message property
+                    var output;
+                    try { output = RED.util.getMessageProperty(msg,node.statusVal); }
+                    catch(err) { output = undefined; }
+                    done(null,{msg:output});
+                }
             }
         }
 
@@ -93,10 +107,16 @@ module.exports = function(RED) {
                     if (st.length > 32) { st = st.substr(0,32) + "..."; }
                     var fill = "grey";
                     var shape = "dot";
-                    if (node.statusVal === "error.message" && msg.hasOwnProperty("error")) { fill = "red"; }
-                    if (node.statusVal === "status.text" && msg.hasOwnProperty("status")) {
-                        if (msg.status.hasOwnProperty("fill")) { fill = msg.status.fill; }
-                        if (msg.status.hasOwnProperty("shape")) { shape = msg.status.shape; }
+                    if (node.statusType === "auto") {
+                        if (msg.hasOwnProperty("error")) { 
+                            fill = "red"; 
+                            st = msg.error.message;
+                        }
+                        if (msg.hasOwnProperty("status")) {
+                            if (msg.status.hasOwnProperty("fill")) { fill = msg.status.fill; }
+                            if (msg.status.hasOwnProperty("shape")) { shape = msg.status.shape; }
+                            if (msg.status.hasOwnProperty("text")) { st = msg.status.text; }
+                        }
                     }
                     node.status({fill:fill, shape:shape, text:st});
                 });

--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.js
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.js
@@ -2,7 +2,7 @@ module.exports = function(RED) {
     "use strict";
     var util = require("util");
     var events = require("events");
-    var path = require("path");
+    //var path = require("path");
     var debuglength = RED.settings.debugMaxLength || 1000;
     var useColors = RED.settings.debugUseColors || false;
     util.inspect.styles.boolean = "red";
@@ -20,7 +20,6 @@ module.exports = function(RED) {
         this.statusVal = n.statusVal || this.complete;
         this.tosidebar = n.tosidebar;
         if (this.tosidebar === undefined) { this.tosidebar = true; }
-        this.severity = n.severity || 40;
         this.active = (n.active === null || typeof n.active === "undefined") || n.active;
         if (this.tostatus) { this.status({fill:"grey", shape:"ring"}); }
         else { this.status({}); }
@@ -28,26 +27,6 @@ module.exports = function(RED) {
         var statExpression = hasStatExpression ? n.statusVal : null;
 
         var node = this;
-        var levels = {
-            off: 1,
-            fatal: 10,
-            error: 20,
-            warn: 30,
-            info: 40,
-            debug: 50,
-            trace: 60,
-            audit: 98,
-            metric: 99
-        };
-        var colors = {
-            "0": "grey",
-            "10": "grey",
-            "20": "red",
-            "30": "yellow",
-            "40": "grey",
-            "50": "green",
-            "60": "blue"
-        };
         var preparedEditExpression = null;
         var preparedStatExpression = null;
         if (editExpression) {
@@ -107,13 +86,19 @@ module.exports = function(RED) {
 
         this.on("input", function(msg, send, done) {
             if (node.tostatus === true) {
-                prepareStatus(msg,function(err,debugMsg) {
+                prepareStatus(msg, function(err,debugMsg) {
                     if (err) { node.error(err); return; }
                     var output = debugMsg.msg;
                     var st = (typeof output === 'string') ? output : util.inspect(output);
-                    var severity = msg.errorlevel || node.severity;
                     if (st.length > 32) { st = st.substr(0,32) + "..."; }
-                    node.status({fill:colors[severity] || "grey", shape:"dot", text:st});
+                    var fill = "grey";
+                    var shape = "dot";
+                    if (node.statusVal === "error.message" && msg.hasOwnProperty("error")) { fill = "red"; }
+                    if (node.statusVal === "status.text" && msg.hasOwnProperty("status")) {
+                        if (msg.status.hasOwnProperty("fill")) { fill = msg.status.fill; }
+                        if (msg.status.hasOwnProperty("shape")) { shape = msg.status.shape; }
+                    }
+                    node.status({fill:fill, shape:shape, text:st});
                 });
             }
 

--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.js
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.js
@@ -104,7 +104,6 @@ module.exports = function(RED) {
                     if (err) { node.error(err); return; }
                     var output = debugMsg.msg;
                     var st = (typeof output === 'string') ? output : util.inspect(output);
-                    if (st.length > 32) { st = st.substr(0,32) + "..."; }
                     var fill = "grey";
                     var shape = "dot";
                     if (node.statusType === "auto") {
@@ -118,6 +117,7 @@ module.exports = function(RED) {
                             if (msg.status.hasOwnProperty("text")) { st = msg.status.text; }
                         }
                     }
+                    if (st.length > 32) { st = st.substr(0,32) + "..."; }
                     node.status({fill:fill, shape:shape, text:st});
                 });
             }

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -123,6 +123,7 @@
         "invalid-exp": "Invalid JSONata expression: __error__",
         "msgprop": "message property",
         "msgobj": "complete msg object",
+        "autostatus": "automatic",
         "to": "To",
         "debtab": "debug tab",
         "tabcon": "debug tab and console",

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -118,6 +118,7 @@
     },
     "debug": {
         "output": "Output",
+        "status": "status",
         "none": "None",
         "invalid-exp": "Invalid JSONata expression: __error__",
         "msgprop": "message property",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

The PR lets the Debug node set it's status (under the node) independent of the main side bar and console outputs. It can select a msg.property or use a JSONata expression
![image](https://user-images.githubusercontent.com/5375409/81949442-c48a9300-95fa-11ea-9854-db5a2313cf58.png)



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
