### PR TITLE
add IE11 polyfill to support URI download scheme

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/polyfills.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/polyfills.js
@@ -52,32 +52,5 @@
             Set.prototype = _Set.prototype;
             Set.prototype.constructor = Set;
         }
-
-        if (window.navigator.msSaveBlob) {
-            // IE does not support data uri scheme for downloading data
-            window.addEventListener("click", function (ev) {
-                var tgt = ev.target;
-                if ((tgt.tagName === "A") &&
-                    tgt.hasAttribute("download") &&
-                    tgt.hasAttribute("href")) {
-                    // partial support of data uri downloading
-                    var filename = tgt.getAttribute("download");
-                    var dataUri = tgt.getAttribute("href");
-                    var match = /^data:([^,]+),(.*)/.exec(dataUri);
-                    if (match) {
-                        ev.preventDefault();
-                        var enc = match[1];
-                        var data = decodeURIComponent(match[2]);
-                        var blob = new Blob([data], {
-                            type: enc,
-                        });
-                        navigator.msSaveBlob(blob, filename);
-                    }
-                    else {
-                        console.log("download not supported:", tgt);
-                    }
-                }
-            });
-        }
     }
 })();

--- a/packages/node_modules/@node-red/editor-client/src/js/polyfills.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/polyfills.js
@@ -53,5 +53,31 @@
             Set.prototype.constructor = Set;
         }
 
+        if (window.navigator.msSaveBlob) {
+            // IE does not support data uri scheme for downloading data
+            window.addEventListener("click", function (ev) {
+                var tgt = ev.target;
+                if ((tgt.tagName === "A") &&
+                    tgt.hasAttribute("download") &&
+                    tgt.hasAttribute("href")) {
+                    // partial support of data uri downloading
+                    var filename = tgt.getAttribute("download");
+                    var dataUri = tgt.getAttribute("href");
+                    var match = /^data:([^,]+),(.*)/.exec(dataUri);
+                    if (match) {
+                        ev.preventDefault();
+                        var enc = match[1];
+                        var data = decodeURIComponent(match[2]);
+                        var blob = new Blob([data], {
+                            type: enc,
+                        });
+                        navigator.msSaveBlob(blob, filename);
+                    }
+                    else {
+                        console.log("download not supported:", tgt);
+                    }
+                }
+            });
+        }
     }
 })();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -30,6 +30,27 @@ RED.clipboard = (function() {
 
     var pendingImportConfig;
 
+
+    function downloadData(file, data) {
+        if (window.navigator.msSaveBlob) {
+            // IE11 workaround
+            // IE does not support data uri scheme for downloading data
+            var blob = new Blob([data], {
+                type: "data:text/plain;charset=utf-8"
+            });
+            navigator.msSaveBlob(blob, file);
+        }
+        else {
+            var element = document.createElement('a');
+            element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(data));
+            element.setAttribute('download', file);
+            element.style.display = 'none';
+            document.body.appendChild(element);
+            element.click();
+            document.body.removeChild(element);
+        }
+    }
+
     function setupDialogs() {
         dialog = $('<div id="red-ui-clipboard-dialog" class="hide"><form class="dialog-form form-horizontal"></form></div>')
             .appendTo("#red-ui-editor")
@@ -56,13 +77,8 @@ RED.clipboard = (function() {
                         class: "primary",
                         text: RED._("clipboard.download"),
                         click: function() {
-                            var element = document.createElement('a');
-                            element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent($("#red-ui-clipboard-dialog-export-text").val()));
-                            element.setAttribute('download', "flows.json");
-                            element.style.display = 'none';
-                            document.body.appendChild(element);
-                            element.click();
-                            document.body.removeChild(element);
+                            var data = $("#red-ui-clipboard-dialog-export-text").val();
+                            downloadData("flows.json", data);
                             $( this ).dialog( "close" );
                         }
                     },


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->
As described in this [issue](https://github.com/node-red/node-red/issues/2755), exporting flow do not work on IE11.
This is caused by use of data uri scheme for downloading.
This PR try to fix this problem by adding polyfill for supporting this feature.

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
