### PR TITLE
Add get subflow information

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -27,6 +27,8 @@ var Log;
 var nodeCloseTimeout = 15000;
 var asyncMessageDelivery = true;
 
+var subflowInstance = [];
+
 /**
  * This class represents a flow within the runtime. It is responsible for
  * creating, starting and stopping all nodes within the flow.
@@ -209,7 +211,9 @@ class Flow {
                                     node
                                 );
                                 this.subflowInstanceNodes[id] = subflow;
+                                subflowInstance[id] = subflow;
                                 subflow.start();
+                                delete subflowInstance[id];
                                 this.activeNodes[id] = subflow.node;
 
                                 // this.subflowInstanceNodes[id] = nodes.map(function(n) { return n.id});
@@ -377,6 +381,11 @@ class Flow {
             // Node not found inside this flow - ask the parent
             return this.parent.getNode(id);
         }
+
+        if (subflowInstance[id]) {
+            return subflowInstance[id];
+        }
+
         return undefined;
     }
 


### PR DESCRIPTION
Add get subflow info

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

In order to place the widget belonging to UI_Module in the proper position, it is necessary to acquire the subflow information in the process of UI node generation.
I need the ID of the subflow instance to which the generated widget belongs.
For widgets nested within a subflow, IDs are required up to the parent subflow.

Example:
```
  "fda95d7e.fb54/3b5a5523.01d41a/d771a7ef.6586e8/cc844746.a516f8"
```

In node-red-dashbord ui.js#function add(opt), I want to use the above value when arranging the widget, so I considered the idea of getting the subflow instance from the value of opt.node.z.

The following usage is assumed.

node-red-dashboard#ui.js:
```Javascript:ui.js
function add(opt) {
    :
   var subflow = nodes.getNode(opt.node.z);
   var path = subflow.path;  // Subflow IDs
    :
}
```

This is a revision proposal under discussion in [the design note](https://github.com/node-red/designs/pull/24#issuecomment-744342878).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
