### PR TITLE
Fix subflow module with internal subflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1751,7 +1751,6 @@ RED.view = (function() {
             }
         }
         if (mouse_mode == RED.state.IMPORT_DRAGGING) {
-            RED.keyboard.remove("escape");
             updateActiveNodes();
             RED.nodes.dirty(true);
         }
@@ -1786,6 +1785,9 @@ RED.view = (function() {
     }
 
     function selectNone() {
+        if (mouse_mode === RED.state.MOVING || mouse_mode === RED.state.MOVING_ACTIVE) {
+            return;
+        }
         if (mouse_mode === RED.state.IMPORT_DRAGGING) {
             clearSelection();
             RED.history.pop();


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Installing SUBFLOW module that contains internal subflows causes following error on deploy of a flow containing the SUBFLOW instance:

```
TypeError: Cannot read property 'configs' of undefined
    at new Subflow (/Users/nisiyama/src/Curry/Git/node-red-hitachi/packages/nod\
e_modules/@node-red/runtime/lib/flows/Subflow.js:79:24)
    at Object.createSubflow [as create] (/Users/nisiyama/src/Curry/Git/node-red\
-hitachi/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js:544:12)
    at SubflowModule.start (/Users/nisiyama/src/Curry/Git/node-red-hitachi/pack\
ages/node_modules/@node-red/runtime/lib/flows/Flow.js:216:55)
    at SubflowModule.start (/Users/nisiyama/src/Curry/Git/node-red-hitachi/pack\
ages/node_modules/@node-red/runtime/lib/flows/Subflow.js:313:15)
    at Object.createNode (/Users/nisiyama/src/Curry/Git/node-red-hitachi/packag\
es/node_modules/@node-red/runtime/lib/flows/util.js:130:21)
    at Flow.start (/Users/nisiyama/src/Curry/Git/node-red-hitachi/packages/node\
_modules/@node-red/runtime/lib/flows/Flow.js:205:48)
    at start (/Users/nisiyama/src/Curry/Git/node-red-hitachi/packages/node_modu\
les/@node-red/runtime/lib/flows/index.js:371:33)
```

This seems to be caused by missing information of internal subflows.
This PR try to fix this issue.

Example subflow module:
[subflow.tar.gz](https://github.com/node-red/node-red/files/6391358/subflow.tar.gz)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
