### PR TITLE
Better check in getObjectProperty()

### DIFF
--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -328,7 +328,7 @@ function getObjectProperty(msg,expr) {
     var msgPropParts = normalisePropertyExpression(expr);
     var m;
     msgPropParts.reduce(function(obj, key) {
-        result = (typeof obj[key] !== "undefined" ? obj[key] : undefined);
+        result = (typeof obj !== "undefined" && typeof obj !== "null" && typeof obj[key] !== "undefined" ? obj[key] : undefined);
         return result;
     }, msg);
     return result;


### PR DESCRIPTION
Added two more checks to ensure that `obj` is not `undefined` or `null`. If either are the case, the function will error without these checks.


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
