### PR TITLE
Fix char at error on undefined when opening websocket-listner

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.html
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.html
@@ -148,10 +148,12 @@
             if (root.slice(-1) != "/") {
                 root = root+"/";
             }
-            if (this.path.charAt(0) == "/") {
-                root += this.path.slice(1);
-            } else {
-                root += this.path;
+            if (this.path) {
+                if (this.path.charAt(0) == "/") {
+                    root += this.path.slice(1);
+                } else {
+                    root += this.path;
+                }
             }
             return root;
         },


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Opening `websocket-listner` settings panel causes following editor error:
```
Definition error: websocket-listener.label TypeError: Cannot read property 'charAt' of undefined
    at Object.label (<anonymous>:113:27)
    at Object.getNodeLabel (red.min.js:16)
    at Object.p [as refresh] (red.min.js:16)
    at Object.show (red.min.js:16)
    at red.min.js:16
```

This PR tries to fix this problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
