### PR TITLE
File node: Add fileWorkingDirectory to customise how relative paths are resolved

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.js
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.js
@@ -51,6 +51,10 @@ module.exports = function(RED) {
 
         function processMsg(msg,nodeSend, done) {
             var filename = node.filename || msg.filename || "";
+            var fullFilename = filename;
+            if (filename && RED.settings.fileWorkingDirectory && !path.isAbsolute(filename)) {
+                fullFilename = path.resolve(path.join(RED.settings.fileWorkingDirectory,filename));
+            }
             if ((!node.filename) && (!node.tout)) {
                 node.tout = setTimeout(function() {
                     node.status({fill:"grey",shape:"dot",text:filename});
@@ -62,7 +66,7 @@ module.exports = function(RED) {
                 node.warn(RED._("file.errors.nofilename"));
                 done();
             } else if (node.overwriteFile === "delete") {
-                fs.unlink(filename, function (err) {
+                fs.unlink(fullFilename, function (err) {
                     if (err) {
                         node.error(RED._("file.errors.deletefail",{error:err.toString()}),msg);
                     } else {
@@ -74,7 +78,7 @@ module.exports = function(RED) {
                     done();
                 });
             } else if (msg.hasOwnProperty("payload") && (typeof msg.payload !== "undefined")) {
-                var dir = path.dirname(filename);
+                var dir = path.dirname(fullFilename);
                 if (node.createDir) {
                     try {
                         fs.ensureDirSync(dir);
@@ -94,7 +98,7 @@ module.exports = function(RED) {
                 if ((node.appendNewline) && (!Buffer.isBuffer(data))) { data += os.EOL; }
                 var buf = encode(data, node.encoding);
                 if (node.overwriteFile === "true") {
-                    var wstream = fs.createWriteStream(filename, { encoding:'binary', flags:'w', autoClose:true });
+                    var wstream = fs.createWriteStream(fullFilename, { encoding:'binary', flags:'w', autoClose:true });
                     node.wstream = wstream;
                     wstream.on("error", function(err) {
                         node.error(RED._("file.errors.writefail",{error:err.toString()}),msg);
@@ -116,7 +120,7 @@ module.exports = function(RED) {
                         // of the file. Check the file hasn't been deleted
                         // or deleted and recreated.
                         try {
-                            var stat = fs.statSync(filename);
+                            var stat = fs.statSync(fullFilename);
                             // File exists - check the inode matches
                             if (stat.ino !== node.wstreamIno) {
                                 // The file has been recreated. Close the current
@@ -135,10 +139,10 @@ module.exports = function(RED) {
                         }
                     }
                     if (recreateStream) {
-                        node.wstream = fs.createWriteStream(filename, { encoding:'binary', flags:'a', autoClose:true });
+                        node.wstream = fs.createWriteStream(fullFilename, { encoding:'binary', flags:'a', autoClose:true });
                         node.wstream.on("open", function(fd) {
                             try {
-                                var stat = fs.statSync(filename);
+                                var stat = fs.statSync(fullFilename);
                                 node.wstreamIno = stat.ino;
                             } catch(err) {
                             }
@@ -258,6 +262,10 @@ module.exports = function(RED) {
 
         this.on("input",function(msg, nodeSend, nodeDone) {
             var filename = (node.filename || msg.filename || "").replace(/\t|\r|\n/g,'');
+            var fullFilename = filename;
+            if (filename && RED.settings.fileWorkingDirectory && !path.isAbsolute(filename)) {
+                fullFilename = path.resolve(path.join(RED.settings.fileWorkingDirectory,filename));
+            }
             if (!node.filename) {
                 node.status({fill:"grey",shape:"dot",text:filename});
             }
@@ -279,7 +287,7 @@ module.exports = function(RED) {
                 var hwm;
                 var getout = false;
 
-                var rs = fs.createReadStream(filename)
+                var rs = fs.createReadStream(fullFilename)
                     .on('readable', function () {
                         var chunk;
                         var hwm = rs._readableState.highWaterMark;

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -46,6 +46,10 @@ module.exports = {
     //  defaults to 10Mb
     //execMaxBufferSize: 10000000,
 
+    // The working directory to handle relative file paths from within the File nodes
+    //  defaults to the working directory of the Node-RED process.
+    //fileWorkingDirectory: "",
+    
     // The maximum length, in characters, of any message sent to the debug sidebar tab
     debugMaxLength: 1000,
 


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Currently if a relative path is used in the File nodes, it is resolved relative to the working directory of the Node-RED process. 

That is non-obvious to new users and they don't necessarily know what the cwd is.

This change introduces `RED.settings.fileWorkingDirectory` that allows the user to set a specific directory to be used to resolve relative paths.

This PR only touches the File nodes. We should review other nodes that handle local paths and update them to honour this setting.

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
