### PR TITLE
Clarify empty rules in switch node documentation

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/10-switch.html
@@ -38,9 +38,8 @@
     <h4>Notes</h4>
     <p>The <code>is true/false</code> and <code>is null</code> rules perform strict
        comparisons against those types. They do not convert between types.</p>
-    <p>The <code>is empty</code> and <code>is not empty</code> rules passes for Strings, Arrays and Buffers that have
-       a length of 0, or Objects that have no properties. It does not pass for <code>boolean</code>, <code>null</code> 
-       or <code>undefined</code> values.</p>
+    <p>The <code>is empty</code> and <code>is not empty</code> rules can be used to test the length of Strings, Arrays and Buffers, or the number of properties an Object has. Neither rule will pass if the property being tested has a <code>boolean</code>, <code>null</code> 
+       or <code>undefined</code> value.</p>
     <h4>Handling message sequences</h4>
     <p>By default, the node does not modify the <code>msg.parts</code> property of messages
        that are part of a sequence.</p>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/10-switch.html
@@ -38,8 +38,8 @@
     <h4>Notes</h4>
     <p>The <code>is true/false</code> and <code>is null</code> rules perform strict
        comparisons against those types. They do not convert between types.</p>
-    <p>The <code>is empty</code> rule passes for Strings, Arrays and Buffers that have
-       a length of 0, or Objects that have no properties. It does not pass for <code>null</code>
+    <p>The <code>is empty</code> and <code>is not empty</code> rules passes for Strings, Arrays and Buffers that have
+       a length of 0, or Objects that have no properties. It does not pass for <code>boolean</code>, <code>null</code> 
        or <code>undefined</code> values.</p>
     <h4>Handling message sequences</h4>
     <p>By default, the node does not modify the <code>msg.parts</code> property of messages


### PR DESCRIPTION
Clarify switch help regarding booleans for the is empty / is not empty rules.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
