### PR TITLE
Library: properly handle symlinked folders

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/library.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/library.js
@@ -102,7 +102,8 @@ function getLibraryEntry(type,path) {
             var files = [];
             fns.sort().filter(function(fn) {
                 var fullPath = fspath.join(path,fn);
-                var absoluteFullPath = fspath.join(root,fullPath);
+                // we use fs.realpathSync to also resolve Symbolic Link
+                var absoluteFullPath = fs.realpathSync(fspath.join(root,fullPath));
                 if (fn[0] != ".") {
                     var stats = fs.lstatSync(absoluteFullPath);
                     if (stats.isDirectory()) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

This small fix allows the library to scan symbolic links inside lib/flows and lib/function folders.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
