### PR TITLE
fix error on auto commit for no flow change

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/index.js
@@ -608,8 +608,15 @@ async function saveFlows(flows, user) {
             var workflowMode = (gitSettings.workflow||{}).mode || settings.editorTheme.projects.workflow.mode;
             if (workflowMode === 'auto') {
                 return activeProject.stageFile([flowsFullPath, credentialsFile]).then(() => {
-                    return activeProject.commit(user,{message:"Update flow files"})
-                })
+                    return activeProject.status(user, false).then((result) => {
+                        const items = Object.values(result.files || {});
+                        // check if saved flow make modification to repository
+                        if (items.findIndex((item) => (item.status === "M ")) < 0) {
+                            return Promise.resolve();
+                        }
+                        return activeProject.commit(user,{message:"Update flow files"})
+                    });
+                });
             }
         }
     });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
When `editorTheme.projects.enabled=true` and `editorTheme.projects.workflow.mode="auto"`,  
1. add a node to workspace
2. remove the node added by (1)
3. press deploy button
causes following error:
```
Apr 09:02:42 - [warn] Error saving flows:
26 Apr 09:02:42 - [warn] Error
    at /Users/nisiyama/src/Curry/Git/node-red-hitachi/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/git/index.js:35:19
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
26 Apr 09:02:42 - [error] Error
```
The reason for this is that editor is trying to commit in the case where there is no change in the flow.
This PR try to fix the problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
