### PR TITLE
Support moment/moment-timezone in jsonata expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "media-typer": "1.1.0",
         "memorystore": "1.6.2",
         "mime": "2.4.4",
+        "moment-timezone": "^0.5.31",
         "mqtt": "2.18.8",
         "multer": "1.4.2",
         "mustache": "4.0.1",

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -22,6 +22,7 @@
 
 const clone = require("clone");
 const jsonata = require("jsonata");
+const moment = require("moment");
 const safeJSONStringify = require("json-stringify-safe");
 const util = require("util");
 
@@ -558,10 +559,10 @@ function evaluateNodeProperty(value, type, node, msg, callback) {
  */
 function prepareJSONataExpression(value,node) {
     var expr = jsonata(value);
-    expr.assign('flowContext',function(val, store) {
+    expr.assign('flowContext', function(val, store) {
         return node.context().flow.get(val, store);
     });
-    expr.assign('globalContext',function(val, store) {
+    expr.assign('globalContext', function(val, store) {
         return node.context().global.get(val, store);
     });
     expr.assign('env', function(name) {
@@ -569,9 +570,12 @@ function prepareJSONataExpression(value,node) {
         if (typeof val !== 'undefined') {
             return val;
         } else {
-            return ""
+            return "";
         }
-    })
+    });
+    expr.assign('moment', function(arg1, arg2, arg3, arg4) {
+        return moment(arg1, arg2, arg3, arg4);
+    });
     expr.registerFunction('clone', cloneMessage, '<(oa)-:o>');
     expr._legacyMode = /(^|[^a-zA-Z0-9_'"])msg([^a-zA-Z0-9_'"]|$)/.test(value);
     expr._node = node;

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -22,7 +22,7 @@
 
 const clone = require("clone");
 const jsonata = require("jsonata");
-const moment = require("moment");
+const moment = require("moment-timezone");
 const safeJSONStringify = require("json-stringify-safe");
 const util = require("util");
 

--- a/packages/node_modules/@node-red/util/package.json
+++ b/packages/node_modules/@node-red/util/package.json
@@ -19,6 +19,7 @@
         "i18next": "15.1.2",
         "json-stringify-safe": "5.0.1",
         "jsonata": "1.8.3",
+        "moment-timezone": "^0.5.31",
         "when": "3.7.8"
     }
 }

--- a/test/unit/@node-red/util/lib/util_spec.js
+++ b/test/unit/@node-red/util/lib/util_spec.js
@@ -505,6 +505,11 @@ describe("@node-red/util/util", function() {
               var result = util.evaluateJSONataExpression(expr,{});
               result.should.eql('foo');
           });
+          it('accesses moment from an expression', function() {
+              var expr = util.prepareJSONataExpression('$moment("2020-05-27", "YYYY-MM-DD").add("days", 7).add("months", 1).format("YYYY-MM-DD")',{});
+              var result = util.evaluateJSONataExpression(expr,{});
+              result.should.eql('2020-07-03');
+          });
           it('handles non-existant flow context variable', function() {
               var expr = util.prepareJSONataExpression('$flowContext("nonExistant")',{context:function() { return {flow:{get: function(key) { return {'foo':'bar'}[key]}}}}});
               var result = util.evaluateJSONataExpression(expr,{payload:"hello"});

--- a/test/unit/@node-red/util/lib/util_spec.js
+++ b/test/unit/@node-red/util/lib/util_spec.js
@@ -499,6 +499,11 @@ describe("@node-red/util/util", function() {
               var result = util.evaluateJSONataExpression(expr,{payload:"hello"});
               result.should.eql("bar");
           });
+          it('accesses undefined environment variable from an expression', function() {
+              var expr = util.prepareJSONataExpression('$env("UTIL_ENV")',{});
+              var result = util.evaluateJSONataExpression(expr,{});
+              result.should.eql('');
+          });
           it('accesses environment variable from an expression', function() {
               process.env.UTIL_ENV = 'foo';
               var expr = util.prepareJSONataExpression('$env("UTIL_ENV")',{});

--- a/test/unit/@node-red/util/lib/util_spec.js
+++ b/test/unit/@node-red/util/lib/util_spec.js
@@ -515,6 +515,11 @@ describe("@node-red/util/util", function() {
               var result = util.evaluateJSONataExpression(expr,{});
               result.should.eql('2020-07-03');
           });
+          it('accesses moment-timezone from an expression', function() {
+              var expr = util.prepareJSONataExpression('$moment("2013-11-18 11:55Z").tz("Asia/Taipei").format()',{});
+              var result = util.evaluateJSONataExpression(expr,{});
+              result.should.eql('2013-11-18T19:55:00+08:00');
+          });
           it('handles non-existant flow context variable', function() {
               var expr = util.prepareJSONataExpression('$flowContext("nonExistant")',{context:function() { return {flow:{get: function(key) { return {'foo':'bar'}[key]}}}}});
               var result = util.evaluateJSONataExpression(expr,{payload:"hello"});


### PR DESCRIPTION
## Add support for `moment` and `moment-timezone` in jsonata expressions, based on [jsonata-moment](https://github.com/elasticio/jsonata-moment)

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

There is not proper date formatting or timezone support in jsonata (for example, see https://github.com/jsonata-js/jsonata/issues/347). This creates a lot of limitations.

This functionality makes jsonata expressions like `$moment().format("Y MMMM Do YYYY, h:mm:ss a")` possible, and adds a great amount of functionality for debug nodes (and other nodes) to show proper timestamps for things like last run, etc.

![image](https://user-images.githubusercontent.com/7200365/83099100-f1668d80-a071-11ea-91d8-4b8c98d0ee53.png)

```js
[{"id":"537050c5.c41ff","type":"inject","z":"f2ecc746.8566a8","name":"","topic":"","payload":"","payloadType":"date","repeat":"","crontab":"","once":false,"onceDelay":0.1,"x":1160,"y":440,"wires":[["4114611f.d6507"]]},{"id":"4114611f.d6507","type":"debug","z":"f2ecc746.8566a8","name":"","active":true,"tosidebar":false,"console":false,"tostatus":true,"complete":"$moment().format(\"Y MMMM Do YYYY, h:mm:ss a\")","targetType":"jsonata","x":1340,"y":440,"wires":[]}]
```

- Note that no static methods have been included (see https://github.com/elasticio/jsonata-moment/issues/11) due to how jsonata works. There are other ways to achieve this so I'm not sure it's critical to adopt, and may add more confusion with additional expressions.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
