### PR TITLE
Add option for file-in node to include all properties (default off)

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.html
@@ -48,9 +48,14 @@
             <option value="stream" data-i18n="file.output.stream"></option>
         </select>
     </div>
+    <div class="form-row" id="file-allprops">
+        <label>&nbsp;</label>
+        <input type="checkbox" id="node-input-allProps" style="display:inline-block; width:auto; vertical-align:top;">
+        <label for="node-input-allProps" style="width: 70%;"><span data-i18n="file.label.allProps"></span></label>
+    </div>
     <div class="form-row" id="encoding-spec">
         <label for="node-input-encoding"><i class="fa fa-flag"></i> <span data-i18n="file.label.encoding"></span></label>
-        <select type="text" id="node-input-encoding" style="width: 250px;">
+        <select type="text" id="node-input-encoding" style="width:250px;">
         </select>
     </div>
     <div class="form-row">
@@ -264,7 +269,8 @@
             format: {value:"utf8"},
             chunk: {value:false},
             sendError: {value: false},
-            encoding: {value: "none"}
+            encoding: {value: "none"},
+            allProps: {value: false}
         },
         color:"BurlyWood",
         inputs:1,
@@ -316,6 +322,12 @@
                 }
                 else {
                     $("#encoding-spec").hide();
+                }
+                if ((format === "lines") || (format === "stream")) {
+                    $("#file-allprops").show();
+                }
+                else {
+                    $("#file-allprops").hide();
                 }
             });
         }

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.js
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.js
@@ -261,6 +261,7 @@ module.exports = function(RED) {
         this.format = n.format;
         this.chunk = false;
         this.encoding = n.encoding || "none";
+        this.allProps = n.allProps || false;
         if (n.sendError === undefined) {
             this.sendError = true;
         } else {
@@ -299,6 +300,7 @@ module.exports = function(RED) {
                 var rs = fs.createReadStream(fullFilename)
                     .on('readable', function () {
                         var chunk;
+                        var m;
                         var hwm = rs._readableState.highWaterMark;
                         while (null !== (chunk = rs.read())) {
                             if (node.chunk === true) {
@@ -307,24 +309,32 @@ module.exports = function(RED) {
                                     spare += decode(chunk, node.encoding);
                                     var bits = spare.split("\n");
                                     for (var i=0; i < bits.length - 1; i++) {
-                                        var m = {
-                                            payload:bits[i],
-                                            topic:msg.topic,
-                                            filename:msg.filename,
-                                            parts:{index:count, ch:ch, type:type, id:msg._msgid}
+                                        m = {};
+                                        if (node.allProps == true) {
+                                            m = RED.util.cloneMessage(msg);
                                         }
+                                        else {
+                                            m.topic = msg.topic;
+                                            m.filename = msg.filename;
+                                        }
+                                        m.payload = bits[i];
+                                        m.parts= {index:count, ch:ch, type:type, id:msg._msgid}
                                         count += 1;
                                         nodeSend(m);
                                     }
                                     spare = bits[i];
                                 }
                                 if (node.format === "stream") {
-                                    var m = {
-                                        payload:chunk,
-                                        topic:msg.topic,
-                                        filename:msg.filename,
-                                        parts:{index:count, ch:ch, type:type, id:msg._msgid}
+                                    m = {};
+                                    if (node.allProps == true) {
+                                        m = RED.util.cloneMessage(msg);
                                     }
+                                    else {
+                                        m.topic = msg.topic;
+                                        m.filename = msg.filename;
+                                    }
+                                    m.payload = chunk;
+                                    m.parts = {index:count, ch:ch, type:type, id:msg._msgid}
                                     count += 1;
                                     if (chunk.length < hwm) { // last chunk is smaller that high water mark = eof
                                         getout = false;
@@ -357,17 +367,22 @@ module.exports = function(RED) {
                             nodeSend(msg);
                         }
                         else if (node.format === "lines") {
-                            var m = {
-                                payload: spare,
-                                topic:msg.topic,
-                                parts: {
-                                    index: count,
-                                    count: count+1,
-                                    ch: ch,
-                                    type: type,
-                                    id: msg._msgid
-                                }
-                            };
+                            var m = {};
+                            if (node.allProps) {
+                                m = RED.util.cloneMessage(msg);
+                            }
+                            else {
+                                m.topic = msg.topic;
+                                m.filename = msg.filename;
+                            }
+                            m.payload = spare;
+                            m.parts = {
+                                index: count,
+                                count: count + 1,
+                                ch: ch,
+                                type: type,
+                                id: msg._msgid
+                            }
                             nodeSend(m);
                         }
                         else if (getout) { // last chunk same size as high water mark - have to send empty extra packet.

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -861,7 +861,8 @@
             "encoding": "Encoding",
             "deletelabel": "delete __file__",
             "utf8String": "UTF8 string",
-            "binaryBuffer": "binary buffer"
+            "binaryBuffer": "binary buffer",
+            "allProps": "include all existing properties in each msg"
         },
         "action": {
             "append": "append to file",


### PR DESCRIPTION
and add test

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Add option to file-in node so when in per line or per chunk mode it will add all existing properties to the msg rather than creating a new one.. As this is a new feature it is targeted to dev.
To close Issue #3034

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
