### PR TITLE
fix deletion of group

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
@@ -362,9 +362,6 @@ RED.sidebar.info.outliner = (function() {
         var existingObject = objects[n.id];
         var parent = n.g||n.z;
 
-        if (!existingObject) {
-            return;
-        }
         var nodeLabelText = getNodeLabelText(n);
         if (nodeLabelText) {
             existingObject.element.find(".red-ui-info-outline-item-label").text(nodeLabelText);
@@ -373,9 +370,7 @@ RED.sidebar.info.outliner = (function() {
         }
 
         if (parent !== existingObject.parent.id) {
-            if (existingObject.treeList) {
-                existingObject.treeList.remove();
-            }
+            existingObject.treeList.remove();
             if (!parent) {
                 globalConfigNodes.treeList.addChild(existingObject);
             } else {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
@@ -362,6 +362,9 @@ RED.sidebar.info.outliner = (function() {
         var existingObject = objects[n.id];
         var parent = n.g||n.z;
 
+        if (!existingObject) {
+            return;
+        }
         var nodeLabelText = getNodeLabelText(n);
         if (nodeLabelText) {
             existingObject.element.find(".red-ui-info-outline-item-label").text(nodeLabelText);
@@ -370,7 +373,9 @@ RED.sidebar.info.outliner = (function() {
         }
 
         if (parent !== existingObject.parent.id) {
-            existingObject.treeList.remove();
+            if (existingObject.treeList) {
+                existingObject.treeList.remove();
+            }
             if (!parent) {
                 globalConfigNodes.treeList.addChild(existingObject);
             } else {
@@ -386,10 +391,19 @@ RED.sidebar.info.outliner = (function() {
     function onObjectRemove(n) {
         var existingObject = objects[n.id];
         existingObject.treeList.remove();
-        delete objects[n.d]
+        delete objects[n.id]
         var parent = existingObject.parent;
         if (parent.children.length === 0) {
             parent.treeList.addChild(getEmptyItem(parent.id));
+        }
+        if (existingObject.children && (existingObject.children.length > 0)) {
+            existingObject.children.forEach(function (nc) {
+                if (!nc.empty) {
+                    var childObject = objects[nc.id];
+                    nc.parent = parent;
+                    objects[parent.id].treeList.addChild(childObject);
+                }
+            });
         }
     }
     function getGutter(n) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1943,10 +1943,14 @@ if (DEBUG_EVENTS) { console.warn("clearSelection", mouse_mode); }
             if (moving_set.length > 0) {
                 for (var i=0;i<moving_set.length;i++) {
                     var node = moving_set[i].n;
-                    node.selected = false;
                     if (node.type === "group") {
                         selectedGroups.push(node);
-                    } else if (node.type != "subflow") {
+                    }
+                }
+                for (var i=0;i<moving_set.length;i++) {
+                    var node = moving_set[i].n;
+                    node.selected = false;
+                    if ((node.type !== "group") && (node.type != "subflow")) {
                         if (node.x < 0) {
                             node.x = 25
                         }
@@ -1957,8 +1961,13 @@ if (DEBUG_EVENTS) { console.warn("clearSelection", mouse_mode); }
                         if (node.g) {
                             var group = RED.nodes.group(node.g);
                             if (!group.selected || group.active) {
-                                RED.group.removeFromGroup(group,node);
-                                node.g = group.id;
+                                var isSelectedGroup = selectedGroups.find(function (ng) {
+                                    return (ng.id === node.g);
+                                });
+                                if (!isSelectedGroup) {
+                                    RED.group.removeFromGroup(group,node);
+                                    node.g = group.id;
+                                }
                             }
                         }
                     } else {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1943,14 +1943,10 @@ if (DEBUG_EVENTS) { console.warn("clearSelection", mouse_mode); }
             if (moving_set.length > 0) {
                 for (var i=0;i<moving_set.length;i++) {
                     var node = moving_set[i].n;
+                    node.selected = false;
                     if (node.type === "group") {
                         selectedGroups.push(node);
-                    }
-                }
-                for (var i=0;i<moving_set.length;i++) {
-                    var node = moving_set[i].n;
-                    node.selected = false;
-                    if ((node.type !== "group") && (node.type != "subflow")) {
+                    } else if (node.type != "subflow") {
                         if (node.x < 0) {
                             node.x = 25
                         }
@@ -1960,14 +1956,9 @@ if (DEBUG_EVENTS) { console.warn("clearSelection", mouse_mode); }
                         removedLinks = removedLinks.concat(removedEntities.links);
                         if (node.g) {
                             var group = RED.nodes.group(node.g);
-                            if (!group.selected || group.active) {
-                                var isSelectedGroup = selectedGroups.find(function (ng) {
-                                    return (ng.id === node.g);
-                                });
-                                if (!isSelectedGroup) {
-                                    RED.group.removeFromGroup(group,node);
-                                    node.g = group.id;
-                                }
+                            if ((!group.selected || group.active) && (selectedGroups.indexOf(group) < 0)) {
+                                RED.group.removeFromGroup(group,node);
+                                node.g = group.id;
                             }
                         }
                     } else {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

A browser error occurs when deleting a group in the following steps (sample flow is included below).

1. select candidate group
2. press `DELETE` key

Then error occurs in a browser: `TypeError: Cannot read property 'remove' of undefined`

- Sample Flow
```
[{"id":"5bcefa6.e5ffb04","type":"tab","label":"Flow 1","disabled":false,"info":""},{"id":"d2cc1f36.9502d","type":"group","z":"5bcefa6.e5ffb04","style":{"stroke":"#999999","stroke-opacity":"1","fill":"none","fill-opacity":"1"},"nodes":["7c362d0f.e25f24"],"x":170,"y":95,"w":220,"h":130},{"id":"7c362d0f.e25f24","type":"group","z":"5bcefa6.e5ffb04","g":"d2cc1f36.9502d","style":{"stroke":"#999999","stroke-opacity":"1","fill":"none","fill-opacity":"1"},"nodes":["7ce34a04.2777cc"],"x":195,"y":120,"w":170,"h":80},{"id":"7ce34a04.2777cc","type":"comment","z":"5bcefa6.e5ffb04","g":"7c362d0f.e25f24","name":"","info":"","x":280,"y":160,"wires":[]}]
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
