### PR TITLE
Support setting title on typedInput option/ check

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -449,6 +449,9 @@
                 if (opt.label) {
                     op.text(opt.label);
                 }
+                if (opt.title) {
+                    op.prop('title', opt.title)
+                }
                 if (opt.icon) {
                     if (opt.icon.indexOf("<") === 0) {
                         $(opt.icon).prependTo(op);


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Proposed changes
A small enhancement to the typedInput widget - permitting a node to set the tooltip of an option or checkbox item in the typed input.

Re: [Forum discussion](https://discourse.nodered.org/t/typedinput-option-tooltip/27607/2)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass - (I dont think tests cover this? - not ran)
- [ ] I have added suitable unit tests to cover the new/changed functionality
