### PR TITLE
fix vanishing link in subflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -413,6 +413,27 @@ RED.nodes = (function() {
             nodeTabMap[z] = {};
         }
         nodeTabMap[z][node.id] = node;
+        var nl = nodeLinks[node.id];
+        if (nl) {
+            nl.in.forEach((l) => {
+                var idx = linkTabMap[node.z].indexOf(l);
+                if (idx != -1) {
+                    linkTabMap[node.z].splice(idx, 1);
+                }
+                if ((l.source.z === z) && linkTabMap[z]) {
+                    linkTabMap[z].push(l);
+                }
+            });
+            nl.out.forEach((l) => {
+                var idx = linkTabMap[node.z].indexOf(l);
+                if (idx != -1) {
+                    linkTabMap[node.z].splice(idx, 1);
+                }
+                if ((l.target.z === z) && linkTabMap[z]) {
+                    linkTabMap[z].push(l);
+                }
+            });
+        }
         node.z = z;
         RED.events.emit("nodes:change",node);
     }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
After creating a SUBFLOW using `Subflow` → `Selection to Subflow` menu, link from input port and link to output port of the SUBFLOW template are vanished as follows but internally connected.

![スクリーンショット 2021-03-10 9 10 01](https://user-images.githubusercontent.com/30289092/110556708-6b3fb180-8182-11eb-8b67-af55cb5b3270.png)

This PR tries to fix this problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
