### PR TITLE
fix getModuleFiles function

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/localfilesystem.js
+++ b/packages/node_modules/@node-red/registry/lib/localfilesystem.js
@@ -361,6 +361,7 @@ function getModuleFiles(module) {
         nodeList[moduleFile.package.name] = {
             name: moduleFile.package.name,
             version: moduleFile.package.version,
+            path: moduleFile.dir,
             nodes: {},
             icons: nodeModuleFiles.icons,
             examples: nodeModuleFiles.examples


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

### What are the steps to reproduce?

1. Prepare a new Node-RED environment.

2. Install two nodes.

   - node-red-dashboard
   - node-red-contrib-ui-led

3. Insert "led" node to Flow, then group and tab setup, and deploy.

### What happens?

The following message is displayed on the terminal.
And the node in error doesn't work.

```
While constructing LEDNode widget: Error: Cannot find module 'node-red-dashboard'
at Object.requireModule [as require] (D:\heroku\node-red-sample\local_packages\@node-red\registry\lib\util.js:48:19)
at new LEDNode (D:\heroku\node-red-sample\data\node_modules\node-red-contrib-ui-led\led.js:13:26)
at Object.createNode (D:\heroku\node-red-sample\local_packages\@node-red\runtime\lib\nodes\flows\util.js:493:31)
at Flow.start (D:\heroku\node-red-sample\local_packages\@node-red\runtime\lib\nodes\flows\Flow.js:193:48)
at start (D:\heroku\node-red-sample\local_packages\@node-red\runtime\lib\nodes\flows\index.js:345:33)
at D:\heroku\node-red-sample\local_packages\@node-red\runtime\lib\nodes\flows\index.js:212:21
at processTicksAndRejections (internal/process/task_queues.js:97:5) {
code: 'MODULE_NOT_FOUND'
}
```
### What do you expect to happen?

Some nodes that use "node-red-dashboard" have the following implementation.

```
ui = RED.require("node-red-dashboard")(RED);
```

Rebooting Node-RED will resolve this issue.
However, in an environment like Heroku where file resources are rolled back at boot time, the problem is not resolved.

### Proposed changes

Like the getNodeFiles function, the getModuleFiles function also handles the path.


<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
