### PR TITLE
fix debug status to not loop, make migration more seamless, detect status type objects

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.html
@@ -25,7 +25,7 @@
     </label>
     </div>
     <div class="form-row" id="node-tostatus-line">
-        <label for="node-input-typed-status"><i class="fa fa-ellipsis-h"></i> <span data-i18n="debug.status"></span></label>
+        <label for="node-input-typed-status"></label>
         <input id="node-input-typed-status" type="text" style="width: 70%">
         <input id="node-input-statusVal" type="hidden">
         <input id="node-input-statusType" type="hidden">
@@ -435,7 +435,7 @@
                 $("#node-input-typed-status").typedInput('value',this.statusVal || "");
             }
             if (this.statusType === undefined) {
-                this.statusType = this.targetType;
+                this.statusType = "auto";
                 $("#node-input-typed-status").typedInput('type',this.statusType || "auto");
             }
             if (typeof this.console === "string") {

--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.js
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.js
@@ -99,6 +99,10 @@ module.exports = function(RED) {
         }
 
         this.on("input", function(msg, send, done) {
+            if (msg.hasOwnProperty("status") && msg.status.hasOwnProperty("source") && msg.status.source.hasOwnProperty("id") && (msg.status.source.id === node.id)) {
+                done();
+                return;
+            }
             if (node.tostatus === true) {
                 prepareStatus(msg, function(err,debugMsg) {
                     if (err) { node.error(err); return; }
@@ -106,19 +110,29 @@ module.exports = function(RED) {
                     var st = (typeof output === 'string') ? output : util.inspect(output);
                     var fill = "grey";
                     var shape = "dot";
+                    if (typeof output === 'object' && output.hasOwnProperty("fill") && output.hasOwnProperty("shape") && output.hasOwnProperty("text")) {
+                        fill = output.fill;
+                        shape = output.shape;
+                        st = output.text;
+                    }
                     if (node.statusType === "auto") {
                         if (msg.hasOwnProperty("error")) {
                             fill = "red";
                             st = msg.error.message;
                         }
                         if (msg.hasOwnProperty("status")) {
-                            if (msg.status.hasOwnProperty("fill")) { fill = msg.status.fill; }
-                            if (msg.status.hasOwnProperty("shape")) { shape = msg.status.shape; }
-                            if (msg.status.hasOwnProperty("text")) { st = msg.status.text; }
+                            fill = msg.status.fill || "grey";
+                            shape = msg.status.shape || "ring";
+                            st = msg.status.text || "";
                         }
                     }
+
                     if (st.length > 32) { st = st.substr(0,32) + "..."; }
-                    node.status({fill:fill, shape:shape, text:st});
+                    var newStatus = {fill:fill, shape:shape, text:st};
+                    if (JSON.stringify(newStatus) !== node.oldState) { // only send if we have to
+                        node.status(newStatus);
+                        node.oldState = JSON.stringify(newStatus);
+                    }
                 });
             }
 

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -123,7 +123,7 @@
         "invalid-exp": "Invalid JSONata expression: __error__",
         "msgprop": "message property",
         "msgobj": "complete msg object",
-        "autostatus": "automatic",
+        "autostatus": "show Output",
         "to": "To",
         "debtab": "debug tab",
         "tabcon": "debug tab and console",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This is a fix/update/improvement to #2564

Removes the extra status label that confused some users. 
Renamed "auto" mode to "show Output" to reflect that is just trying to show the default output as before. 
Tidied up loop detection logic so if a status node was set to pick up the status from all nodes (the default) - then fed into a debug set to show status - the debug would recognise the message had come from itself and not update (so breaking a spin loop).
Also only send status if it had actually changed from last status set ( also helps to break loops )
It also now checks the property it is set to and if that is an object containing a shape, fill and text then it uses those as if it were a real status message (rather than just printing the object.)
Finally - it improves the migration from older version of the debug node by defaulting to "show Output" mode rather than copying the existing output formula to the status - which looked wtf and caused confusion.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
