### PR TITLE
Add 'done' metric log for message tracing

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
@@ -124,6 +124,7 @@ Node.prototype.context = function() {
  * @param  {error} error (optional) an error hit whilst handling the message
  */
 Node.prototype._complete = function(msg,error) {
+    this.metric("done",msg);
     if (error) {
         // For now, delegate this to this.error
         // But at some point, the timeout handling will need to know about


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

To enable precise tracing of each message, we propose to make the runtime emit log message whenever the message processing is finished. 
By this PR, nodes which use Messaging API (i.e., call done() at end of message processing) emit "done" event on metric log.

Example log output:
```
18 Aug 09:11:09 - [metric] {"level":99,"nodeid":"f748808a.a2b39","event":"node.http response.done","msgid":"59bf7151.69477","timestamp":1597709469150}
```

Further details are on the design note of [Message Tracing by metric log](https://github.com/node-red/designs/pull/34).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
