### PR TITLE
Add action to toggle node label visiblity

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
@@ -120,8 +120,69 @@ RED.view.tools = (function() {
         }
     }
 
+    function setSelectedNodeLabelState(labelShown) {
+        var selection = RED.view.selection();
+        var historyEvents = [];
+        var nodes = [];
+        if (selection.nodes) {
+            selection.nodes.forEach(function(n) {
+                if (n.type !== 'subflow' && n.type !== 'group') {
+                    nodes.push(n);
+                } else if (n.type === 'group') {
+                    nodes = nodes.concat( RED.group.getNodes(n,true));
+                }
+            });
+        }
+        nodes.forEach(function(n) {
+            var modified = false;
+            var oldValue = n.l === undefined?true:n.l;
+            var isLink = /^link (in|out)$/.test(n._def.type);
+
+            if (labelShown) {
+                if (n.l === false || (isLink && !n.hasOwnProperty('l'))) {
+                    n.l = true;
+                    modified = true;
+                }
+            } else {
+                if ((!isLink && (!n.hasOwnProperty('l') || n.l === true)) || (isLink && n.l === true) ) {
+                    n.l = false;
+                    modified = true;
+                }
+            }
+            if (modified) {
+                historyEvents.push({
+                    t: "edit",
+                    node: n,
+                    changed: n.changed,
+                    changes: {
+                        l: oldValue
+                    }
+                })
+                n.changed = true;
+                n.dirty = true;
+                n.resize = true;
+            }
+        })
+
+        if (historyEvents.length > 0) {
+            RED.history.push({
+                t: "multi",
+                events: historyEvents,
+                dirty: RED.nodes.dirty()
+            })
+            RED.nodes.dirty(true);
+        }
+
+        RED.view.redraw();
+
+
+    }
+
     return {
         init: function() {
+            RED.actions.add("core:show-selected-node-labels", function() { setSelectedNodeLabelState(true); })
+            RED.actions.add("core:hide-selected-node-labels", function() { setSelectedNodeLabelState(false); })
+
             RED.actions.add("core:align-selection-to-grid", alignToGrid);
 
             RED.actions.add("core:scroll-view-up", function() { RED.view.scroll(0,-RED.view.gridSize());});


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Adds a pair of actions to toggle the node label visibility in the editor.

 - `core:show-selected-node-labels`
 - `core:hide-selected-node-labels`

Created live on twitch!

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
