### PR TITLE
Fix change log in help tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,16 @@ Migration from 1.x
    they should be fully backward compatible.
 
    - RBE:  Relabelled as 'filter' to make it more discoverable and made part of
-           the core palette, rather than as a separate module.
+     the core palette, rather than as a separate module.
    - Tail: This node has been removed from the default palette. You can reinstall it
-           from node-red-node-tail
+     from node-red-node-tail
    - HTTP Request: Reimplemented with a different underlying module. We have
-           tried to maintain 100% functional compatibility, but it is possible
-           some edge cases remain. In particular, if you are use http proxies in
-           your environment
+     tried to maintain 100% functional compatibility, but it is possible
+     some edge cases remain. In particular, if you are using http proxies in
+     your environment.
    - JSON: The schema validation option no longer supports JSON-Schema draft-04
    - HTML: Its underlying module has had a major version update. Should be fully
-           backward compatible.
+     backward compatible.
 
 Runtime
 
@@ -45,7 +45,7 @@ Editor
  - Update Node-RED Function typings in Monaco (#3008) @Steve-Mcl
  - Add css named variables for certain key colours (#2994) @knolleary
  - Improve contrast of export dialog JSON font color
- - Switch editableList buttons from <a> to <button> elements
+ - Switch editableList buttons from \<a\> to \<button\> elements
  - Add option to RED.nodes.createCompleteNodeSet to include node dimensions
  - Fix css of node help table of contents elements
  - Improve red-ui-node-icon css and add red-ui-node-icon-small modifier class


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
On GitHub, the CHANGELOG.md shows correctly. But the changelog is currently corrupted in the help tab.

- Unintended code blocks

  <img src="https://user-images.githubusercontent.com/20310935/123785784-e389d880-d913-11eb-9b13-aacf8d2364c6.png" width="300px">

- Unintended links

  <img src="https://user-images.githubusercontent.com/20310935/123786942-3dd76900-d915-11eb-8644-edb89b4bfeaf.png" width="300px">

To show them on both GitHub and the help tab, I changed the Markdown.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
