### PR TITLE
exec node: add windowsHide option

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.html
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.html
@@ -41,6 +41,10 @@
         <span data-i18n="exec.label.seconds"></span>
     </div>
     <div class="form-row">
+        <label for="node-input-windowsHide" style="width: auto !important; padding-right:10px"><i class="fa fa-windows"></i> <span data-i18n="exec.label.windowshide"></span></label>
+        <input type="checkbox" id="node-input-windowsHide" style="display:inline-block; width:auto;">
+    </div>
+    <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
     </div>
@@ -56,6 +60,7 @@
             append: {value:""},
             useSpawn: {value:"false"},
             timer: {value:""},
+            windowsHide: {value:false},
             oldrc: {value:false},
             name: {value:""}
         },
@@ -92,6 +97,12 @@
             });
 
             $("#node-input-addpay-cb").trigger("change")
+            
+            if (this.windowsHide === "true" || this.windowsHide === true) {
+                $("#node-input-windowsHide").prop("checked",true);
+            } else {
+                $("#node-input-windowsHide").prop("checked",false);
+            }
         },
         oneditsave: function() {
             if (!$("#node-input-addpay-cb").prop("checked")) {

--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.js
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.js
@@ -87,7 +87,7 @@ module.exports = function(RED) {
                     var cmd = arg.shift();
                     /* istanbul ignore else  */
                     if (RED.settings.verbose) { node.log(cmd+" ["+arg+"]"); }
-                    child = spawn(cmd,arg);
+                    child = spawn(cmd,arg,node.spawnOpt);
                     node.status({fill:"blue",shape:"dot",text:"pid:"+child.pid});
                     var unknownCommand = (child.pid === undefined);
                     if (node.timer !== 0) {

--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.js
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.js
@@ -34,7 +34,8 @@ module.exports = function(RED) {
         this.timer = Number(n.timer || 0)*1000;
         this.activeProcesses = {};
         this.oldrc = (n.oldrc || false).toString();
-        this.execOpt = {encoding:'binary', maxBuffer:RED.settings.execMaxBufferSize||10000000};
+        this.execOpt = {encoding:'binary', maxBuffer:RED.settings.execMaxBufferSize||10000000, windowsHide: (n.windowsHide === true)};
+        this.spawnOpt = {windowsHide: (n.windowsHide === true) }
         var node = this;
 
         if (process.platform === 'linux' && fs.existsSync('/bin/bash')) { node.execOpt.shell = '/bin/bash'; }

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/90-exec.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/90-exec.html
@@ -80,5 +80,5 @@
     <p>If the node has more than one process running then <code>msg.pid</code> must also be set with the value of the PID to be killed.</p>
     <p>If a value is provided in the <code>Timeout</code> field then, if the process has not completed when the specified number of seconds has elapsed, the process will be killed automatically</p>
     <p>Tip: if running a Python app you may need to use the <code>-u</code> parameter to stop the output being buffered.</p>
-    <p>The <code>Hide windows</code> option can be set to hide shell windows under Windows.</p>
+    <p>The <code>Hide windows</code> option can be set to hide shell windows under Windows. This option will only affect Windows operating systems.</p>
 </script>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/90-exec.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/90-exec.html
@@ -80,4 +80,5 @@
     <p>If the node has more than one process running then <code>msg.pid</code> must also be set with the value of the PID to be killed.</p>
     <p>If a value is provided in the <code>Timeout</code> field then, if the process has not completed when the specified number of seconds has elapsed, the process will be killed automatically</p>
     <p>Tip: if running a Python app you may need to use the <code>-u</code> parameter to stop the output being buffered.</p>
+    <p>The <code>Hide windows</code> option can be set to hide shell windows under Windows.</p>
 </script>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -198,7 +198,8 @@
             "seconds": "seconds",
             "stdout": "stdout",
             "stderr": "stderr",
-            "retcode": "return code"
+            "retcode": "return code",
+            "windowshide": "Hide windows"
         },
         "placeholder": {
             "extraparams": "extra input parameters"

--- a/test/nodes/core/function/90-exec_spec.js
+++ b/test/nodes/core/function/90-exec_spec.js
@@ -44,7 +44,8 @@ describe('exec node', function() {
             n1.should.have.property("addpay","payload");
             n1.should.have.property("timer",0);
             n1.should.have.property("oldrc","false");
-            n1.should.have.property("windowsHide",false);
+            n1.should.have.property("execOpt", {encoding:'binary', maxBuffer:10000000, windowsHide: false});
+            n1.should.have.property("spawnOpt", {windowsHide:false});
             done();
         });
     });

--- a/test/nodes/core/function/90-exec_spec.js
+++ b/test/nodes/core/function/90-exec_spec.js
@@ -44,6 +44,7 @@ describe('exec node', function() {
             n1.should.have.property("addpay","payload");
             n1.should.have.property("timer",0);
             n1.should.have.property("oldrc","false");
+            n1.should.have.property("windowsHide",false);
             done();
         });
     });


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

This adds a `Hide windows` checkbox to the exec node to allow hiding shell windows under windows. Without this, the windowsHide option of exec and spawn defaults to false and shell windows will appear briefly when running commands.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
