### PR TITLE
Add easier ways to find subflow instances

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -170,7 +170,9 @@ RED.palette = (function() {
                     metaData = typeInfo.set.module+" : ";
                 }
                 metaData += type;
-                $('<button type="button" onclick="RED.sidebar.help.show(\''+type+'\'); return false;" class="red-ui-button red-ui-button-small" style="float: right"><i class="fa fa-book"></i></button>').appendTo(popOverContent)
+                var safeType = type.replace(/'/g,"\\'");
+                $('<button type="button" onclick="RED.sidebar.info.outliner.search(\'type:'+safeType+'\'); RED.sidebar.info.show(); return false;" class="red-ui-button red-ui-button-small" style="float: right; margin-left: 5px;"><i class="fa fa-search"></i></button>').appendTo(popOverContent)
+                $('<button type="button" onclick="RED.sidebar.help.show(\''+safeType+'\'); return false;" class="red-ui-button red-ui-button-small" style="float: right"><i class="fa fa-book"></i></button>').appendTo(popOverContent)
                 $('<p>',{style:"font-size: 0.8em"}).text(metaData).appendTo(popOverContent);
             }
         } catch(err) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
@@ -119,34 +119,17 @@ RED.sidebar.info.outliner = (function() {
         return div;
     }
 
-    function getSubflowLabel(n) {
-
-        var div = $('<div>',{class:"red-ui-info-outline-item"});
-        RED.utils.createNodeIcon(n).appendTo(div);
-        var contentDiv = $('<div>',{class:"red-ui-search-result-description"}).appendTo(div);
-        var labelText = getNodeLabelText(n);
-        var label = $('<div>',{class:"red-ui-search-result-node-label red-ui-info-outline-item-label"}).appendTo(contentDiv);
-        if (labelText) {
-            label.text(labelText)
-        } else {
-            label.html("&nbsp;")
-        }
-
-        addControls(n, div);
-
-        return div;
-
-
-        // var div = $('<div>',{class:"red-ui-info-outline-item red-ui-info-outline-item-flow"});
-        // var contentDiv = $('<div>',{class:"red-ui-search-result-description red-ui-info-outline-item-label"}).appendTo(div);
-        // contentDiv.text(n.name || n.id);
-        // addControls(n, div);
-        // return div;
-    }
-
     function addControls(n,div) {
         var controls = $('<div>',{class:"red-ui-info-outline-item-controls red-ui-info-outline-item-hover-controls"}).appendTo(div);
 
+        if (n.type === "subflow") {
+            var subflowInstanceBadge = $('<button type="button" class="red-ui-info-outline-item-control-users red-ui-button red-ui-button-small"><i class="fa fa-toggle-right"></i></button>').text(n.instances.length).appendTo(controls).on("click",function(evt) {
+                evt.preventDefault();
+                evt.stopPropagation();
+                RED.search.show("type:subflow:"+n.id);
+            })
+            // RED.popover.tooltip(userCountBadge,function() { return RED._('editor.nodesUse',{count:n.users.length})});
+        }
         if (n._def.category === "config" && n.type !== "group") {
             var userCountBadge = $('<button type="button" class="red-ui-info-outline-item-control-users red-ui-button red-ui-button-small"><i class="fa fa-toggle-right"></i></button>').text(n.users.length).appendTo(controls).on("click",function(evt) {
                 evt.preventDefault();
@@ -486,6 +469,13 @@ RED.sidebar.info.outliner = (function() {
         existingObject.treeList.remove();
         delete objects[n.id]
 
+        if (/^subflow:/.test(n.type)) {
+            var sfType = n.type.substring(8);
+            if (objects[sfType]) {
+                objects[sfType].element.find(".red-ui-info-outline-item-control-users").text(RED.nodes.subflow(sfType).instances.length);
+            }
+        }
+
         // If this is a group being removed, it may have an empty item
         if (empties[n.id]) {
             delete empties[n.id];
@@ -587,6 +577,12 @@ RED.sidebar.info.outliner = (function() {
             configNodeTypes[parent].types[n.type].treeList.addChild(objects[n.id]);
         }
         objects[n.id].element.toggleClass("red-ui-info-outline-item-disabled", !!n.d)
+        if (/^subflow:/.test(n.type)) {
+            var sfType = n.type.substring(8);
+            if (objects[sfType]) {
+                objects[sfType].element.find(".red-ui-info-outline-item-control-users").text(RED.nodes.subflow(sfType).instances.length);
+            }
+        }
         updateSearch();
     }
 


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Feedback from the forum highlighted the fact it is quite hard to find all instances of a given subflow. To do that with the search today, you need to know the subflow's id - which is non-trivial to discover as we hide it quite well.

This PR adds two new mechanisms for finding instances of subflows.

1. The palette tooltip now has a button that sets the info sidebar search to reveal all nodes of the given type. This button is on all node tooltips, not just subflows.

![image](https://user-images.githubusercontent.com/51083/106073420-f2b8f000-6101-11eb-8d41-bd7026df911b.png)


2. The outline view now has an instance count next to each subflow - in the same way we already do for configuration nodes. Clicking on the number opens the search dialog to list the instances.

![image](https://user-images.githubusercontent.com/51083/106073515-1da34400-6102-11eb-86fc-4d6e49c59fdb.png)

