### PR TITLE
ensure context get/set key is a string

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/nodes/context/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/context/index.js
@@ -256,6 +256,9 @@ function createContext(id,seed,parent) {
             value: function(key, storage, callback) {
                 var context;
 
+                if (typeof key !== "string" || !key.length) {
+                    throw new Error("context get() requires 'key' to be a valid string");
+                }
                 if (!callback && typeof storage === 'function') {
                     callback = storage;
                     storage = undefined;
@@ -338,6 +341,9 @@ function createContext(id,seed,parent) {
             value: function(key, value, storage, callback) {
                 var context;
 
+                if (typeof key !== "string" || !key.length) {
+                    throw new Error("context set() requires 'key' to be a valid string");
+                }
                 if (!callback && typeof storage === 'function') {
                     callback = storage;
                     storage = undefined;

--- a/packages/node_modules/@node-red/runtime/lib/nodes/context/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/context/index.js
@@ -215,6 +215,22 @@ function followParentContext(parent, key) {
     return null;
 }
 
+function validateContextKey(key) {
+    try {
+        const keys =  Array.isArray(key) ? key : [key];
+        if(!keys.length) { return false }; //no key to get/set
+        for (let index = 0; index < keys.length; index++) {
+            const k = keys[index];
+            if (typeof k !== "string" || !k.length) {
+                return false; //not string or zero-length
+            }
+        }
+    } catch (error) {
+        return false;
+    }
+    return true;
+}
+
 function createContext(id,seed,parent) {
     // Seed is only set for global context - sourced from functionGlobalContext
     var scope = id;
@@ -251,14 +267,11 @@ function createContext(id,seed,parent) {
             }
         }
     }
+
     Object.defineProperties(obj, {
         get: {
             value: function(key, storage, callback) {
                 var context;
-
-                if (typeof key !== "string" || !key.length) {
-                    throw new Error("context get() requires 'key' to be a valid string");
-                }
                 if (!callback && typeof storage === 'function') {
                     callback = storage;
                     storage = undefined;
@@ -266,7 +279,14 @@ function createContext(id,seed,parent) {
                 if (callback && typeof callback !== 'function'){
                     throw new Error("Callback must be a function");
                 }
-
+                if (!validateContextKey(key)) {
+                    var err = Error("Invalid context key");
+                    if(callback) {
+                        return callback(err);
+                    } else {
+                        throw err;
+                    }
+                }
                 if (!Array.isArray(key)) {
                     var keyParts = util.parseContextStore(key);
                     key = keyParts.key;
@@ -340,10 +360,6 @@ function createContext(id,seed,parent) {
         set: {
             value: function(key, value, storage, callback) {
                 var context;
-
-                if (typeof key !== "string" || !key.length) {
-                    throw new Error("context set() requires 'key' to be a valid string");
-                }
                 if (!callback && typeof storage === 'function') {
                     callback = storage;
                     storage = undefined;
@@ -351,7 +367,14 @@ function createContext(id,seed,parent) {
                 if (callback && typeof callback !== 'function'){
                     throw new Error("Callback must be a function");
                 }
-
+                if (!validateContextKey(key)) {
+                    var err = Error("Invalid context key");
+                    if(callback) {
+                        return callback(err);
+                    } else {
+                        throw err;
+                    }
+                }
                 if (!Array.isArray(key)) {
                     var keyParts = util.parseContextStore(key);
                     key = keyParts.key;

--- a/test/unit/@node-red/runtime/lib/nodes/context/index_spec.js
+++ b/test/unit/@node-red/runtime/lib/nodes/context/index_spec.js
@@ -1006,7 +1006,155 @@ describe('context', function() {
                     done();
                 }).catch(done);
             });
+            it('should throw an error in context.get if key is empty string', function (done) {
+                Context.init({ contextStorage: memoryStorage });
+                Context.load().then(function () {
+                    var context = Context.get("1", "flow");
+                    context.get("");
+                    done("should throw an error.");
+                }).catch(function () {
+                    done();
+                });
+            });
+            it('should throw an error in context.get if key is an object', function (done) {
+                Context.init({ contextStorage: memoryStorage });
+                Context.load().then(function () {
+                    var context = Context.get("1", "flow");
+                    context.get({});
+                    done("should throw an error.");
+                }).catch(function () {
+                    done();
+                });
+            });
+            it('should throw an error in context.get if key is a number', function (done) {
+                Context.init({ contextStorage: memoryStorage });
+                Context.load().then(function () {
+                    var context = Context.get("1", "flow");
+                    context.get(1);
+                    done("should throw an error.");
+                }).catch(function () {
+                    done();
+                });
+            });
+            it('should throw an error in context.get if key array contains an empty string', function (done) {
+                Context.init({ contextStorage: memoryStorage });
+                Context.load().then(function () {
+                    var context = Context.get("1", "flow");
+                    context.get(["ok1", "", "ok2"]);
+                    done("should throw an error.");
+                }).catch(function () {
+                    done();
+                });
+            });
+            it('should throw an error in context.get if key array contains an object', function (done) {
+                Context.init({ contextStorage: memoryStorage });
+                Context.load().then(function () {
+                    var context = Context.get("1", "flow");
+                    context.get(["ok1", {}, "ok2"]);
+                    done("should throw an error.");
+                }).catch(function () {
+                    done();
+                });
+            });
+            it('should throw an error in context.get if key array contains a number', function (done) {
+                Context.init({ contextStorage: memoryStorage });
+                Context.load().then(function () {
+                    var context = Context.get("1", "flow");
+                    context.get(["ok1", 1, "ok2"]);
+                    done("should throw an error.");
+                }).catch(function () {
+                    done();
+                });
+            });
 
+            it('should throw an error in context.set if key is empty string', function (done) {
+                Context.init({ contextStorage: memoryStorage });
+                Context.load().then(function () {
+                    var context = Context.get("1", "flow");
+                    context.set("", 1);
+                    done("should throw an error.");
+                }).catch(function () {
+                    done();
+                });
+            });
+            it('should throw an error in context.set if key is an object', function (done) {
+                Context.init({ contextStorage: memoryStorage });
+                Context.load().then(function () {
+                    var context = Context.get("1", "flow");
+                    context.set({}, 1);
+                    done("should throw an error.");
+                }).catch(function () {
+                    done();
+                });
+            });
+            it('should throw an error in context.set if key is a number', function (done) {
+                Context.init({ contextStorage: memoryStorage });
+                Context.load().then(function () {
+                    var context = Context.get("1", "flow");
+                    context.set(1, 1);
+                    done("should throw an error.");
+                }).catch(function () {
+                    done();
+                });
+            });
+            it('should throw an error in context.set if key array contains an empty string', function (done) {
+                Context.init({ contextStorage: memoryStorage });
+                Context.load().then(function () {
+                    var context = Context.get("1", "flow");
+                    context.set(["ok1", "", "ok2"], 1);
+                    done("should throw an error.");
+                }).catch(function () {
+                    done();
+                });
+            });
+            it('should throw an error in context.set if key array contains an object', function (done) {
+                Context.init({ contextStorage: memoryStorage });
+                Context.load().then(function () {
+                    var context = Context.get("1", "flow");
+                    context.set(["ok1", {}, "ok2"], 1);
+                    done("should throw an error.");
+                }).catch(function () {
+                    done();
+                });
+            });
+            it('should throw an error in context.set if key array contains a number', function (done) {
+                Context.init({ contextStorage: memoryStorage });
+                Context.load().then(function () {
+                    var context = Context.get("1", "flow");
+                    context.set(["ok1", 1, "ok2"], 1);
+                    done("should throw an error.");
+                }).catch(function () {
+                    done();
+                });
+            });
+
+            it('should have an err set in callback for invalid key in context.get', function (done) {
+                Context.init({ contextStorage: memoryStorage });
+                Context.load().then(function () {
+                    var context = Context.get("1", "flow");
+                    context.get("", function(err) {
+                        if(err) {
+                            done();
+                        } else {
+                            done("should throw an error.");
+                        }
+                    });
+                }).catch(done);
+            });
+
+            it('should have an err set in callback for invalid key in context.set', function (done) {
+                Context.init({ contextStorage: memoryStorage });
+                Context.load().then(function () {
+                    var context = Context.get("1", "flow");
+                    context.set("", "value", function(err) {
+                        if(err) {
+                            done();
+                        } else {
+                            done("should throw an error.");
+                        }
+                    });
+                }).catch(done);
+            });
         });
 
         describe('listStores', function () {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

As discussed [here](https://discourse.nodered.org/t/typeerror-cannot-read-property-startswith-of-undefined/46212/8?u=steve-mcl)

Ensure `key` is a string when getting and setting context. 

At first i used the error string `"key must be a string"` 
![image](https://user-images.githubusercontent.com/44235289/119511667-8cb83e80-bd6a-11eb-8a67-e76b402f78bd.png)

... but once i tested it, i felt it was net clear enough to the user where this error was coming from. 

I eventually settled on `"context set() requires 'key' to be a valid string"` and `"context set() requires 'key' to be a valid string"`

Any thoughts on a better error string?

<br>

This is the result of my test...
![image](https://user-images.githubusercontent.com/44235289/119511516-672b3500-bd6a-11eb-87db-86b25a45efab.png)

```
[{"id":"95d47f9e.765ca","type":"function","z":"c559743c.82b088","name":"context.set(undefined, 1) ERROR","func":"context.set(undefined, 1);\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":1580,"y":200,"wires":[[]]},{"id":"9f4dc13d.09dc9","type":"function","z":"c559743c.82b088","name":"context.set(null, 1) ERROR","func":"context.set(null, 1)\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":1560,"y":240,"wires":[[]]},{"id":"7ce6aac7.0dd234","type":"function","z":"c559743c.82b088","name":"context.set({}, 1) ERROR","func":"context.set({}, 1)\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":1550,"y":280,"wires":[[]]},{"id":"ffd4b116.01345","type":"inject","z":"c559743c.82b088","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"1","payloadType":"num","x":1290,"y":349,"wires":[["95d47f9e.765ca","9f4dc13d.09dc9","7ce6aac7.0dd234","bf7f54b.42e57a8","d96b1924.cd1838","22ad3e8e.bd5ed2","d22e1d25.fc103","9e582c35.8c57e","f6ba35f9.e9cee8","b67317bd.6c0158","507cc5a0.6e0bdc","43f7ed8a.8935e4"]]},{"id":"bf7f54b.42e57a8","type":"function","z":"c559743c.82b088","name":"context.set(1, 1) ERROR","func":"context.set(1, 1)\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":1550,"y":160,"wires":[[]]},{"id":"d96b1924.cd1838","type":"function","z":"c559743c.82b088","name":"context.set(\"1\", 1) OK","func":"context.set(\"1\", 1);\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":1540,"y":120,"wires":[[]]},{"id":"9e582c35.8c57e","type":"function","z":"c559743c.82b088","name":"context.get(undefined) ERROR","func":"context.get(undefined);\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":1570,"y":460,"wires":[[]]},{"id":"f6ba35f9.e9cee8","type":"function","z":"c559743c.82b088","name":"context.get(null) ERROR","func":"context.get(null)\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":1550,"y":500,"wires":[[]]},{"id":"b67317bd.6c0158","type":"function","z":"c559743c.82b088","name":"context.get({}) ERROR","func":"context.get({})\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":1540,"y":540,"wires":[[]]},{"id":"d22e1d25.fc103","type":"function","z":"c559743c.82b088","name":"context.get(1) ERROR","func":"context.get(1)\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":1540,"y":420,"wires":[[]]},{"id":"22ad3e8e.bd5ed2","type":"function","z":"c559743c.82b088","name":"context.get(\"1\", 1) OK","func":"context.get(\"1\");\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":1540,"y":380,"wires":[[]]},{"id":"507cc5a0.6e0bdc","type":"function","z":"c559743c.82b088","name":"context.set(\"\", 1) ERROR","func":"context.set(\"\", 1);\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":1550,"y":320,"wires":[[]]},{"id":"43f7ed8a.8935e4","type":"function","z":"c559743c.82b088","name":"context.get(\"\") ERROR","func":"context.get(\"\")\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":1540,"y":580,"wires":[[]]}]
```



## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
