### PR TITLE
Allow filtering of debug node output within subflow

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/lib/debug/debug-utils.js
+++ b/packages/node_modules/@node-red/nodes/core/common/lib/debug/debug-utils.js
@@ -120,7 +120,7 @@ RED.debug = (function() {
                         filteredNodes[node.id] = !$(this).prop('checked');
                         $(".red-ui-debug-msg-node-"+node.id.replace(/\./g,"_")).toggleClass('hide',filteredNodes[node.id]);
                     });
-                    if (!node.active || RED.nodes.workspace(node.z).disabled) {
+                    if ((node.hasOwnProperty("active") && !node.active) || RED.nodes.workspace(node.z).disabled) {
                         container.addClass('disabled');
                         muteControl.checkboxSet('disable');
                     }
@@ -233,6 +233,35 @@ RED.debug = (function() {
 
     }
 
+    function containsDebug(sid, map) {
+        if (sid in map) {
+            return true;
+        }
+        var nodes = RED.nodes.filterNodes({z: sid});
+        var contain = false;
+        nodes.forEach(function (n) {
+            if (contain) {
+                return;
+            }
+            var nt = n.type;
+            if (nt === "debug") {
+                contain = true;
+                return;
+            }
+            if (nt.substring(0, 8) === "subflow:") {
+                var id = nt.substring(8);
+                if (containsDebug(id, map)) {
+                    contain = true;
+                    return;
+                }
+            }
+        });
+        if (contain) {
+            map[sid] = true;
+        }
+        return contain;
+    }
+
     function refreshDebugNodeList() {
         debugNodeList.editableList('empty');
         var candidateNodes = RED.nodes.filterNodes({type:'debug'});
@@ -243,7 +272,18 @@ RED.debug = (function() {
         });
         candidateNodes = candidateNodes.filter(function(node) {
             return workspaceOrderMap.hasOwnProperty(node.z);
-        })
+        });
+        var map = {};
+        RED.nodes.eachNode(function (n) {
+            var nt = n.type;
+            if ((n.z in workspaceOrderMap) &&
+                (nt.substring(0, 8) === "subflow:")) {
+                var sid = nt.substring(8);
+                if (containsDebug(sid, map)) {
+                    candidateNodes.push(n);
+                }
+            }
+        });
         candidateNodes.sort(function(A,B) {
             var wsA = workspaceOrderMap[A.z];
             var wsB = workspaceOrderMap[B.z];
@@ -253,7 +293,7 @@ RED.debug = (function() {
             var labelA = RED.utils.getNodeLabel(A,A.id);
             var labelB = RED.utils.getNodeLabel(B,B.id);
             return labelA.localeCompare(labelB);
-        })
+        });
         var currentWs = null;
         var nodeList = [];
         candidateNodes.forEach(function(node) {
@@ -262,10 +302,8 @@ RED.debug = (function() {
                 nodeList.push(RED.nodes.workspace(node.z));
             }
             nodeList.push(node);
-        })
-
-
-        debugNodeList.editableList('addItems',nodeList)
+        });
+        debugNodeList.editableList('addItems',nodeList);
     }
 
     function getTimestamp() {

--- a/packages/node_modules/@node-red/nodes/core/common/lib/debug/debug-utils.js
+++ b/packages/node_modules/@node-red/nodes/core/common/lib/debug/debug-utils.js
@@ -224,66 +224,91 @@ RED.debug = (function() {
         });
         RED.popover.tooltip(toolbar.find("#red-ui-sidebar-debug-clear"),RED._('node-red:debug.sidebar.clearLog'),"core:clear-debug-messages");
 
-
-
         return {
             content: content,
             footer: footerToolbar
-        }
+        };
 
     }
+
 
     function containsDebug(sid, map) {
-        if (sid in map) {
-            return true;
-        }
-        var nodes = RED.nodes.filterNodes({z: sid});
-        var contain = false;
-        nodes.forEach(function (n) {
-            if (contain) {
-                return;
-            }
-            var nt = n.type;
-            if (nt === "debug") {
-                contain = true;
-                return;
-            }
-            if (nt.substring(0, 8) === "subflow:") {
-                var id = nt.substring(8);
-                if (containsDebug(id, map)) {
-                    contain = true;
-                    return;
+        var item = map[sid];
+        if (item) {
+            if (item.debug === undefined) {
+                var sfs = Object.keys(item.subflows);
+                var contain = false;
+                for (var i = 0; i < sfs.length; i++) {
+                    var sf = sfs[i];
+                    if (containsDebug(sf, map)) {
+                        contain = true;
+                        break;
+                    }
                 }
+                item.debug = contain;
             }
-        });
-        if (contain) {
-            map[sid] = true;
+            return item.debug;
         }
-        return contain;
+        return false;
     }
+
 
     function refreshDebugNodeList() {
         debugNodeList.editableList('empty');
-        var candidateNodes = RED.nodes.filterNodes({type:'debug'});
+
         var workspaceOrder = RED.nodes.getWorkspaceOrder();
         var workspaceOrderMap = {};
         workspaceOrder.forEach(function(ws,i) {
             workspaceOrderMap[ws] = i;
         });
-        candidateNodes = candidateNodes.filter(function(node) {
-            return workspaceOrderMap.hasOwnProperty(node.z);
-        });
-        var map = {};
+
+        var candidateNodes = [];
+        var candidateSFs = [];
+        var subflows = {};
         RED.nodes.eachNode(function (n) {
             var nt = n.type;
-            if ((n.z in workspaceOrderMap) &&
-                (nt.substring(0, 8) === "subflow:")) {
-                var sid = nt.substring(8);
-                if (containsDebug(sid, map)) {
+            if (nt === "debug") {
+                if (n.z in workspaceOrderMap) {
                     candidateNodes.push(n);
+                }
+                else {
+                    var sf = RED.nodes.subflow(n.z);
+                    if (sf) {
+                        subflows[sf.id] = {
+                            debug: true,
+                            subflows: {}
+                        };
+                    }
+                }
+            }
+            else if(nt.substring(0, 8) === "subflow:") {
+                if (n.z in workspaceOrderMap) {
+                    candidateSFs.push(n);
+                }
+                else {
+                    var psf = RED.nodes.subflow(n.z);
+                    if (psf) {
+                        var sid = nt.substring(8);
+                        var item = subflows[psf.id];
+                        if (!item) {
+                            item = {
+                                debug: undefined,
+                                subflows: {}
+                            };
+                            subflows[psf.id] = item;
+                        }
+                        item.subflows[sid] = true;
+                    }
                 }
             }
         });
+        candidateSFs.forEach(function (sf) {
+            var sid = sf.type.substring(8);
+            if (containsDebug(sid, subflows)) {
+                candidateNodes.push(sf);
+            }
+        });
+
         candidateNodes.sort(function(A,B) {
             var wsA = workspaceOrderMap[A.z];
             var wsB = workspaceOrderMap[B.z];


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
As described in this [issue](https://github.com/node-red/node-red/issues/2745), filtering of debug node output do not work debug nodes contained within subflow.
This PR try to fix this problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
