### PR TITLE
Moved options property from Outputs to Inputs section

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/de/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/parsers/70-XML.html
@@ -20,6 +20,10 @@
     <dl class="message-properties">
         <dt>payload<span class="property-type">Objekt | String</span></dt>
         <dd>Ein JavaScript Objekt oder ein XML String.</dd>
+        <dt class="optional">options <span class="property-type">Objekt</span></dt>
+        <dd>This optional property can be used to pass in any of the options supported by the underlying
+            library used to convert to and from XML. See <a href="https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options" target="_blank">the xml2js docs</a>
+            for more information.</dd>
     </dl>
     <h3>Ausgaben</h3>
     <dl class="message-properties">
@@ -30,10 +34,6 @@
                 <li>Wenn die Eingabe ein JavaScript-Objekt ist, wird versucht ein XML-String zu erstellen.</li>
             </ul>
         </dd>
-        <dt class="optional">Optionen <span class="property-type">Objekt</span></dt>
-        <dd>This optional property can be used to pass in any of the options supported by the underlying
-            library used to convert to and from XML. See <a href="https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options" target="_blank">the xml2js docs</a>
-            for more information.</dd>
     </dl>
     <h3>Details</h3>
     <p>Bei der Konvertierung zwischen XML und einem Objekt werden standardmäßig alle XML-Attribute als Eigenschaft namens <code>$</code> hinzugefügt. 

--- a/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/parsers/70-XML.html
@@ -20,6 +20,10 @@
     <dl class="message-properties">
         <dt>payload<span class="property-type">object | string</span></dt>
         <dd>A JavaScript object or XML string.</dd>
+        <dt class="optional">options <span class="property-type">object</span></dt>
+        <dd>This optional property can be used to pass in any of the options supported by the underlying
+            library used to convert to and from XML. See <a href="https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options" target="_blank">the xml2js docs</a>
+            for more information.</dd>
     </dl>
     <h3>Outputs</h3>
     <dl class="message-properties">
@@ -30,10 +34,6 @@
                 <li>If the input is a JavaScript object it tries to build an XML string.</li>
             </ul>
         </dd>
-        <dt class="optional">options <span class="property-type">object</span></dt>
-        <dd>This optional property can be used to pass in any of the options supported by the underlying
-            library used to convert to and from XML. See <a href="https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options" target="_blank">the xml2js docs</a>
-            for more information.</dd>
     </dl>
     <h3>Details</h3>
     <p>When converting between XML and an object, any XML attributes are added as a property named <code>$</code> by default.

--- a/packages/node_modules/@node-red/nodes/locales/ja/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/parsers/70-XML.html
@@ -20,6 +20,8 @@
     <dl class="message-properties">
         <dt>payload<span class="property-type">オブジェクト | 文字列</span></dt>
         <dd>JavaScriptオブジェクトもしくはXML文字列</dd>
+        <dt class="optional">options <span class="property-type">オブジェクト</span></dt>
+        <dd>内部で用いているXMLへの変換ライブラリに対してオプションを渡すことができます。詳しくは<a href="https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options" target="_blank">the xml2js docs</a>を参照してください。</dd>
     </dl>
     <h3>出力</h3>
     <dl class="message-properties">
@@ -30,8 +32,6 @@
                 <li>入力がJavaScriptオブジェクトの場合、XML文字列に変換します。</li>
             </ul>
         </dd>
-        <dt class="optional">options <span class="property-type">オブジェクト</span></dt>
-        <dd>内部で用いているXMLへの変換ライブラリに対してオプションを渡すことができます。詳しくは<a href="https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options" target="_blank">the xml2js docs</a>を参照してください。</dd>
     </dl>
     <h3>詳細</h3>
     <p>XMLとオブジェクトの間での変換を行う場合、デフォルトでは、XML属性は<code>$</code>という名称のプロパティに追加します。

--- a/packages/node_modules/@node-red/nodes/locales/ko/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/locales/ko/parsers/70-XML.html
@@ -20,6 +20,8 @@
     <dl class="message-properties">
         <dt>payload<span class="property-type">오브젝트 | 문자열</span></dt>
         <dd>JavaScript오브젝트 혹은 XML문자열</dd>
+        <dt class="optional">options <span class="property-type">오브젝트</span></dt>
+        <dd>내부에서 사용중인 XML로의 변환 라이브러리에 대해 옵션을 전달할 수 있습니다. 자세한 사항은 <a href="https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options" target="_blank">the xml2js docs</a>를 참조해 주세요.</dd>
     </dl>
     <h3>출력</h3>
     <dl class="message-properties">
@@ -30,8 +32,6 @@
                 <li>입력이 JavaScript오브젝트인 경우, XML문자열로 변환합니다.</li>
             </ul>
         </dd>
-        <dt class="optional">options <span class="property-type">오브젝트</span></dt>
-        <dd>내부에서 사용중인 XML로의 변환 라이브러리에 대해 옵션을 전달할 수 있습니다. 자세한 사항은 <a href="https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options" target="_blank">the xml2js docs</a>를 참조해 주세요.</dd>
     </dl>
     <h3>상세</h3>
     <p>XML와 오브젝트의 사이에서의 변환을 수행할 경우, 기본값으로는 XML속성은 <code>$</code>이라는 명칭의 프로퍼티에 추가합니다.

--- a/packages/node_modules/@node-red/nodes/locales/zh-CN/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/locales/zh-CN/parsers/70-XML.html
@@ -20,6 +20,8 @@
     <dl class="message-properties">
         <dt>payload<span class="property-type">object | 字符串</span></dt>
         <dd>JavaScript对象或XML字符串。</dd>
+        <dt class="optional">options <span class="property-type">object</span></dt>
+        <dd>可以将选项传递给内部使用的XML转换库。请参见<a href="https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options" target="_blank"> xml2js文档</a> 来获取更多信息。</dd>
     </dl>
     <h3>输出</h3>
     <dl class="message-properties">
@@ -30,8 +32,6 @@
                 <li>如果输入是JavaScript对象，它将尝试构建XML字符串。</li>
             </ul>
         </dd>
-        <dt class="optional">options <span class="property-type">object</span></dt>
-        <dd>可以将选项传递给内部使用的XML转换库。请参见<a href="https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options" target="_blank"> xml2js文档</a> 来获取更多信息。</dd>
     </dl>
     <h3>详细</h3>
     <p>在XML和对象之间进行转换时，默认情况下XML属性会添加到名为<code>$</code>的属性中。将文本内容添加到名为<code>_</code>的属性中。这些属性名称可以在节点设置中更改。</p>

--- a/packages/node_modules/@node-red/nodes/locales/zh-TW/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/locales/zh-TW/parsers/70-XML.html
@@ -20,6 +20,8 @@
   <dl class="message-properties">
       <dt>payload<span class="property-type">object | 字符串</span></dt>
       <dd>JavaScript對象或XML字符串。</dd>
+      <dt class="optional">options <span class="property-type">object</span></dt>
+      <dd>可以將選項傳遞給內部使用的XML轉換庫。請參見<a href="https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options" target="_blank"> xml2js文檔</a> 來獲取更多信息。</dd>
   </dl>
   <h3>輸出</h3>
   <dl class="message-properties">
@@ -30,8 +32,6 @@
               <li>如果輸入是JavaScript對象，它將嘗試構建XML字符串。</li>
           </ul>
       </dd>
-      <dt class="optional">options <span class="property-type">object</span></dt>
-      <dd>可以將選項傳遞給內部使用的XML轉換庫。請參見<a href="https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options" target="_blank"> xml2js文檔</a> 來獲取更多信息。</dd>
   </dl>
   <h3>詳細</h3>
   <p>在XML和對象之間進行轉換時，默認情況下XML屬性會添加到名爲<code>$</code>的屬性中。將文本內容添加到名爲<code>_</code>的屬性中。這些屬性名稱可以在節點設置中更改。</p>


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

The XML node help docs include the property `options` in the Outputs when it should be listed under Inputs. 

Old docs:

<img width="336" alt="Screen Shot 2020-05-19 at 8 40 31 PM" src="https://user-images.githubusercontent.com/1245985/82402429-2d19ab80-9a11-11ea-9004-81d1e967181c.png">

Fixed:

<img width="328" alt="Screen Shot 2020-05-19 at 8 51 44 PM" src="https://user-images.githubusercontent.com/1245985/82402967-98b04880-9a12-11ea-8163-a16ca24106a8.png">

Also restored the property name (which was translated) in the German version.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
