### PR TITLE
Function node: add `node.outputCount` property to sandbox

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -93,6 +93,7 @@ module.exports = function(RED) {
         var node = this;
         node.name = n.name;
         node.func = n.func;
+        node.outputs = n.outputs;
         node.ini = n.initialize ? n.initialize.trim() : "";
         node.fin = n.finalize ? n.finalize.trim() : "";
         node.libs = n.libs || [];
@@ -116,6 +117,7 @@ module.exports = function(RED) {
             "var node = {"+
             "id:__node__.id,"+
             "name:__node__.name,"+
+            "outputs:__node__.outputs,"+
             "log:__node__.log,"+
             "error:__node__.error,"+
             "warn:__node__.warn,"+
@@ -146,6 +148,7 @@ module.exports = function(RED) {
             __node__: {
                 id: node.id,
                 name: node.name,
+                outputs: node.outputs,
                 log: function() {
                     node.log.apply(node, arguments);
                 },
@@ -330,6 +333,7 @@ module.exports = function(RED) {
                     var node = {
                         id:__node__.id,
                         name:__node__.name,
+                        outputs:__node__.outputs,
                         log:__node__.log,
                         error:__node__.error,
                         warn:__node__.warn,
@@ -351,6 +355,7 @@ module.exports = function(RED) {
                     var node = {
                         id:__node__.id,
                         name:__node__.name,
+                        outputs:__node__.outputs,
                         log:__node__.log,
                         error:__node__.error,
                         warn:__node__.warn,

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -113,22 +113,22 @@ module.exports = function(RED) {
 
         var functionText = "var results = null;"+
             "results = (async function(msg,__send__,__done__){ "+
-            "var __msgid__ = msg._msgid;"+
-            "var node = {"+
-            "id:__node__.id,"+
-            "name:__node__.name,"+
-            "outputs:__node__.outputs,"+
-            "log:__node__.log,"+
-            "error:__node__.error,"+
-            "warn:__node__.warn,"+
-            "debug:__node__.debug,"+
-            "trace:__node__.trace,"+
-            "on:__node__.on,"+
-            "status:__node__.status,"+
-            "send:function(msgs,cloneMsg){ __node__.send(__send__,__msgid__,msgs,cloneMsg);},"+
-            "done:__done__"+
-            "};\n"+
-            node.func+"\n"+
+                "var __msgid__ = msg._msgid;"+
+                "var node = {"+
+                    "id:__node__.id,"+
+                    "name:__node__.name,"+
+                    "outputs:__node__.outputs,"+
+                    "log:__node__.log,"+
+                    "error:__node__.error,"+
+                    "warn:__node__.warn,"+
+                    "debug:__node__.debug,"+
+                    "trace:__node__.trace,"+
+                    "on:__node__.on,"+
+                    "status:__node__.status,"+
+                    "send:function(msgs,cloneMsg){ __node__.send(__send__,__msgid__,msgs,cloneMsg);},"+
+                    "done:__done__"+
+                "};\n"+
+                node.func+"\n"+
             "})(msg,__send__,__done__);";
         var finScript = null;
         var finOpt = null;

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -117,7 +117,7 @@ module.exports = function(RED) {
                 "var node = {"+
                     "id:__node__.id,"+
                     "name:__node__.name,"+
-                    "outputs:__node__.outputs,"+
+                    "outputCount:__node__.outputCount,"+
                     "log:__node__.log,"+
                     "error:__node__.error,"+
                     "warn:__node__.warn,"+
@@ -148,7 +148,7 @@ module.exports = function(RED) {
             __node__: {
                 id: node.id,
                 name: node.name,
-                outputs: node.outputs,
+                outputCount: node.outputs,
                 log: function() {
                     node.log.apply(node, arguments);
                 },
@@ -333,7 +333,7 @@ module.exports = function(RED) {
                     var node = {
                         id:__node__.id,
                         name:__node__.name,
-                        outputs:__node__.outputs,
+                        outputCount:__node__.outputCount,
                         log:__node__.log,
                         error:__node__.error,
                         warn:__node__.warn,
@@ -355,7 +355,7 @@ module.exports = function(RED) {
                     var node = {
                         id:__node__.id,
                         name:__node__.name,
-                        outputs:__node__.outputs,
+                        outputCount:__node__.outputCount,
                         log:__node__.log,
                         error:__node__.error,
                         warn:__node__.warn,

--- a/test/nodes/core/function/10-function_spec.js
+++ b/test/nodes/core/function/10-function_spec.js
@@ -132,6 +132,28 @@ describe('function node', function() {
         });
     });
 
+    it('should allow accessing node.id and node.name and node.outputs', function(done) {
+        var flow = [{id:"n1",name:"test-function", outputs: 2, type:"function",wires:[["n2"]],func: "return [{ topic: node.name, payload:node.id, outputs: node.outputs }];"},
+        {id:"n2", type:"helper"}];
+        helper.load(functionNode, flow, function() {
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            n2.on("input", function(msg) {
+                try {
+                    // Use this form of assert as `msg` is created inside
+                    // the sandbox and doesn't get all the should.js monkey patching
+                    should.equal(msg.payload, n1.id);
+                    should.equal(msg.topic, n1.name);
+                    should.equal(msg.outputs, n1.outputs);
+                    done();
+                } catch(err) {
+                    done(err);
+                }
+            });
+            n1.receive({payload:""});
+        });
+    });
+
     function testSendCloning(args,done) {
         var flow = [{id:"n1",type:"function",wires:[["n2"],["n2"]],func:"node.send("+args+"); msg.payload = 'changed';"},
         {id:"n2", type:"helper"}];
@@ -1402,17 +1424,38 @@ describe('function node', function() {
         });
     });
 
-    it('should execute finalization', function(done) {
-        var flow = [{id:"n1",type:"function",wires:[],func:"return msg;",finalize:"global.set('X','bar');"}];
-        helper.load(functionNode, flow, function() {
-            var n1 = helper.getNode("n1");
-            var ctx = n1.context().global;
-            helper.unload().then(function () {
-                ctx.get('X').should.equal("bar");
-                done();
+
+
+    describe("finalize function", function() {
+
+        it('should execute', function(done) {
+            var flow = [{id:"n1",type:"function",wires:[],func:"return msg;",finalize:"global.set('X','bar');"}];
+            helper.load(functionNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var ctx = n1.context().global;
+                helper.unload().then(function () {
+                    ctx.get('X').should.equal("bar");
+                    done();
+                });
             });
         });
-    });
+
+        it('should allow accessing node.id and node.name and node.outputs', function(done) {
+            var flow = [{id:"n1",name:"test-function", outputs: 2, type:"function",wires:[["n2"]],finalize:"global.set('finalize-data', { topic: node.name, payload:node.id, outputs: node.outputs});", func: "return msg;"}];
+            helper.load(functionNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var ctx = n1.context().global;
+                helper.unload().then(function () {
+                    const finalizeData = ctx.get('finalize-data');
+                    should.equal(finalizeData.payload, n1.id);
+                    should.equal(finalizeData.topic, n1.name);
+                    should.equal(finalizeData.outputs, n1.outputs);
+                    done();
+                });
+            });
+        });
+
+    })
 
     describe('externalModules', function() {
         afterEach(function() {
@@ -1655,8 +1698,8 @@ describe('function node', function() {
             });
         });
 
-        it('should allow accessing node.id and node.name and sending message', function(done) {
-            var flow = [{id:"n1",name:"test-function", type:"function",wires:[["n2"]],initialize:"setTimeout(function() { node.send({ topic: node.name, payload:node.id})},10)", func: ""},
+        it('should allow accessing node.id and node.name and node.outputs and sending message', function(done) {
+            var flow = [{id:"n1",name:"test-function", outputs: 1, type:"function",wires:[["n2"]],initialize:"setTimeout(function() { node.send({ topic: node.name, payload:node.id, outputs: node.outputs})},10)", func: ""},
             {id:"n2", type:"helper"}];
             helper.load(functionNode, flow, function() {
                 var n1 = helper.getNode("n1");
@@ -1667,6 +1710,7 @@ describe('function node', function() {
                         // the sandbox and doesn't get all the should.js monkey patching
                         should.equal(msg.payload, n1.id);
                         should.equal(msg.topic, n1.name);
+                        should.equal(msg.outputs, n1.outputs);
                         done();
                     } catch(err) {
                         done(err);
@@ -1675,5 +1719,5 @@ describe('function node', function() {
             });
         });
 
-    })
+    });
 });

--- a/test/nodes/core/function/10-function_spec.js
+++ b/test/nodes/core/function/10-function_spec.js
@@ -132,8 +132,8 @@ describe('function node', function() {
         });
     });
 
-    it('should allow accessing node.id and node.name and node.outputs', function(done) {
-        var flow = [{id:"n1",name:"test-function", outputs: 2, type:"function",wires:[["n2"]],func: "return [{ topic: node.name, payload:node.id, outputs: node.outputs }];"},
+    it('should allow accessing node.id and node.name and node.outputCount', function(done) {
+        var flow = [{id:"n1",name:"test-function", outputs: 2, type:"function",wires:[["n2"]],func: "return [{ topic: node.name, payload:node.id, outputCount: node.outputCount }];"},
         {id:"n2", type:"helper"}];
         helper.load(functionNode, flow, function() {
             var n1 = helper.getNode("n1");
@@ -144,7 +144,7 @@ describe('function node', function() {
                     // the sandbox and doesn't get all the should.js monkey patching
                     should.equal(msg.payload, n1.id);
                     should.equal(msg.topic, n1.name);
-                    should.equal(msg.outputs, n1.outputs);
+                    should.equal(msg.outputCount, n1.outputs);
                     done();
                 } catch(err) {
                     done(err);
@@ -1440,8 +1440,8 @@ describe('function node', function() {
             });
         });
 
-        it('should allow accessing node.id and node.name and node.outputs', function(done) {
-            var flow = [{id:"n1",name:"test-function", outputs: 2, type:"function",wires:[["n2"]],finalize:"global.set('finalize-data', { topic: node.name, payload:node.id, outputs: node.outputs});", func: "return msg;"}];
+        it('should allow accessing node.id and node.name and node.outputCount', function(done) {
+            var flow = [{id:"n1",name:"test-function", outputs: 2, type:"function",wires:[["n2"]],finalize:"global.set('finalize-data', { topic: node.name, payload:node.id, outputCount: node.outputCount});", func: "return msg;"}];
             helper.load(functionNode, flow, function() {
                 var n1 = helper.getNode("n1");
                 var ctx = n1.context().global;
@@ -1449,7 +1449,7 @@ describe('function node', function() {
                     const finalizeData = ctx.get('finalize-data');
                     should.equal(finalizeData.payload, n1.id);
                     should.equal(finalizeData.topic, n1.name);
-                    should.equal(finalizeData.outputs, n1.outputs);
+                    should.equal(finalizeData.outputCount, n1.outputs);
                     done();
                 });
             });
@@ -1698,8 +1698,8 @@ describe('function node', function() {
             });
         });
 
-        it('should allow accessing node.id and node.name and node.outputs and sending message', function(done) {
-            var flow = [{id:"n1",name:"test-function", outputs: 1, type:"function",wires:[["n2"]],initialize:"setTimeout(function() { node.send({ topic: node.name, payload:node.id, outputs: node.outputs})},10)", func: ""},
+        it('should allow accessing node.id and node.name and node.outputCount and sending message', function(done) {
+            var flow = [{id:"n1",name:"test-function", outputs: 1, type:"function",wires:[["n2"]],initialize:"setTimeout(function() { node.send({ topic: node.name, payload:node.id, outputCount: node.outputCount})},10)", func: ""},
             {id:"n2", type:"helper"}];
             helper.load(functionNode, flow, function() {
                 var n1 = helper.getNode("n1");
@@ -1710,7 +1710,7 @@ describe('function node', function() {
                         // the sandbox and doesn't get all the should.js monkey patching
                         should.equal(msg.payload, n1.id);
                         should.equal(msg.topic, n1.name);
-                        should.equal(msg.outputs, n1.outputs);
+                        should.equal(msg.outputCount, n1.outputs);
                         done();
                     } catch(err) {
                         done(err);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Proposed changes

Adds `node.outputCount` property inside function node executors.

![image](https://user-images.githubusercontent.com/11139388/114019943-af080280-9877-11eb-957b-9c0e4c57014b.png)

Briefly discussed here: https://discourse.nodered.org/t/expose-configured-output-count-to-function-node-i-can-pr/43848/5

Along the way, consistent testing of `node.id` and `node.name` across `init`, `func` and `finalize` functions were also added (previously only `init` method was tested).


<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `grunt` to verify the unit tests pass
- [X] I have added suitable unit tests to cover the new/changed functionality
