### PR TITLE
Update util.writeFile to write to tmp file before rename

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/util.js
@@ -17,7 +17,6 @@
 var fs = require('fs-extra');
 var fspath = require('path');
 var when = require('when');
-var nodeFn = require('when/node/function');
 
 var log = require("@node-red/util").log; // TODO: separate module
 
@@ -75,39 +74,58 @@ function readFile(path,backupPath,emptyResponse,type) {
 
 module.exports = {
     /**
-     * Write content to a file using UTF8 encoding.
-     * This forces a fsync before completing to ensure
-     * the write hits disk.
-     */
-     writeFile: function(path,content,backupPath) {
+    * Write content to a file using UTF8 encoding.
+    * This forces a fsync before completing to ensure
+    * the write hits disk.
+    */
+    writeFile: function(path,content,backupPath) {
+        var backupPromise;
         if (backupPath) {
-            if (fs.existsSync(path)) {
-                fs.renameSync(path,backupPath);
-            }
+            backupPromise = fs.copy(path,backupPath);
+        } else {
+            backupPromise = Promise.resolve();
         }
-        return when.promise(function(resolve,reject) {
-            fs.ensureDir(fspath.dirname(path), (err)=>{
-                if (err) {
-                    reject(err);
-                    return;
-                }
-                var stream = fs.createWriteStream(path);
+
+        const dirname = fspath.dirname(path);
+        const tempFile = `${path}.$$$`;
+
+        return backupPromise.then(() => {
+            if (backupPath) {
+                log.trace(`utils.writeFile - copied ${path} TO ${backupPath}`)
+            }
+            return fs.ensureDir(dirname)
+        }).then(() => {
+            return new Promise(function(resolve,reject) {
+                var stream = fs.createWriteStream(tempFile);
                 stream.on('open',function(fd) {
                     stream.write(content,'utf8',function() {
                         fs.fsync(fd,function(err) {
                             if (err) {
-                                log.warn(log._("storage.localfilesystem.fsync-fail",{path: path, message: err.toString()}));
+                                log.warn(log._("storage.localfilesystem.fsync-fail",{path: tempFile, message: err.toString()}));
                             }
                             stream.end(resolve);
                         });
                     });
                 });
                 stream.on('error',function(err) {
+                    log.warn(log._("storage.localfilesystem.fsync-fail",{path: tempFile, message: err.toString()}));
                     reject(err);
                 });
             });
+        }).then(() => {
+            log.trace(`utils.writeFile - written content to ${tempFile}`)
+            return new Promise(function(resolve,reject) {
+                fs.rename(tempFile,path,err => {
+                    if (err) {
+                        log.warn(log._("storage.localfilesystem.fsync-fail",{path: path, message: err.toString()}));
+                        return reject(err);
+                    }
+                    log.trace(`utils.writeFile - renamed ${tempFile} to ${path}`)
+                    resolve();
+                })
+            });
         });
-     },
+    },
     readFile: readFile,
 
     parseJSON: parseJSON


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

## Proposed changes

The Local Filesystem storage module has a utility function used to write files - this is used in a number of places such as the flow/credential files and the runtime settings (`.config.json`).

The existing code does the follow:

 1. renames the existing file to a backup file (if the caller provided a backup file name)
 2. writes the new content to the desired file
 3. tries to sync the file descriptor to get the writes flushed

This means there is a window of time where the original file has been renamed and the new content has not yet been written to the file.

I have seen a small number of times when using `grunt dev` (which will cause the node process to be killed whenever I modify a file) that the `.config.json` file is corrupted and the runtime settings are lost.

I cannot reliably reproduce it, but I'm pretty sure its related to killing Node-RED whilst its starting up.

This PR modifies the logic around the `writeFile` function. It now does:

1. **copies** the existing file to a backup file (if the caller provided a backup file name)
2. writes the new content to a temporary file (the filename is `<file>.$$$`)
3. flushes the file descriptor
4. renames the temporary file to the desired file.

That means the file has valid content through-out the process - as the final rename will be an atomic fs action.


