### PR TITLE
Fix bug: Crash & quit while handling exception with undefine msg.error

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -470,8 +470,8 @@ class Flow {
         }
         // console.log("HE",logMessage);
         var count = 1;
-        if (msg && msg.hasOwnProperty("error") && msg.error !== null) {
-            if (msg.error.hasOwnProperty("source") && msg.error.source !== null) {
+        if (msg && msg.hasOwnProperty("error") && msg.error) {
+            if (msg.error.hasOwnProperty("source") && msg.error.source) {
                 if (msg.error.source.id === node.id) {
                     count = msg.error.source.count+1;
                     if (count === 10) {


### PR DESCRIPTION
Fix bug: Crash & quit while handling exception with undefine msg.error. i.e. flow with 3 nodes, http-in, delay 5-10s, http-out; client with 3s timeout request the flow; TypeError: Cannot read property 'hasOwnProperty' of undefined\r at Flow.handleError (/usr/src/node-red/node_modules/@node-red/runtime/lib/flows/Flow.js:474:27)

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
