### PR TITLE
Fix crash in completeSend before first payload

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -427,60 +427,62 @@ module.exports = function(RED) {
 
         var completeSend = function(partId) {
             var group = inflight[partId];
-            if (group.timeout) { clearTimeout(group.timeout); }
-            if ((node.accumulate !== true) || group.msg.hasOwnProperty("complete")) { delete inflight[partId]; }
-            if (group.type === 'array' && group.arrayLen > 1) {
-                var newArray = [];
-                group.payload.forEach(function(n) {
-                    newArray = newArray.concat(n);
-                })
-                group.payload = newArray;
-            }
-            else if (group.type === 'buffer') {
-                var buffers = [];
-                var bufferLen = 0;
-                if (group.joinChar !== undefined) {
-                    var joinBuffer = Buffer.from(group.joinChar);
-                    for (var i=0; i<group.payload.length; i++) {
-                        if (i > 0) {
-                            buffers.push(joinBuffer);
-                            bufferLen += joinBuffer.length;
+            if (group !== undefined) {
+                if (group.timeout) { clearTimeout(group.timeout); }
+                if ((node.accumulate !== true) || group.msg.hasOwnProperty("complete")) { delete inflight[partId]; }
+                if (group.type === 'array' && group.arrayLen > 1) {
+                    var newArray = [];
+                    group.payload.forEach(function(n) {
+                        newArray = newArray.concat(n);
+                    })
+                    group.payload = newArray;
+                }
+                else if (group.type === 'buffer') {
+                    var buffers = [];
+                    var bufferLen = 0;
+                    if (group.joinChar !== undefined) {
+                        var joinBuffer = Buffer.from(group.joinChar);
+                        for (var i=0; i<group.payload.length; i++) {
+                            if (i > 0) {
+                                buffers.push(joinBuffer);
+                                bufferLen += joinBuffer.length;
+                            }
+                            if (!Buffer.isBuffer(group.payload[i])) { 
+                                group.payload[i] = Buffer.from(group.payload[i]);
+                            }
+                            buffers.push(group.payload[i]);
+                            bufferLen += group.payload[i].length;
                         }
-                        if (!Buffer.isBuffer(group.payload[i])) { 
-                            group.payload[i] = Buffer.from(group.payload[i]);
-                        }
-                        buffers.push(group.payload[i]);
-                        bufferLen += group.payload[i].length;
                     }
+                    else {
+                        bufferLen = group.bufferLen;
+                        buffers = group.payload;
+                    }
+                    group.payload = Buffer.concat(buffers,bufferLen);
+                }
+
+                if (group.type === 'string') {
+                    var groupJoinChar = group.joinChar;
+                    if (typeof group.joinChar !== 'string') {
+                        groupJoinChar = group.joinChar.toString();
+                    }
+                    RED.util.setMessageProperty(group.msg,node.property,group.payload.join(groupJoinChar));
                 }
                 else {
-                    bufferLen = group.bufferLen;
-                    buffers = group.payload;
+                    if (node.propertyType === 'full') {
+                        group.msg = RED.util.cloneMessage(group.msg);
+                    }
+                    RED.util.setMessageProperty(group.msg,node.property,group.payload);
                 }
-                group.payload = Buffer.concat(buffers,bufferLen);
-            }
-
-            if (group.type === 'string') {
-                var groupJoinChar = group.joinChar;
-                if (typeof group.joinChar !== 'string') {
-                    groupJoinChar = group.joinChar.toString();
+                if (group.msg.hasOwnProperty('parts') && group.msg.parts.hasOwnProperty('parts')) {
+                    group.msg.parts = group.msg.parts.parts;
                 }
-                RED.util.setMessageProperty(group.msg,node.property,group.payload.join(groupJoinChar));
-            }
-            else {
-                if (node.propertyType === 'full') {
-                    group.msg = RED.util.cloneMessage(group.msg);
+                else {
+                    delete group.msg.parts;
                 }
-                RED.util.setMessageProperty(group.msg,node.property,group.payload);
+                delete group.msg.complete;
+                node.send(RED.util.cloneMessage(group.msg));
             }
-            if (group.msg.hasOwnProperty('parts') && group.msg.parts.hasOwnProperty('parts')) {
-                group.msg.parts = group.msg.parts.parts;
-            }
-            else {
-                delete group.msg.parts;
-            }
-            delete group.msg.complete;
-            node.send(RED.util.cloneMessage(group.msg));
         }
 
         var pendingMessages = [];


### PR DESCRIPTION
This fixed the crash, if a msg.complete triggers the completeSend, before any other message (msg.payload) was received.
Typically inflight is empty and group is undefined in this case.

An example flow and more comments in in #2471

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality

### Review hint
Please check changes whithout white spaces to see the only one injected `if` on top line