### PR TITLE
fix flowfile name to flows.json in settings

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/index.js
@@ -38,6 +38,8 @@ var activeProject;
 
 var globalGitUser = false;
 
+var usingHostName = false;
+
 function init(_settings, _runtime) {
     settings = _settings;
     runtime = _runtime;
@@ -77,6 +79,7 @@ function init(_settings, _runtime) {
     } else {
         flowsFile = 'flows_'+require('os').hostname()+'.json';
         flowsFullPath = fspath.join(settings.userDir,flowsFile);
+        usingHostName = true;
     }
     var ffExt = fspath.extname(flowsFullPath);
     var ffBase = fspath.basename(flowsFullPath,ffExt);
@@ -526,7 +529,7 @@ async function getFlows() {
         if (projectsEnabled) {
             log.info(log._("storage.localfilesystem.projects.projects-directory", {projectsDirectory: projectsDir}));
         }
-        
+
         if (activeProject) {
             // At this point activeProject will be a string, so go load it and
             // swap in an instance of Project
@@ -541,6 +544,7 @@ async function getFlows() {
             } else {
                 projectLogMessages.forEach(log.warn);
             }
+            if (usingHostName) { log.warn(log._("storage.localfilesystem.warn_name")) };
             log.info(log._("storage.localfilesystem.flows-file",{path:flowsFullPath}));
         }
     }

--- a/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
@@ -159,6 +159,7 @@
             "restore": "Restoring __type__ file backup : __path__",
             "restore-fail": "Restoring __type__ file backup failed : __message__",
             "fsync-fail": "Flushing file __path__ to disk failed : __message__",
+            "warn_name": "Flows file name not explicitly set. Using hostname.",
             "projects": {
                 "changing-project": "Setting active project : __project__",
                 "active-project": "Active project : __project__",

--- a/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
@@ -159,7 +159,7 @@
             "restore": "Restoring __type__ file backup : __path__",
             "restore-fail": "Restoring __type__ file backup failed : __message__",
             "fsync-fail": "Flushing file __path__ to disk failed : __message__",
-            "warn_name": "Flows file name not explicitly set. Using hostname.",
+            "warn_name": "Flows file name not set. Generating name using hostname.",
             "projects": {
                 "changing-project": "Setting active project : __project__",
                 "active-project": "Active project : __project__",

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -12,6 +12,13 @@
  **/
 
 module.exports = {
+    // The file containing the flows. If not set, it defaults to flows_<hostname>.json
+    flowFile: 'flows.json',
+
+    // To enabled pretty-printing of the flow within the flow file, set the following
+    //  property to true:
+    //flowFilePretty: true,
+
     // the tcp port that the Node-RED web server is listening on
     uiPort: process.env.PORT || 1880,
 
@@ -60,13 +67,6 @@ module.exports = {
 
     // Colourise the console output of the debug node
     //debugUseColors: true,
-
-    // The file containing the flows. If not set, it defaults to flows_<hostname>.json
-    //flowFile: 'flows.json',
-
-    // To enabled pretty-printing of the flow within the flow file, set the following
-    //  property to true:
-    //flowFilePretty: true,
 
     // By default, credentials are encrypted in storage using a generated key. To
     // specify your own secret, set the following property.


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This PR presets the flow file name to flows.json in the settings.js file  - thus it will only apply to new installs unless people update their settings file.  It also adds a warning if it is not set - so say that the hostname is being used. 

This should make things more obvious for people moving flows from one machine to another in that the flow should just work without having to be renamed. Will also make running on some other platforms (like docker) easier as then the default settings can be used.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
