### PR TITLE
Allow default keymap to be overridden in settings file

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -200,6 +200,10 @@ module.exports = {
             themeSettings.projects = theme.projects;
         }
 
+        if (theme.hasOwnProperty("keymap")) {
+            themeSettings.keymap = theme.keymap;
+        }
+
         if (theme.theme) {
             themeSettings.theme = theme.theme;
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/keyboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/keyboard.js
@@ -43,10 +43,10 @@ RED.keyboard = (function() {
         "?":191 // <- QWERTY specific
     }
     var metaKeyCodes = {
-        16:true,
-        17:true,
+        16: true,
+        17: true,
         18: true,
-        91:true,
+        91: true,
         93: true
     }
     var actionToKeyMap = {}
@@ -60,46 +60,79 @@ RED.keyboard = (function() {
     }
 
     function migrateOldKeymap() {
+        // pre-0.18
         if ('localStorage' in window && window['localStorage'] !== null) {
             var oldKeyMap = localStorage.getItem("keymap");
             if (oldKeyMap !== null) {
                 localStorage.removeItem("keymap");
-                var currentEditorSettings = RED.settings.get('editor') || {};
-                currentEditorSettings.keymap  = JSON.parse(oldKeyMap);
-                RED.settings.set('editor',currentEditorSettings);
+                RED.settings.set('editor.keymap',JSON.parse(oldKeyMap));
             }
         }
+
     }
+
     function getUserKey(action) {
-        var currentEditorSettings = RED.settings.get('editor') || {};
-        var userKeymap = currentEditorSettings.keymap || {};
-        return userKeymap[action];
+        return RED.settings.get('editor.keymap',{})[action]
     }
+
+    function mergeKeymaps(defaultKeymap, themeKeymap) {
+        // defaultKeymap has format: { scope: { action: key , action: key }}
+        // themeKeymap has format: {action: {scope,key}, action: {scope:key}}
+
+        var mergedKeymap = {};
+        for (var scope in defaultKeymap) {
+            if (defaultKeymap.hasOwnProperty(scope)) {
+                var keys = defaultKeymap[scope];
+                for (var key in keys) {
+                    if (keys.hasOwnProperty(key)) {
+                        mergedKeymap[keys[key]] = {
+                            scope:scope,
+                            key:key,
+                            user:false
+                        };
+                    }
+                }
+            }
+        }
+        for (var action in themeKeymap) {
+            if (themeKeymap.hasOwnProperty(action)) {
+                if (!themeKeymap[action].key) {
+                    // No key for this action - default is no keybinding
+                    delete mergedKeymap[action]
+                } else {
+                    mergedKeymap[action] = {
+                        scope: themeKeymap[action].scope || "*",
+                        key: themeKeymap[action].key,
+                        user: false
+                    }
+                    if (mergedKeymap[action].scope === "workspace") {
+                        mergedKeymap[action].scope = "red-ui-workspace";
+                    }
+                }
+            }
+        }
+        return mergedKeymap;
+    }
+
     function init() {
         // Migrate from pre-0.18
         migrateOldKeymap();
 
-        var currentEditorSettings = RED.settings.get('editor') || {};
-        var userKeymap = currentEditorSettings.keymap || {};
+        var userKeymap = RED.settings.get('editor.keymap', {});
+        $.getJSON("red/keymap.json",function(defaultKeymap) {
+            var keymap = mergeKeymaps(defaultKeymap, RED.settings.theme('keymap',{}));
+            // keymap has the format:  {action: {scope,key}, action: {scope:key}}
 
-        $.getJSON("red/keymap.json",function(data) {
-            for (var scope in data) {
-                if (data.hasOwnProperty(scope)) {
-                    var keys = data[scope];
-                    for (var key in keys) {
-                        if (keys.hasOwnProperty(key)) {
-                            if (!userKeymap.hasOwnProperty(keys[key])) {
-                                addHandler(scope,key,keys[key],false);
-                            }
-                            defaultKeyMap[keys[key]] = {
-                                scope:scope,
-                                key:key,
-                                user:false
-                            };
-                        }
+            var action;
+            for (action in keymap) {
+                if (keymap.hasOwnProperty(action)) {
+                    if (!userKeymap.hasOwnProperty(action)) {
+                        addHandler(keymap[action].scope,keymap[action].key,action,false);
                     }
+                    defaultKeyMap[action] = keymap[action];
                 }
             }
+
             for (var action in userKeymap) {
                 if (userKeymap.hasOwnProperty(action) && userKeymap[action]) {
                     var obj = userKeymap[action];
@@ -437,13 +470,10 @@ RED.keyboard = (function() {
                 e.stopPropagation();
                 container.empty();
                 container.removeClass('keyboard-shortcut-entry-expanded');
-                // var userKeymap = RED.settings.get('keymap') || {};
 
-                var currentEditorSettings = RED.settings.get('editor') || {};
-                var userKeymap = currentEditorSettings.keymap || {};
+                var userKeymap = RED.settings.get('editor.keymap', {});
                 userKeymap[object.id] = null;
-                currentEditorSettings.keymap = userKeymap;
-                RED.settings.set('editor',currentEditorSettings);
+                RED.settings.set('editor.keymap',userKeymap);
 
                 RED.keyboard.revertToDefault(object.id);
 
@@ -496,11 +526,14 @@ RED.keyboard = (function() {
                             RED.keyboard.add(object.scope,object.key,object.id,true);
                         }
 
-                        var currentEditorSettings = RED.settings.get('editor') || {};
-                        var userKeymap = currentEditorSettings.keymap || {};
-                        userKeymap[object.id] = RED.keyboard.getShortcut(object.id);
-                        currentEditorSettings.keymap = userKeymap;
-                        RED.settings.set('editor',currentEditorSettings);
+
+                        var userKeymap = RED.settings.get('editor.keymap', {});
+                        var shortcut = RED.keyboard.getShortcut(object.id);
+                        userKeymap[object.id] = {
+                            scope:shortcut.scope,
+                            key:shortcut.key
+                        }
+                        RED.settings.set('editor.keymap',userKeymap);
                     }
                 }
             }


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

This has been on the trello backlog for a while. Node-RED provides a set of default keyboard shortcuts in the editor and a user is able to customise those shortcuts manually in the editor.

This PR allows a custom set of default keyboard shortcuts to be provided in the settings file.

Under the `editorTheme` property, the new `keymap` setting can be used:

```
        keymap: {
            "core:add-flow": {
                "key": "shift-ctrl-a"
            },
            "core:new-project": {}
        }
```

In this example, it sets the shortcut for `core-add-flow` to `shift-ctrl-a`, and it *removes* the built-in shortcut for `core:new-project`. The format of this property is the same as we store under `.config.users.json` - this means a user can customise their shortcuts in the editor, and then copy/paste the configuration from the .config file into their settings file.
