### PR TITLE
Fix line break of subflow label on palette

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -97,15 +97,20 @@ RED.palette = (function() {
         label = RED.utils.sanitize(label);
 
 
-        var words = label.split(/[ -]/);
+        var words = label.split(/([ -]|\\n )/);
 
         var displayLines = [];
 
         var currentLine = "";
         for (var i=0;i<words.length;i++) {
             var word = words[i];
+            if (word === "\\n ") {
+                displayLines.push(currentLine);
+                currentLine = "";
+                continue;
+            }
             var sep = (i == 0) ? "" : " ";
-            var newWidth = RED.view.calculateTextWidth(currentLine+sep+word, "red-ui-palette-label", true);
+            var newWidth = RED.view.calculateTextWidth(currentLine+sep+word, "red-ui-palette-label");
             if (newWidth < nodeWidth) {
                 currentLine += sep +word;
             } else {
@@ -113,12 +118,12 @@ RED.palette = (function() {
                     displayLines.push(currentLine);
                 }
                 while (true) {
-                    var wordWidth = RED.view.calculateTextWidth(word, "red-ui-palette-label", true);
+                    var wordWidth = RED.view.calculateTextWidth(word, "red-ui-palette-label");
                     if (wordWidth >= nodeWidth) {
                         // break word if too wide
                         for(var j = word.length; j > 0; j--) {
                             var s = word.substring(0, j);
-                            var width = RED.view.calculateTextWidth(s, "red-ui-palette-label", true);
+                            var width = RED.view.calculateTextWidth(s, "red-ui-palette-label");
                             if (width < nodeWidth) {
                                 displayLines.push(s);
                                 word = word.substring(j);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -105,7 +105,7 @@ RED.palette = (function() {
         for (var i=0;i<words.length;i++) {
             var word = words[i];
             var sep = (i == 0) ? "" : " ";
-            var newWidth = RED.view.calculateTextWidth(currentLine+sep+word, "red-ui-palette-label");
+            var newWidth = RED.view.calculateTextWidth(currentLine+sep+word, "red-ui-palette-label", true);
             if (newWidth < nodeWidth) {
                 currentLine += sep +word;
             } else {
@@ -113,12 +113,12 @@ RED.palette = (function() {
                     displayLines.push(currentLine);
                 }
                 while (true) {
-                    var wordWidth = RED.view.calculateTextWidth(word, "red-ui-palette-label");
+                    var wordWidth = RED.view.calculateTextWidth(word, "red-ui-palette-label", true);
                     if (wordWidth >= nodeWidth) {
                         // break word if too wide
                         for(var j = word.length; j > 0; j--) {
                             var s = word.substring(0, j);
-                            var width = RED.view.calculateTextWidth(s, "red-ui-palette-label");
+                            var width = RED.view.calculateTextWidth(s, "red-ui-palette-label", true);
                             if (width < nodeWidth) {
                                 displayLines.push(s);
                                 word = word.substring(j);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -2275,8 +2275,8 @@ RED.view = (function() {
         }
     }
 
-    function calculateTextWidth(str, className) {
-        var result=convertLineBreakCharacter(str);
+    function calculateTextWidth(str, className, noLineBreak) {
+        var result = noLineBreak ? [str] : convertLineBreakCharacter(str);
         var width = 0;
         for (var i=0;i<result.length;i++) {
             var calculateTextW=calculateTextDimensions(result[i],className)[0];

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -2275,8 +2275,8 @@ RED.view = (function() {
         }
     }
 
-    function calculateTextWidth(str, className, noLineBreak) {
-        var result = noLineBreak ? [str] : convertLineBreakCharacter(str);
+    function calculateTextWidth(str, className) {
+        var result = convertLineBreakCharacter(str);
         var width = 0;
         for (var i=0;i<result.length;i++) {
             var calculateTextW=calculateTextDimensions(result[i],className)[0];


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
If the label of a SUBFLOW contains a line break (`\n `), the label may be displayed outside of the SUBFLOW as shown below. 

![スクリーンショット 2021-01-20 23 12 42](https://user-images.githubusercontent.com/30289092/105188766-95f48d00-5b77-11eb-962c-90b101d685c9.png)

This PR attempts to fix this.

![スクリーンショット 2021-01-20 23 12 07](https://user-images.githubusercontent.com/30289092/105188943-c76d5880-5b77-11eb-99ac-25b6846f5c45.png)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
