### PR TITLE
Move Inject node to CronosJS module

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "cookie": "0.4.1",
         "cookie-parser": "1.4.5",
         "cors": "2.8.5",
-        "cron": "1.7.2",
+        "cronosjs": "1.7.1",
         "denque": "1.5.0",
         "express": "4.17.1",
         "express-session": "1.17.1",

--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.js
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.js
@@ -16,7 +16,7 @@
 
 module.exports = function(RED) {
     "use strict";
-    var cron = require("cron");
+    const {scheduleTask} = require("cronosjs");
 
     function InjectNode(n) {
         RED.nodes.createNode(this,n);
@@ -85,7 +85,7 @@ module.exports = function(RED) {
                 if (RED.settings.verbose) {
                     this.log(RED._("inject.crontab", this));
                 }
-                this.cronjob = new cron.CronJob(this.crontab, function() { node.emit("input", {}); }, null, true);
+                this.cronjob = scheduleTask(this.crontab,() => { node.emit("input", {})});
             }
         };
 

--- a/packages/node_modules/@node-red/nodes/package.json
+++ b/packages/node_modules/@node-red/nodes/package.json
@@ -22,7 +22,7 @@
         "cookie-parser": "1.4.5",
         "cookie": "0.4.1",
         "cors": "2.8.5",
-        "cron": "1.7.2",
+        "cronosjs": "1.7.1",
         "denque": "1.5.0",
         "fs-extra": "9.1.0",
         "fs.notify": "0.0.4",


### PR DESCRIPTION
## Proposed changes

Moves the Inject node over to the `CronosJS` module.

The previous module `cron` has a growing number of issues against it on the latest version - one we had to revert upgrading to last year.

`CronosJS` is the module used by the cron-plus node and is actively maintained.

This will open up some options for improving what the Inject node can offer - although that's a separate discussion for another day.