### PR TITLE
Fix error on empty subflow input types

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -1438,7 +1438,8 @@ RED.subflow = (function() {
 
         }).on("change", function(evt,type) {
             if (ui.type === 'input') {
-                ui.opts.types = inputCellInput.typedInput('value').split(",");
+                var types = inputCellInput.typedInput('value');
+                ui.opts.types = (types === "") ? ["str"] : types.split(",");
                 valueField.typedInput('types',ui.opts.types);
             }
         });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Editor causes following error if no selection on subflow input types is made.

```
Uncaught TypeError: Cannot read property 'value' of undefined
    at red.min.js:16
    at Array.map (<anonymous>)
    at t.<computed>.<computed>.types (red.min.js:16)
    at t.<computed>.<computed>.types (vendor.js:10)
    at HTMLInputElement.<anonymous> (vendor.js:10)
    at Function.each (vendor.js:2)
    at s.fn.init.each (vendor.js:2)
    at s.fn.init.t.fn.<computed> [as typedInput] (vendor.js:10)
    at HTMLInputElement.<anonymous> (red.min.js:16)
    at HTMLInputElement.dispatch (vendor.js:2)
```
This may be due to specifying an empty string as input type. 
In the proposed fix, use `str` type in such cases.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
