### PR TITLE
Re-order inject typedinput to de-emphasise context options

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.html
@@ -455,7 +455,7 @@
                     var propertyValue = $('<input/>',{class:"node-input-prop-property-value",type:"text"})
                         .css("width","calc(70% - 30px)")
                         .appendTo(row)
-                        .typedInput({default:'str',types:['msg','flow','global','str','num','bool','json','bin','date','jsonata','env']});
+                        .typedInput({default:'str',types:['str','num','bool','json','bin','date','jsonata','env','global','flow','msg']});
 
                     propertyName.typedInput('value',prop.p);
 

--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.html
@@ -455,7 +455,7 @@
                     var propertyValue = $('<input/>',{class:"node-input-prop-property-value",type:"text"})
                         .css("width","calc(70% - 30px)")
                         .appendTo(row)
-                        .typedInput({default:'str',types:['str','num','bool','json','bin','date','jsonata','env','global','flow','msg']});
+                        .typedInput({default:'str',types:['flow','global','str','num','bool','json','bin','date','jsonata','env','msg']});
 
                     propertyName.typedInput('value',prop.p);
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This just reorganises the typedinput list to move the context options to the bottom of the list to de-emphasise them - in particular msg. that has no real meaning here as there is no msg (though it could be used to duplicate a previous entry I suppose) - see https://github.com/orgs/node-red/projects/8#card-56046423

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
