### PR TITLE
add engine-strict flag to npm install args

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/externalModules.js
+++ b/packages/node_modules/@node-red/registry/lib/externalModules.js
@@ -194,7 +194,7 @@ async function installModule(moduleDetails) {
         "module": moduleDetails.module,
         "version": moduleDetails.version,
         "dir": installDir,
-        "args": ["--production"]
+        "args": ["--production","--engine-strict"]
     }
     return hooks.trigger("preInstall", triggerPayload).then((result) => {
         // preInstall passed

--- a/packages/node_modules/@node-red/registry/lib/installer.js
+++ b/packages/node_modules/@node-red/registry/lib/installer.js
@@ -175,7 +175,7 @@ async function installModule(module,version,url) {
             "dir": installDir,
             "isExisting": isExisting,
             "isUpgrade": isUpgrade,
-            "args": ['--no-audit','--no-update-notifier','--no-fund','--save','--save-prefix=~','--production']
+            "args": ['--no-audit','--no-update-notifier','--no-fund','--save','--save-prefix=~','--production','--engine-strict']
         }
 
         return hooks.trigger("preInstall", triggerPayload).then((result) => {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
<!-- Describe the nature of this change. What problem does it address? -->
This PR adds [`--engine-strict`](https://docs.npmjs.com/cli/v7/using-npm/config#engine-strict) flag to the npm install command for installing custom nodes. This flag ensures that if a specific nodejs version is included under *engines* section in `package.json` the npm install command will fail if it does not satisfy the nodejs version requirements rather than only generate a warning message.
to use this feature , a node developer adds an [engines](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#engines) section in `package.json` and specify the version requirements such as 
```{ "engines" : { "node" : ">=0.11.15" } }```

This is tested to check for a specific nodejs version. This could possibly be extended to also stipulate a minimum node-red version which will be very useful to ensure that end users are not installing any incompatible nodes which will prevent node-red to load in some cases [however, using this flag to check for node-red version is not tested]

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
running grunt failed at `1) externalModules api checkFlowDependencies:`  I don't know whether the change caused grunt to fail or is it something else?! first PR so I am not sure whether I need to update the unit test or not. Please let me know
- [ ] I have added suitable unit tests to cover the new/changed functionality
