### PR TITLE
Fix outliner display of newly created subflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
@@ -346,6 +346,10 @@ RED.sidebar.info.outliner = (function() {
             if (!parent) {
                 globalConfigNodes.treeList.addChild(existingObject);
             } else {
+                if (empties[parent]) {
+                    empties[parent].treeList.remove();
+                    delete empties[parent];
+                }
                 objects[parent].treeList.addChild(existingObject)
             }
         }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
After creating subflow from `Subflows > Selections to Subflow` menu,  outliner leaves *empty* item in tree list as shown below: 

![スクリーンショット 2020-05-16 11 31 31](https://user-images.githubusercontent.com/30289092/82108523-0128cc80-976a-11ea-98d7-98ae40127265.png)

This PR tries to fixe this problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
