### PR TITLE
Fixed esbuild bundle error "installRetry" was declared a constant and changed

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/index.js
@@ -218,7 +218,7 @@ var reinstallTimeout;
 function reinstallModules(moduleList) {
     const promises = [];
     const reinstallList = [];
-    let installRetry = 30000;
+    var installRetry = 30000;
     if (settings.hasOwnProperty('autoInstallModulesRetry')) {
         log.warn(log._("server.deprecatedOption",{old:"autoInstallModulesRetry", new:"externalModules.autoInstallRetry"}));
         installRetry = settings.autoInstallModulesRetry;

--- a/packages/node_modules/@node-red/runtime/lib/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/index.js
@@ -218,7 +218,7 @@ var reinstallTimeout;
 function reinstallModules(moduleList) {
     const promises = [];
     const reinstallList = [];
-    const installRetry = 30000;
+    let installRetry = 30000;
     if (settings.hasOwnProperty('autoInstallModulesRetry')) {
         log.warn(log._("server.deprecatedOption",{old:"autoInstallModulesRetry", new:"externalModules.autoInstallRetry"}));
         installRetry = settings.autoInstallModulesRetry;


### PR DESCRIPTION
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Declaration of `const installRetry = 30000;` with `var installRetry = 30000;` as it will be changed a couple of lines later which creates an error when code is bundled with `esbuild --bundle --target=node14`:
```
 > node_modules/@node-red/runtime/lib/index.js:224:8: error: Cannot assign to "installRetry" because it is a constant
    224 │         installRetry = settings.autoInstallModulesRetry;
        ╵         ~~~~~~~~~~~~
   node_modules/@node-red/runtime/lib/index.js:221:10: note: "installRetry" was declared a constant here
    221 │     const installRetry = 30000;
```
_I used `var` instead of `let` as I do not know the requirements for the minimal target architecture and it was the main coding style in this code segment._

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [] I have run `grunt` to verify the unit tests pass 
- [ ] I have added suitable unit tests to cover the new/changed functionality

I could not run `grunt` as `npm install` failed on MacOS:
```
gyp ERR! build error 
npm ERR! gyp ERR! stack Error: `make` failed with exit code: 2
npm ERR! gyp ERR! stack     at ChildProcess.onExit (/Users/ah/SVN-Checkouts/TST/node-red/node_modules/node-gyp/lib/build.js:194:23)
npm ERR! gyp ERR! stack     at ChildProcess.emit (node:events:365:28)
npm ERR! gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:290:12)
npm ERR! gyp ERR! System Darwin 20.4.0
npm ERR! gyp ERR! command "/usr/local/Cellar/node/16.0.0_1/bin/node" "/Users/ah/SVN-Checkouts/TST/node-red/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
npm ERR! gyp ERR! cwd /Users/ah/SVN-Checkouts/TST/node-red/node_modules/node-sass
npm ERR! gyp ERR! node -v v16.0.0
npm ERR! gyp ERR! node-gyp -v v7.1.2
npm ERR! gyp ERR! not ok 
npm ERR! Build failed with error code: 1
```
