### PR TITLE
expose send, status, log, warn, error, debug, trace, name, id in setup code of function node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -25,7 +25,6 @@ module.exports = function(RED) {
         } else if (!util.isArray(msgs)) {
             msgs = [msgs];
         }
-        if(_msgid === "") _msgid = RED.util.generateId();
         var msgCount = 0;
         for (var m=0; m<msgs.length; m++) {
             if (msgs[m]) {
@@ -281,7 +280,7 @@ module.exports = function(RED) {
                             trace:__node__.trace,
                             status:__node__.status,
                             send: function(msgs, cloneMsg) { 
-                                __node__.send(__send__, "", msgs, cloneMsg); 
+                                __node__.send(__send__, RED.util.generateId(), msgs, cloneMsg); 
                             }
                         };
                         `+ node.ini +`

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -25,6 +25,7 @@ module.exports = function(RED) {
         } else if (!util.isArray(msgs)) {
             msgs = [msgs];
         }
+        if(_msgid === "") _msgid = RED.util.generateId();
         var msgCount = 0;
         for (var m=0; m<msgs.length; m++) {
             if (msgs[m]) {
@@ -268,7 +269,23 @@ module.exports = function(RED) {
             var iniScript = null;
             var iniOpt = null;
             if (node.ini && (node.ini !== "")) {
-                var iniText = "(async function () {\n"+node.ini +"\n})();";
+                var iniText = `
+                    (async function(__send__) {
+                        var node = {
+                            id:__node__.id,
+                            name:__node__.name,
+                            log:__node__.log,
+                            error:__node__.error,
+                            warn:__node__.warn,
+                            debug:__node__.debug,
+                            trace:__node__.trace,
+                            status:__node__.status,
+                            send: function(msgs, cloneMsg) { 
+                                __node__.send(__send__, "", msgs, cloneMsg); 
+                            }
+                        };
+                        `+ node.ini +`
+                    })(send);`;
                 iniOpt = createVMOpt(node, " setup");
                 iniScript = new vm.Script(iniText, iniOpt);
             }
@@ -280,7 +297,9 @@ module.exports = function(RED) {
             }
             var promise = Promise.resolve();
             if (iniScript) {
+                context.send = function(m) { node.send(m); };
                 promise = iniScript.runInContext(context, iniOpt);
+                delete context.send;
             }
 
             function processMessage(msg, send, done) {


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes
Starting with v1.1 the function node has a setup and close handler.
However, compared to the main function body that is executed each time a message arrives, the setup handler (and the close handler) does only expose a subset of the functionality of the main function body.
This PR exposes `send, status, log, warn, error, debug, trace, name, id` in the setup handler.

See also https://discourse.nodered.org/t/setup-and-close-of-new-function-node-discussion-about-use-cases-extensions/29570

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team. 
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
