### PR TITLE
Fix editor underscore visibility on Linux systems

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/ace.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/ace.scss
@@ -52,6 +52,9 @@
         @include component-shadow;
         border-color: $popover-background;
     }
+    .ace_content {
+        line-height: 1;
+    }
     textarea.ace_text-input {
         overflow: hidden;
         padding: 0px 1px !important;


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

As reported on #2104, on some systems (mainly Linux), the underscore character is not visible in Node-RED editor without zooming in or out. The issue seems to be related to DejaVu Sans font rendering [as pointed out on the forum](https://discourse.nodered.org/t/cant-see-my-underline-char/26957/23?u=ristomatti) by @Steve-Mcl.

Change of `line-height` to '1' on ACE editor lines seems to fix the issue at least on my system (Linux Mint / latest Chrome) without actually affecting the actual height of the editor lines.

Before:

![image](https://user-images.githubusercontent.com/9029939/82734780-d15b6500-9d25-11ea-9311-158fee9ca3f8.png)

After:

![image](https://user-images.githubusercontent.com/9029939/82734785-d4eeec00-9d25-11ea-9972-a39804c04e11.png)

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
