### PR TITLE
Fix upload button width on Safari

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -882,7 +882,7 @@ RED.palette.editor = (function() {
 
         if (RED.settings.theme('palette.upload') !== false) {
             var uploadSpan = $('<span class="button-group">').prependTo(toolBar);
-            var uploadButton = $('<button type="button" class="red-ui-sidebar-header-button red-ui-palette-editor-upload-button"><label><i class="fa fa-upload"></i><form id="red-ui-palette-editor-upload-form" enctype="multipart/form-data" style="width: 0px;"><input name="tarball" type="file" accept=".tgz"></label></button>').appendTo(uploadSpan);
+            var uploadButton = $('<button type="button" class="red-ui-sidebar-header-button red-ui-palette-editor-upload-button"><label><i class="fa fa-upload"></i><form id="red-ui-palette-editor-upload-form" enctype="multipart/form-data"><input name="tarball" type="file" accept=".tgz"></label></button>').appendTo(uploadSpan);
 
             var uploadInput = uploadButton.find('input[type="file"]');
             uploadInput.on("change", function(evt) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -882,7 +882,7 @@ RED.palette.editor = (function() {
 
         if (RED.settings.theme('palette.upload') !== false) {
             var uploadSpan = $('<span class="button-group">').prependTo(toolBar);
-            var uploadButton = $('<button type="button" class="red-ui-sidebar-header-button red-ui-palette-editor-upload-button"><label><i class="fa fa-upload"></i><form id="red-ui-palette-editor-upload-form" enctype="multipart/form-data"><input name="tarball" type="file" accept=".tgz"></label></button>').appendTo(uploadSpan);
+            var uploadButton = $('<button type="button" class="red-ui-sidebar-header-button red-ui-palette-editor-upload-button"><label><i class="fa fa-upload"></i><form id="red-ui-palette-editor-upload-form" enctype="multipart/form-data" style="width: 0px;"><input name="tarball" type="file" accept=".tgz"></label></button>').appendTo(uploadSpan);
 
             var uploadInput = uploadButton.find('input[type="file"]');
             uploadInput.on("change", function(evt) {

--- a/packages/node_modules/@node-red/editor-client/src/sass/palette-editor.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/palette-editor.scss
@@ -253,6 +253,9 @@ button.red-ui-palette-editor-upload-button {
         min-width: 0;
         padding: 2px 8px;
     }
+    form {
+	width: 0;
+    }
 }
 .red-ui-palette-editor-upload {
     display: none;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
NPM moduloe upload button is shown widely on Safari as follows.
This PR try to fix this problem.

![スクリーンショット 2020-10-07 13 37 45](https://user-images.githubusercontent.com/30289092/95288735-0b2ba300-08a4-11eb-82f2-c1cec8c3ba3a.png)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
