### PR TITLE
Batch messages sent over Comms link

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/comms.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/comms.js
@@ -158,24 +158,30 @@ function CommsConnection(ws, user) {
 }
 
 CommsConnection.prototype.send = function(topic,data) {
-    var self = this;
     if (topic && data) {
         this.stack.push({topic:topic,data:data});
     }
+    this._queueSend();
+}
+CommsConnection.prototype._queueSend = function() {
+    var self = this;
     if (!this._xmitTimer) {
         this._xmitTimer = setTimeout(function() {
             try {
-                self.ws.send(JSON.stringify(self.stack));
+                self.ws.send(JSON.stringify(self.stack.splice(0,50)));
                 self.lastSentTime = Date.now();
             } catch(err) {
                 removeActiveConnection(self);
                 log.warn(log._("comms.error-send",{message:err.toString()}));
             }
             delete self._xmitTimer;
-            self.stack = [];
+            if (self.stack.length > 0) {
+                self._queueSend();
+            }
         },50);
     }
 }
+
 
 CommsConnection.prototype.subscribe = function(topic) {
     runtimeAPI.comms.subscribe({


### PR DESCRIPTION
## Proposed changes

Currently, the Comms layer in the runtime will batch up events to send to the editor in a 50ms timer and then send the whole lot in one go. That helps to reduce the work done by not sending each event as its own packet over the websocket.

With the Flow Debugger, it is now possible to get a huge storm of events all queued up to send which get sent in one go. This has the problem of dumping a huge workload on the editor in a single message.

This PR modifies the runtime side of comms to send no more than 50 events per message, with the 50ms pause between message. This should give the editor some breathing space when such storms occur.

## Checklist

- [ ] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
