### PR TITLE
fix groups to keep partial order

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -874,6 +874,23 @@ RED.nodes = (function() {
         return true;
     }
 
+    // sort groups to keep partial order (parent to child)
+    function sortGroups(groups) {
+        var order = {};
+        groups.forEach(function (g) {
+            var id = g.id;
+            var parent = g.g;
+            var level = (order[id] || 0);
+            order[id] = level;
+            if (parent) {
+                order[parent] = Math.max((order[parent] || 0), level +1);
+            }
+        });
+        groups.sort(function (a, b) {
+            return order[b.id] -order[a.id];
+        });
+    }
+
     function importNodes(newNodesObj,createNewIds,createMissingWorkspace) {
         var i;
         var n;
@@ -1409,6 +1426,7 @@ RED.nodes = (function() {
                 delete n.status.wires;
             }
         }
+        sortGroups(new_groups);
         for (i=0;i<new_groups.length;i++) {
             n = new_groups[i];
             if (n.g && node_map[n.g]) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Loading a flow containing a nested group causes following browser error in some case  (attached an example flow below):  

```
RED.events.emit error: [nodes:add] TypeError: Cannot read property 'addChild' of undefined
TypeError: Cannot read property 'addChild' of undefined
```

The reason for this seems to be that when adding a node to outliner, it is expecting the parent group already added.  

There are two possible amendments: either the outliner does not assume the order of addition, or it guarantees the order of addition of the group.  This PR uses the latter.

```
[{"id":"7f57e49b.ead56c","type":"tab","label":"Flow 1","disabled":false,"info":""},{"id":"613513dc.4062ec","type":"group","z":"7f57e49b.ead56c","g":"b94be2e0.f8859","style":{"stroke":"#999999","stroke-opacity":"1","fill":"none","fill-opacity":"1"},"nodes":["5aa54fe8.09ade"],"x":135,"y":220,"w":170,"h":80},{"id":"b94be2e0.f8859","type":"group","z":"7f57e49b.ead56c","style":{"stroke":"#999999","stroke-opacity":"1","fill":"none","fill-opacity":"1"},"nodes":["613513dc.4062ec"],"x":110,"y":195,"w":220,"h":130},{"id":"5aa54fe8.09ade","type":"comment","z":"7f57e49b.ead56c","g":"613513dc.4062ec","name":"","info":"","x":220,"y":260,"wires":[]}]
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
