### PR TITLE
add optional lang select

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/de/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/de/editor.json
@@ -32,7 +32,7 @@
     "label" : {
       "view" : {
         "view" : "Ansicht",
-        "grid" : "Gitter",
+        "grid" : "Raster",
         "showGrid" : "Raster anzeigen",
         "snapGrid" : "Am Raster ausrichten",
         "gridSize" : "Rastergröße",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -965,6 +965,18 @@
         },
         hide: function() {
             this.uiSelect.hide();
+        },
+        disable: function(val) {
+            if(val === true) {
+                this.uiSelect.attr("disabled", "disabled");
+            } else if (val === false) {
+                this.uiSelect.attr("disabled", null); //remove attr
+            } else {
+                this.uiSelect.attr("disabled", val); //user value
+            }
+        },
+        disabled: function() {
+            return this.uiSelect.attr("disabled");
         }
     });
 })(jQuery);

--- a/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
@@ -26,6 +26,14 @@
     box-sizing: border-box;
     overflow:visible;
     position: relative;
+    &[disabled] {
+        input, button {
+            background: $secondary-background-inactive;
+            pointer-events: none;
+            cursor: not-allowed;
+        }
+    }
+    
     .red-ui-typedInput-input-wrap {
         flex-grow: 1;
     }

--- a/packages/node_modules/@node-red/nodes/locales/de/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/de/messages.json
@@ -583,11 +583,11 @@
       "regex" : "Reguläre Ausdrücke verwenden"
     },
     "action" : {
-      "set" : "Festlegen",
+      "set" : "Setze",
       "change" : "Ändern",
       "delete" : "Löschen",
       "move" : "Bewegen",
-      "to" : "bis",
+      "to" : "auf",
       "search" : "Suchen nach",
       "replace" : "Ersetzen durch"
     },

--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -470,8 +470,8 @@ class Flow {
         }
         // console.log("HE",logMessage);
         var count = 1;
-        if (msg && msg.hasOwnProperty("error") && msg.error !== null) {
-            if (msg.error.hasOwnProperty("source") && msg.error.source !== null) {
+        if (msg && msg.hasOwnProperty("error") && msg.error) {
+            if (msg.error.hasOwnProperty("source") && msg.error.source) {
                 if (msg.error.source.id === node.id) {
                     count = msg.error.source.count+1;
                     if (count === 10) {

--- a/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
@@ -112,8 +112,8 @@ class Subflow extends Flow {
         this.node_map = node_map;
         this.path = parent.path+"/"+(subflowInstance._alias||subflowInstance.id);
 
-        this.templateCredentials = credentials.get(subflowDef.id);
-        this.instanceCredentials = credentials.get(this.id);
+        this.templateCredentials = credentials.get(subflowDef.id) || {};
+        this.instanceCredentials = credentials.get(this.id) || {};
 
         var env = [];
         if (this.subflowDef.env) {

--- a/packages/node_modules/@node-red/util/index.js
+++ b/packages/node_modules/@node-red/util/index.js
@@ -33,7 +33,7 @@ module.exports = {
     */
     init: function(settings) {
         log.init(settings);
-        i18n.init();
+        i18n.init(settings);
     },
 
     /**

--- a/packages/node_modules/@node-red/util/lib/i18n.js
+++ b/packages/node_modules/@node-red/util/lib/i18n.js
@@ -142,7 +142,7 @@ function getCurrentLocale() {
     return undefined;
 }
 
-function init() {
+function init(settings) {
     if (!initPromise) {
         // Keep this as a 'when' promise as top-level red.js uses 'otherwise'
         // and embedded users of NR may have copied that.
@@ -160,7 +160,7 @@ function init() {
                     suffix: '__'
                 }
             };
-            var lang = getCurrentLocale();
+            var lang = settings.lang || getCurrentLocale();
             if (lang) {
                 opt.lng = lang;
             }

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -248,6 +248,8 @@ module.exports = {
     // their values. Setting this to true will cause the keys to be listed.
     exportGlobalContextKeys: false,
 
+    // Uncomment the following to run node-red in your preferred language:
+    // lang: "de",
 
     // Context Storage
     // The following property can be used to enable context storage. The configuration


### PR DESCRIPTION
## Types of changes
- [X] New feature (non-breaking change which adds functionality)

## Proposed changes
Adds an option to change the language regardless of the operating systems language. 
This is a suggestion, briefly discussed with @dceejay. Sometimes administrators want to run an English server but might want to provide node-red (and the dashboard) in another language. 

## Checklist
- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
