### PR TITLE
fix line break of group label

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4287,16 +4287,18 @@ if (DEBUG_EVENTS) { console.warn("nodeMouseDown", mouse_mode,d); }
                             .style("fill", d.style.hasOwnProperty('color')?d.style.color:"#999")
                             .attr("transform","translate("+labelX+","+labelY+")")
                             .attr("text-anchor",labelAnchor);
-                        var ypos = 0;
-                        g.selectAll(".red-ui-flow-group-label-text").remove();
-                        d.labels.forEach(function (name) {
-                            label.append("tspan")
-                                .classed("red-ui-flow-group-label-text", true)
-                                .text(name)
-                                .attr("x", 0)
-                                .attr("y", ypos);
-                            ypos += 15;
-                        });
+                        if (d.labels) {
+                            var ypos = 0;
+                            g.selectAll(".red-ui-flow-group-label-text").remove();
+                            d.labels.forEach(function (name) {
+                                label.append("tspan")
+                                    .classed("red-ui-flow-group-label-text", true)
+                                    .text(name)
+                                    .attr("x", 0)
+                                    .attr("y", ypos);
+                                ypos += 15;
+                            });
+                        }
                     }
 
                     delete dirtyGroups[d.id];

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4156,7 +4156,7 @@ if (DEBUG_EVENTS) { console.warn("nodeMouseDown", mouse_mode,d); }
                         "stroke": d.stroke||"none",
                     })
                 g.on("mousedown",groupMouseDown).on("mouseup",groupMouseUp)
-                g.append('svg:text').attr("class","red-ui-flow-group-label").text(d.name);
+                g.append('svg:text').attr("class","red-ui-flow-group-label");
                 d.dirty = true;
             });
             if (addedGroups) {
@@ -4207,12 +4207,20 @@ if (DEBUG_EVENTS) { console.warn("nodeMouseDown", mouse_mode,d); }
                     if (!d.minWidth) {
                         if (d.style.label && d.name) {
                             d.minWidth = calculateTextWidth(d.name||"","red-ui-flow-group-label",8);
+                            d.labels = separateTextByLineBreak;
                         } else {
                             d.minWidth = 40;
                         }
                     }
                     d.w = Math.max(d.minWidth,d.w);
-
+                    if (d.style.label && d.labels) {
+                        var h = (d.labels.length -1) *15;
+                        var labelPos = d.style["label-position"] || "nw";
+                        d.h += h;
+                        if (labelPos[0] === "n") {
+                            d.y -= h;
+                        }
+                    }
 
                     g.attr("transform","translate("+d.x+","+d.y+")")
                     g.selectAll(".red-ui-flow-group-outline")
@@ -4263,7 +4271,7 @@ if (DEBUG_EVENTS) { console.warn("nodeMouseDown", mouse_mode,d); }
                         if (labelPos[0] === 'n') {
                             labelY = 0+15; // Allow for font-height
                         } else {
-                            labelY = d.h - 5;
+                            labelY = d.h - 5 -(d.labels.length -1) *15;
                         }
                         if (labelPos[1] === 'w') {
                             labelX = 5;
@@ -4275,10 +4283,20 @@ if (DEBUG_EVENTS) { console.warn("nodeMouseDown", mouse_mode,d); }
                             labelX = d.w/2;
                             labelAnchor = "middle"
                         }
-                        label.text(d.name)
-                        .style("fill", d.style.hasOwnProperty('color')?d.style.color:"#999")
-                        .attr("transform","translate("+labelX+","+labelY+")")
-                        .attr("text-anchor",labelAnchor);
+                        label
+                            .style("fill", d.style.hasOwnProperty('color')?d.style.color:"#999")
+                            .attr("transform","translate("+labelX+","+labelY+")")
+                            .attr("text-anchor",labelAnchor);
+                        var ypos = 0;
+                        g.selectAll(".red-ui-flow-group-label-text").remove();
+                        d.labels.forEach(function (name) {
+                            label.append("tspan")
+                                .classed("red-ui-flow-group-label-text", true)
+                                .text(name)
+                                .attr("x", 0)
+                                .attr("y", ypos);
+                            ypos += 15;
+                        });
                     }
 
                     delete dirtyGroups[d.id];


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

When a group name contains line breaks (\n), the label and surrounding boxes of the group are node displayed correctly as follows:

<!-- Describe the nature of this change. What problem does it address? -->
![スクリーンショット 2020-05-16 21 03 28](https://user-images.githubusercontent.com/30289092/82119404-38729a00-97b9-11ea-9e50-48ced0e148a8.png)

This PR tries to fix this problem to make the group displayed as follows:

![スクリーンショット 2020-05-16 21 04 43](https://user-images.githubusercontent.com/30289092/82119407-3c9eb780-97b9-11ea-8942-040e04ab346e.png)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
