### PR TITLE
Avoid loading node html if disableEditor set

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,6 +25,11 @@ module.exports = function(grunt) {
     if (flowFile) {
         nodemonArgs.push(flowFile);
     }
+    var userDir = grunt.option('userDir');
+    if (userDir) {
+        nodemonArgs.push("-u");
+        nodemonArgs.push(userDir);
+    }
 
     var browserstack = grunt.option('browserstack');
     if (browserstack) {
@@ -623,7 +628,7 @@ module.exports = function(grunt) {
     grunt.registerTask('build',
         'Builds editor content',
         ['clean:build','jsonlint','concat:build','concat:vendor','copy:build','uglify:build','sass:build','attachCopyright']);
-        
+
     grunt.registerTask('build-dev',
         'Developer mode: build dev version',
         ['clean:build','concat:build','concat:vendor','copy:build','sass:build','setDevEnv']);

--- a/packages/node_modules/@node-red/registry/lib/loader.js
+++ b/packages/node_modules/@node-red/registry/lib/loader.js
@@ -15,7 +15,7 @@
  **/
 
 var when = require("when");
-var fs = require("fs");
+var fs = require("fs-extra");
 var path = require("path");
 var semver = require("semver");
 
@@ -113,118 +113,123 @@ function loadNodeFiles(nodeFiles) {
     });
 }
 
-function loadNodeConfig(fileInfo) {
-    return new Promise(function(resolve) {
-        var file = fileInfo.file;
-        var module = fileInfo.module;
-        var name = fileInfo.name;
-        var version = fileInfo.version;
+async function loadNodeTemplate(node) {
+    return fs.readFile(node.template,'utf8').then(content => {
+        var types = [];
 
-        var id = module + "/" + name;
-        var info = registry.getNodeInfo(id);
-        var isEnabled = true;
-        if (info) {
-            if (info.hasOwnProperty("loaded")) {
-                throw new Error(file+" already loaded");
+        var regExp = /<script (?:[^>]*)data-template-name\s*=\s*['"]([^'"]*)['"]/gi;
+        var match = null;
+
+        while ((match = regExp.exec(content)) !== null) {
+            types.push(match[1]);
+        }
+        node.types = types;
+
+        var langRegExp = /^<script[^>]* data-lang\s*=\s*['"](.+?)['"]/i;
+        regExp = /(<script[^>]* data-help-name=[\s\S]*?<\/script>)/gi;
+        match = null;
+        var mainContent = "";
+        var helpContent = {};
+        var index = 0;
+        while ((match = regExp.exec(content)) !== null) {
+            mainContent += content.substring(index,regExp.lastIndex-match[1].length);
+            index = regExp.lastIndex;
+            var help = content.substring(regExp.lastIndex-match[1].length,regExp.lastIndex);
+
+            var lang = i18n.defaultLang;
+            if ((match = langRegExp.exec(help)) !== null) {
+                lang = match[1];
             }
-            isEnabled = info.enabled;
-        }
+            if (!helpContent.hasOwnProperty(lang)) {
+                helpContent[lang] = "";
+            }
 
-        var node = {
-            id: id,
-            module: module,
-            name: name,
-            file: file,
-            template: file.replace(/\.js$/,".html"),
-            enabled: isEnabled,
-            loaded:false,
-            version: version,
-            local: fileInfo.local
-        };
-        if (fileInfo.hasOwnProperty("types")) {
-            node.types = fileInfo.types;
+            helpContent[lang] += help;
         }
+        mainContent += content.substring(index);
 
-        fs.readFile(node.template,'utf8', function(err,content) {
-            if (err) {
+        node.config = mainContent;
+        node.help = helpContent;
+        // TODO: parse out the javascript portion of the template
+        //node.script = "";
+        for (var i=0;i<node.types.length;i++) {
+            if (registry.getTypeId(node.types[i])) {
+                node.err = node.types[i]+" already registered";
+                break;
+            }
+        }
+        return node
+    }).catch(err => {
+        node.types = [];
+        if (err.code === 'ENOENT') {
+            if (!node.types) {
                 node.types = [];
-                if (err.code === 'ENOENT') {
-                    if (!node.types) {
-                        node.types = [];
-                    }
-                    node.err = "Error: "+node.template+" does not exist";
-                } else {
-                    node.types = [];
-                    node.err = err.toString();
-                }
-                resolve(node);
-            } else {
-                var types = [];
-
-                var regExp = /<script (?:[^>]*)data-template-name\s*=\s*['"]([^'"]*)['"]/gi;
-                var match = null;
-
-                while ((match = regExp.exec(content)) !== null) {
-                    types.push(match[1]);
-                }
-                node.types = types;
-
-                var langRegExp = /^<script[^>]* data-lang\s*=\s*['"](.+?)['"]/i;
-                regExp = /(<script[^>]* data-help-name=[\s\S]*?<\/script>)/gi;
-                match = null;
-                var mainContent = "";
-                var helpContent = {};
-                var index = 0;
-                while ((match = regExp.exec(content)) !== null) {
-                    mainContent += content.substring(index,regExp.lastIndex-match[1].length);
-                    index = regExp.lastIndex;
-                    var help = content.substring(regExp.lastIndex-match[1].length,regExp.lastIndex);
-
-                    var lang = i18n.defaultLang;
-                    if ((match = langRegExp.exec(help)) !== null) {
-                        lang = match[1];
-                    }
-                    if (!helpContent.hasOwnProperty(lang)) {
-                        helpContent[lang] = "";
-                    }
-
-                    helpContent[lang] += help;
-                }
-                mainContent += content.substring(index);
-
-                node.config = mainContent;
-                node.help = helpContent;
-                // TODO: parse out the javascript portion of the template
-                //node.script = "";
-                for (var i=0;i<node.types.length;i++) {
-                    if (registry.getTypeId(node.types[i])) {
-                        node.err = node.types[i]+" already registered";
-                        break;
-                    }
-                }
-                if (node.module === 'node-red') {
-                    // do not look up locales directory for core nodes
-                    node.namespace = node.module;
-                    resolve(node);
-                    return;
-                }
-                fs.stat(path.join(path.dirname(file),"locales"),function(err,stat) {
-                    if (!err) {
-                        node.namespace = node.id;
-                        i18n.registerMessageCatalog(node.id,
-                                path.join(path.dirname(file),"locales"),
-                                path.basename(file,".js")+".json")
-                            .then(function() {
-                                resolve(node);
-                            });
-                    } else {
-                        node.namespace = node.module;
-                        resolve(node);
-                    }
-                });
             }
-        });
+            node.err = "Error: "+node.template+" does not exist";
+        } else {
+            node.types = [];
+            node.err = err.toString();
+        }
+        return node;
     });
+}
+
+async function loadNodeLocales(node) {
+    if (node.module === 'node-red') {
+        // do not look up locales directory for core nodes
+        node.namespace = node.module;
+        return node
+    }
+    return fs.stat(path.join(path.dirname(node.file),"locales")).then(stat => {
+        node.namespace = node.id;
+        return i18n.registerMessageCatalog(node.id,
+                path.join(path.dirname(node.file),"locales"),
+                path.basename(node.file,".js")+".json")
+            .then(() => node);
+    }).catch(err => {
+        node.namespace = node.module;
+        return node;
+    });
+}
+
+async function loadNodeConfig(fileInfo) {
+    var file = fileInfo.file;
+    var module = fileInfo.module;
+    var name = fileInfo.name;
+    var version = fileInfo.version;
+
+    var id = module + "/" + name;
+    var info = registry.getNodeInfo(id);
+    var isEnabled = true;
+    if (info) {
+        if (info.hasOwnProperty("loaded")) {
+            throw new Error(file+" already loaded");
+        }
+        isEnabled = info.enabled;
+    }
+
+    var node = {
+        id: id,
+        module: module,
+        name: name,
+        file: file,
+        template: file.replace(/\.js$/,".html"),
+        enabled: isEnabled,
+        loaded:false,
+        version: version,
+        local: fileInfo.local,
+        types: [],
+        config: "",
+        help: {}
+    };
+    if (fileInfo.hasOwnProperty("types")) {
+        node.types = fileInfo.types;
+    }
+    await loadNodeLocales(node)
+    if (!settings.disableEditor) {
+        return loadNodeTemplate(node);
+    }
+    return node;
 }
 
 /**


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

This change modifies how nodes are loaded so that if `disableEditor` is set, we now skip loading the node html into memory.

This shaves a small amount off the startup time - not as much as I'd hoped. But it will save a bit of memory usage.

It still loads the locales files as a node may have runtime messages in its catalog.

## Checklist

- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
