### PR TITLE
Fixed remove item when depth=0 and wrong gutter calc treeList widget

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
@@ -312,7 +312,7 @@
             }
             if (child.depth !== parent.depth+1) {
                 child.depth = parent.depth+1;
-                var labelPaddingWidth = ((child.gutter?child.gutter.width()+2:0)+(child.depth*20));
+                var labelPaddingWidth = ((child.gutter ? child.gutter[0].offsetWidth + 2 : 0) + (child.depth * 20));
                 child.treeList.labelPadding.width(labelPaddingWidth+'px');
                 if (child.element) {
                     $(child.element).css({
@@ -348,6 +348,16 @@
                 that._selected.delete(item);
                 delete item.treeList;
                 delete that._items[item.id];
+                if(item.depth === 0) {
+                    for(var key in that._items) {
+                        var child = that._items[key];
+                        if(child.parent && child.parent.id === item.id) {
+                            delete that._items[key].treeList;
+                            delete that._items[key];
+                        }
+                    }
+                    that._data = that._data.filter(data => data.id !== item.id)
+                }
             }
             item.treeList.insertChildAt = function(newItem,position,select) {
                 newItem.parent = item;
@@ -480,7 +490,10 @@
                     if (item.treeList.container) {
                         $(item.element).remove();
                         $(element).appendTo(item.treeList.label);
-                        var labelPaddingWidth = (item.gutter?item.gutter.width()+2:0)+(item.depth*20);
+                        // using the JQuery Object, the gutter width will
+                        // be wrong when the element is reattached the second time
+                        var labelPaddingWidth = (item.gutter ? item.gutter[0].offsetWidth + 2 : 0) + (item.depth * 20);
+
                         $(element).css({
                             width: "calc(100% - "+(labelPaddingWidth+20+(item.icon?20:0))+"px)"
                         })
@@ -516,7 +529,7 @@
                 }).appendTo(label)
 
             }
-            var labelPaddingWidth = (item.gutter?item.gutter.width()+2:0)+(depth*20);
+            var labelPaddingWidth = (item.gutter ? item.gutter[0].offsetWidth + 2 : 0) + (depth * 20)
             item.treeList.labelPadding = $('<span>').css({
                 display: "inline-block",
                 width:  labelPaddingWidth+'px'

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
@@ -356,7 +356,7 @@
                             delete that._items[key];
                         }
                     }
-                    that._data = that._data.filter(data => data.id !== item.id)
+                    that._data = that._data.filter(function(data) { return data.id !== item.id})
                 }
             }
             item.treeList.insertChildAt = function(newItem,position,select) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

1. Currently it is not possible to remove an level 0 item from the treeList widget.

```
var item = myList.treeList('get', 'deleted');
item.treeList.remove();

myList.treeList('get', 'deleted');
-> works as expected

myList.treeList('data')
     .filter(item => item.id == 'deleted')
     .map(item => item.label);

-> it does not work as expected, the deleted item returns anyway
```

2. Currently if you remove a child element from the list, and then insert it again the gutter width is calculated incorrectly

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
