### PR TITLE
Handle timeouts when trying to load node credentials in editor

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -397,6 +397,7 @@
         "icon": "Icon",
         "inputType": "Input type",
         "selectType": "select types...",
+        "loadCredentials": "Loading node credentials",
         "inputs" : {
             "input": "input",
             "select": "select",
@@ -431,7 +432,8 @@
         },
         "errors": {
             "scopeChange": "Changing the scope will make it unavailable to nodes in other flows that use it",
-            "invalidProperties": "Invalid properties:"
+            "invalidProperties": "Invalid properties:",
+            "credentialLoadFailed": "Failed to load node credentials"
         }
     },
     "keyboard": {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -496,11 +496,13 @@ RED.editor = (function() {
                 populateCredentialsInputs(node, definition.credentials, node.credentials, prefix);
                 completePrepare();
             } else {
-                $.getJSON(getCredentialsURL(node.type, node.id), function (data) {
-                    node.credentials = data;
-                    node.credentials._ = $.extend(true,{},data);
-                    if (!/^subflow:/.test(definition.type)) {
-                        populateCredentialsInputs(node, definition.credentials, node.credentials, prefix);
+                getNodeCredentials(node.type, node.id, function(data) {
+                    if (data) {
+                        node.credentials = data;
+                        node.credentials._ = $.extend(true,{},data);
+                        if (!/^subflow:/.test(definition.type)) {
+                            populateCredentialsInputs(node, definition.credentials, node.credentials, prefix);
+                        }
                     }
                     completePrepare();
                 });
@@ -1088,8 +1090,11 @@ RED.editor = (function() {
         node.infoEditor = nodeInfoEditor;
         return nodeInfoEditor;
     }
+var buildingEditDialog = false;
 
     function showEditDialog(node, defaultTab) {
+        if (buildingEditDialog) { return }
+        buildingEditDialog = true;
         var editing_node = node;
         var isDefaultIcon;
         var defaultIcon;
@@ -1614,6 +1619,7 @@ RED.editor = (function() {
                     if (defaultTab) {
                         editorTabs.activateTab(defaultTab);
                     }
+                    buildingEditDialog = false;
                     done();
                 });
             },
@@ -1665,6 +1671,8 @@ RED.editor = (function() {
      * prefix - the input prefix of the parent property
      */
     function showEditConfigNodeDialog(name,type,id,prefix) {
+        if (buildingEditDialog) { return }
+        buildingEditDialog = true;
         var adding = (id == "_ADD_");
         var node_def = RED.nodes.getType(type);
         var editing_config_node = RED.nodes.node(id);
@@ -1828,6 +1836,7 @@ RED.editor = (function() {
                     trayBody.i18n();
                     trayFooter.i18n();
                     finishedBuilding = true;
+                    buildingEditDialog = false;
                     done();
                 });
             },
@@ -2151,6 +2160,8 @@ RED.editor = (function() {
     }
 
     function showEditSubflowDialog(subflow) {
+        if (buildingEditDialog) { return }
+        buildingEditDialog = true;
         var editing_node = subflow;
         editStack.push(subflow);
         RED.view.state(RED.state.EDITING);
@@ -2407,15 +2418,17 @@ RED.editor = (function() {
 
                 buildEditForm(nodePropertiesTab.content,"dialog-form","subflow-template", undefined, editing_node);
                 trayBody.i18n();
-
-                $.getJSON(getCredentialsURL("subflow", subflow.id), function (data) {
-                    subflow.credentials = data;
-                    subflow.credentials._ = $.extend(true,{},data);
-
+                getNodeCredentials("subflow", subflow.id, function(data) {
+                    if (data) {
+                        subflow.credentials = data;
+                        subflow.credentials._ = $.extend(true,{},data);
+                    }
                     $("#subflow-input-name").val(subflow.name);
                     RED.text.bidi.prepareInput($("#subflow-input-name"));
 
                     finishedBuilding = true;
+                    buildingEditDialog = false;
+
                     done();
                 });
             },
@@ -2436,7 +2449,39 @@ RED.editor = (function() {
         RED.tray.show(trayOptions);
     }
 
+    function getNodeCredentials(type, id, done) {
+        var timeoutNotification;
+        var intialTimeout = setTimeout(function() {
+            timeoutNotification = RED.notify($('<p data-i18n="[prepend]editor.loadCredentials">  <img src="red/images/spin.svg"/></p>').i18n(),{fixed: true})
+        },800);
+
+        $.ajax({
+            url: getCredentialsURL(type,id),
+            dataType: 'json',
+            success: function(data) {
+                if (timeoutNotification) {
+                    timeoutNotification.close();
+                    timeoutNotification = null;
+                }
+                clearTimeout(intialTimeout);
+                done(data);
+            },
+            error: function(jqXHR,status,error) {
+                if (timeoutNotification) {
+                    timeoutNotification.close();
+                    timeoutNotification = null;
+                }
+                clearTimeout(intialTimeout);
+                RED.notify(RED._("editor.errors.credentialLoadFailed"),"error")
+                done(null);
+            },
+            timeout: 10000,
+        });
+    }
+
     function showEditGroupDialog(group) {
+        if (buildingEditDialog) { return }
+        buildingEditDialog = true;
         var editing_node = group;
         editStack.push(group);
         RED.view.state(RED.state.EDITING);
@@ -2660,6 +2705,7 @@ RED.editor = (function() {
                 prepareEditDialog(group,group._def,"node-input", function() {
                     trayBody.i18n();
                     finishedBuilding = true;
+                    buildingEditDialog = false;
                     done();
                 });
             },

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -2475,7 +2475,7 @@ var buildingEditDialog = false;
                 RED.notify(RED._("editor.errors.credentialLoadFailed"),"error")
                 done(null);
             },
-            timeout: 10000,
+            timeout: 30000,
         });
     }
 


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

Fixes #2840

## Proposed changes

When opening an node/subflow editor dialog that includes credentials, the editor makes a call back to the runtime to get the credential information. If that call takes a long time for some reason, the edit dialog doesn't appear and there is no feedback to the user. The user may get bored and double-click on the node again - kicking off another request to load the credentials.

When the request(s) finally timeout or complete, you then get multiple edit dialogs open.

This PR fixes two aspects of this:

1. If a node edit dialog is still being built, a second dbl click on a node is ignored. This stops you from getting multiple dialogs open for the same node.
2. There is now timeout handling for loading credentials.

For the timeout handling, there are two stages to this.

1. If the request to load credentials takes more than 800ms we first show this notification which includes the spinner to give feedback to the user that something is happening
    <img width="552" alt="Node-RED" src="https://user-images.githubusercontent.com/51083/106132059-5b808680-615b-11eb-9966-67db01bfd033.png">

2. If the request has not completed after 30 seconds, we show this notification:

![image](https://user-images.githubusercontent.com/51083/106132215-9387c980-615b-11eb-84a0-94d8d657d859.png)

And the edit dialog opens *without* the credential information.

I think the 800ms / 30s timeouts for the two stages are reasonable values to go with. When the user is running locally, the request to load credentials responds instantly so they are never troubled by the notifications.


