### PR TITLE
Allow project workflow to be configured via settings file

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/projects/projectUserSettings.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/projects/projectUserSettings.js
@@ -43,9 +43,11 @@ RED.projects.userSettings = (function() {
 
     function createWorkflowSection(pane) {
 
+        var defaultWorkflowMode = RED.settings.theme("projects.workflow.mode","manual");
+
         var currentGitSettings = RED.settings.get('git') || {};
         currentGitSettings.workflow = currentGitSettings.workflow || {};
-        currentGitSettings.workflow.mode = currentGitSettings.workflow.mode || "manual";
+        currentGitSettings.workflow.mode = currentGitSettings.workflow.mode || defaultWorkflowMode;
 
         var title = $('<h3></h3>').text(RED._("editor:sidebar.project.userSettings.workflow")).appendTo(pane);
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/projects/tab-versionControl.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/projects/tab-versionControl.js
@@ -294,7 +294,10 @@ RED.sidebar.versionControl = (function() {
                 // TODO: this is a full refresh of the files - should be able to
                 //       just do an incremental refresh
 
-                var workflowMode = ((RED.settings.get('git') || {}).workflow || {}).mode || "manual";
+                // Get the default workflow mode from theme settings
+                var defaultWorkflowMode = RED.settings.theme("projects.workflow.mode","manual");
+                // Check for the user-defined choice of mode
+                var workflowMode = ((RED.settings.get('git') || {}).workflow || {}).mode || defaultWorkflowMode;
                 if (workflowMode === 'auto') {
                     refresh(true);
                 } else {

--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/Project.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/Project.js
@@ -421,7 +421,7 @@ Project.prototype.update = function (user, data) {
     }
     return when.settle(promises).then(function(res) {
         var gitSettings = getUserGitSettings(user) || {};
-        var workflowMode = (gitSettings.workflow||{}).mode || "manual";
+        var workflowMode = (gitSettings.workflow||{}).mode || settings.editorTheme.projects.workflow.mode;
         if (workflowMode === 'auto') {
             return project.stageFile(modifiedFiles.map(f => project.paths[f])).then(() => {
                 return project.commit(user,{message:"Update "+modifiedFiles.join(", ")})

--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/index.js
@@ -580,11 +580,13 @@ function saveFlows(flows, user) {
     }
     return util.writeFile(flowsFullPath, flowData, flowsFileBackup).then(() => {
         var gitSettings = getUserGitSettings(user) || {};
-        var workflowMode = (gitSettings.workflow||{}).mode || settings.editorTheme.projects.workflow.mode;
-        if (activeProject && workflowMode === 'auto') {
-            return activeProject.stageFile([flowsFullPath, credentialsFile]).then(() => {
-                return activeProject.commit(user,{message:"Update flow files"})
-            })
+        if (activeProject) {
+            var workflowMode = (gitSettings.workflow||{}).mode || settings.editorTheme.projects.workflow.mode;
+            if (workflowMode === 'auto') {
+                return activeProject.stageFile([flowsFullPath, credentialsFile]).then(() => {
+                    return activeProject.commit(user,{message:"Update flow files"})
+                })
+            }
         }
     });
 }

--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/index.js
@@ -35,7 +35,7 @@ var projectsEnabled = false;
 var projectLogMessages = [];
 
 var projectsDir;
-var activeProject
+var activeProject;
 
 var globalGitUser = false;
 
@@ -107,6 +107,10 @@ function init(_settings, _runtime) {
                     } catch(err) {
                     }
                 } else {
+                    // Ensure there's a default workflow mode set
+                    settings.editorTheme.projects.workflow = {
+                        mode: (settings.editorTheme.projects.workflow || {}).mode || "manual"
+                    }
                     globalGitUser = gitConfig.user;
                     Projects.init(settings,runtime);
                     sshTools.init(settings);
@@ -576,7 +580,7 @@ function saveFlows(flows, user) {
     }
     return util.writeFile(flowsFullPath, flowData, flowsFileBackup).then(() => {
         var gitSettings = getUserGitSettings(user) || {};
-        var workflowMode = (gitSettings.workflow||{}).mode || "manual";
+        var workflowMode = (gitSettings.workflow||{}).mode || settings.editorTheme.projects.workflow.mode;
         if (activeProject && workflowMode === 'auto') {
             return activeProject.stageFile([flowsFullPath, credentialsFile]).then(() => {
                 return activeProject.commit(user,{message:"Update flow files"})

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -290,7 +290,15 @@ module.exports = {
     editorTheme: {
         projects: {
             // To enable the Projects feature, set this value to true
-            enabled: false
+            enabled: false,
+            workflow: {
+                // Set the default projects workflow mode.
+                //  - manual - you must manually commit changes
+                //  - auto - changes are automatically committed
+                // This can be overridden per-user from the 'Git config'
+                // section of 'User Settings' within the editor
+                mode: "manual"
+            }
         }
     }
 }


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

We introduced the option of an automatic git workflow in the 1.2 release. This auto-commits changes whenever they are made from the editor.

This PR allows the choice of workflow to be made via the settings file. This acts as the default choice until the user goes into the User Settings dialog and changes it.

The default settings file has been updated to include the default `manual` setting:

```
    editorTheme: {
        projects: {
            // To enable the Projects feature, set this value to true
            enabled: false,
            workflow: {
                // Set the default projects workflow mode.
                //  - manual - you must manually commit changes
                //  - auto - changes are automatically committed
                // This can be overridden per-user from the 'Git config'
                // section of 'User Settings' within the editor
                mode: "manual"
            }
        }
    }
```

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
