### PR TITLE
Recover nodes with invalid z property

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -213,6 +213,9 @@
         "groupCopied_plural": "__count__ groups copied",
         "groupStyleCopied": "Group style copied",
         "invalidFlow": "Invalid flow: __message__",
+        "recoveredNodes": "Recovered Nodes",
+        "recoveredNodesInfo": "The nodes on this flow were missing a valid flow id when they were imported. They have been added to this flow so you can either restore or delete them.",
+        "recoveredNodesNotification": "<p>Imported nodes without a valid flow id</p><p>They have been added to a new flow called '__flowName__'.</p>",
         "export": {
             "selected":"selected nodes",
             "current":"current flow",

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -971,10 +971,15 @@ RED.nodes = (function() {
                 // Hit the rare issue where node z values get set to 0.
                 // Repair the flow - but we really need to track that down.
                 if (!recoveryWorkspace) {
-                    recoveryWorkspace = RED.workspaces.add(null,true);
-                    recoveryWorkspace.label = RED._("clipboard.recoveredNodes");
-                    recoveryWorkspace.info = RED._("clipboard.recoveredNodesInfo");
-
+                    recoveryWorkspace = {
+                        id: RED.nodes.id(),
+                        type: "tab",
+                        disabled: false,
+                        label: RED._("clipboard.recoveredNodes"),
+                        info: RED._("clipboard.recoveredNodesInfo")
+                    }
+                    addWorkspace(recoveryWorkspace);
+                    RED.workspaces.add(recoveryWorkspace);
                     nodeZmap[recoveryWorkspace.id] = [];
                 }
                 n.z = recoveryWorkspace.id;

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -897,12 +897,23 @@ RED.nodes = (function() {
         }
         return true;
     }
-
-    function importNodes(newNodesObj,createNewIds,createMissingWorkspace) {
+    /**
+     * Options:
+     *  - generateIds - whether to replace all node ids
+     *  - addFlow - whether to import nodes to a new tab
+     */
+    function importNodes(newNodesObj,options) { // createNewIds,createMissingWorkspace) {
+        options = options || {
+            generateIds: false,
+            addFlow: false
+        }
+        var createNewIds = options.generateIds;
+        var createMissingWorkspace = options.addFlow;
         var i;
         var n;
         var newNodes;
         var nodeZmap = {};
+        var recoveryWorkspace;
         if (typeof newNodesObj === "string") {
             if (newNodesObj === "") {
                 return;
@@ -956,6 +967,18 @@ RED.nodes = (function() {
             if (n.z) {
                 nodeZmap[n.z] = nodeZmap[n.z] || [];
                 nodeZmap[n.z].push(n);
+            } else if (n.z === 0) {
+                // Hit the rare issue where node z values get set to 0.
+                // Repair the flow - but we really need to track that down.
+                if (!recoveryWorkspace) {
+                    recoveryWorkspace = RED.workspaces.add(null,true);
+                    recoveryWorkspace.label = RED._("clipboard.recoveredNodes");
+                    recoveryWorkspace.info = RED._("clipboard.recoveredNodesInfo");
+
+                    nodeZmap[recoveryWorkspace.id] = [];
+                }
+                n.z = recoveryWorkspace.id;
+                nodeZmap[recoveryWorkspace.id].push(n);
             }
 
         }
@@ -1004,6 +1027,10 @@ RED.nodes = (function() {
         var configNode;
         var missingWorkspace = null;
         var d;
+
+        if (recoveryWorkspace) {
+            new_workspaces.push(recoveryWorkspace);
+        }
 
         // Find all tabs and subflow templates
         for (i=0;i<newNodes.length;i++) {
@@ -1492,6 +1519,18 @@ RED.nodes = (function() {
         }
 
         RED.workspaces.refresh();
+
+
+        if (recoveryWorkspace) {
+            var notification = RED.notify(RED._("clipboard.recoveredNodesNotification",{flowName:RED._("clipboard.recoveredNodes")}),{
+                type:"warning",
+                fixed:true,
+                buttons: [
+                    {text: RED._("common.label.close"), click: function() { notification.close() }}
+                ]
+            });
+        }
+
         return [new_nodes,new_links,new_groups,new_workspaces,new_subflows,missingWorkspace];
     }
 
@@ -1688,7 +1727,7 @@ RED.nodes = (function() {
                     // Force the redraw to be synchronous so the view updates
                     // *now* and removes the unknown node
                     RED.view.redraw(true, true);
-                    var result = importNodes(reimportList,false);
+                    var result = importNodes(reimportList,{generateIds:false});
                     var newNodeMap = {};
                     result[0].forEach(function(n) {
                         newNodeMap[n.id] = n;

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -141,7 +141,7 @@ RED.clipboard = (function() {
                         click: function() {
                             var addNewFlow = ($("#red-ui-clipboard-dialog-import-opt > a.selected").attr('id') === 'red-ui-clipboard-dialog-import-opt-new');
                             if (activeTab === "red-ui-clipboard-dialog-import-tab-clipboard") {
-                                RED.view.importNodes($("#red-ui-clipboard-dialog-import-text").val(),addNewFlow);
+                                importNodes($("#red-ui-clipboard-dialog-import-text").val(),addNewFlow);
                             } else {
                                 var selectedPath;
                                 if (activeTab === "red-ui-clipboard-dialog-import-tab-library") {
@@ -151,7 +151,7 @@ RED.clipboard = (function() {
                                 }
                                 if (selectedPath.path) {
                                     $.get('library/'+selectedPath.library+'/'+selectedPath.type+'/'+selectedPath.path, function(data) {
-                                        RED.view.importNodes(data,addNewFlow);
+                                        importNodes(data,addNewFlow);
                                     });
                                 }
                             }
@@ -359,7 +359,7 @@ RED.clipboard = (function() {
         }
     }
 
-    function importNodes(mode) {
+    function showImportNodes(mode) {
         if (disabled) {
             return;
         }
@@ -494,7 +494,7 @@ RED.clipboard = (function() {
         });
     }
 
-    function exportNodes(mode) {
+    function showExportNodes(mode) {
         if (disabled) {
             return;
         }
@@ -746,19 +746,39 @@ RED.clipboard = (function() {
         }
         return result;
     }
+
+
+    function importNodes(nodesStr,addFlow) {
+        var newNodes;
+        try {
+            nodesStr = nodesStr.trim();
+            if (nodesStr.length === 0) {
+                return;
+            }
+            newNodes = JSON.parse(nodesStr);
+        } catch(err) {
+            var e = new Error(RED._("clipboard.invalidFlow",{message:err.message}));
+            e.code = "NODE_RED";
+            throw e;
+        }
+
+
+        RED.view.importNodes(newNodes,{addFlow: addFlow});
+    }
+
     return {
         init: function() {
             setupDialogs();
 
             $('<input type="text" id="red-ui-clipboard-hidden" tabIndex="-1">').appendTo("#red-ui-editor");
 
-            RED.actions.add("core:show-export-dialog",exportNodes);
-            RED.actions.add("core:show-import-dialog",importNodes);
+            RED.actions.add("core:show-export-dialog",showExportNodes);
+            RED.actions.add("core:show-import-dialog",showImportNodes);
 
-            RED.actions.add("core:show-library-export-dialog",function() { exportNodes('library') });
-            RED.actions.add("core:show-library-import-dialog",function() { importNodes('library') });
+            RED.actions.add("core:show-library-export-dialog",function() { showExportNodes('library') });
+            RED.actions.add("core:show-library-import-dialog",function() { showImportNodes('library') });
 
-            RED.actions.add("core:show-examples-import-dialog",function() { importNodes('examples') });
+            RED.actions.add("core:show-examples-import-dialog",function() { showImportNodes('examples') });
 
             RED.events.on("editor:open",function() { disabled = true; });
             RED.events.on("editor:close",function() { disabled = false; });
@@ -792,7 +812,7 @@ RED.clipboard = (function() {
                 if ($.inArray("text/plain",event.originalEvent.dataTransfer.types) != -1) {
                     var data = event.originalEvent.dataTransfer.getData("text/plain");
                     data = data.substring(data.indexOf('['),data.lastIndexOf(']')+1);
-                    RED.view.importNodes(data);
+                    importNodes(data);
                 } else if ($.inArray("Files",event.originalEvent.dataTransfer.types) != -1) {
                     var files = event.originalEvent.dataTransfer.files;
                     if (files.length === 1) {
@@ -800,7 +820,7 @@ RED.clipboard = (function() {
                         var reader = new FileReader();
                         reader.onload = (function(theFile) {
                             return function(e) {
-                                RED.view.importNodes(e.target.result);
+                                importNodes(e.target.result);
                             };
                         })(file);
                         reader.readAsText(file);
@@ -811,8 +831,8 @@ RED.clipboard = (function() {
             });
 
         },
-        import: importNodes,
-        export: exportNodes,
+        import: showImportNodes,
+        export: showExportNodes,
         copyText: copyText
     }
 })();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -3479,7 +3479,7 @@ RED.view = (function() {
         options.push({name:"delete",disabled:(movingSet.length()===0 && selected_link === null),onselect:function() {deleteSelection();}});
         options.push({name:"cut",disabled:(movingSet.length()===0),onselect:function() {copySelection();deleteSelection();}});
         options.push({name:"copy",disabled:(movingSet.length()===0),onselect:function() {copySelection();}});
-        options.push({name:"paste",disabled:(clipboard.length===0),onselect:function() {importNodes(clipboard,false,true);}});
+        options.push({name:"paste",disabled:(clipboard.length===0),onselect:function() {importNodes(clipboard,{touchImport:true});}});
         options.push({name:"edit",disabled:(movingSet.length() != 1),onselect:function() { RED.editor.edit(mdn);}});
         options.push({name:"select",onselect:function() {selectAll();}});
         options.push({name:"undo",disabled:(RED.history.depth() === 0),onselect:function() {RED.history.pop();}});
@@ -4630,11 +4630,26 @@ RED.view = (function() {
 
     /**
      * Imports a new collection of nodes from a JSON String.
+     *
      *  - all get new IDs assigned
      *  - all "selected"
      *  - attached to mouse for placing - "IMPORT_DRAGGING"
+     * @param  {String/Array} newNodesStr nodes to import
+     * @param  {Object} options options object
+     *
+     * Options:
+     *  - addFlow - whether to import nodes to a new tab
+     *  - touchImport - whether this is a touch import. If not, imported nodes are
+     *                  attachedto mouse for placing - "IMPORT_DRAGGING" state
      */
-    function importNodes(newNodesStr,addNewFlow,touchImport) {
+    function importNodes(newNodesStr,options) {
+        options = options || {
+            addFlow: false,
+            touchImport: false
+        }
+        var addNewFlow = options.addFlow
+        var touchImport = options.touchImport;
+
         if (mouse_mode === RED.state.SELECTING_NODE) {
             return;
         }
@@ -4643,7 +4658,7 @@ RED.view = (function() {
             if (activeSubflow) {
                 activeSubflowChanged = activeSubflow.changed;
             }
-            var result = RED.nodes.import(newNodesStr,true,addNewFlow);
+            var result = RED.nodes.import(newNodesStr,{generateIds:true, addFlow: addNewFlow});
             if (result) {
                 var new_nodes = result[0];
                 var new_links = result[1];


### PR DESCRIPTION
Closes #2170
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

We have seen rare occasions where a node ends up with its `z` property set to `0`. This is invalid and should not be possible - yet it does happen.

This PR adds the code to detect when we import such nodes, and creates a new workspace to put them on. The user is notified with the following message:

![image](https://user-images.githubusercontent.com/51083/92148192-1e1a0600-ee14-11ea-8fa1-f71e85465f3b.png)

