### PR TITLE
editor action to disable all debug nodes on a global/current workspace level

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/history.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/history.js
@@ -452,6 +452,11 @@ RED.history = (function() {
                 }
             }
 
+            if(ev.sideEffectCallback && typeof ev.sideEffectCallback === 'function') {
+                inverseEv.sideEffectCallback = ev.sideEffectCallback;
+                ev.sideEffectCallback(ev);
+            }
+
             Object.keys(modifiedTabs).forEach(function(id) {
                 var subflow = RED.nodes.subflow(id);
                 if (subflow) {

--- a/packages/node_modules/@node-red/editor-client/src/js/history.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/history.js
@@ -452,9 +452,9 @@ RED.history = (function() {
                 }
             }
 
-            if(ev.sideEffectCallback && typeof ev.sideEffectCallback === 'function') {
-                inverseEv.sideEffectCallback = ev.sideEffectCallback;
-                ev.sideEffectCallback(ev);
+            if(ev.callback && typeof ev.callback === 'function') {
+                inverseEv.callback = ev.callback;
+                ev.callback(ev);
             }
 
             Object.keys(modifiedTabs).forEach(function(id) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -401,8 +401,6 @@ RED.view = (function() {
             $("#red-ui-workspace-tabs").removeClass("red-ui-workspace-focussed");
         });
 
-        RED.actions.add("core:disable-all-debug-nodes", function() { disableAllDebugNodes(false); });
-        RED.actions.add("core:disable-all-flow-debug-nodes", function() { disableAllDebugNodes(true); });
         RED.actions.add("core:copy-selection-to-internal-clipboard",copySelection);
         RED.actions.add("core:cut-selection-to-internal-clipboard",function(){copySelection();deleteSelection();});
         RED.actions.add("core:paste-from-internal-clipboard",function(){importNodes(clipboard);});
@@ -1434,34 +1432,6 @@ RED.view = (function() {
         redraw();
     }
 
-    function disableAllDebugNodes(currentFlowOnly) {
-        var historyEvents = [];
-        RED.nodes.eachNode(function(n) {
-            if (n.type === "debug" && n.active === true && ( currentFlowOnly === false || n.z == RED.workspaces.active() )) {
-                var oldValue = n.active;
-                historyEvents.push({
-                    t: "edit",
-                    node: n,
-                    changed: n.changed,
-                    changes: {
-                        active: oldValue
-                    }
-                });
-                n.active = false;
-                n.changed = true;
-                n.dirty = true;
-            }
-        });
-        if (historyEvents.length > 0) {
-            RED.history.push({
-                t: "multi",
-                events: historyEvents,
-                dirty: RED.nodes.dirty()
-            });
-            RED.nodes.dirty(true);
-        }
-        RED.view.redraw();
-    }
 
     function selectAll() {
         if (mouse_mode === RED.state.SELECTING_NODE && selectNodesOptions.single) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -401,6 +401,8 @@ RED.view = (function() {
             $("#red-ui-workspace-tabs").removeClass("red-ui-workspace-focussed");
         });
 
+        RED.actions.add("core:disable-all-debug-nodes", function() { disableAllDebugNodes(false); });
+        RED.actions.add("core:disable-all-flow-debug-nodes", function() { disableAllDebugNodes(true); });
         RED.actions.add("core:copy-selection-to-internal-clipboard",copySelection);
         RED.actions.add("core:cut-selection-to-internal-clipboard",function(){copySelection();deleteSelection();});
         RED.actions.add("core:paste-from-internal-clipboard",function(){importNodes(clipboard);});
@@ -1432,6 +1434,34 @@ RED.view = (function() {
         redraw();
     }
 
+    function disableAllDebugNodes(currentFlowOnly) {
+        var historyEvents = [];
+        RED.nodes.eachNode(function(n) {
+            if (n.type === "debug" && n.active === true && ( currentFlowOnly === false || n.z == RED.workspaces.active() )) {
+                var oldValue = n.active;
+                historyEvents.push({
+                    t: "edit",
+                    node: n,
+                    changed: n.changed,
+                    changes: {
+                        active: oldValue
+                    }
+                });
+                n.active = false;
+                n.changed = true;
+                n.dirty = true;
+            }
+        });
+        if (historyEvents.length > 0) {
+            RED.history.push({
+                t: "multi",
+                events: historyEvents,
+                dirty: RED.nodes.dirty()
+            });
+            RED.nodes.dirty(true);
+        }
+        RED.view.redraw();
+    }
 
     function selectAll() {
         if (mouse_mode === RED.state.SELECTING_NODE && selectNodesOptions.single) {

--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.html
@@ -101,7 +101,7 @@
                         },
                         dirty:node.dirty,
                         changed:node.changed,
-                        sideEffectCallback: function(ev) {
+                        callback: function(ev) {
                             activateAjaxCall(ev.node, ev.node.active);
                         }
                     };
@@ -119,6 +119,7 @@
             }
         },
         onpaletteadd: function() {
+            console.log(RED);
             var options = {
                 messageMouseEnter: function(sourceId) {
                     if (sourceId) {
@@ -284,21 +285,23 @@
                 RED.nodes.eachNode(function(n) {
                     if (n.type === "debug" && n.active === true) {
                         if (globally === true || n.z == RED.workspaces.active()) {
-                            historyEvents.push({
-                                t: "edit",
-                                node: n,
-                                changed: n.changed,
-                                changes: {
-                                    active: n.active
-                                },
-                                sideEffectCallback: function() {
-                                    activateAjaxCall(n, n.active);
-                                }
-                            });
-                            n.active = false;
-                            n.changed = true;
-                            n.dirty = true;
-                            activateAjaxCall(n, n.active);
+                            if(RED.nodes.subflow(n.z) === undefined) {
+                                historyEvents.push({
+                                    t: "edit",
+                                    node: n,
+                                    changed: n.changed,
+                                    changes: {
+                                        active: n.active
+                                    },
+                                    callback: function() {
+                                        activateAjaxCall(n, n.active);
+                                    }
+                                });
+                                n.active = false;
+                                n.changed = true;
+                                n.dirty = true;
+                                activateAjaxCall(n, n.active);
+                            }
                         }
                     }
                 });

--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.html
@@ -36,6 +36,25 @@
 <script type="text/javascript">
 (function() {
     var subWindow = null;
+
+    function activateAjaxCall(node, active, successCallback) {
+        $.ajax({
+            url: "debug/"+node.id+"/"+(active?"enable":"disable"),
+            type: "POST",
+            success: successCallback,
+            error: function(jqXHR,textStatus,errorThrown) {
+                if (jqXHR.status == 404) {
+                    RED.notify(node._("common.notification.error", {message: node._("common.notification.errors.not-deployed")}),"error");
+                } else if (jqXHR.status === 0) {
+                    RED.notify(node._("common.notification.error", {message: node._("common.notification.errors.no-response")}),"error");
+                } else {
+                    // TODO where is the err.status comming from?
+                    RED.notify(node._("common.notification.error",{message:node._("common.notification.errors.unexpected",{status:err.status,message:err.response})}),"error");
+                }
+            }
+        });
+    }
+
     RED.nodes.registerType('debug',{
         category: 'common',
         defaults: {
@@ -73,38 +92,28 @@
             onclick: function() {
                 var label = this.name||"debug";
                 var node = this;
-                $.ajax({
-                    url: "debug/"+this.id+"/"+(this.active?"enable":"disable"),
-                    type: "POST",
-                    success: function(resp, textStatus, xhr) {
-                        var historyEvent = {
-                            t:'edit',
-                            node:node,
-                            changes:{
-                                active:!node.active
-                            },
-                            dirty:node.dirty,
-                            changed:node.changed
-                        };
-                        node.changed = true;
-                        node.dirty = true;
-                        RED.nodes.dirty(true);
-                        RED.history.push(historyEvent);
-                        RED.view.redraw();
-                        if (xhr.status == 200) {
-                            RED.notify(node._("debug.notification.activated",{label:label}),"success");
-                        } else if (xhr.status == 201) {
-                            RED.notify(node._("debug.notification.deactivated",{label:label}),"success");
+                activateAjaxCall(node, node.active, function(resp, textStatus, xhr) {
+                    var historyEvent = {
+                        t:'edit',
+                        node:node,
+                        changes:{
+                            active:!node.active
+                        },
+                        dirty:node.dirty,
+                        changed:node.changed,
+                        sideEffectCallback: function(ev) {
+                            activateAjaxCall(ev.node, ev.node.active);
                         }
-                    },
-                    error: function(jqXHR,textStatus,errorThrown) {
-                        if (jqXHR.status == 404) {
-                            RED.notify(node._("common.notification.error", {message: node._("common.notification.errors.not-deployed")}),"error");
-                        } else if (jqXHR.status === 0) {
-                            RED.notify(node._("common.notification.error", {message: node._("common.notification.errors.no-response")}),"error");
-                        } else {
-                            RED.notify(node._("common.notification.error",{message:node._("common.notification.errors.unexpected",{status:err.status,message:err.response})}),"error");
-                        }
+                    };
+                    node.changed = true;
+                    node.dirty = true;
+                    RED.nodes.dirty(true);
+                    RED.history.push(historyEvent);
+                    RED.view.redraw();
+                    if (xhr.status == 200) {
+                        RED.notify(node._("debug.notification.activated",{label:label}),"success");
+                    } else if (xhr.status == 201) {
+                        RED.notify(node._("debug.notification.deactivated",{label:label}),"success");
                     }
                 });
             }
@@ -281,11 +290,15 @@
                                 changed: n.changed,
                                 changes: {
                                     active: n.active
+                                },
+                                sideEffectCallback: function() {
+                                    activateAjaxCall(n, n.active);
                                 }
                             });
                             n.active = false;
                             n.changed = true;
                             n.dirty = true;
+                            activateAjaxCall(n, n.active);
                         }
                     }
                 });

--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.html
@@ -266,6 +266,40 @@
             RED.events.on("project:change", this.clearMessageList);
             RED.actions.add("core:clear-debug-messages", function() { RED.debug.clearMessageList(true) });
 
+
+            RED.actions.add("core:deactivate-all-debug-nodes", function() { deactivateAllDebugNodes(true); });
+            RED.actions.add("core:deactivate-all-flow-debug-nodes", function() { deactivateAllDebugNodes(false); });
+
+            function deactivateAllDebugNodes(globally) {
+                var historyEvents = [];
+                RED.nodes.eachNode(function(n) {
+                    if (n.type === "debug" && n.active === true) {
+                        if (globally === true || n.z == RED.workspaces.active()) {
+                            historyEvents.push({
+                                t: "edit",
+                                node: n,
+                                changed: n.changed,
+                                changes: {
+                                    active: n.active
+                                }
+                            });
+                            n.active = false;
+                            n.changed = true;
+                            n.dirty = true;
+                        }
+                    }
+                });
+                if (historyEvents.length > 0) {
+                    RED.history.push({
+                        t: "multi",
+                        events: historyEvents,
+                        dirty: RED.nodes.dirty()
+                    });
+                    RED.nodes.dirty(true);
+                }
+                RED.view.redraw();
+            }
+
             $("#red-ui-sidebar-debug-open").on("click", function(e) {
                 e.preventDefault();
                 subWindow = window.open(document.location.toString().replace(/[?#].*$/,"")+"debug/view/view.html"+document.location.search,"nodeREDDebugView","menubar=no,location=no,toolbar=no,chrome,height=500,width=600");


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes
added editor action to disable all debug nodes globally or on the current workspace.

There is a thread in the forum (https://discourse.nodered.org/t/debug-node-output-show-complete-message-options/26577) where I mentioned this, but no discussion happened around this specific feature (the thread is mostly about another feature)
This PR is a response to the first twitch live stream to show that the presentation was very clear and allowed me to create that feature including the history.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
