### PR TITLE
Allow to explicit use userMenu in the theme configuration

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/user.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/user.js
@@ -219,7 +219,7 @@ RED.user = (function() {
 
     function init() {
         if (RED.settings.user) {
-            if (!RED.settings.editorTheme || !RED.settings.editorTheme.hasOwnProperty("userMenu")) {
+            if (!RED.settings.editorTheme || !RED.settings.editorTheme.hasOwnProperty("userMenu") || RED.settings.editorTheme.userMenu) {
 
                 var userMenu = $('<li><a id="red-ui-header-button-user" class="button hide" href="#"></a></li>')
                     .prependTo(".red-ui-header-toolbar");

--- a/test/unit/@node-red/editor-api/lib/editor/theme_spec.js
+++ b/test/unit/@node-red/editor-api/lib/editor/theme_spec.js
@@ -143,4 +143,19 @@ describe("api/editor/theme", function () {
         settings.projects.should.have.a.property("enabled", false);
     });
 
+    it("test explicit userMenu set to true in theme setting", function () {
+      theme.init({
+          editorTheme: {
+              userMenu: true,
+          }
+      });
+
+      theme.app();
+
+      var settings = theme.settings();
+      settings.should.have.a.property("userMenu");
+      settings.userMenu.should.be.eql(true);
+
+    });
+
 });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
Allow using `userMenu` explicitly in the theme configuration by enabling to set to true or false and have the expected behavior of show and hide the user menu.
<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
