### PR TITLE
Fix i18n bug in outliner

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -20,7 +20,9 @@
             "fill": "塗りつぶし",
             "label": "ラベル",
             "color": "色",
-            "position": "配置"
+            "position": "配置",
+            "enable": "有効",
+            "disable": "無効"
         },
         "type": {
             "string": "文字列",
@@ -595,7 +597,16 @@
             "showTips": "設定からヒントを表示できます",
             "outline": "アウトライン",
             "empty": "空",
-            "globalConfig": "グローバル設定ノード"
+            "globalConfig": "グローバル設定ノード",
+            "triggerAction": "アクションを実行",
+            "find": "ワークスペース内を検索",
+            "search": {
+                "configNodes": "設定ノード",
+                "unusedConfigNodes": "未使用の設定ノード",
+                "invalidNodes": "不正なノード",
+                "uknownNodes": "未知のノード",
+                "unusedSubflows": "未使用のサブフロー"
+            }
         },
         "help": {
             "name": "ヘルプ",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/jsonata.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/jsonata.json
@@ -266,5 +266,9 @@
     "$type": {
         "args": "value",
         "desc": "`value` の型を文字列として返します。もし `value` が未定義の場合、 `undefined` が返されます。"
+    },
+    "$moment": {
+        "args": "[str]",
+        "desc": "Momentライブラリを使用して日付オブジェクトを取得します。"
     }
 }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
@@ -203,7 +203,7 @@ RED.sidebar.info.outliner = (function() {
                 }
             });
             RED.popover.tooltip(toggleButton,function() {
-                return RED._("common.label."+((n.type==='tab' && n.disabled) || (n.type!=='tab' && n.d))?"enable":"disable")
+                return RED._("common.label."+(((n.type==='tab' && n.disabled) || (n.type!=='tab' && n.d))?"enable":"disable"));
             });
         } else {
             $('<div class="red-ui-info-outline-item-control-spacer">').appendTo(controls)

--- a/packages/node_modules/@node-red/runtime/locales/ja/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/ja/runtime.json
@@ -31,6 +31,8 @@
             "install-failed": "インストールに失敗しました",
             "install-failed-long": "モジュール __name__ のインストールに失敗しました:",
             "install-failed-not-found": "$t(server.install.install-failed-long) モジュールが見つかりません",
+            "install-failed-name": "$t(server.install.install-failed-long) 不正なモジュール名: __name__",
+            "install-failed-url": "$t(server.install.install-failed-long) 不正なURL: __url__",
             "upgrading": "モジュール __name__ をバージョン __version__ に更新します",
             "upgraded": "モジュール __name__ を更新しました。新しいバージョンを使うには、Node-REDを再起動してください。",
             "upgrade-failed-not-found": "$t(server.install.install-failed-long) バージョンが見つかりません",


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I found that the enable/disable button in the outliner is always "enable". I fixed the i18n problem in this commit. And I added Japanese translations for outliner, jsonata, and runtime.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality