### PR TITLE
Add settings.execMaxBufferSize to control buffer size of exec node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.js
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.js
@@ -31,12 +31,12 @@ module.exports = function(RED) {
         this.timer = Number(n.timer || 0)*1000;
         this.activeProcesses = {};
         this.oldrc = (n.oldrc || false).toString();
-	this.execOpt = {encoding:'binary', maxBuffer:10000000};
+        this.execOpt = {encoding:'binary', maxBuffer:RED.settings.execMaxBufferSize||10000000};
         var node = this;
 
-	if (process.platform === 'linux' && fs.existsSync('/bin/bash')) { node.execOpt.shell = '/bin/bash'; }
-	    
-	var cleanup = function(p) {
+    if (process.platform === 'linux' && fs.existsSync('/bin/bash')) { node.execOpt.shell = '/bin/bash'; }
+
+    var cleanup = function(p) {
             node.activeProcesses[p].kill();
             //node.status({fill:"red",shape:"dot",text:"timeout"});
             //node.error("Exec node timeout");

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -41,6 +41,10 @@ module.exports = {
     // Timeout in milliseconds for HTTP request connections
     //  defaults to 120 seconds
     //httpRequestTimeout: 120000,
+    
+    // Maximum buffer size for the exec node
+    //  defaults to 10Mb
+    //execMaxBufferSize: 10000000,
 
     // The maximum length, in characters, of any message sent to the debug sidebar tab
     debugMaxLength: 1000,


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

This adds a execMaxBufferSize settings to allow  the user to customize the maximum buffer size for the output of the exec node.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
