### PR TITLE
Add config node to refer to when exporting subflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -849,40 +849,47 @@ RED.nodes = (function() {
                             subflowSet.push(n);
                         }
                     });
+                    RED.nodes.eachConfig(function(n) {
+                        if (n.z == subflowId) {
+                            subflowSet.push(n);
+                        }
+                    });
                     var exportableSubflow = createExportableNodeSet(subflowSet, exportedIds, exportedSubflows, exportedConfigNodes);
                     nns = exportableSubflow.concat(nns);
                 }
             }
             if (node.type !== "subflow") {
-                var convertedNode = RED.nodes.convertNode(node);
-                for (var d in node._def.defaults) {
-                    if (node._def.defaults[d].type) {
-                        var nodeList = node[d];
-                        if (!Array.isArray(nodeList)) {
-                            nodeList = [nodeList];
-                        }
-                        nodeList = nodeList.filter(function(id) {
-                            if (id in configNodes) {
-                                var confNode = configNodes[id];
-                                if (confNode._def.exportable !== false) {
-                                    if (!(id in exportedConfigNodes)) {
-                                        exportedConfigNodes[id] = true;
-                                        set.push(confNode);
-                                        return true;
-                                    }
-                                }
-                                return false;
+                if (nns.findIndex((v) => v && v.id === node.id) == -1) {
+                    var convertedNode = RED.nodes.convertNode(node);
+                    for (var d in node._def.defaults) {
+                        if (node._def.defaults[d].type) {
+                            var nodeList = node[d];
+                            if (!Array.isArray(nodeList)) {
+                                nodeList = [nodeList];
                             }
-                            return true;
-                        })
-                        if (nodeList.length === 0) {
-                            convertedNode[d] = Array.isArray(node[d])?[]:""
-                        } else {
-                            convertedNode[d] = Array.isArray(node[d])?nodeList:nodeList[0]
+                            nodeList = nodeList.filter(function(id) {
+                                if (id in configNodes) {
+                                    var confNode = configNodes[id];
+                                    if (confNode._def.exportable !== false) {
+                                        if (!(id in exportedConfigNodes)) {
+                                            exportedConfigNodes[id] = true;
+                                            set.push(confNode);
+                                            return true;
+                                        }
+                                    }
+                                    return false;
+                                }
+                                return true;
+                            })
+                            if (nodeList.length === 0) {
+                                convertedNode[d] = Array.isArray(node[d])?[]:""
+                            } else {
+                                convertedNode[d] = Array.isArray(node[d])?nodeList:nodeList[0]
+                            }
                         }
                     }
+                    nns.push(convertedNode);
                 }
-                nns.push(convertedNode);
                 if (node.type === "group") {
                     nns = nns.concat(createExportableNodeSet(node.nodes, exportedIds, exportedSubflows, exportedConfigNodes));
                 }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Normally, the Config node is referenced by the node.
Since createExportableNodeSet() targets the nodes that belong to the subflow, the Config node that has the reference is also exported.
However, the Config nodes of ui_subgroup_t and ui_subgroup_i defined in the currently proposed UI Module do not have references from the nodes.
Only the "z" property*1 of the subflow is designed to be the key for node reference.
Therefore, by adding the Config node that belongs to the subflow to the export target, the ui_subgroup_t and ui_subgroup_i Config nodes are targeted.

*1 In the latest version of Node-RED, the "z" property of the Config node is now preserved when importing a flow.
For this reason, the "subgroup" key of ui_subgroup_t, which had the same meaning, has been abolished and "z" has been used.

UI Module Prototype update
https://github.com/node-red/node-red-dashboard/pull/621/commits/2ef4cf00ebf7cdcd6c0722000e9cd4c468d5f9d2



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality