### PR TITLE
Fix group position of empty group with multi-line label

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4277,7 +4277,9 @@ RED.view = (function() {
                         var labelPos = d.style["label-position"] || "nw";
                         d.h += h;
                         if (labelPos[0] === "n") {
-                            d.y -= h;
+                            if (d.nodes.length > 0) {
+                                d.y -= h;
+                            }
                         }
                     }
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
An empty group with multi-line label moves upward when workspace is redrawn.
This PR tries to fix this problem.

- Example flow:
```
[{"id":"e8f2e3bc.c68f8","type":"tab","label":"Flow 1","disabled":false,"info":""},{"id":"768e1e6b.b2306","type":"group","z":"e8f2e3bc.c68f8","name":"A\\nB","style":{"stroke":"#999999","fill":"none","label":true,"label-position":"nw","color":"#a4a4a4"},"nodes":[],"x":155,"y":148,"w":40,"h":56}]
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
