### PR TITLE
Fix deploy of node in group

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/index.js
@@ -148,7 +148,8 @@ function setFlows(_config,_credentials,type,muteLog,forceStart,user) {
         // Parse the configuration
         newFlowConfig = flowUtil.parseConfig(clone(config));
         // Generate a diff to identify what has changed
-        diff = flowUtil.diffConfigs(activeFlowConfig,newFlowConfig);
+        diff = flowUtil.diffConfigs(activeFlowConfig,newFlowConfig,
+                                    (type === "nodes"));
 
         // Now the flows have been compared, remove any credentials from newFlowConfig
         // so they don't cause false-positive diffs the next time a flow is deployed

--- a/packages/node_modules/@node-red/runtime/lib/flows/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/index.js
@@ -148,8 +148,7 @@ function setFlows(_config,_credentials,type,muteLog,forceStart,user) {
         // Parse the configuration
         newFlowConfig = flowUtil.parseConfig(clone(config));
         // Generate a diff to identify what has changed
-        diff = flowUtil.diffConfigs(activeFlowConfig,newFlowConfig,
-                                    (type === "nodes"));
+        diff = flowUtil.diffConfigs(activeFlowConfig,newFlowConfig);
 
         // Now the flows have been compared, remove any credentials from newFlowConfig
         // so they don't cause false-positive diffs the next time a flow is deployed

--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -438,15 +438,25 @@ module.exports = {
                 if (newConfig.allNodes.hasOwnProperty(id)) {
                     node = newConfig.allNodes[id];
                     for (var prop in node) {
-                        if (ignoreGroup && (prop === "g")) {
-                            continue;
-                        }
                         if (node.hasOwnProperty(prop) && prop != "z" && prop != "id" && prop != "wires") {
                             // This node has a property that references a changed/removed node
                             // Assume it is a config node change and mark this node as
                             // changed.
-                            if (changed[node[prop]] || removed[node[prop]]) {
+
+                            var changeOrigin = changed[node[prop]];
+                            if (changeOrigin || removed[node[prop]]) {
                                 if (!changed[node.id]) {
+                                    if (changeOrigin &&
+                                        (prop === "g") &&
+                                        (changeOrigin.type === "group")) {
+                                        var oldNode = oldConfig.allNodes[node.id];
+                                        // ignore change of group node
+                                        // if group of this node not changed
+                                        if (oldNode &&
+                                            (node.g === oldNode.g)) {
+                                            continue;
+                                        }
+                                    }
                                     madeChange = true;
                                     changed[node.id] = node;
                                     // This node exists within subflow template

--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -271,7 +271,7 @@ module.exports = {
 
     parseConfig: parseConfig,
 
-    diffConfigs: function(oldConfig, newConfig) {
+    diffConfigs: function(oldConfig, newConfig, ignoreGroup) {
         var id;
         var node;
         var nn;
@@ -438,6 +438,9 @@ module.exports = {
                 if (newConfig.allNodes.hasOwnProperty(id)) {
                     node = newConfig.allNodes[id];
                     for (var prop in node) {
+                        if (ignoreGroup && (prop === "g")) {
+                            continue;
+                        }
                         if (node.hasOwnProperty(prop) && prop != "z" && prop != "id" && prop != "wires") {
                             // This node has a property that references a changed/removed node
                             // Assume it is a config node change and mark this node as

--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -271,7 +271,7 @@ module.exports = {
 
     parseConfig: parseConfig,
 
-    diffConfigs: function(oldConfig, newConfig, ignoreGroup) {
+    diffConfigs: function(oldConfig, newConfig) {
         var id;
         var node;
         var nn;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
As described in this [issue](https://github.com/node-red/node-red/issues/2835), changing node's group make the node restarted on deploy regardless of node deployment mode.  
This PR tries to prevent nodes that only change groups from restarting.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
