### PR TITLE
Fix output label in file-in node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.html
@@ -276,8 +276,17 @@
         inputs:1,
         outputs:1,
         outputLabels: function(i) {
-            var l = this._(((this.format === "utf8")||(this.format === "lines")) ? "file.label.utf8String" : "file.label.binaryBuffer");
-            return ( l + (((this.format === "lines")||(this.format === "stream")) ? "s" : "") );
+            var l;
+            if (this.format === "utf8") {
+	        l = "file.label.utf8String";
+            } else if (this.format === "lines") {
+	        l = "file.label.utf8String_plural";
+            } else if (this.format === "stream") {
+	        l = "file.label.binaryBuffer_plural";
+            } else {
+	        l = "file.label.binaryBuffer";
+            }
+            return this._(l);
         },
         icon: "file-in.svg",
         label: function() {

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.html
@@ -278,13 +278,13 @@
         outputLabels: function(i) {
             var l;
             if (this.format === "utf8") {
-	        l = "file.label.utf8String";
+                l = "file.label.utf8String";
             } else if (this.format === "lines") {
-	        l = "file.label.utf8String_plural";
+                l = "file.label.utf8String_plural";
             } else if (this.format === "stream") {
-	        l = "file.label.binaryBuffer_plural";
+                l = "file.label.binaryBuffer_plural";
             } else {
-	        l = "file.label.binaryBuffer";
+                l = "file.label.binaryBuffer";
             }
             return this._(l);
         },

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -861,7 +861,9 @@
             "encoding": "Encoding",
             "deletelabel": "delete __file__",
             "utf8String": "UTF8 string",
+            "utf8String_plural": "UTF8 strings",
             "binaryBuffer": "binary buffer",
+            "binaryBuffer_plural": "binary buffers",
             "allProps": "include all existing properties in each msg"
         },
         "action": {

--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -859,7 +859,9 @@
             "encoding": "文字コード",
             "deletelabel": "delete __file__",
             "utf8String": "UTF8文字列",
+            "utf8String_plural": "UTF8文字列",
             "binaryBuffer": "バイナリバッファ",
+            "binaryBuffer_plural": "バイナリバッファ",
             "allProps": "各メッセージに既存の全プロパティを含める"
         },
         "action": {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
In the Japanese environment, I found that there is "s" in the output labels of the file-in node.

![image](https://user-images.githubusercontent.com/20310935/123769788-9c481b80-d904-11eb-9ca3-bef72fd9b1af.png)

This problem is caused by a hardcode to describe plural words in the English environment. To solve the problem, I added new entries for plural words to be the same as other entries to distinguish singular and plural words.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
