### PR TITLE
Add developer options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -623,6 +623,10 @@ module.exports = function(grunt) {
     grunt.registerTask('build',
         'Builds editor content',
         ['clean:build','jsonlint','concat:build','concat:vendor','copy:build','uglify:build','sass:build','attachCopyright']);
+        
+    grunt.registerTask('build-dev',
+        'Developer mode: build dev version',
+        ['clean:build','concat:build','concat:vendor','copy:build','sass:build','setDevEnv']);
 
     grunt.registerTask('dev',
         'Developer mode: run node-red, watch for source changes and build/restart',

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
         "start": "node packages/node_modules/node-red/red.js",
         "test": "grunt",
         "build": "grunt build",
+        "dev": "grunt dev",
+        "build-dev": "grunt build-dev",
         "docs": "grunt docs"
     },
     "contributors": [


### PR DESCRIPTION
## Commit message
Add developer options
* permits npm run build-dev.  skips minification & doesnt launch nodemon
* permits npm run dev for those without grunt installed globally

## Info
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Proposed changes

In summary...
* Adds `"build-dev": "grunt build-dev"` to `package.json` scripts
  * this permits `npm run build-dev`
  * skips minification & doesnt launch dev server - ideal for VSCode / Atom F5 step debugging in IDE

* Adds `"dev": "grunt dev"` to `package.json` scripts
  * this permits `npm run dev` for those without grunt installed globally

REF: https://discourse.nodered.org/t/live-streaming-some-node-red-development-work/26856/10

<br>

Additional info (for adding to [developer docs](https://nodered.org/docs/developing/)?)

### How to setup F5 Debug Run in VSCode

#### Add a configuration entry in launch.json ...
```
  {
     "version": "0.2.0",
     "configurations": [
        {
            "type": "node",
            "request": "launch",
            "name": "Debug node-red",
            "skipFiles": [
                "<node_internals>/**"
            ],
            "env": { "NODE_ENV": "development" },
            "preLaunchTask": "npm: build-dev",
            "program": "${workspaceFolder}\\packages\\node_modules\\node-red\\red.js"
        }
     ]
  }
```
#### Add an entry in tasks.json
```
{
    "version": "2.0.0",
    "tasks": [
         {
			"type": "npm",
			"script": "build-dev",
			"group": "build",
			"problemMatcher": [],
			"label": "npm: build-dev",
			"detail": "build-dev"
         }
    ]
}
```
...now you can simply press `F5` and VSCode will run the grunt task and start the project with non minified code.



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass 
- [ ] I have added suitable unit tests to cover the new/changed functionality
