### PR TITLE
Fix incorrect shortcut keys in info tips

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info.js
@@ -477,7 +477,7 @@ RED.sidebar.info = (function() {
                     return;
                 }
             }
-            while ((m=/(\[(.*?)\])/.exec(tip))) {
+            while ((m=/(\[([a-z]*?)\])/.exec(tip))) {
                 tip = tip.replace(m[1],RED.keyboard.formatKey(m[2]));
             }
             tipBox.html(tip).fadeIn(200);


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I fixed #2975. Because shortcut keys in the info tips message contain '[' and ']', the regular expression recognized them as special words between '[' and ']'. To avoid the situation, I changed the regular expression to detect special words only which have alphabetical characters.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality