### PR TITLE
Support node property typing

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/history.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/history.js
@@ -343,17 +343,29 @@ RED.history = (function() {
                     if (ev.changes.hasOwnProperty(i)) {
                         inverseEv.changes[i] = ev.node[i];
                         if (ev.node._def.defaults && ev.node._def.defaults[i] && ev.node._def.defaults[i].type) {
-                            // This is a config node property
-                            var currentConfigNode = RED.nodes.node(ev.node[i]);
-                            if (currentConfigNode) {
-                                currentConfigNode.users.splice(currentConfigNode.users.indexOf(ev.node),1);
-                                RED.events.emit("nodes:change",currentConfigNode);
+                            // This property is a reference to another node or nodes.
+                            var nodeList = ev.node[i];
+                            if (!Array.isArray(nodeList)) {
+                                nodeList = [nodeList];
                             }
-                            var newConfigNode = RED.nodes.node(ev.changes[i]);
-                            if (newConfigNode) {
-                                newConfigNode.users.push(ev.node);
-                                RED.events.emit("nodes:change",newConfigNode);
+                            nodeList.forEach(function(id) {
+                                var currentConfigNode = RED.nodes.node(id);
+                                if (currentConfigNode && currentConfigNode._def.category === "config") {
+                                    currentConfigNode.users.splice(currentConfigNode.users.indexOf(ev.node),1);
+                                    RED.events.emit("nodes:change",currentConfigNode);
+                                }
+                            });
+                            nodeList = ev.changes[i];
+                            if (!Array.isArray(nodeList)) {
+                                nodeList = [nodeList];
                             }
+                            nodeList.forEach(function(id) {
+                                var newConfigNode = RED.nodes.node(id);
+                                if (newConfigNode && newConfigNode._def.category === "config") {
+                                    newConfigNode.users.push(ev.node);
+                                    RED.events.emit("nodes:change",newConfigNode);
+                                }
+                            });
                         }
                         ev.node[i] = ev.changes[i];
                     }

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -164,6 +164,21 @@ RED.nodes = (function() {
 
                     // TODO: too tightly coupled into palette UI
                 }
+                if (def.defaults) {
+                    for (var d in def.defaults) {
+                        if (def.defaults.hasOwnProperty(d)) {
+                            if (def.defaults[d].type) {
+                                try {
+                                    def.defaults[d]._type = parseNodePropertyTypeString(def.defaults[d].type)
+                                } catch(err) {
+                                    console.warn(err);
+                                }
+                            }
+                        }
+                    }
+                }
+
+
                 RED.events.emit("registry:node-type-added",nt);
             },
             removeNodeType: function(nt) {
@@ -192,6 +207,59 @@ RED.nodes = (function() {
         // return Math.floor(Math.random()*15728640 + 1048576).toString(16)
         return (1+Math.random()*4294967295).toString(16);
     }
+
+    function parseNodePropertyTypeString(typeString) {
+        typeString = typeString.trim();
+        var c;
+        var pos = 0;
+        var isArray = /\[\]$/.test(typeString);
+        if (isArray) {
+            typeString = typeString.substring(0,typeString.length-2);
+        }
+
+        var l = typeString.length;
+        var inBrackets = false;
+        var inToken = false;
+        var currentToken = "";
+        var types = [];
+        while (pos < l) {
+            c = typeString[pos];
+            if (inToken) {
+                if (c === "|") {
+                    types.push(currentToken.trim())
+                    currentToken = "";
+                    inToken = false;
+                } else if (c === ")") {
+                    types.push(currentToken.trim())
+                    currentToken = "";
+                    inBrackets = false;
+                    inToken = false;
+                } else {
+                    currentToken += c;
+                }
+            } else {
+                if (c === "(") {
+                    if (inBrackets) {
+                        throw new Error("Invalid character '"+c+"' at position "+pos)
+                    }
+                    inBrackets = true;
+                } else if (c !== " ") {
+                    inToken = true;
+                    currentToken = c;
+                }
+            }
+            pos++;
+        }
+        currentToken = currentToken.trim();
+        if (currentToken.length > 0) {
+            types.push(currentToken)
+        }
+        return {
+            types: types,
+            array: isArray
+        }
+    }
+
 
     function addNode(n) {
         if (n.type.indexOf("subflow") !== 0) {
@@ -787,16 +855,29 @@ RED.nodes = (function() {
             if (node.type !== "subflow") {
                 var convertedNode = RED.nodes.convertNode(node);
                 for (var d in node._def.defaults) {
-                    if (node._def.defaults[d].type && node[d] in configNodes) {
-                        var confNode = configNodes[node[d]];
-                        var exportable = registry.getNodeType(node._def.defaults[d].type).exportable;
-                        if ((exportable == null || exportable)) {
-                            if (!(node[d] in exportedConfigNodes)) {
-                                exportedConfigNodes[node[d]] = true;
-                                set.push(confNode);
+                    if (node._def.defaults[d].type) {
+                        var nodeList = node[d];
+                        if (!Array.isArray(nodeList)) {
+                            nodeList = [nodeList];
+                        }
+                        nodeList = nodeList.filter(function(id) {
+                            if (id in configNodes) {
+                                var confNode = configNodes[id];
+                                if (confNode._def.exportable !== false) {
+                                    if (!(id in exportedConfigNodes)) {
+                                        exportedConfigNodes[id] = true;
+                                        set.push(confNode);
+                                        return true;
+                                    }
+                                }
+                                return false;
                             }
+                            return true;
+                        })
+                        if (nodeList.length === 0) {
+                            convertedNode[d] = Array.isArray(node[d])?[]:""
                         } else {
-                            convertedNode[d] = "";
+                            convertedNode[d] = Array.isArray(node[d])?nodeList:nodeList[0]
                         }
                     }
                 }
@@ -1587,15 +1668,6 @@ RED.nodes = (function() {
                 }
             }
         }
-        // TODO: make this a part of the node definition so it doesn't have to
-        //       be hardcoded here
-        var nodeTypeArrayReferences = {
-            "catch":"scope",
-            "status":"scope",
-            "complete": "scope",
-            "link in":"links",
-            "link out":"links"
-        }
 
         // Remap all wires and config node references
         for (i=0;i<new_nodes.length;i++) {
@@ -1624,19 +1696,24 @@ RED.nodes = (function() {
             }
             for (var d3 in n._def.defaults) {
                 if (n._def.defaults.hasOwnProperty(d3)) {
-                    if (n._def.defaults[d3].type && node_map[n[d3]]) {
-                        configNode = node_map[n[d3]];
-                        n[d3] = configNode.id;
-                        if (configNode.users.indexOf(n) === -1) {
-                            configNode.users.push(n);
+                    if (n._def.defaults[d3].type) {
+                        var nodeList = n[d3];
+                        if (!Array.isArray(nodeList)) {
+                            nodeList = [nodeList];
                         }
-                    } else if (nodeTypeArrayReferences.hasOwnProperty(n.type) && nodeTypeArrayReferences[n.type] === d3 && n[d3] !== undefined && n[d3] !== null) {
-                        for (var j = 0;j<n[d3].length;j++) {
-                            if (node_map[n[d3][j]]) {
-                                n[d3][j] = node_map[n[d3][j]].id;
+                        nodeList = nodeList.map(function(id) {
+                            var node = node_map[id];
+                            if (node) {
+                                if (node._def.category === 'config') {
+                                    if (node.users.indexOf(n) === -1) {
+                                        node.users.push(n);
+                                    }
+                                }
+                                return node.id;
                             }
-                        }
-
+                            return id;
+                        })
+                        n[d3] = Array.isArray(n[d3])?nodeList:nodeList[0];
                     }
                 }
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -186,6 +186,7 @@ var RED = (function() {
                             RED.workspaces.show(currentHash.substring(6));
                         }
                     } catch(err) {
+                        console.warn(err);
                         RED.notify(
                             RED._("event.importError", {message: err.message}),
                             {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -442,16 +442,18 @@ RED.editor = (function() {
         for (var d in definition.defaults) {
             if (definition.defaults.hasOwnProperty(d)) {
                 if (definition.defaults[d].type) {
-                    var configTypeDef = RED.nodes.getType(definition.defaults[d].type);
-                    if (configTypeDef) {
-                        if (configTypeDef.exclusive) {
-                            prepareConfigNodeButton(node,d,definition.defaults[d].type,prefix);
+                    if (!definition.defaults[d]._type.array) {
+                        var configTypeDef = RED.nodes.getType(definition.defaults[d].type);
+                        if (configTypeDef && configTypeDef.category === 'config') {
+                            if (configTypeDef.exclusive) {
+                                prepareConfigNodeButton(node,d,definition.defaults[d].type,prefix);
+                            } else {
+                                prepareConfigNodeSelect(node,d,definition.defaults[d].type,prefix);
+                            }
                         } else {
-                            prepareConfigNodeSelect(node,d,definition.defaults[d].type,prefix);
+                            console.log("Unknown type:", definition.defaults[d].type);
+                            preparePropertyEditor(node,d,prefix,definition.defaults);
                         }
-                    } else {
-                        console.log("Unknown type:", definition.defaults[d].type);
-                        preparePropertyEditor(node,d,prefix,definition.defaults);
                     }
                 } else {
                     preparePropertyEditor(node,d,prefix,definition.defaults);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info.js
@@ -338,7 +338,7 @@ RED.sidebar.info = (function() {
                                 count++;
                                 propRow = $('<tr class="red-ui-help-info-property-row'+(expandedSections.property?"":" hide")+'"><td></td><td></td></tr>').appendTo(tableBody);
                                 $(propRow.children()[0]).text(n);
-                                if (defaults[n].type) {
+                                if (defaults[n].type && !defaults[n]._type.array) {
                                     var configNode = RED.nodes.node(val);
                                     if (!configNode) {
                                         RED.utils.createObjectElement(undefined).appendTo(propRow.children()[1]);

--- a/packages/node_modules/@node-red/editor-client/src/sass/palette.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/palette.scss
@@ -131,10 +131,10 @@
     width: 120px;
     background-size: contain;
     position: relative;
-    &:not(.red-ui-palette-node-config):first-child {
+    &:not(.red-ui-palette-node-config):not(.red-ui-palette-node-small):first-child {
         margin-top: 15px;
     }
-    &:not(.red-ui-palette-node-config):last-child {
+    &:not(.red-ui-palette-node-config):not(.red-ui-palette-node-small):first-child {
         margin-bottom: 15px;
     }
 }

--- a/packages/node_modules/@node-red/nodes/core/common/24-complete.html
+++ b/packages/node_modules/@node-red/nodes/core/common/24-complete.html
@@ -18,7 +18,7 @@
         color:"#c0edc0",
         defaults: {
             name: {value:""},
-            scope: {value:[]},
+            scope: {value:[], type:"*[]"},
             uncaught: {value:false}
         },
         inputs:0,

--- a/packages/node_modules/@node-red/nodes/core/common/25-catch.html
+++ b/packages/node_modules/@node-red/nodes/core/common/25-catch.html
@@ -30,7 +30,7 @@
         color:"#e49191",
         defaults: {
             name: {value:""},
-            scope: {value:null},
+            scope: {value:null, type:"*[]"},
             uncaught: {value:false}
         },
         inputs:0,

--- a/packages/node_modules/@node-red/nodes/core/common/25-status.html
+++ b/packages/node_modules/@node-red/nodes/core/common/25-status.html
@@ -26,7 +26,7 @@
         color:"#94c1d0",
         defaults: {
             name: {value:""},
-            scope: {value:null}
+            scope: {value:null, type:"*[]"}
         },
         inputs:0,
         outputs:1,

--- a/packages/node_modules/@node-red/nodes/core/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.html
@@ -187,7 +187,7 @@
         color:"#ddd",//"#87D8CF",
         defaults: {
             name: {value:""},
-            links: { value: [] }
+            links: { value: [], type:"link out[]" }
         },
         inputs:0,
         outputs:1,
@@ -216,7 +216,7 @@
         color:"#ddd",//"#87D8CF",
         defaults: {
             name: {value:""},
-            links: { value: []}
+            links: { value: [], type:"link in[]"}
         },
         align:"right",
         inputs:1,


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This implements initial support for node property typing as described in the design note: https://github.com/node-red/designs/pull/37

From the design note:

> A node's `defaults` object in its HTML definition provides a list of its properties
with some metadata associated with them.

> If a property is intended to be a reference to a configuration node, its entry
in the defaults object will include the `type` property that identifies the type
of config node it should point to.

> This allows the editor to automatically generate the Config Node select box UI
and manage the relationship between the nodes.

This PR implements support for nodes to declare properties that hold references to other nodes that may or may not be configuration nodes. The editor is then able to ensure those properties get properly remapped when importing a copy of a flow (and thus nodes being given new ids).

The editor used to have hardcoded awareness of the Catch, Status, Complete and Link nodes - so that it could remap their `scope`/`links` properties.

This PR removes the need for that hardcoded awareness.

For example, the `link out` node's `links` property is now defined as:
```
    links: { value: [], type:"link in[]"}
```

The `type` of `"link in[]"` tells the editor this property will contain an array of references to `link in` nodes.

The `catch`, `status` and `complete` nodes' `scope` property is now defined as:
```
    scope: {value:null, type:"*[]"},
```
This tells the editor the `scope` property is an array of references to *any* node type.

## Notes

 - Previously, when exporting a node, the editor used the simple presence of the `type` attribute to decide whether there was a related config node that also needed to be exported. Now that the `type` attribute can be used to identify relationships between nodes that may not be config nodes, the editor will still only pull in that referenced node if it is a config node. Otherwise, exporting a Catch node, for example, would pull in all of the nodes it was pointed at.

## Remaining work

 - Whilst the syntax for property types allows for multiple types (`"ui_group | ui_widget"`), no UI changes have been made to enhance the config node select box to support selecting from multiple types.

