### PR TITLE
Ensure the first sidebar tab is shown when editor loads

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -516,6 +516,9 @@ var RED = (function() {
 
         $(".red-ui-header-toolbar").show();
 
+
+        RED.sidebar.show(":first");
+        
         setTimeout(function() {
             loader.end();
         },100);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
@@ -195,6 +195,9 @@ RED.sidebar = (function() {
     }
 
     function showSidebar(id) {
+        if (id === ":first") {
+            id = RED.settings.get("editor.sidebar.order",["info", "help", "version-control", "debug"])[0]
+        }
         if (id) {
             if (!containsTab(id)) {
                 sidebar_tabs.addTab(knownTabs[id]);


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

## Proposed changes

We added the ability to reorder the sidebar tabs in a recent release. However, when the editor loads, whilst the order of tabs would be restored, you'd still get the Info sidebar tab show regardless of where in the order it was. This is because the sidebar would always show the first tab **added**.

This PR fixes the behaviour so that the first tab is always the one shown when the editor loads.