### PR TITLE
Add Japanese translation for http-in node

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -403,7 +403,7 @@
         "label": {
             "method": "メソッド",
             "url": "URL",
-            "doc": "Docs",
+            "doc": "ドキュメント",
             "return": "出力形式",
             "upload": "ファイルのアップロード",
             "status": "ステータスコード",


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I translated "Docs" button in the http-in node to be the same as documentation of the node-red-node-swagger node.
https://github.com/node-red/node-red-node-swagger/pull/76

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality