### PR TITLE
Add enable/disable toggle button for groups in info-outliner

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
@@ -169,7 +169,7 @@ RED.sidebar.info.outliner = (function() {
         //     evt.stopPropagation();
         //     RED.view.reveal(n.id);
         // })
-        if (n.type !== 'group' && n.type !== 'subflow') {
+        if (n.type !== 'subflow') {
             var toggleButton = $('<button type="button" class="red-ui-info-outline-item-control-disable red-ui-button red-ui-button-small"><i class="fa fa-circle-thin"></i><i class="fa fa-ban"></i></button>').appendTo(controls).on("click",function(evt) {
                 evt.preventDefault();
                 evt.stopPropagation();
@@ -179,6 +179,45 @@ RED.sidebar.info.outliner = (function() {
                     } else {
                         RED.workspaces.disable(n.id)
                     }
+                } else if (n.type === 'group') {
+                    var groupNodes = RED.group.getNodes(n,true);
+                    var groupHistoryEvent = {
+                        t:'multi',
+                        events:[],
+                        dirty: RED.nodes.dirty()
+                    }
+                    var targetState;
+                    groupNodes.forEach(function(n) {
+                        if (n.type !== 'group') {
+                            if (targetState === undefined) {
+                                targetState = !n.d;
+                            }
+                            if (!!n.d !== targetState) {
+                                var historyEvent = {
+                                    t: "edit",
+                                    node: n,
+                                    changed: n.changed,
+                                    changes: {
+                                        d: n.d
+                                    }
+                                }
+                                if (n.d) {
+                                    delete n.d;
+                                } else {
+                                    n.d = true;
+                                }
+                                n.dirty = true;
+                                n.changed = true;
+                                RED.events.emit("nodes:change",n);
+                                groupHistoryEvent.events.push(historyEvent);
+                            }
+                        }
+                        if (groupHistoryEvent.events.length > 0) {
+                            RED.history.push(groupHistoryEvent);
+                            RED.nodes.dirty(true)
+                            RED.view.redraw();
+                        }
+                    })
                 } else {
                     // TODO: this ought to be a utility function in RED.nodes
                     var historyEvent = {
@@ -198,11 +237,15 @@ RED.sidebar.info.outliner = (function() {
                     n.dirty = true;
                     n.changed = true;
                     RED.events.emit("nodes:change",n);
+                    RED.history.push(historyEvent);
                     RED.nodes.dirty(true)
                     RED.view.redraw();
                 }
             });
             RED.popover.tooltip(toggleButton,function() {
+                if (n.type === "group") {
+                    return RED._("common.label.enable")+" / "+RED._("common.label.disable")
+                }
                 return RED._("common.label."+(((n.type==='tab' && n.disabled) || (n.type!=='tab' && n.d))?"enable":"disable"));
             });
         } else {


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

The Info outliner provides a button to toggle the enabled/disabled state of nodes and flows. This PR adds the button to Group nodes as well - although the behaviour is slightly different.

When you disable a Flow, the nodes within it are not individually disabled, but are implicitly disabled.

A Group doesn't have the same concept of being disabled - and this PR doesn't change that fact. The button this PR adds will toggle the enable/disable state of all nodes within the group. More specifically, it swaps the state of the *first* node in the group, and ensures all of the others match. This means if you have a group with a mixture of states, they will all get aligned to the same state.

This also fixes the Undo history handling of the existing button.