### PR TITLE
Deprecate usage of httpRoot and add warning

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/index.js
@@ -181,6 +181,9 @@ function start() {
                 if (settings.settingsFile) {
                     log.info(log._("runtime.paths.settings",{path:settings.settingsFile}));
                 }
+                if (settings.httpRoot !== undefined) {
+                    log.warn(log._("server.httproot-deprecated"));
+                }
                 if (settings.httpStatic) {
                     log.info(log._("runtime.paths.httpStatic",{path:path.resolve(settings.httpStatic)}));
                 }

--- a/packages/node_modules/@node-red/runtime/lib/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/index.js
@@ -182,7 +182,7 @@ function start() {
                     log.info(log._("runtime.paths.settings",{path:settings.settingsFile}));
                 }
                 if (settings.httpRoot !== undefined) {
-                    log.warn(log._("server.httproot-deprecated"));
+                    log.warn(log._("server.deprecatedOption",{old:"httpRoot", new: "httpNodeRoot/httpAdminRoot"));
                 }
                 if (settings.httpStatic) {
                     log.info(log._("runtime.paths.httpStatic",{path:path.resolve(settings.httpStatic)}));

--- a/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
@@ -51,7 +51,6 @@
         "failed-to-start": "Failed to start server:",
         "headless-mode": "Running in headless mode",
         "httpadminauth-deprecated": "Use of httpAdminAuth is DEPRECATED. Use adminAuth instead",
-        "httproot-deprecated": "Use of httpRoot is DEPRECATED. Use httpNodeRoot and httpAdminRoot instead",
         "https": {
             "refresh-interval": "Refreshing https settings every __interval__ hours",
             "settings-refreshed": "Server https settings have been refreshed",

--- a/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
@@ -42,7 +42,7 @@
             "uninstall-failed-long": "Uninstall of module __name__ failed:",
             "uninstalled": "Uninstalled module: __name__"
         },
-        "deprecatedOption": "Use of __old__ is deprecated. Use __new__ instead",
+        "deprecatedOption": "Use of __old__ is DEPRECATED. Use __new__ instead",
         "unable-to-listen": "Unable to listen on __listenpath__",
         "port-in-use": "Error: port in use",
         "uncaught-exception": "Uncaught Exception:",
@@ -50,7 +50,8 @@
         "now-running": "Server now running at __listenpath__",
         "failed-to-start": "Failed to start server:",
         "headless-mode": "Running in headless mode",
-        "httpadminauth-deprecated": "use of httpAdminAuth is deprecated. Use adminAuth instead",
+        "httpadminauth-deprecated": "Use of httpAdminAuth is DEPRECATED. Use adminAuth instead",
+        "httproot-deprecated": "Use of httpRoot is DEPRECATED. Use httpNodeRoot and httpAdminRoot instead",
         "https": {
             "refresh-interval": "Refreshing https settings every __interval__ hours",
             "settings-refreshed": "Server https settings have been refreshed",

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -96,7 +96,7 @@ module.exports = {
     // disabled.
     //httpNodeRoot: '/red-nodes',
 
-    // The following property can be used in place of 'httpAdminRoot' and 'httpNodeRoot',
+    // **DEPRECATED** The following property can be used in place of 'httpAdminRoot' and 'httpNodeRoot',
     // to apply the same root to both parts.
     //httpRoot: '/red',
 

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -96,10 +96,6 @@ module.exports = {
     // disabled.
     //httpNodeRoot: '/red-nodes',
 
-    // **DEPRECATED** The following property can be used in place of 'httpAdminRoot' and 'httpNodeRoot',
-    // to apply the same root to both parts.
-    //httpRoot: '/red',
-
     // When httpAdminRoot is used to move the UI to a different root path, the
     // following property can be used to identify a directory of static content
     // that should be served at http://localhost:1880/.


### PR DESCRIPTION
(no change is actual behaviour yet - just warning)
Should we remove option from settings ? or just label it ?

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This PR - deprecates the usage of httpRoot in settings .js - having overlapping options can cause confusion - Cleaner just to be explicit about httpNodeRoot and httpAdminRoot.  This PR only adds a warning - and does not actually change functionality yet.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
