### PR TITLE
add optional lang select

### DIFF
--- a/packages/node_modules/@node-red/util/index.js
+++ b/packages/node_modules/@node-red/util/index.js
@@ -33,7 +33,7 @@ module.exports = {
     */
     init: function(settings) {
         log.init(settings);
-        i18n.init();
+        i18n.init(settings);
     },
 
     /**

--- a/packages/node_modules/@node-red/util/lib/i18n.js
+++ b/packages/node_modules/@node-red/util/lib/i18n.js
@@ -142,7 +142,7 @@ function getCurrentLocale() {
     return undefined;
 }
 
-function init() {
+function init(settings) {
     if (!initPromise) {
         // Keep this as a 'when' promise as top-level red.js uses 'otherwise'
         // and embedded users of NR may have copied that.

--- a/packages/node_modules/@node-red/util/lib/i18n.js
+++ b/packages/node_modules/@node-red/util/lib/i18n.js
@@ -160,7 +160,7 @@ function init() {
                     suffix: '__'
                 }
             };
-            var lang = getCurrentLocale();
+            var lang = settings.lang || getCurrentLocale();
             if (lang) {
                 opt.lng = lang;
             }

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -248,6 +248,8 @@ module.exports = {
     // their values. Setting this to true will cause the keys to be listed.
     exportGlobalContextKeys: false,
 
+    // Uncomment the following to run node-red in your preferred language:
+    // lang: "de",
 
     // Context Storage
     // The following property can be used to enable context storage. The configuration


### PR DESCRIPTION
## Types of changes
- [X] New feature (non-breaking change which adds functionality)

## Proposed changes
Adds an option to change the language regardless of the operating systems language. 
This is a suggestion, briefly discussed with @dceejay. Sometimes administrators want to run an English server but might want to provide node-red (and the dashboard) in another language. 

## Checklist
- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
