### PR TITLE
Update Japanese translation for switch node

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/ja/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/function/10-switch.html
@@ -28,11 +28,9 @@
         <li><b>JSONata式</b> - メッセージ全体に対して評価を行い、結果が真の場合にマッチ</li>
         <li><b>その他</b> - これより前のルールにマッチするものがなかった場合に適用</li>
     </ol>
-
     <h4>注釈</h4>
     <p><code>is true/false</code>と<code>is null</code>のルールは、型に対して厳密な比較を行います。型変換した上での比較はしません。</p>
-    <p><code>is empty</code>のルールは、長さ０の文字列・配列・バッファ、またはプロパティを持たないオブジェクトを出力します。<code>null</code>や<code>undefined</code>は出力しません。</p>
-
+    <p><code>is empty</code>と<code>is not empty</code>のルールは、文字列・配列・バッファの長さや、オブジェクトが持つプロパティの数をテストするために用いられます。どちらのルールも、テストされるプロパティが<code>boolean</code>や<code>null</code>、<code>undefined</code>の値を持つ場合、通過しません。</p>
     <h4>メッセージ列の扱い</h4>
     <p>switchノードは入力メッセージの列に関する情報を保持する<code>msg.parts</code>をデフォルトでは変更しません。</p>
     <p>「<b>メッセージ列の補正</b>」オプションを指定すると、マッチした各ルールに対して新しいメッセージ列を生成します。このモードでは、switchノードは新たなメッセージ列を送信する前に、入力メッセージ列全体を内部に蓄積します。<b>settings.js</b>の<code>nodeMessageBufferMaxLength</code>を設定すると、蓄積するメッセージ数を制限できます。</p>


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Because documentation about empty rules in the switch node is updated in #2649, I also updated the Japanese translation for it.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality