### PR TITLE
EditableList custom buttons

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -857,7 +857,8 @@
         }
     },
     "editableList": {
-        "add": "add"
+        "add": "add",
+        "addTitle": "add an item"
     },
     "search": {
         "empty": "No matches found",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
@@ -94,19 +94,7 @@
             }
 
             buttons.forEach(function(button) {
-                var text = "";
-                var titleAttribute="";
-                if (button.icon) {
-                    text = '<i class="'+button.icon+'"></i> ';
-                }
-                if (button.label) {
-                    text += button.label;
-                }
-                if (button.title) {
-                    titleAttribute = 'title="'+button.title+'"';
-                }
-                $('<a href="#" class="red-ui-button red-ui-button-small red-ui-editableList-addButton" style="margin-top: 4px; margin-right: 5px;" '+titleAttribute+'></a>')
-                    .text(text)
+                var element = $('<a href="#" class="red-ui-button red-ui-button-small red-ui-editableList-addButton" style="margin-top: 4px; margin-right: 5px;"></a>')
                     .appendTo(that.topContainer)
                     .on("click", function(evt) {
                         evt.preventDefault();
@@ -114,6 +102,16 @@
                             button.click(evt);
                         }
                     });
+                    
+                if (button.title) {
+                    element.attr("title", button.title);
+                }
+                if (button.icon) {
+                    element.append($("<i></i>").attr("class", button.icon));
+                }
+                if (button.label) {
+                    element.append($("<span></span>").text(" " + button.label));
+                }
             });
  
             if (this.element.css("position") === "absolute") {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
@@ -94,18 +94,19 @@
             }
 
             buttons.forEach(function(button) {
-                var innerHtml = "";
+                var text = "";
                 var titleAttribute="";
                 if (button.icon) {
-                    innerHtml = '<i class="'+button.icon+'"></i> ';
+                    text = '<i class="'+button.icon+'"></i> ';
                 }
                 if (button.label) {
-                    innerHtml += button.label;
+                    text += button.label;
                 }
                 if (button.title) {
                     titleAttribute = 'title="'+button.title+'"';
                 }
-                $('<a href="#" class="red-ui-button red-ui-button-small red-ui-editableList-addButton" style="margin-top: 4px; margin-right: 5px;" '+titleAttribute+'>'+innerHtml+'</a>')
+                $('<a href="#" class="red-ui-button red-ui-button-small red-ui-editableList-addButton" style="margin-top: 4px; margin-right: 5px;" '+titleAttribute+'></a>')
+                    .text(text)
                     .appendTo(that.topContainer)
                     .on("click", function(evt) {
                         evt.preventDefault();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
@@ -18,6 +18,7 @@
 /**
  * options:
  *   - addButton : boolean|string - text for add label, default 'add'
+ *   - buttons : array - list of custom buttons (objects with fields 'label', 'icon', 'title', 'click')
  *   - height : number|'auto'
  *   - resize : function - called when list as a whole is resized
  *   - resizeItem : function(item) - called to resize individual item

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
@@ -110,7 +110,7 @@
                     .on("click", function(evt) {
                         evt.preventDefault();
                         if (button.click !== undefined) {
-                            button.click();
+                            button.click(evt);
                         }
                     });
             });

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
@@ -67,24 +67,53 @@
                 this.topContainer.addClass(this.options.class);
             }
 
+            var buttons = this.options.buttons || [];
+
             if (this.options.addButton !== false) {
-                var addLabel;
+                var addLabel, addTittle;
                 if (typeof this.options.addButton === 'string') {
                     addLabel = this.options.addButton
                 } else {
                     if (RED && RED._) {
                         addLabel = RED._("editableList.add");
+                        addTitle = RED._("editableList.addTitle");
                     } else {
                         addLabel = 'add';
+                        addTitle = 'add new item';
                     }
                 }
-                $('<a href="#" class="red-ui-button red-ui-button-small red-ui-editableList-addButton" style="margin-top: 4px;"><i class="fa fa-plus"></i> '+addLabel+'</a>')
-                    .appendTo(this.topContainer)
+                buttons.unshift({
+                    label: addLabel,
+                    icon: "fa fa-plus",
+                    click: function(evt) {
+                        that.addItem({});
+                    },
+                    title: addTitle
+                });
+            }
+
+            buttons.forEach(function(button) {
+                var innerHtml = "";
+                var titleAttribute="";
+                if (button.icon) {
+                    innerHtml = '<i class="'+button.icon+'"></i> ';
+                }
+                if (button.label) {
+                    innerHtml += button.label;
+                }
+                if (button.title) {
+                    titleAttribute = 'title="'+button.title+'"';
+                }
+                $('<a href="#" class="red-ui-button red-ui-button-small red-ui-editableList-addButton" style="margin-top: 4px; margin-right: 5px;" '+titleAttribute+'>'+innerHtml+'</a>')
+                    .appendTo(that.topContainer)
                     .on("click", function(evt) {
                         evt.preventDefault();
-                        that.addItem({});
+                        if (button.click !== undefined) {
+                            button.click();
+                        }
                     });
-            }
+            });
+ 
             if (this.element.css("position") === "absolute") {
                 ["top","left","bottom","right"].forEach(function(s) {
                     var v = that.element.css(s);


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)

See [discussion](https://discourse.nodered.org/t/custom-button-for-editablelist/41342) on Discourse.

## Proposed changes

This PR allows developers to show custom buttons at the bottom of an EditableList, next to the "Add" button, by filling the `buttons` property of the options.  For example:
```
$("ol.list").editableList({
   addItem: function(container, i, clickableShape) {
      //...
   },
   removable: true,
   sortable: true,
   buttons: [{
      label: "with icon",
      icon: "fa fa-star",
      title: "my custom button",
      click: function(evt) { 
         alert("button clicked");
      }
   }]
});
```

## Checklist

- [ X ] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ X ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ X ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
