### PR TITLE
Fix unexpected line break of sidebar tab name popover

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
@@ -84,6 +84,7 @@ RED.popover = (function() {
                 var targetHeight = target.outerHeight();
                 var divHeight = div.height();
                 var divWidth = div.width();
+                var paddingRight = 10;
 
                 var viewportTop = $(window).scrollTop();
                 var viewportLeft = $(window).scrollLeft();
@@ -105,7 +106,7 @@ RED.popover = (function() {
                         d = "right";
                         top = targetPos.top+targetHeight/2-divHeight/2-deltaSizes[size].top;
                         left = targetPos.left+targetWidth+deltaSizes[size].leftRight;
-                    } else if (left+divWidth > viewportRight) {
+                    } else if (left+divWidth+paddingRight > viewportRight) {
                         d = "left";
                         top = targetPos.top+targetHeight/2-divHeight/2-deltaSizes[size].top;
                         left = targetPos.left-deltaSizes[size].leftLeft-divWidth;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
In some cases, popover of sidebar tab is displayed in two line as follows.

![スクリーンショット 2020-10-07 9 48 31](https://user-images.githubusercontent.com/30289092/95276178-7d40bf80-0885-11eb-9a42-3df0f1592fab.png)

This PR tries to fix this problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
