### PR TITLE
Add confirm dialog when deleting subflow with instances in use

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -338,6 +338,7 @@
         "output": "outputs:",
         "status": "status node",
         "deleteSubflow": "delete subflow",
+        "confirmDelete": "Are you sure you want to delete this subflow?",
         "info": "Description",
         "category": "Category",
         "module": "Module",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -464,12 +464,43 @@ RED.subflow = (function() {
 
         $("#red-ui-subflow-delete").on("click", function(event) {
             event.preventDefault();
-            var startDirty = RED.nodes.dirty();
-            var historyEvent = removeSubflow(RED.workspaces.active());
-            historyEvent.t = 'delete';
-            historyEvent.dirty = startDirty;
+            var subflow = RED.nodes.subflow(RED.workspaces.active());
+            if (subflow.instances.length > 0) {
+                var msg = $('<div>')
+                $('<p>').text(RED._("subflow.subflowInstances",{count: subflow.instances.length})).appendTo(msg);
+                $('<p>').text(RED._("subflow.confirmDelete")).appendTo(msg);
+                var confirmDeleteNotification = RED.notify(msg, {
+                    modal: true,
+                    fixed: true,
+                    buttons: [
+                        {
+                            text: RED._('common.label.cancel'),
+                            click: function() {
+                                confirmDeleteNotification.close();
+                            }
+                        },
+                        {
+                            text: RED._('workspace.confirmDelete'),
+                            class: "primary",
+                            click: function() {
+                                confirmDeleteNotification.close();
+                                completeDelete();
+                            }
+                        }
+                    ]
+                });
 
-            RED.history.push(historyEvent);
+                return;
+            } else {
+                completeDelete();
+            }
+            function completeDelete() {
+                var startDirty = RED.nodes.dirty();
+                var historyEvent = removeSubflow(RED.workspaces.active());
+                historyEvent.t = 'delete';
+                historyEvent.dirty = startDirty;
+                RED.history.push(historyEvent);
+            }
 
         });
 


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Based on feedback from the forum, this PR adds a confirmation dialog if the user clicks the 'delete subflow' button when there are instances of the subflow within the flows.

![image](https://user-images.githubusercontent.com/51083/106210170-3709c600-61be-11eb-88ea-6da40c55daf8.png)
