### PR TITLE
Full semver comparison in palettte-editor.js

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -70,8 +70,8 @@ RED.palette.editor = (function() {
     };
 
     function SemVer ( ver ) {
-        const { major, minor, patch, pre, build } = ver.match( semverre ).groups;
-        this.parts = [ new SemVerPart( major ), new SemVerPart( minor ), new SemVerPart( patch ), new SemVerPart( pre ), new SemVerPart( build ) ];
+        const groups = ver.match( semverre ).groups;
+        this.parts = [ new SemVerPart( groups.major ), new SemVerPart( groups.minor ), new SemVerPart( groups.patch ), new SemVerPart( groups.pre ), new SemVerPart( groups.build ) ];
     }
 
     SemVer.prototype.compare = function ( other ) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -31,16 +31,74 @@ RED.palette.editor = (function() {
     var eventTimers = {};
     var activeFilter = "";
 
-    function semVerCompare(A,B) {
-        var aParts = A.split(".").map(function(m) { return parseInt(m);});
-        var bParts = B.split(".").map(function(m) { return parseInt(m);});
-        for (var i=0;i<3;i++) {
-            var j = aParts[i]-bParts[i];
-            if (j<0) { return -1 }
-            if (j>0) { return 1 }
+    var semverre = /^(?<major>\d+)(\.(?<minor>\d+))?(\.(?<patch>\d+))?(-(?<pre>[0-9A-Za-z-]+))?(\.(?<build>[0-9A-Za-z-.]+))?$/;
+	var NUMBERS_ONLY = /^\d+$/;
+
+
+	function SemVerPart ( part ) {
+        this.number = 0;
+        this.text = part;
+        if ( isNumeric( part ) )
+        {
+            this.number = parseInt( part );
+            this.type = "N";
+        } else
+        {
+            this.type = part == undefined || part.length < 1 ? "E" : "T";
         }
-        return 0;
     }
+
+    SemVerPart.prototype.compare = function ( other ) {
+        const types = this.type + other.type;
+
+        switch ( types )
+        {
+            case "EE": return 0;
+
+            case "NT":
+            case "TE":
+            case "EN": return -1;
+
+            case "NN": return this.number - other.number;
+
+            case "TT": return this.text.localeCompare( other.text );
+
+            case "ET":
+            case "TN":
+            case "NE": return 1;
+        }
+    };
+
+    function SemVer ( ver ) {
+        const { major, minor, patch, pre, build } = ver.match( semverre ).groups;
+        this.parts = [ new SemVerPart( major ), new SemVerPart( minor ), new SemVerPart( patch ), new SemVerPart( pre ), new SemVerPart( build ) ];
+    }
+
+    SemVer.prototype.compare = function ( other ) {
+        let result = 0;
+        for ( let i = 0, n = this.parts.length; result == 0 && i < n; i++ )
+        {
+            result = this.parts[ i ].compare( other.parts[ i ] );
+        }
+
+        return result;
+    };
+
+
+    function isNumeric ( toe ) {
+        return NUMBERS_ONLY.test( toe );
+    }
+
+
+    function semVerCompare ( ver1, ver2 ) {
+        const semver1 = new SemVer( ver1 );
+        const semver2 = new SemVer( ver2 );
+
+        const result = semver1.compare( semver2 );
+
+        return result;
+    }
+
 
     function delayCallback(start,callback) {
         var delta = Date.now() - start;

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -32,13 +32,13 @@ RED.palette.editor = (function() {
     var activeFilter = "";
 
     var semverre = /^(?<major>\d+)(\.(?<minor>\d+))?(\.(?<patch>\d+))?(-(?<pre>[0-9A-Za-z-]+))?(\.(?<build>[0-9A-Za-z-.]+))?$/;
-	var NUMBERS_ONLY = /^\d+$/;
+    var NUMBERS_ONLY = /^\d+$/;
 
 
 	function SemVerPart ( part ) {
         this.number = 0;
         this.text = part;
-        if ( isNumeric( part ) )
+        if ( NUMBERS_ONLY.test( toe ) )
         {
             this.number = parseInt( part );
             this.type = "N";
@@ -83,12 +83,6 @@ RED.palette.editor = (function() {
 
         return result;
     };
-
-
-    function isNumeric ( toe ) {
-        return NUMBERS_ONLY.test( toe );
-    }
-
 
     function semVerCompare ( ver1, ver2 ) {
         const semver1 = new SemVer( ver1 );


### PR DESCRIPTION
Full SemVer comparison in palette-editor.js, as discussed in #39177


- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Proposed changes

The palette editor only checks the first three numbers of a module version. When using pre-release additions, the editor does not correctly shows updated modules.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
