### PR TITLE
Add node-red admin support

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "mqtt": "2.18.8",
         "multer": "1.4.2",
         "mustache": "4.0.1",
-        "node-red-admin": "^0.2.2",
+        "node-red-admin": "^0.2.3",
         "node-red-node-rbe": "^0.2.6",
         "node-red-node-sentiment": "^0.1.6",
         "node-red-node-tail": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "mqtt": "2.18.8",
         "multer": "1.4.2",
         "mustache": "4.0.1",
+        "node-red-admin": "^0.2.2",
         "node-red-node-rbe": "^0.2.6",
         "node-red-node-sentiment": "^0.1.6",
         "node-red-node-tail": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "mqtt": "2.18.8",
         "multer": "1.4.2",
         "mustache": "4.0.1",
-        "node-red-admin": "^0.2.3",
+        "node-red-admin": "^0.2.4",
         "node-red-node-rbe": "^0.2.6",
         "node-red-node-sentiment": "^0.1.6",
         "node-red-node-tail": "^0.1.0",

--- a/packages/node_modules/node-red/package.json
+++ b/packages/node_modules/node-red/package.json
@@ -39,7 +39,7 @@
         "bcryptjs": "2.4.3",
         "express": "4.17.1",
         "fs-extra": "8.1.0",
-        "node-red-admin": "^0.2.2",
+        "node-red-admin": "^0.2.3",
         "node-red-node-rbe": "^0.2.6",
         "node-red-node-tail": "^0.1.0",
         "nopt": "4.0.3",

--- a/packages/node_modules/node-red/package.json
+++ b/packages/node_modules/node-red/package.json
@@ -39,7 +39,7 @@
         "bcryptjs": "2.4.3",
         "express": "4.17.1",
         "fs-extra": "8.1.0",
-        "node-red-admin": "^0.2.3",
+        "node-red-admin": "^0.2.4",
         "node-red-node-rbe": "^0.2.6",
         "node-red-node-tail": "^0.1.0",
         "nopt": "4.0.3",

--- a/packages/node_modules/node-red/package.json
+++ b/packages/node_modules/node-red/package.json
@@ -39,6 +39,7 @@
         "bcryptjs": "2.4.3",
         "express": "4.17.1",
         "fs-extra": "8.1.0",
+        "node-red-admin": "^0.2.2",
         "node-red-node-rbe": "^0.2.6",
         "node-red-node-tail": "^0.1.0",
         "nopt": "4.0.3",

--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -14,6 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+
+if (process.argv[2] === 'admin') {
+    try {
+        require("node-red-admin")(process.argv.slice(3))
+    } catch(err) {
+        console.log(err)
+    }
+    return;
+}
+
 var http = require('http');
 var https = require('https');
 var util = require("util");
@@ -63,6 +73,7 @@ if (parsedArgs.help) {
     console.log("Node-RED v"+RED.version());
     console.log("Usage: node-red [-v] [-?] [--settings settings.js] [--userDir DIR]");
     console.log("                [--port PORT] [--title TITLE] [--safe] [flows.json]");
+    console.log("       node-red admin <command> [args] [-?] [--userDir DIR] [--json]");
     console.log("");
     console.log("Options:");
     console.log("  -p, --port     PORT  port to listen on");
@@ -73,6 +84,7 @@ if (parsedArgs.help) {
     console.log("      --safe           enable safe mode");
     console.log("  -D, --define   X=Y   overwrite value in settings file");
     console.log("  -?, --help           show this help");
+    console.log("  admin <command>      run an admin command");
     console.log("");
     console.log("Documentation can be found at http://nodered.org");
     process.exit();


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Adds `node-red-admin` as a dependency of the main node-red module.

Exposes it via the `admin` argument to the main `node-red` executable.

So to generate a password hash, users will be able to run:

```
node-red admin hash-pw
```

`admin` *must* be the first argument to the `node-red` command. If that is detected, all of the remaining arguments are passed to `node-red-admin` as-is. Any comments on the style or behaviour of the command should be directed at `node-red-admin`.

 - `node-red -? admin` will give you help for `node-red`.
 - `node-red admin -?` will give you help for `node-red-admin`.
