### PR TITLE
Fix allow Flow.getNode to return subflowInstance nodes

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -369,12 +369,12 @@ class Flow {
             return undefined;
         }
         // console.log((new Error().stack).toString().split("\n").slice(1,3).join("\n"))
-        if ((this.flow.configs && this.flow.configs[id]) || (this.flow.nodes && this.flow.nodes[id])) {
+        if ((this.flow.configs && this.flow.configs[id]) || (this.flow.nodes && this.flow.nodes[id] && this.flow.nodes[id].type.substring(0,8) != "subflow:")) {
             // This is a node owned by this flow, so return whatever we have got
             // During a stop/restart, activeNodes could be null for this id
             return this.activeNodes[id];
         } else if (this.activeNodes[id]) {
-            // TEMP: this is a subflow internal node within this flow
+            // TEMP: this is a subflow internal node within this flow or subflow instance node
             return this.activeNodes[id];
         } else if (this.subflowInstanceNodes[id]) {
             return this.subflowInstanceNodes[id];


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Thank you for considering the [Add get subflow information #2898](https://github.com/node-red/node-red/pull/2898) pull request.

Regarding the correction added in [the comment](https://github.com/node-red/node-red/pull/2898#issuecomment-811501640) of this request, there was a problem that the node could not be acquired, so I considered the correction.
Subflow instance node acquisition on line 380 does not work and the expected value is not obtained.
Instead, this.activeNodes [id] on line 375 returns null.
By excluding the subflow instance node in line 372, the expected value of the node can be obtained.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
