### PR TITLE
Add mutex lock to saveSettings storage call

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/index.js
@@ -25,6 +25,9 @@ var storageModule;
 var settingsAvailable;
 var sessionsAvailable;
 
+var Mutex = require('async-mutex').Mutex;
+const settingsSaveMutex = new Mutex();
+
 var libraryFlowsCachedResult = null;
 
 function moduleSelector(aSettings) {
@@ -114,7 +117,7 @@ var storageModuleInterface = {
         },
         saveSettings: function(settings) {
             if (settingsAvailable) {
-                return storageModule.saveSettings(settings);
+                return settingsSaveMutex.runExclusive(() => storageModule.saveSettings(settings))
             } else {
                 return when.resolve();
             }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

Fixes #2736

When disabling (or enabling) a module that contains lots of individual node sets (ie .js files), the code disables each one in turn - but without any locking to ensure one is done before the next is disabled. Each call to disable causes the settings file to be updated to record the set as being disabled.

This would cause multiple calls to `saveSettings` that overlap, leading to the error reported in #2736 

This fix is to add a mutex lock on `saveSettings` to ensure it can only have one active call at a time. Applying the fix here will ensure the same symptom can't crop up through other parts of the API that drive rapid changes to the settings file.

There is a separate item to consider - that disabling a whole module causes so many calls to update settings. It would be nice if the calls could be batched up as we know we're about to make lots of updates. The tricky part is how far apart the logic to disable an individual set and the logic to disable the whole module sits. That's for another day.

