### PR TITLE
Disable group merge for single item or non-group items

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
@@ -178,7 +178,7 @@ RED.group = (function() {
         RED.events.on("view:selection-changed",function(selection) {
             RED.menu.setDisabled("menu-item-group-group",!!!selection.nodes);
             RED.menu.setDisabled("menu-item-group-ungroup",!!!selection.nodes || selection.nodes.filter(function(n) { return n.type==='group'}).length === 0);
-            RED.menu.setDisabled("menu-item-group-merge",!!!selection.nodes);
+            RED.menu.setDisabled("menu-item-group-merge", !!!selection.nodes || (selection.nodes.length <= 1) || selection.nodes.filter(function(n) { return n.type==='group'}).length === 0);
             RED.menu.setDisabled("menu-item-group-remove",!!!selection.nodes || selection.nodes.filter(function(n) { return !!n.g }).length === 0);
         });
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
@@ -176,10 +176,27 @@ RED.group = (function() {
     function init() {
 
         RED.events.on("view:selection-changed",function(selection) {
-            RED.menu.setDisabled("menu-item-group-group",!!!selection.nodes);
-            RED.menu.setDisabled("menu-item-group-ungroup",!!!selection.nodes || selection.nodes.filter(function(n) { return n.type==='group'}).length === 0);
-            RED.menu.setDisabled("menu-item-group-merge", !!!selection.nodes || (selection.nodes.length <= 1) || selection.nodes.filter(function(n) { return n.type==='group'}).length === 0);
-            RED.menu.setDisabled("menu-item-group-remove",!!!selection.nodes || selection.nodes.filter(function(n) { return !!n.g }).length === 0);
+            var activateGroup = !!selection.nodes;
+            var activateUngroup = false;
+            var activateMerge = false;
+            var activateRemove = false;
+            if (activateGroup) {
+                selection.nodes.forEach(function (n) {
+                    if (n.type === "group") {
+                        activateUngroup = true;
+                    }
+                    if (!!n.g) {
+                        activateRemove = true;
+                    }
+                });
+                if (activateUngroup) {
+                    activateMerge = (selection.nodes.length > 1);
+                }
+            }
+            RED.menu.setDisabled("menu-item-group-group", !activateGroup);
+            RED.menu.setDisabled("menu-item-group-ungroup", !activateUngroup);
+            RED.menu.setDisabled("menu-item-group-merge", !activateMerge);
+            RED.menu.setDisabled("menu-item-group-remove", !activateRemove);
         });
 
         RED.actions.add("core:group-selection", function() { groupSelection() })


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
`Groups > Merge selection` menu do not merge group for single element or non-group items.  
The operation for these items is the same as for `Groups > Group selection`. 
Therefore, This PR try to disable the `Group selection` menu for these cases.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
