### PR TITLE
Stop config nodes after flow nodes

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -308,6 +308,17 @@ class Flow {
             removedMap[id] = true;
         });
 
+        let nodesToStop = [];
+        let configsToStop = [];
+        stopList.forEach(id => {
+            if (this.flow.configs[id]) {
+                configsToStop.push(id);
+            } else {
+                nodesToStop.push(id);
+            }
+        });
+        stopList = nodesToStop.concat(configsToStop);
+        
         var promises = [];
         for (i=0;i<stopList.length;i++) {
             var node = this.activeNodes[stopList[i]];

--- a/packages/node_modules/@node-red/runtime/lib/flows/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/index.js
@@ -424,7 +424,7 @@ function stop(type,diff,muteLog) {
     });
 
     return Promise.all(promises).then(function() {
-        for (id in activeNodesToFlow) {
+        for (let id in activeNodesToFlow) {
             if (activeNodesToFlow.hasOwnProperty(id)) {
                 if (!activeFlows[activeNodesToFlow[id]]) {
                     delete activeNodesToFlow[id];

--- a/packages/node_modules/@node-red/runtime/lib/flows/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/index.js
@@ -404,7 +404,15 @@ function stop(type,diff,muteLog) {
 
     events.emit("flows:stopping",{config: activeConfig, type: type, diff: diff})
 
-    for (var id in activeFlows) {
+    // Stop the global flow object last
+    let activeFlowIds = Object.keys(activeFlows);
+    let globalIndex = activeFlowIds.indexOf("global");
+    if (globalIndex !== -1) {
+        activeFlowIds.splice(globalIndex,1);
+        activeFlowIds.push("global");
+    }
+
+    activeFlowIds.forEach(id => {
         if (activeFlows.hasOwnProperty(id)) {
             var flowStateChanged = diff && (diff.added.indexOf(id) !== -1 || diff.removed.indexOf(id) !== -1);
             log.debug("red/nodes/flows.stop : stopping flow : "+id);
@@ -413,7 +421,7 @@ function stop(type,diff,muteLog) {
                 delete activeFlows[id];
             }
         }
-    }
+    });
 
     return Promise.all(promises).then(function() {
         for (id in activeNodesToFlow) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

Fixes #2876

## Proposed changes

When Node-RED starts up flows we make sure to start config nodes before flow nodes as that is typically the right thing to do - flow nodes want their config nodes to already be available.

However we weren't doing anything special when it comes to stopping the flows.

This PR changes how we stop flows. It does two things:

1. it stops the `global` flow *last* - where previously it would be stopped first. This means any global config nodes are stopped *after* any flows are stopped
2. within a flow, it stops all flow nodes before config nodes

A very important point - this just changes the order the calls to stop are made. It doesn't do anything to wait until the flow nodes have stopped before stopping config nodes. 

If nodes need to do anything with the config nodes as part of the `close` event handler, they will need to make the call synchronously. If they do it asynchronously, it could be too late.

It would be possible to change it to wait for flow nodes to fully stop before stopping config nodes, but unless we find we really need to do it, I'm not considering that change as part of this fix.


## Checklist

- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
