### PR TITLE
fix handling of empty switch rules

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.js
@@ -217,6 +217,10 @@ module.exports = function(RED) {
 
     function applyRules(node, msg, property,state,done) {
         if (!state) {
+            if (node.rules.length === 0) {
+                done(undefined, []);
+                return;
+            }
             state = {
                 currentRule: 0,
                 elseflag: true,

--- a/test/nodes/core/function/10-switch_spec.js
+++ b/test/nodes/core/function/10-switch_spec.js
@@ -1134,4 +1134,20 @@ describe('switch Node', function() {
         });
     });
 
+
+    it('should handle empty rule', function(done) {
+        var flow = [{id:"switchNode1",type:"switch",name:"switchNode",property:"payload",rules:[],checkall:true,outputs:0,wires:[]}];
+        helper.load(switchNode, flow, function() {
+            var n1 = helper.getNode("switchNode1");
+            setTimeout(function() {
+                var logEvents = helper.log().args.filter(function (evt) {
+                    return evt[0].type == "switch";
+                });
+                if (logEvents.length === 0) {
+                    done();
+                }
+            }, 150);
+            n1.receive({payload:1});
+        });
+    });
 });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Switch node with empty rules causes following error:
```
23 May 10:15:13 - [error] [switch:a4bcdee3.4848d] TypeError: Cannot read property 'vt' of undefined
```

This PR tries to fix this problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
