### PR TITLE
Change node id generation to give fixed length values without '.'

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -210,8 +210,11 @@ RED.nodes = (function() {
     })();
 
     function getID() {
-        // return Math.floor(Math.random()*15728640 + 1048576).toString(16)
-        return (1+Math.random()*4294967295).toString(16);
+        var bytes = [];
+        for (var i=0;i<8;i++) {
+            bytes.push(Math.round(0xff*Math.random()).toString(16).padStart(2,'0'));
+        }
+        return bytes.join("");
     }
 
     function parseNodePropertyTypeString(typeString) {

--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -314,7 +314,7 @@ module.exports = function(RED) {
         }
 
         // Build options for passing to the MQTT.js API
-        this.options.clientId = this.clientid || 'mqtt_' + (1+Math.random()*4294967295).toString(16);
+        this.options.clientId = this.clientid || 'mqtt_' + RED.util.generateId();
         this.options.username = this.username;
         this.options.password = this.password;
         this.options.keepalive = this.keepalive;

--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
@@ -62,14 +62,14 @@ module.exports = function(RED) {
             if (process.env.HTTP_PROXY) { prox = process.env.HTTP_PROXY; }
             if (process.env.no_proxy) { noprox = process.env.no_proxy.split(","); }
             if (process.env.NO_PROXY) { noprox = process.env.NO_PROXY.split(","); }
-            
+
             var noproxy = false;
             if (noprox) {
                 for (var i in noprox) {
                     if (node.path.indexOf(noprox[i].trim()) !== -1) { noproxy=true; }
                 }
             }
-            
+
             var agent = undefined;
             if (prox && !noproxy) {
                 agent = new HttpsProxyAgent(prox);
@@ -92,7 +92,7 @@ module.exports = function(RED) {
         }
 
         function handleConnection(/*socket*/socket) {
-            var id = (1+Math.random()*4294967295).toString(16);
+            var id = RED.util.generateId();
             if (node.isServer) {
                 node._clients[id] = socket;
                 node.emit('opened',{count:Object.keys(node._clients).length,id:id});

--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
@@ -69,7 +69,7 @@ module.exports = function(RED) {
             var setupTcpClient = function() {
                 node.log(RED._("tcpin.status.connecting",{host:node.host,port:node.port}));
                 node.status({fill:"grey",shape:"dot",text:"common.status.connecting"});
-                var id = (1+Math.random()*4294967295).toString(16);
+                var id = RED.util.generateId();
                 client = net.connect(node.port, node.host, function() {
                     buffer = (node.datatype == 'buffer') ? Buffer.alloc(0) : "";
                     node.connected = true;
@@ -153,7 +153,7 @@ module.exports = function(RED) {
             var server = net.createServer(function (socket) {
                 socket.setKeepAlive(true,120000);
                 if (socketTimeout !== null) { socket.setTimeout(socketTimeout); }
-                var id = (1+Math.random()*4294967295).toString(16);
+                var id = RED.util.generateId();
                 var fromi;
                 var fromp;
                 connectionPool[id] = socket;

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -31,7 +31,11 @@ const util = require("util");
  * @memberof @node-red/util_util
  */
 function generateId() {
-    return (1+Math.random()*4294967295).toString(16);
+    var bytes = [];
+    for (var i=0;i<8;i++) {
+        bytes.push(Math.round(0xff*Math.random()).toString(16).padStart(2,'0'));
+    }
+    return bytes.join("");
 }
 
 /**


### PR DESCRIPTION
## Proposed changes

This PR changes the algorithm used to generate ids in the editor and runtime.

The existing code could produce variable length ids and had a `.` in the middle - which was accidental rather than intentional because all those years ago, I forgot to include `Math.floor()` in the code. eg `bfc71766.923608`

The new algorithm creates 8-byte fixed length ids without the `.` - eg `4ab59dd6503989b6`. This gives us a range of 2^64 − 1 values - which is suitably random to avoid collisions within individual NR instances. 
