### PR TITLE
remove JSONata Array.from check for IE11

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/polyfills.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/polyfills.js
@@ -12,12 +12,6 @@
             Object.defineProperty(SVGElement.prototype, 'children', Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'children'));
         }
 
-        if (!Array.from) {
-            // JSONata provides an Array.from polyfill that doesn't handle iterables.
-            // So in IE11 we expect Array.from to exist already, it just needs some
-            // changes to support iterables.
-            throw new Error("Missing Array.from base polyfill");
-        }
         Array.from = function() {
             if (arguments.length > 1) {
                 throw new Error("Node-RED's IE11 Array.from polyfill doesn't support multiple arguments");


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Node-RED editor fails to load on IE11.
This is because the code for IE11 fails to check that `Array.from` is defined in JSONata.
`Array.from` is no longer defined from JSONata 1.8.3, so this PR removes the check code.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
