### PR TITLE
Hide unused input field of tcp request node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
@@ -235,6 +235,7 @@
         oneditprepare: function() {
             var previous = null;
             $("#node-input-out").on('focus', function () { previous = this.value; }).on("change", function() {
+                $("#node-input-splitc").show();
                 if (previous === null) { previous = $("#node-input-out").val(); }
                 if ($("#node-input-out").val() == "char") {
                     if (previous != "char") { $("#node-input-splitc").val("\\n"); }
@@ -247,6 +248,7 @@
                 else if ($("#node-input-out").val() == "immed") {
                     if (previous != "immed") { $("#node-input-splitc").val(" "); }
                     $("#node-units").text("");
+                    $("#node-input-splitc").hide();
                 }
                 else if ($("#node-input-out").val() == "count") {
                     if (previous != "count") { $("#node-input-splitc").val("12"); }
@@ -255,6 +257,7 @@
                 else {
                     if (previous != "sit") { $("#node-input-splitc").val(" "); }
                     $("#node-units").text("");
+                    $("#node-input-splitc").hide();
                 }
             });
         }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

`splitc` input field of **tcp request** node has no meaning for `sit` and `immed` output option.

<img width="515" alt="スクリーンショット 2021-01-16 12 03 07" src="https://user-images.githubusercontent.com/30289092/104795599-f3dd4980-57f2-11eb-9c93-37c3a6a0ec89.png">

This PR hides the field for these options.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
