### PR TITLE
implement error handling

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/library.js
+++ b/packages/node_modules/@node-red/registry/lib/library.js
@@ -26,6 +26,7 @@ function getFlowsFromPath(path) {
     return new Promise(function(resolve,reject) {
         var result = {};
         fs.readdir(path,function(err,files) {
+            if (err) { return reject(err); }
             var promises = [];
             var validFiles = [];
             files.forEach(function(file) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

- Add error handling to avoid the following error in electron 10.1.3 using asar.

```
TypeError: Cannot read property 'forEach' of undefined
    at C:\Users\xxxxx\AppData\Local\Programs\node-red-desktop\resources\app.asar\node_modules\@node-red\registry\lib\library.js:31:19
    at electron/js2c/asar.js:26:28
    at processTicksAndRejections (internal/process/task_queues.js:79:11)
```
This error occurs in the [registry/lib/library.js#L31](https://github.com/node-red/node-red/blob/master/packages/node_modules/%40node-red/registry/lib/library.js#L31)

In this error case, 
`fs.readdir(path,function(err,files) {...}`  called back with `err`  is the following and  `files` is `undefined` .

```
Error: ENOENT, node_modules\@node-red\nodes\examples not found in C:\Users\xxxxx\AppData\Local\Programs\node-red-desktop\resources\app.asar
    at createError (electron/js2c/asar.js:111:17)
    at Object.fs.readdir (electron/js2c/asar.js:592:23)
    at C:\Users\xxxxx\AppData\Local\Programs\node-red-desktop\resources\app.asar\node_modules\@node-red\registry\lib\library.js:28:12
    at new Promise (<anonymous>)
    at getFlowsFromPath (C:\Users\xxxxx\AppData\Local\Programs\node-red-desktop\resources\app.asar\node_modules\@node-red\registry\lib\library.js:26:12)
    at Object.addNodeExamplesDir [as addExamplesDir] (C:\Users\xxxxx\AppData\Local\Programs\node-red-desktop\resources\app.asar\node_modules\@node-red\registry\lib\library.js:66:12)
    at Object.addModule (C:\Users\xxxxx\AppData\Local\Programs\node-red-desktop\resources\app.asar\node_modules\@node-red\registry\lib\registry.js:211:17)
    at C:\Users\xxxxx\AppData\Local\Programs\node-red-desktop\resources\app.asar\node_modules\@node-red\registry\lib\loader.js:108:30
    at tryCatchReject (C:\Users\xxxxx\AppData\Local\Programs\node-red-desktop\resources\app.asar\node_modules\when\lib\makePromise.js:845:30)
    at runContinuation1 (C:\Users\xxxxx\AppData\Local\Programs\node-red-desktop\resources\app.asar\node_modules\when\lib\makePromise.js:804:4) {
  code: 'ENOENT',
  errno: -2
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
