### PR TITLE
Fix error on deleting tab

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -220,7 +220,9 @@ RED.workspaces = (function() {
                 if (RED.view.state() != RED.state.IMPORT_DRAGGING) {
                     RED.view.state(RED.state.DEFAULT);
                 }
-                RED.sidebar.info.refresh(workspace);
+                if (workspace_tabs.contains(workspace.id)) {
+                    RED.sidebar.info.refresh(workspace);
+                }
                 tabflowEditor.destroy();
             }
         }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Deleting tab (workspace) from following tab information edit panel causes 
`Uncaught TypeError: Cannot read property 'label' of undefined` error.

![スクリーンショット 2020-05-19 9 40 24](https://user-images.githubusercontent.com/30289092/82272188-d1b9d000-99b4-11ea-8a73-66ff21616262.png)

This seems to be caused by refreshing sidebar of deleted tab on closing panel.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
