### PR TITLE
Support typedInput in msg.payload field of exec node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.html
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.html
@@ -24,7 +24,6 @@
         <input type="checkbox" id="node-input-addpay" style="display:inline-block; width:auto;">
         &nbsp;
         <input type="text" id="node-input-addpayValue" style="width:160px;">
-        <input type="hidden" id="node-input-addpayValueType">
     </div>
     <div class="form-row">
         <label for="node-input-append"> </label>
@@ -56,7 +55,6 @@
             command: {value:""},
             addpay: {value:false},
             addpayValue: {value:"payload"},
-            addpayValueType: {value:"msg"},
             append: {value:""},
             useSpawn: {value:"false"},
             timer: {value:""},
@@ -88,7 +86,6 @@
             }
             $("#node-input-addpayValue").typedInput({
                 default: "msg",
-                typeField: $("#node-input-addpayValueType"),
                 types: ["msg"]
             });
         }

--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.html
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.html
@@ -21,8 +21,10 @@
     </div>
     <div class="form-row">
         <label><i class="fa fa-plus"></i> <span data-i18n="exec.label.append"></span></label>
-        <input type="checkbox" id="node-input-addpay" style="display:inline-block; width:auto; vertical-align:top;">
-        &nbsp;msg.payload
+        <input type="checkbox" id="node-input-addpay" style="display:inline-block; width:auto;">
+        &nbsp;
+        <input type="text" id="node-input-addpayValue" style="width:160px;">
+        <input type="hidden" id="node-input-addpayValueType">
     </div>
     <div class="form-row">
         <label for="node-input-append"> </label>
@@ -53,6 +55,8 @@
         defaults: {
             command: {value:""},
             addpay: {value:false},
+            addpayValue: {value:"payload"},
+            addpayValueType: {value:"msg"},
             append: {value:""},
             useSpawn: {value:"false"},
             timer: {value:""},
@@ -79,6 +83,14 @@
             if ($("#node-input-useSpawn").val() === null) {
                 $("#node-input-useSpawn").val(this.useSpawn.toString());
             }
+            if ($("#node-input-addpayValue").val() === "") {
+                $("#node-input-addpayValue").val("payload");
+            }
+            $("#node-input-addpayValue").typedInput({
+                default: "msg",
+                typeField: $("#node-input-addpayValueType"),
+                types: ["msg"]
+            });
         }
     });
 </script>

--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.js
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.js
@@ -66,8 +66,9 @@ module.exports = function(RED) {
                 // then prepend with the msg.payload
                 var arg = node.cmd;
                 if (node.addpay) {
-                    if (msg.hasOwnProperty(node.addpayValue)) {
-                         arg += " " + RED.util.getMessageProperty(msg, node.addpayValue);
+                    var value = RED.util.getMessageProperty(msg, node.addpayValue);
+                    if (value !== undefined) {
+                        arg += " " + value;
                     }
                 }
                 if (node.append.trim() !== "") { arg += " " + node.append; }

--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.js
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.js
@@ -26,6 +26,8 @@ module.exports = function(RED) {
         this.cmd = (n.command || "").trim();
         if (n.addpay === undefined) { n.addpay = true; }
         this.addpay = n.addpay;
+        this.addpayValue = n.addpayValue || "payload";
+        this.addpayValueType = n.addpayValueType || "msg";
         this.append = (n.append || "").trim();
         this.useSpawn = (n.useSpawn == "true");
         this.timer = Number(n.timer || 0)*1000;
@@ -61,12 +63,16 @@ module.exports = function(RED) {
             }
             else {
                 var child;
+                // make the extra args into an array
+                // then prepend with the msg.payload
+                var arg = node.cmd;
+                if (node.addpay) {
+                    if (node.addpayValueType === "msg" && msg.hasOwnProperty(node.addpayValue)) {
+                         arg += " " + RED.util.getMessageProperty(msg, node.addpayValue);
+                    }
+                }
+                if (node.append.trim() !== "") { arg += " " + node.append; }
                 if (this.useSpawn === true) {
-                    // make the extra args into an array
-                    // then prepend with the msg.payload
-                    var arg = node.cmd;
-                    if ((node.addpay === true) && msg.hasOwnProperty("payload")) { arg += " "+msg.payload; }
-                    if (node.append.trim() !== "") { arg += " "+node.append; }
                     // slice whole line by spaces and removes any quotes since spawn can't handle them
                     arg = arg.match(/(?:[^\s"]+|"[^"]*")+/g).map((a) => {
                         if (/^".*"$/.test(a)) {
@@ -126,12 +132,9 @@ module.exports = function(RED) {
                     });
                 }
                 else {
-                    var cl = node.cmd;
-                    if ((node.addpay === true) && msg.hasOwnProperty("payload")) { cl += " "+msg.payload; }
-                    if (node.append.trim() !== "") { cl += " "+node.append; }
                     /* istanbul ignore else  */
-                    if (RED.settings.verbose) { node.log(cl); }
-                    child = exec(cl, node.execOpt, function (error, stdout, stderr) {
+                    if (RED.settings.verbose) { node.log(arg); }
+                    child = exec(arg, node.execOpt, function (error, stdout, stderr) {
                         var msg2, msg3;
                         delete msg.payload;
                         if (stderr) {

--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.js
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.js
@@ -27,7 +27,6 @@ module.exports = function(RED) {
         if (n.addpay === undefined) { n.addpay = true; }
         this.addpay = n.addpay;
         this.addpayValue = n.addpayValue || "payload";
-        this.addpayValueType = n.addpayValueType || "msg";
         this.append = (n.append || "").trim();
         this.useSpawn = (n.useSpawn == "true");
         this.timer = Number(n.timer || 0)*1000;
@@ -67,7 +66,7 @@ module.exports = function(RED) {
                 // then prepend with the msg.payload
                 var arg = node.cmd;
                 if (node.addpay) {
-                    if (node.addpayValueType === "msg" && msg.hasOwnProperty(node.addpayValue)) {
+                    if (msg.hasOwnProperty(node.addpayValue)) {
                          arg += " " + RED.util.getMessageProperty(msg, node.addpayValue);
                     }
                 }

--- a/test/nodes/core/function/90-exec_spec.js
+++ b/test/nodes/core/function/90-exec_spec.js
@@ -115,7 +115,7 @@ describe('exec node', function() {
         });
 
         it('should exec a simple command with appended value from message', function (done) {
-            var flow = [{id:"n1", type:"exec", wires:[["n2"]], command:"echo", addpay:true, addpayValue:"topic", addpayValueType:"msg", append:"more", oldrc:"false"},
+            var flow = [{id:"n1", type:"exec", wires:[["n2"]], command:"echo", addpay:true, addpayValue:"topic", append:"more", oldrc:"false"},
                         {id:"n2", type:"helper"}];
             helper.load(execNode, flow, function () {
                 var n1 = helper.getNode("n1");

--- a/test/nodes/core/function/90-exec_spec.js
+++ b/test/nodes/core/function/90-exec_spec.js
@@ -114,6 +114,22 @@ describe('exec node', function() {
             });
         });
 
+        it('should exec a simple command with appended value from message', function (done) {
+            var flow = [{id:"n1", type:"exec", wires:[["n2"]], command:"echo", addpay:true, addpayValue:"topic", addpayValueType:"msg", append:"more", oldrc:"false"},
+                        {id:"n2", type:"helper"}];
+            helper.load(execNode, flow, function () {
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                n2.on("input", function (msg) {
+                        msg.should.have.property("payload");
+                        msg.payload.should.be.a.String();
+                        msg.payload.should.equal("bar more\n");
+                        done();
+                });
+                n1.receive({payload:"foo", topic:"bar"});
+            });
+        });
+
         it('should exec a simple command with extra parameters', function(done) {
             var flow = [{id:"n1",type:"exec",wires:[["n2"],["n3"],["n4"]],command:"echo", addpay:true, append:"more", oldrc:"false"},
                         {id:"n2", type:"helper"},{id:"n3", type:"helper"},{id:"n4", type:"helper"}];


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes
I think that exec node needs the ability to handle not only `msg.payload` but also other variables like `msg.filename`.
As we discussed in the following forum, I added `typedInput` for `msg.payload` to support changing the variable name.

https://discourse.nodered.org/t/suggestion-to-support-jsonata-in-exec-node/42794

Image: (the `typedInput` has msg. only)

<img width="646" src="https://user-images.githubusercontent.com/20310935/111955480-e4e58100-8b2c-11eb-88c4-8ac6fcac4e69.png">



## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
