### PR TITLE
Allow TypedInput to be disabled

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -954,6 +954,18 @@
         },
         hide: function() {
             this.uiSelect.hide();
+        },
+        disable: function(val) {
+            if(val === true) {
+                this.uiSelect.attr("disabled", "disabled");
+            } else if (val === false) {
+                this.uiSelect.attr("disabled", null); //remove attr
+            } else {
+                this.uiSelect.attr("disabled", val); //user value
+            }
+        },
+        disabled: function() {
+            return this.uiSelect.attr("disabled");
         }
     });
 })(jQuery);

--- a/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
@@ -25,6 +25,14 @@
     box-sizing: border-box;
     overflow:visible;
     position: relative;
+    &[disabled] {
+        input, button {
+            background: $secondary-background-inactive;
+            pointer-events: none;
+            cursor: not-allowed;
+        }
+    }
+    
     .red-ui-typedInput-input-wrap {
         flex-grow: 1;
     }


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Proposed changes

As discussed on [Discourse](https://discourse.nodered.org/t/readonly-typedinput/35358/4?u=bartbutenaers), it would be nice if a TypedInput could be disabled.

Via this PR a TypedInput can easily be disabled like this:
```
$("#my_typedinput_id").typedInput("disable", true);
```
To get this result:

![image](https://user-images.githubusercontent.com/14224149/98340404-9a47ea00-200d-11eb-815d-c2cb038dde1e.png)

This allows values to be displayed, without allowing the user to change those values ...

All credits for this solution go to @Steve-Mcl!

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
