### PR TITLE
use bash as shell for exec command if on linux

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.js
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.js
@@ -18,6 +18,7 @@ module.exports = function(RED) {
     "use strict";
     var spawn = require('child_process').spawn;
     var exec = require('child_process').exec;
+    var fs = require('fs');
     var isUtf8 = require('is-utf8');
 
     function ExecNode(n) {
@@ -122,12 +123,14 @@ module.exports = function(RED) {
                     });
                 }
                 else {
+                    var execOpt = {encoding:'binary', maxBuffer:10000000};
+					if (process.platform === 'linux' && fs.existsSync('/bin/bash')) { execOpt.shell = '/bin/bash'; }
                     var cl = node.cmd;
                     if ((node.addpay === true) && msg.hasOwnProperty("payload")) { cl += " "+msg.payload; }
                     if (node.append.trim() !== "") { cl += " "+node.append; }
                     /* istanbul ignore else  */
                     if (RED.settings.verbose) { node.log(cl); }
-                    child = exec(cl, {encoding:'binary', maxBuffer:10000000}, function (error, stdout, stderr) {
+                    child = exec(cl, execOpt, function (error, stdout, stderr) {
                         var msg2, msg3;
                         delete msg.payload;
                         if (stderr) {

--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.js
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.js
@@ -31,10 +31,10 @@ module.exports = function(RED) {
         this.timer = Number(n.timer || 0)*1000;
         this.activeProcesses = {};
         this.oldrc = (n.oldrc || false).toString();
+	this.execOpt = {encoding:'binary', maxBuffer:10000000};
         var node = this;
 
-        var execOpt = {encoding:'binary', maxBuffer:10000000};
-	if (process.platform === 'linux' && fs.existsSync('/bin/bash')) { execOpt.shell = '/bin/bash'; }
+	if (process.platform === 'linux' && fs.existsSync('/bin/bash')) { node.execOpt.shell = '/bin/bash'; }
 	    
 	var cleanup = function(p) {
             node.activeProcesses[p].kill();
@@ -131,7 +131,7 @@ module.exports = function(RED) {
                     if (node.append.trim() !== "") { cl += " "+node.append; }
                     /* istanbul ignore else  */
                     if (RED.settings.verbose) { node.log(cl); }
-                    child = exec(cl, execOpt, function (error, stdout, stderr) {
+                    child = exec(cl, node.execOpt, function (error, stdout, stderr) {
                         var msg2, msg3;
                         delete msg.payload;
                         if (stderr) {

--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.js
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.js
@@ -33,7 +33,10 @@ module.exports = function(RED) {
         this.oldrc = (n.oldrc || false).toString();
         var node = this;
 
-        var cleanup = function(p) {
+        var execOpt = {encoding:'binary', maxBuffer:10000000};
+	if (process.platform === 'linux' && fs.existsSync('/bin/bash')) { execOpt.shell = '/bin/bash'; }
+	    
+	var cleanup = function(p) {
             node.activeProcesses[p].kill();
             //node.status({fill:"red",shape:"dot",text:"timeout"});
             //node.error("Exec node timeout");
@@ -123,8 +126,6 @@ module.exports = function(RED) {
                     });
                 }
                 else {
-                    var execOpt = {encoding:'binary', maxBuffer:10000000};
-					if (process.platform === 'linux' && fs.existsSync('/bin/bash')) { execOpt.shell = '/bin/bash'; }
                     var cl = node.cmd;
                     if ((node.addpay === true) && msg.hasOwnProperty("payload")) { cl += " "+msg.payload; }
                     if (node.append.trim() !== "") { cl += " "+node.append; }


### PR DESCRIPTION
This relates to:
https://github.com/node-red/node-red/issues/2604
and
https://discourse.nodered.org/t/exec-node-timeout-not-working-in-exec-mode/28040
and is a possible workaround for most issues related to kill described there.
This has only been tested on linux where this change applies so it would most definitely need more testing on windows/mac and maybe linux distributions where there is no bash(?).

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
