### PR TITLE
Join: change default manual mode to object

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
@@ -201,7 +201,7 @@
         defaults: {
             name: {value:""},
             mode: {value:"auto"},
-            build: { value:"string"},
+            build: { value:"object"},
             property: { value:"payload", validate:RED.validators.typedInput("propertyType")},
             propertyType: { value:"msg"},
             key: {value:"topic"},


### PR DESCRIPTION
## Proposed changes

Changes the default manual mode of the Join node to be key/value Object rather than String.

In our experience, users tend to want to use the Object mode to join streams of messages. Having that as the default option makes sense.

