### PR TITLE
fix csv node template reset when array complete

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/parsers/70-CSV.js
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-CSV.js
@@ -52,7 +52,8 @@ module.exports = function(RED) {
             else { node.goodtmpl = true; }
             return col;
         }
-        node.template = clean(node.template);
+        var template = clean(node.template);
+        var notemplate = node.template.length === 1 && node.template[0] === '';
         node.hdrSent = false;
 
         this.on("input", function(msg) {
@@ -62,18 +63,21 @@ module.exports = function(RED) {
             if (msg.hasOwnProperty("payload")) {
                 if (typeof msg.payload == "object") { // convert object to CSV string
                     try {
+                        if (!(notemplate && (msg.hasOwnProperty("parts") && msg.parts.hasOwnProperty("index") && msg.parts.index > 0))) {
+                            template = clean(node.template);
+                        }
                         var ou = "";
                         if (!Array.isArray(msg.payload)) { msg.payload = [ msg.payload ]; }
                         if (node.hdrout !== "none" && node.hdrSent === false) {
-                            if ((node.template.length === 1) && (node.template[0] === '')) {
+                            if ((template.length === 1) && (template[0] === '')) {
                                 if (msg.hasOwnProperty("columns")) {
-                                    node.template = clean((msg.columns || "").split(","));
+                                    template = clean((msg.columns || "").split(","));
                                 }
                                 else {
-                                    node.template = Object.keys(msg.payload[0]);
+                                    template = Object.keys(msg.payload[0]);
                                 }
                             }
-                            ou += node.template.join(node.sep) + node.ret;
+                            ou += template.join(node.sep) + node.ret;
                             if (node.hdrout === "once") { node.hdrSent = true; }
                         }
                         for (var s = 0; s < msg.payload.length; s++) {
@@ -92,10 +96,10 @@ module.exports = function(RED) {
                                 ou += msg.payload[s].join(node.sep) + node.ret;
                             }
                             else {
-                                if ((node.template.length === 1) && (node.template[0] === '') && (msg.hasOwnProperty("columns"))) {
-                                    node.template = clean((msg.columns || "").split(","));
+                                if ((template.length === 1) && (template[0] === '') && (msg.hasOwnProperty("columns"))) {
+                                    template = clean((msg.columns || "").split(","));
                                 }
-                                if ((node.template.length === 1) && (node.template[0] === '')) {
+                                if ((template.length === 1) && (template[0] === '')) {
                                     /* istanbul ignore else */
                                     if (tmpwarn === true) { // just warn about missing template once
                                         node.warn(RED._("csv.errors.obj_csv"));
@@ -121,12 +125,12 @@ module.exports = function(RED) {
                                     ou = ou.slice(0,-1) + node.ret;
                                 }
                                 else {
-                                    for (var t=0; t < node.template.length; t++) {
-                                        if (node.template[t] === '') {
+                                    for (var t=0; t < template.length; t++) {
+                                        if (template[t] === '') {
                                             ou += node.sep;
                                         }
                                         else {
-                                            var p = RED.util.ensureString(RED.util.getMessageProperty(msg,"payload["+s+"]['"+node.template[t]+"']"));
+                                            var p = RED.util.ensureString(RED.util.getMessageProperty(msg,"payload["+s+"]['"+template[t]+"']"));
                                             /* istanbul ignore else */
                                             if (p === "undefined") { p = ""; }
                                             if (p.indexOf(node.quo) !== -1) { // add double quotes if any quotes
@@ -144,7 +148,7 @@ module.exports = function(RED) {
                             }
                         }
                         msg.payload = ou;
-                        msg.columns = node.template.join(',');
+                        msg.columns = template.join(',');
                         if (msg.payload !== '') { node.send(msg); }
                     }
                     catch(e) { node.error(e,msg); }


### PR DESCRIPTION
and add tests
to close #2853

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This fix ensures the template is reset once complete (either an array or msg with .parts or a single message) - such that a subsequent msg with msg.columns defined will then use that new definition.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
