### PR TITLE
Allow module to provide resources and automatically expose them

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/index.js
@@ -75,6 +75,8 @@ module.exports = {
             editorApp.get("/icons/:module/:icon",ui.icon);
             editorApp.get("/icons/:scope/:module/:icon",ui.icon);
 
+            editorApp.get(/^\/resources\/((?:@[^\/]+\/)?[^\/]+)\/(.+)$/,ui.moduleResource);
+
             var theme = require("./theme");
             theme.init(settings, runtimeAPI);
             editorApp.use("/theme",theme.app());

--- a/packages/node_modules/@node-red/editor-api/lib/editor/ui.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/ui.js
@@ -68,6 +68,28 @@ module.exports = {
             apiUtils.rejectHandler(req,res,err);
         })
     },
+
+    moduleResource: function(req, res) {
+        let resourcePath = req.params[1];
+        let opts = {
+            user: req.user,
+            module: req.params[0],
+            path: resourcePath
+        }
+        runtimeAPI.nodes.getModuleResource(opts).then(function(data) {
+            if (data) {
+                var contentType = mime.getType(resourcePath);
+                res.set("Content-Type", contentType);
+                res.send(data);
+            } else {
+                res.status(404).end()
+            }
+        }).catch(function(err) {
+            console.log(err.stack);
+            apiUtils.rejectHandler(req,res,err);
+        })
+    },
+
     editor: async function(req,res) {
         res.send(Mustache.render(editorTemplate,await theme.context()));
     },

--- a/packages/node_modules/@node-red/registry/lib/index.js
+++ b/packages/node_modules/@node-red/registry/lib/index.js
@@ -301,6 +301,17 @@ module.exports = {
      */
     getNodeExampleFlowPath: library.getExampleFlowPath,
 
+    /**
+     * Gets the full path to a module's resource file
+     * @param {String} module - the name of the module providing the resource file
+     * @param {String} path - the relative path of the resource file
+     * @return {String} the full path to the resource file
+     *
+     * @function
+     * @memberof @node-red/registry
+     */
+    getModuleResource: registry.getModuleResource,
+
     checkFlowDependencies: externalModules.checkFlowDependencies,
 
     registerPlugin: plugins.registerPlugin,
@@ -309,7 +320,8 @@ module.exports = {
     getPluginList: plugins.getPluginList,
     getPluginConfigs: plugins.getPluginConfigs,
     exportPluginSettings: plugins.exportPluginSettings,
-    
+
+
     deprecated: require("./deprecated")
 
 };

--- a/packages/node_modules/@node-red/registry/lib/localfilesystem.js
+++ b/packages/node_modules/@node-red/registry/lib/localfilesystem.js
@@ -262,6 +262,14 @@ function getModuleNodeFiles(module) {
         result.examples = {path:examplesDir};
     } catch(err) {
     }
+
+    var resourcesDir = path.join(moduleDir,"resources");
+    try {
+        fs.statSync(resourcesDir)
+        result.resources = {path:resourcesDir};
+    } catch(err) {
+    }
+
     return result;
 }
 
@@ -406,6 +414,7 @@ function convertModuleFileListToObject(moduleFiles,seedObject) {
             user: moduleFile.user||false,
             nodes: {},
             plugins: {},
+            resources: nodeModuleFiles.resources,
             icons: nodeModuleFiles.icons,
             examples: nodeModuleFiles.examples
         };

--- a/packages/node_modules/@node-red/registry/lib/registry.js
+++ b/packages/node_modules/@node-red/registry/lib/registry.js
@@ -15,8 +15,8 @@
  **/
 
  //var UglifyJS = require("uglify-js");
-var path = require("path");
-var fs = require("fs");
+const path = require("path");
+const fs = require("fs");
 
 var library = require("./library");
 const {events} = require("@node-red/util")
@@ -680,7 +680,6 @@ function getNodeIconPath(module,icon) {
 
 function getNodeIcons() {
     var iconList = {};
-
     for (var module in moduleConfigs) {
         if (moduleConfigs.hasOwnProperty(module)) {
             if (moduleConfigs[module].icons) {
@@ -690,6 +689,21 @@ function getNodeIcons() {
         }
     }
     return iconList;
+}
+
+function getModuleResource(module, resourcePath) {
+    let mod = moduleConfigs[module];
+    if (mod && mod.resources) {
+        let basePath = mod.resources.path;
+        let fullPath = path.join(basePath,resourcePath);
+        if (/^\.\./.test(path.relative(basePath,fullPath))) {
+            return null;
+        }
+        if (fs.existsSync(fullPath)) {
+            return fullPath;
+        }
+    }
+    return null;
 }
 
 var registry = module.exports = {
@@ -722,6 +736,8 @@ var registry = module.exports = {
 
     getNodeIconPath: getNodeIconPath,
     getNodeIcons: getNodeIcons,
+    getModuleResource: getModuleResource,
+
     /**
      * Gets all of the node template configs
      * @return all of the node templates in a single string

--- a/packages/node_modules/@node-red/runtime/lib/api/nodes.js
+++ b/packages/node_modules/@node-red/runtime/lib/api/nodes.js
@@ -463,5 +463,30 @@ var api = module.exports = {
         } else {
             return null
         }
+    },
+
+    /**
+    * Gets a resource from a module
+    * @param {Object} opts
+    * @param {User} opts.user - the user calling the api
+    * @param {String} opts.module - the id of the module requesting the resource
+    * @param {String} opts.path - the path of the resource
+    * @param {Object} opts.req - the request to log (optional)
+    * @return {Promise<Buffer>} - the resource file as a Buffer or null if not found
+    * @memberof @node-red/runtime_nodes
+    */
+    getModuleResource: async function(opts) {
+        var resourcePath = runtime.nodes.getModuleResource(opts.module, opts.path);
+        if (resourcePath) {
+            return fs.readFile(resourcePath).catch(err => {
+                if (err.code === 'EISDIR') {
+                    return null;
+                }
+                err.status = 400;
+                throw err;
+            });
+        } else {
+            return null
+        }
     }
 }

--- a/packages/node_modules/@node-red/runtime/lib/nodes/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/index.js
@@ -230,6 +230,7 @@ module.exports = {
     getNodeIcons: registry.getNodeIcons,
     getNodeExampleFlows: registry.getNodeExampleFlows,
     getNodeExampleFlowPath: registry.getNodeExampleFlowPath,
+    getModuleResource: registry.getModuleResource,
 
     clearRegistry: registry.clear,
     cleanModuleList: registry.cleanModuleList,

--- a/test/resources/plugin/test-plugin/test.html
+++ b/test/resources/plugin/test-plugin/test.html
@@ -2,3 +2,5 @@
     console.log("Loaded test-plugin/test")
     // RED.plugins.registerPlugin("")
 </script>
+
+<script src="resources/test-plugin/script.js">


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)
## Proposed changes

If a Plugin or Node module has a top-level directory called `resources`, the runtime will now automatically expose it over the http admin route handler using the path:

`/resources/<name-of-module>/<path-to-resource>`

This removes the need for the plugin/node to manually setup route handlers to do the same.
