### PR TITLE
Fix error report on  node load

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/loader.js
+++ b/packages/node_modules/@node-red/registry/lib/loader.js
@@ -385,10 +385,17 @@ function loadNodeSet(node) {
         var stack = err.stack;
         var message;
         if (stack) {
-            var i = stack.indexOf(node.file);
+            var filePath = node.file;
+            try {
+                filePath = fs.realpathSync(filePath);
+            }
+            catch (e) {
+                // ignore canonicalization error
+            }
+            var i = stack.indexOf(filePath);
             if (i > -1) {
-                var excerpt = stack.substring(i+node.file.length+1,i+node.file.length+20);
-                var m = /^(\d+):(\d+)/.exec(excerpt);
+                var excerpt = stack.substring(i+filePath.length+1,i+filePath.length+20);
+                var m = /^(\d+)/.exec(excerpt);
                 if (m) {
                     node.err = err+" (line:"+m[1]+")";
                 }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
If an error occurs while loading a node, the line number where the error occurred is not reported.

- Current
    ```
    9 Mar 10:16:35 - [warn] [node-red-contrib-subflow2node/subflow2node] SyntaxError: Unexpected token ':'
    ```
- Expected
    ```
    9 Mar 10:16:35 - [warn] [node-red-contrib-subflow2node/subflow2node] SyntaxError: Unexpected token ':' (line:47)
    ```

This PR attempts to fix the following two problems:
- Line number in error object is not recognized correctly,
- If the path contains a symbolic link, error number is not detected.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
