### PR TITLE
Prevent crash when coreNodesDir is empty

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
@@ -291,14 +291,6 @@ module.exports = function(RED) {
                 } else if (typeof msg.payload === "string" || Buffer.isBuffer(msg.payload)) {
                     opts.body = msg.payload;
                 }
-            } else if ( method == "GET" && typeof msg.payload !== "undefined") {
-                if (typeof msg.payload === "object") {
-                    opts.body = JSON.stringify(msg.payload);
-                } else if (typeof msg.payload == "number") {
-                    opts.body = msg.payload+"";
-                } else if (typeof msg.payload === "string" || Buffer.isBuffer(msg.payload)) {
-                    opts.body = msg.payload;
-                }
             }
 
             // revert to user supplied Capitalisation if needed.

--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
@@ -291,6 +291,14 @@ module.exports = function(RED) {
                 } else if (typeof msg.payload === "string" || Buffer.isBuffer(msg.payload)) {
                     opts.body = msg.payload;
                 }
+            } else if ( method == "GET" && typeof msg.payload !== "undefined") {
+                if (typeof msg.payload === "object") {
+                    opts.body = JSON.stringify(msg.payload);
+                } else if (typeof msg.payload == "number") {
+                    opts.body = msg.payload+"";
+                } else if (typeof msg.payload === "string" || Buffer.isBuffer(msg.payload)) {
+                    opts.body = msg.payload;
+                }
             }
 
             // revert to user supplied Capitalisation if needed.

--- a/packages/node_modules/@node-red/registry/lib/library.js
+++ b/packages/node_modules/@node-red/registry/lib/library.js
@@ -28,17 +28,19 @@ function getFlowsFromPath(path) {
         fs.readdir(path,function(err,files) {
             var promises = [];
             var validFiles = [];
-            files.forEach(function(file) {
-                var fullPath = fspath.join(path,file);
-                var stats = fs.lstatSync(fullPath);
-                if (stats.isDirectory()) {
-                    validFiles.push(file);
-                    promises.push(getFlowsFromPath(fullPath));
-                } else if (/\.json$/.test(file)){
-                    validFiles.push(file);
-                    promises.push(Promise.resolve(file.split(".")[0]))
-                }
-            })
+            if (files) {
+                files.forEach(function(file) {
+                    var fullPath = fspath.join(path,file);
+                    var stats = fs.lstatSync(fullPath);
+                    if (stats.isDirectory()) {
+                        validFiles.push(file);
+                        promises.push(getFlowsFromPath(fullPath));
+                    } else if (/\.json$/.test(file)){
+                        validFiles.push(file);
+                        promises.push(Promise.resolve(file.split(".")[0]))
+                    }
+                })
+            }
             var i=0;
             Promise.all(promises).then(function(results) {
                 results.forEach(function(r) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This checks if the coreNodesDir is empty before trying to iterate over the files in that directory.
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
