### PR TITLE
Add Japanese translations for Node-RED v1.3.0

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -343,6 +343,7 @@
         "category": "Category",
         "module": "Module",
         "license": "License",
+        "licenseNone": "none",
         "licenseOther": "Other",
         "type": "Node Type",
         "version": "Version",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -38,6 +38,7 @@
         }
     },
     "event": {
+        "loadPlugins": "プラグインを読み込み中",
         "loadPalette": "パレットを読み込み中",
         "loadNodeCatalogs": "ノードカタログを読み込み中",
         "loadNodes": "ノードを読み込み中 __count__",
@@ -85,7 +86,7 @@
             "userSettings": "ユーザ設定",
             "nodes": "ノード",
             "displayStatus": "ノードのステータスを表示",
-            "displayConfig": "ノードの設定",
+            "displayConfig": "設定ノード",
             "import": "読み込み",
             "export": "書き出し",
             "search": "ノードを検索",
@@ -203,8 +204,8 @@
         "replacedNodes_plural": "置換された __count__ 個のノード",
         "pasteNodes": "JSON形式のフローデータを貼り付け",
         "selectFile": "読み込むファイルを選択",
-        "importNodes": "フローをクリップボードから読み込み",
-        "exportNodes": "フローをクリップボードへ書き出し",
+        "importNodes": "フローを読み込み",
+        "exportNodes": "フローを書き出し",
         "download": "ダウンロード",
         "importUnrecognised": "認識できない型が読み込まれました:",
         "importUnrecognised_plural": "認識できない型が読み込まれました:",
@@ -266,7 +267,7 @@
         "successfulDeploy": "デプロイが成功しました",
         "successfulRestart": "フローの再起動が成功しました",
         "deployFailed": "デプロイが失敗しました: __message__",
-        "unusedConfigNodes": "使われていない「ノードの設定」があります。",
+        "unusedConfigNodes": "使われていない設定ノードがあります。",
         "unusedConfigNodesLink": "設定を参照する",
         "errors": {
             "noResponse": "サーバの応答がありません"
@@ -337,13 +338,20 @@
         "output": "出力:",
         "status": "ステータスノード",
         "deleteSubflow": "サブフローを削除",
+        "confirmDelete": "このサブフローを削除しても良いですか？",
         "info": "詳細",
         "category": "カテゴリ",
         "module": "モジュール",
         "license": "ライセンス",
+        "licenseNone": "なし",
+        "licenseOther": "その他",
+        "type": "ノードの型",
         "version": "バージョン",
+        "versionPlaceholder": "x.y.z",
         "keys": "キーワード",
+        "keysPlaceholder": "カンマ区切りのキーワード",
         "author": "作者",
+        "authorPlaceholder": "名前 <email@example.com>",
         "desc": "説明",
         "env": {
             "restore": "デフォルト値に戻す",
@@ -368,9 +376,9 @@
         "configDelete": "削除",
         "nodesUse": "__count__ 個のノードが、この設定を使用しています",
         "nodesUse_plural": "__count__ 個のノードが、この設定を使用しています",
-        "addNewConfig": "新規に __type__ ノードの設定を追加",
+        "addNewConfig": "新規に __type__ 設定ノードを追加",
         "editNode": "__type__ ノードを編集",
-        "editConfig": "__type__ ノードの設定を編集",
+        "editConfig": "__type__ 設定ノードを編集",
         "addNewType": "新規に __type__ を追加...",
         "nodeProperties": "プロパティ",
         "label": "ラベル",
@@ -391,6 +399,7 @@
         "icon": "記号",
         "inputType": "入力形式",
         "selectType": "形式選択...",
+        "loadCredentials": "ノードの認証情報を読み込み中",
         "inputs": {
             "input": "入力",
             "select": "メニュー",
@@ -425,7 +434,8 @@
         },
         "errors": {
             "scopeChange": "スコープの変更は、他のフローで使われているノードを無効にします",
-            "invalidProperties": "プロパティが不正です:"
+            "invalidProperties": "プロパティが不正です:",
+            "credentialLoadFailed": "ノードの認証情報の読み込みに失敗"
         }
     },
     "keyboard": {
@@ -643,8 +653,8 @@
             "noHelp": "ヘルプのトピックが未選択"
         },
         "config": {
-            "name": "ノードの設定を表示",
-            "label": "ノードの設定",
+            "name": "設定ノードを表示",
+            "label": "設定ノード",
             "global": "全てのフロー上",
             "none": "なし",
             "subflows": "サブフロー",
@@ -1085,6 +1095,7 @@
     "editor-tab": {
         "properties": "プロパティ",
         "envProperties": "環境変数",
+        "module": "モジュールプロパティ",
         "description": "説明",
         "appearance": "外観",
         "preview": "UIプレビュー",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -2025,7 +2025,11 @@ RED.subflow = (function() {
         var licenses = ["none", "Apache-2.0", "BSD-3-Clause", "BSD-2-Clause", "GPL-2.0", "GPL-3.0", "MIT", "MPL-2.0", "CDDL-1.0", "EPL-2.0"];
         var typedLicenses = {
             types: licenses.map(function(l) {
-                return {value:l,label:l,hasValue:false}
+                return {
+                    value: l,
+                    label: l === "none" ? RED._("editor:subflow.licenseNone") : l,
+                    hasValue: false
+                };
             })
         }
         typedLicenses.types.push({

--- a/packages/node_modules/@node-red/runtime/locales/ja/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/ja/runtime.json
@@ -41,6 +41,7 @@
             "uninstall-failed-long": "モジュール __name__ のアンインストールに失敗しました:",
             "uninstalled": "モジュール __name__ をアンインストールしました"
         },
+        "deprecatedOption": "__old__ の利用は非推奨です。代わりに __new__ を使用してください",
         "unable-to-listen": "__listenpath__ に対してlistenできません",
         "port-in-use": "エラー: ポートが使用中です",
         "uncaught-exception": "未補足の例外:",
@@ -149,6 +150,7 @@
             "projects": {
                 "changing-project": "プロジェクトを設定します : __project__",
                 "active-project": "選択中のプロジェクト : __project__",
+                "projects-directory": "プロジェクトディレクトリ: __projectsDirectory__",
                 "project-not-found": "プロジェクトが見つかりません : __project__",
                 "no-active-project": "プロジェクトが選択されていません : デフォルトのフローファイルを使用します",
                 "disabled": "プロジェクトは無効化されています : editorTheme.projects.enabled=false",


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I added Japanese translations for Node-RED v1.3.0. Because my acquaintance kindly pointed out the mistranslations of the configuration node, I also changed them to the correct translations.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
