### PR TITLE
i18n module refresh tooltip

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -545,6 +545,7 @@
             "sortRecent": "recent",
             "more": "+ __count__ more",
             "upload": "Upload module tgz file",
+            "refresh": "Refresh module list",            
             "errors": {
                 "catalogLoadFailed": "<p>Failed to load node catalogue.</p><p>Check the browser console for more information</p>",
                 "installFailed": "<p>Failed to install: __module__</p><p>__message__</p><p>Check the log for more information</p>",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -545,6 +545,7 @@
             "sortRecent": "日付順",
             "more": "+ さらに __count__ 個",
             "upload": "モジュールのtgzファイルをアップロード",
+            "refresh": "モジュールリスト更新",            
             "errors": {
                 "catalogLoadFailed": "<p>ノードのカタログの読み込みに失敗しました。</p><p>詳細はブラウザのコンソールを確認してください。</p>",
                 "installFailed": "<p>追加処理が失敗しました: __module__</p><p>__message__</p><p>詳細はログを確認してください。</p>",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -796,7 +796,7 @@ RED.palette.editor = (function() {
             loadedIndex = {};
             initInstallTab();
         })
-        RED.popover.tooltip(refreshButton,"NLS-TODO: Refresh module list");
+        RED.popover.tooltip(refreshButton,RED._("palette.editor.refresh"));
 
         packageList = $('<ol>',{style:"position: absolute;top: 79px;bottom: 0;left: 0;right: 0px;"}).appendTo(installTab).editableList({
             addButton: false,


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Tooltip for module list refresh is not i18n-ed.
This PR makes it i18n-ed and adds Japanese translation.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
