### PR TITLE
Fix join node array index and reset

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -259,7 +259,7 @@ module.exports = function(RED) {
                     }
                 } else { // otherwise drop the message.
                     done();
-                }  
+                }
             }
         });
     }
@@ -561,7 +561,7 @@ module.exports = function(RED) {
             reduceMessage(node, nextMsgInfo, err => {
                 if (err) {
                     nextMsgInfo.done(err);//.error(err,nextMsg);
-                } 
+                }
                 activeMessage = null;
                 processReduceMessageQueue();
             })
@@ -570,12 +570,7 @@ module.exports = function(RED) {
         this.on("input", function(msg, send, done) {
             try {
                 var property;
-                if (node.mode === 'auto' && (!msg.hasOwnProperty("parts")||!msg.parts.hasOwnProperty("id"))) {
-                    node.warn("Message missing msg.parts property - cannot join in 'auto' mode")
-                    done();
-                    return;
-                }
-
+                var partId = "_";
                 if (node.propertyType == "full") {
                     property = msg;
                 }
@@ -589,7 +584,21 @@ module.exports = function(RED) {
                     }
                 }
 
-                var partId;
+                if (node.mode === 'auto' && (!msg.hasOwnProperty("parts")||!msg.parts.hasOwnProperty("id"))) {
+                    // if a blank reset messag erest it all.
+                    if (msg.hasOwnProperty("reset")) {
+                        if (inflight && inflight.hasOwnProperty("partId") && inflight[partId].timeout) {
+                            clearTimeout(inflight[partId].timeout);
+                        }
+                        inflight = {};
+                    }
+                    else {
+                        node.warn("Message missing msg.parts property - cannot join in 'auto' mode")
+                    }
+                    done();
+                    return;
+                }
+
                 var payloadType;
                 var propertyKey;
                 var targetCount;
@@ -611,7 +620,6 @@ module.exports = function(RED) {
                 }
                 else {
                     // Use the node configuration to identify all of the group information
-                    partId = "_";
                     payloadType = node.build;
                     targetCount = node.count;
                     joinChar = node.joiner;
@@ -620,6 +628,9 @@ module.exports = function(RED) {
                     }
                     if (node.build === 'object') {
                         propertyKey = RED.util.getMessageProperty(msg,node.key);
+                    }
+                    if (msg.hasOwnProperty("parts")) {
+                        propertyIndex = msg.parts.index;
                     }
                 }
 
@@ -725,8 +736,8 @@ module.exports = function(RED) {
                     }
                 } else {
                     if (!isNaN(propertyIndex)) {
+                        if (group.payload[propertyIndex] == undefined) { group.currentCount++; }
                         group.payload[propertyIndex] = property;
-                        group.currentCount++;
                     } else {
                         if (property !== undefined) {
                             group.payload.push(property);
@@ -762,4 +773,3 @@ module.exports = function(RED) {
     }
     RED.nodes.registerType("join",JoinNode);
 }
-

--- a/test/nodes/core/sequence/17-split_spec.js
+++ b/test/nodes/core/sequence/17-split_spec.js
@@ -1646,6 +1646,51 @@ describe('JOIN node', function() {
         });
     });
 
+    it('should handle join an array when using msg.parts and duplicate indexed parts arrive', function (done) {
+        var flow = [{ id: "n1", type: "join", wires: [["n2"]], joiner: "[44]", joinerType: "bin", build: "array", mode: "auto" },
+                    { id: "n2", type: "helper" }];
+        helper.load(joinNode, flow, function () {
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n2.on("input", function (msg) {
+                try {
+                    msg.should.have.property("payload");
+                    msg.payload[0].should.equal("C");
+                    msg.payload[1].should.equal("D");
+                    done();
+                }
+                catch (e) { done(e); }
+            });
+            n1.receive({ payload: "A", parts: { id:1, type:"array", ch:",", index:0, count:2 } });
+            n1.receive({ payload: "B", parts: { id:1, type:"array", ch:",", index:0, count:2 } });
+            n1.receive({ payload: "C", parts: { id:1, type:"array", ch:",", index:0, count:2 } });
+            n1.receive({ payload: "D", parts: { id:1, type:"array", ch:",", index:1, count:2 } });
+         });
+    });
+
+    it('should handle join an array when using msg.parts and duplicate indexed parts arrive and being reset halfway', function (done) {
+        var flow = [{ id: "n1", type: "join", wires: [["n2"]], joiner: "[44]", joinerType: "bin", build: "array", mode: "auto" },
+                    { id: "n2", type: "helper" }];
+        helper.load(joinNode, flow, function () {
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n2.on("input", function (msg) {
+                try {
+                    msg.should.have.property("payload");
+                    msg.payload[0].should.equal("D");
+                    msg.payload[1].should.equal("C");
+                    done();
+                }
+                catch (e) { done(e); }
+            });
+            n1.receive({ payload: "A", parts: { id:1, type:"array", ch:",", index:0, count:2 } });
+            n1.receive({ payload: "B", parts: { id:1, type:"array", ch:",", index:0, count:2 } });
+            n1.receive({ reset:true });
+            n1.receive({ payload: "C", parts: { id:1, type:"array", ch:",", index:1, count:2 } });
+            n1.receive({ payload: "D", parts: { id:1, type:"array", ch:",", index:0, count:2 } });
+         });
+    });
+
     describe('messaging API', function() {
         function mapiDoneSplitTestHelper(done, splt, spltType, stream, msgAndTimings) {
             const completeNode = require("nr-test-utils").require("@node-red/nodes/core/common/24-complete.js");
@@ -1821,4 +1866,5 @@ describe('JOIN node', function() {
         });
 
     })
+
 });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
this PR allows joining incoming messages into an array 
    a) in manual mode if msg.parts is there then the index is now honoured - so if two array parts arrive with same index the later will replace the former - and not increase the number of parts arrived - ie you need a complete set on indices in order to complete the array.
   b) in auto mode - if you send a msg.reset -  but without any msg.parts set - it will now reset all inflight messages rather than complaining about missing parts.

to close #2866

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
