### PR TITLE
fix empty placeholder not shown on remove from group

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
@@ -20,6 +20,7 @@ RED.sidebar.info.outliner = (function() {
                 children: []
             },
             {
+                id: "__subflow__",
                 label: RED._("menu.label.subflows"),
                 children: []
             },
@@ -272,6 +273,9 @@ RED.sidebar.info.outliner = (function() {
             }
         })
 
+        subflowList.treeList.addChild(getEmptyItem("__subflow__"));
+        globalConfigNodes.treeList.addChild(getEmptyItem("__global__"));
+
         RED.events.on("projects:load", onProjectLoad)
 
         RED.events.on("flows:add", onFlowAdd)
@@ -358,6 +362,10 @@ RED.sidebar.info.outliner = (function() {
         } else {
             objects[sf.id].children.push(getEmptyItem(sf.id));
         }
+        if (empties["__subflow__"]) {
+            empties["__subflow__"].treeList.remove();
+            delete empties["__subflow__"];
+        }
         subflowList.treeList.addChild(objects[sf.id])
         updateSearch();
     }
@@ -384,13 +392,8 @@ RED.sidebar.info.outliner = (function() {
         } else {
             existingObject.element.find(".red-ui-info-outline-item-label").html("&nbsp;");
         }
-        var oldParent = existingObject.parent;
-        var oldParentID = oldParent.id;
-        if (parent !== oldParentID) {
+        if (parent !== existingObject.parent.id) {
             existingObject.treeList.remove(true);
-            if (oldParent.children.length === 0) {
-                objects[oldParentID].treeList.addChild(getEmptyItem(oldParentID));
-            }
             if (parent === "__global__") {
                 globalConfigNodes.treeList.addChild(existingObject);
             } else {
@@ -443,8 +446,8 @@ RED.sidebar.info.outliner = (function() {
                 delete missingParents[n.id]
             }
         }
-        var parent = n.g||n.z;
-        if (parent) {
+        var parent = n.g||n.z||"__global__";
+        if (parent !== "__global__") {
             if (objects[parent]) {
                 if (empties[parent]) {
                     empties[parent].treeList.remove();
@@ -460,8 +463,12 @@ RED.sidebar.info.outliner = (function() {
                 missingParents[parent].push(objects[n.id])
             }
         } else {
+            if (empties[parent]) {
+                empties[parent].treeList.remove();
+                delete empties[parent];
+            }
             // No parent - add to Global flow list
-            globalConfigNodes.treeList.addChild(objects[n.id])
+            globalConfigNodes.treeList.addChild(objects[n.id]);
         }
         objects[n.id].element.toggleClass("red-ui-info-outline-item-disabled", !!n.d)
         updateSearch();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
@@ -384,8 +384,13 @@ RED.sidebar.info.outliner = (function() {
         } else {
             existingObject.element.find(".red-ui-info-outline-item-label").html("&nbsp;");
         }
-        if (parent !== existingObject.parent.id) {
+        var oldParent = existingObject.parent;
+        var oldParentID = oldParent.id;
+        if (parent !== oldParentID) {
             existingObject.treeList.remove(true);
+            if (oldParent.children.length === 0) {
+                objects[oldParentID].treeList.addChild(getEmptyItem(oldParentID));
+            }
             if (parent === "__global__") {
                 globalConfigNodes.treeList.addChild(existingObject);
             } else {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
If the last element is removed from a group, an empty placeholder for the group is not shown on outliner tree.
Following steps can reproduce this:
1. import the following flow
```
[{"id":"e14b8c7f.8eac5","type":"tab","label":"Flow 1","disabled":false,"info":""},{"id":"d49ec8fc.6158c8","type":"group","z":"e14b8c7f.8eac5","style":{"stroke":"#999999","stroke-opacity":"1","fill":"none","fill-opacity":"1"},"nodes":["6b15a0dc.9f785"],"x":175,"y":80,"w":80,"h":80},{"id":"6b15a0dc.9f785","type":"comment","z":"e14b8c7f.8eac5","g":"d49ec8fc.6158c8","name":"","info":"","x":215,"y":120,"wires":[],"l":false}]
```
2. select comment node
3. Select menu item: Groups > Remove from group
4. *empty* placeholder for the outer group is not shown on outliner as follows:
![スクリーンショット 2020-06-11 10 02 06](https://user-images.githubusercontent.com/30289092/84333661-58845600-abcb-11ea-833a-989bb47072cb.png)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
