### PR TITLE
HTML node: cheerio update to 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "basic-auth": "2.0.1",
         "bcryptjs": "2.4.3",
         "body-parser": "1.19.0",
-        "cheerio": "0.22.0",
+        "cheerio": "^1.0.0-rc.9",
         "clone": "2.1.2",
         "content-type": "1.0.4",
         "cookie": "0.4.1",

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-HTML.js
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-HTML.js
@@ -32,7 +32,7 @@ module.exports = function(RED) {
                 var tag = node.tag;
                 if (msg.hasOwnProperty("select")) { tag = node.tag || msg.select; }
                 try {
-                    var $ = cheerio.load(value);
+                    var $ = cheerio.load(value,null,false);
                     var pay = [];
                     var count = 0;
                     $(tag).each(function() {
@@ -42,9 +42,11 @@ module.exports = function(RED) {
                     $(tag).each(function() {
                         if (node.as === "multi") {
                             var pay2 = null;
-                            if (node.ret === "html") { pay2 = cheerio.load($(this).html().trim()).xml(); }
+                            if (node.ret === "html") { pay2 = cheerio.load($(this).html().trim(),null,false).xml(); }
                             if (node.ret === "text") { pay2 = $(this).text(); }
-                            if (node.ret === "attr") { pay2 = this.attribs; }
+                            if (node.ret === "attr") {
+                                pay2 = Object.assign({},this.attribs);
+                            }
                             //if (node.ret === "val")  { pay2 = $(this).val(); }
                             /* istanbul ignore else */
                             if (pay2) {
@@ -61,9 +63,12 @@ module.exports = function(RED) {
                             }
                         }
                         if (node.as === "single") {
-                            if (node.ret === "html") { pay.push( cheerio.load($(this).html().trim()).xml() ); }
+                            if (node.ret === "html") { pay.push( cheerio.load($(this).html().trim(),null,false).xml() ); }
                             if (node.ret === "text") { pay.push( $(this).text() ); }
-                            if (node.ret === "attr") { pay.push( this.attribs ); }
+                            if (node.ret === "attr") {
+                                var attribs = Object.assign({},this.attribs);
+                                pay.push( attribs );
+                            }
                             //if (node.ret === "val")  { pay.push( $(this).val() ); }
                         }
                         index++;

--- a/packages/node_modules/@node-red/nodes/package.json
+++ b/packages/node_modules/@node-red/nodes/package.json
@@ -19,7 +19,7 @@
         "acorn-walk": "8.1.0",
         "ajv": "8.5.0",
         "body-parser": "1.19.0",
-        "cheerio": "0.22.0",
+        "cheerio": "^1.0.0-rc.9",
         "content-type": "1.0.4",
         "cookie-parser": "1.4.5",
         "cookie": "0.4.1",

--- a/test/nodes/core/parsers/70-HTML_spec.js
+++ b/test/nodes/core/parsers/70-HTML_spec.js
@@ -60,9 +60,13 @@ describe('HTML node', function() {
                 var n1 = helper.getNode("n1");
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
-                    msg.should.have.property('topic', 'bar');
-                    should.equal(msg.payload, 'This is a test page for node 70-HTML');
-                    done();
+                    try {
+                        msg.should.have.property('topic', 'bar');
+                        should.equal(msg.payload, 'This is a test page for node 70-HTML');
+                        done();
+                    } catch(err) {
+                        done(err)
+                    }
                 });
                 n1.receive({payload:data,topic:"bar",select:"h1"});
             });
@@ -78,9 +82,13 @@ describe('HTML node', function() {
                 var n1 = helper.getNode("n1");
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
-                    msg.should.have.property('topic', 'bar');
-                    msg.foo[0].should.equal('This is a test page for node 70-HTML');
-                    done();
+                    try {
+                        msg.should.have.property('topic', 'bar');
+                        msg.foo[0].should.equal('This is a test page for node 70-HTML');
+                        done();
+                    } catch(err) {
+                        done(err)
+                    }
                 });
                 n1.receive({foo:data,topic:"bar",select:"h1"});
             });
@@ -96,9 +104,13 @@ describe('HTML node', function() {
                 var n1 = helper.getNode("n1");
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
-                    msg.should.have.property('topic', 'bar');
-                    msg.bar[0].should.equal('This is a test page for node 70-HTML');
-                    done();
+                    try {
+                        msg.should.have.property('topic', 'bar');
+                        msg.bar[0].should.equal('This is a test page for node 70-HTML');
+                        done();
+                    } catch(err) {
+                        done(err)
+                    }
                 });
                 n1.receive({foo:data,topic:"bar"});
             });
@@ -114,10 +126,14 @@ describe('HTML node', function() {
                 var n1 = helper.getNode("n1");
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
-                    msg.should.have.property('topic', 'bar');
-                    msg.should.have.property('payload');
-                    msg.payload.should.be.empty;
-                    done();
+                    try {
+                        msg.should.have.property('topic', 'bar');
+                        msg.should.have.property('payload');
+                        msg.payload.should.be.empty;
+                        done();
+                    } catch(err) {
+                        done(err)
+                    }
                 });
                 n1.receive({payload:data,topic:"bar",select:"h4"});
             });
@@ -133,9 +149,13 @@ describe('HTML node', function() {
                 var n1 = helper.getNode("n1");
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
-                    msg.should.have.property('topic', 'bar');
-                    should.equal(msg.payload, 'There\'s nothing to read here.');
-                    done();
+                    try {
+                        msg.should.have.property('topic', 'bar');
+                        should.equal(msg.payload, 'There\'s nothing to read here.');
+                        done();
+                    } catch(err) {
+                        done(err)
+                    }
                 });
                 n1.receive({payload:data,topic: "bar"});
             });
@@ -151,10 +171,14 @@ describe('HTML node', function() {
                 var n1 = helper.getNode("n1");
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
-                    msg.should.have.property('topic', 'bar');
-                    msg.payload[0].indexOf("<li>Blue</li>").should.be.above(-1);
-                    msg.payload[0].indexOf("<li>Red</li>").should.be.above(-1);
-                    done();
+                    try {
+                        msg.should.have.property('topic', 'bar');
+                        msg.payload[0].indexOf("<li>Blue</li>").should.be.above(-1);
+                        msg.payload[0].indexOf("<li>Red</li>").should.be.above(-1);
+                        done();
+                    } catch(err) {
+                        done(err)
+                    }
                 });
                 n1.receive({payload:data,topic: "bar"});
             });
@@ -170,11 +194,14 @@ describe('HTML node', function() {
                 var n1 = helper.getNode("n1");
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
-                    msg.should.have.property('topic', 'bar');
-                    msg.payload[0].indexOf("Blue").should.be.above(-1);
-                    msg.payload[0].indexOf("Red").should.be.above(-1);
-                    done();
-
+                    try {
+                        msg.should.have.property('topic', 'bar');
+                        msg.payload[0].indexOf("Blue").should.be.above(-1);
+                        msg.payload[0].indexOf("Red").should.be.above(-1);
+                        done();
+                    } catch(err) {
+                        done(err)
+                    }
                 });
                 n1.receive({payload:data,topic: "bar"});
             });
@@ -190,9 +217,13 @@ describe('HTML node', function() {
                 var n1 = helper.getNode("n1");
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
-                    msg.should.have.property('topic', 'bar');
-                    should.equal(msg.payload, '<img src="foo.png"/>');
-                    done();
+                    try {
+                        msg.should.have.property('topic', 'bar');
+                        should.equal(msg.payload, '<img src="foo.png"/>');
+                        done();
+                    } catch(err) {
+                        done(err)
+                    }
                 });
                 n1.receive({payload:data,topic: "bar"});
             });
@@ -208,10 +239,14 @@ describe('HTML node', function() {
                 var n1 = helper.getNode("n1");
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
-                    msg.should.have.property('payload');
-                    msg.payload[0].should.have.property('src','foo.png');
-                    msg.should.have.property('topic', 'bar');
-                    done();
+                    try {
+                        msg.should.have.property('payload');
+                        msg.payload[0].should.have.property('src','foo.png');
+                        msg.should.have.property('topic', 'bar');
+                        done();
+                    } catch(err) {
+                        done(err)
+                    }
                 });
                 n1.receive({payload:data,topic: "bar"});
             });
@@ -258,9 +293,13 @@ describe('HTML node', function() {
                 var n1 = helper.getNode("n1");
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
-                    msg.should.have.property('topic', 'bar');
-                    msg.should.not.have.property('payload');
-                    done();
+                    try {
+                        msg.should.have.property('topic', 'bar');
+                        msg.should.not.have.property('payload');
+                        done();
+                    } catch(err) {
+                        done(err)
+                    }
                 });
                 n1.receive({topic: "bar"});
             });
@@ -301,20 +340,25 @@ describe('HTML node', function() {
                     var n1 = helper.getNode("n1");
                     var n2 = helper.getNode("n2");
                     n2.on("input", function(msg) {
-                        cnt++;
-                        msg.should.have.property('topic', 'bar');
-                        check_parts(msg, cnt -1, 2);
-                        if (cnt !== 1 && cnt !== 2) {
-                            return false;
+                        try {
+                            cnt++;
+                            msg.should.have.property('topic', 'bar');
+                            check_parts(msg, cnt -1, 2);
+                            if (cnt !== 1 && cnt !== 2) {
+                                return false;
+                            }
+                            if (cnt === 1) {
+                                msg.payload.indexOf("<li>Apple</li>").should.be.above(-1);
+                                msg.payload.indexOf("<li>Pear</li>").should.be.above(-1);
+                            } else if (cnt === 2) {
+                                msg.payload.indexOf("<li>Potato</li>").should.be.above(-1);
+                                msg.payload.indexOf("<li>Parsnip</li>").should.be.above(-1);
+                                done();
+                            }
+                        } catch(err) {
+                            done(err)
                         }
-                        if (cnt === 1) {
-                            msg.payload.indexOf("<li>Apple</li>").should.be.above(-1);
-                            msg.payload.indexOf("<li>Pear</li>").should.be.above(-1);
-                        } else if (cnt === 2) {
-                            msg.payload.indexOf("<li>Potato</li>").should.be.above(-1);
-                            msg.payload.indexOf("<li>Parsnip</li>").should.be.above(-1);
-                            done();
-                        }
+
                     });
                     n1.receive({payload:data,topic: "bar"});
                 });
@@ -331,19 +375,23 @@ describe('HTML node', function() {
                     var n1 = helper.getNode("n1");
                     var n2 = helper.getNode("n2");
                     n2.on("input", function(msg) {
-                        cnt++;
-                        msg.should.have.property('topic', 'bar');
-                        check_parts(msg, cnt -1, 2);
-                        if (cnt !== 1 && cnt !== 2) {
-                            return false;
-                        }
-                        if (cnt === 1) {
-                            msg.foo.indexOf("<li>Apple</li>").should.be.above(-1);
-                            msg.foo.indexOf("<li>Pear</li>").should.be.above(-1);
-                        } else if (cnt === 2) {
-                            msg.foo.indexOf("<li>Potato</li>").should.be.above(-1);
-                            msg.foo.indexOf("<li>Parsnip</li>").should.be.above(-1);
-                            done();
+                        try {
+                            cnt++;
+                            msg.should.have.property('topic', 'bar');
+                            check_parts(msg, cnt -1, 2);
+                            if (cnt !== 1 && cnt !== 2) {
+                                return false;
+                            }
+                            if (cnt === 1) {
+                                msg.foo.indexOf("<li>Apple</li>").should.be.above(-1);
+                                msg.foo.indexOf("<li>Pear</li>").should.be.above(-1);
+                            } else if (cnt === 2) {
+                                msg.foo.indexOf("<li>Potato</li>").should.be.above(-1);
+                                msg.foo.indexOf("<li>Parsnip</li>").should.be.above(-1);
+                                done();
+                            }
+                        } catch(err) {
+                            done(err)
                         }
                     });
                     n1.receive({foo:data, topic:"bar"});
@@ -360,19 +408,23 @@ describe('HTML node', function() {
                     var n1 = helper.getNode("n1");
                     var n2 = helper.getNode("n2");
                     n2.on("input", function(msg) {
-                        cnt++;
-                        msg.should.have.property('topic', 'bar');
-                        check_parts(msg, cnt -1, 2);
-                        if (cnt !== 1 && cnt !== 2) {
-                            return false;
-                        }
-                        if (cnt === 1) {
-                            msg.payload.indexOf("Apple").should.be.above(-1);
-                            msg.payload.indexOf("Pear").should.be.above(-1);
-                        } else if (cnt === 2) {
-                            msg.payload.indexOf("Potato").should.be.above(-1);
-                            msg.payload.indexOf("Parsnip").should.be.above(-1);
-                            done();
+                        try {
+                            cnt++;
+                            msg.should.have.property('topic', 'bar');
+                            check_parts(msg, cnt -1, 2);
+                            if (cnt !== 1 && cnt !== 2) {
+                                return false;
+                            }
+                            if (cnt === 1) {
+                                msg.payload.indexOf("Apple").should.be.above(-1);
+                                msg.payload.indexOf("Pear").should.be.above(-1);
+                            } else if (cnt === 2) {
+                                msg.payload.indexOf("Potato").should.be.above(-1);
+                                msg.payload.indexOf("Parsnip").should.be.above(-1);
+                                done();
+                            }
+                        } catch(err) {
+                            done(err)
                         }
                     });
                     n1.receive({payload:data,topic: "bar"});
@@ -389,12 +441,16 @@ describe('HTML node', function() {
                     var n1 = helper.getNode("n1");
                     var n2 = helper.getNode("n2");
                     n2.on("input", function(msg) {
-                        msg.should.have.property('payload');
-                        msg.payload.should.have.property('src','foo.png');
-                        msg.should.have.property('topic', 'bar');
-                        check_parts(msg, 0, 1);
-                        cnt = 2;  // frig the answer as only one img tag
-                        done();
+                        try {
+                            msg.should.have.property('payload');
+                            msg.payload.should.have.property('src','foo.png');
+                            msg.should.have.property('topic', 'bar');
+                            check_parts(msg, 0, 1);
+                            cnt = 2;  // frig the answer as only one img tag
+                            done();
+                        } catch(err) {
+                            done(err)
+                        }
                     });
                     n1.receive({payload:data,topic: "bar"});
                 });
@@ -411,15 +467,19 @@ describe('HTML node', function() {
                     var n2 = helper.getNode("n2");
                     var prev_msg = undefined;
                     n2.on("input", function(msg) {
-                        cnt++;
-                        if (prev_msg == undefined) {
-                            prev_msg = msg;
-                        }
-                        else {
-                            msg.should.not.equal(prev_msg);
-                        }
-                        if (cnt == 2) {
-                            done();
+                        try {
+                            cnt++;
+                            if (prev_msg == undefined) {
+                                prev_msg = msg;
+                            }
+                            else {
+                                msg.should.not.equal(prev_msg);
+                            }
+                            if (cnt == 2) {
+                                done();
+                            }
+                        } catch(err) {
+                            done(err)
                         }
                     });
                     n1.receive({payload:data,topic: "bar"});


### PR DESCRIPTION
Bumping cheerio to their latest version which is a major version bump with api changes.

This PR does the work to handles those changes. The unit tests pass without any changes (although I have fixed the error handling in the tests so failures are properly reported rather than timedout).

There *may* be edge cases our unit tests don't catch, so this needs highlighting in release notes as something for users to check after upgrading.

