### PR TITLE
Emit `nodes:change` for any updated config node when node deleted/added

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -367,6 +367,7 @@ RED.nodes = (function() {
                                 } else {
                                     var users = configNode.users;
                                     users.splice(users.indexOf(node),1);
+                                    RED.events.emit('nodes:change',configNode)
                                 }
                             }
                         }
@@ -2032,6 +2033,7 @@ RED.nodes = (function() {
                         if (configNode) {
                             if (configNode.users.indexOf(n) === -1) {
                                 configNode.users.push(n);
+                                RED.events.emit('nodes:change',configNode)
                             }
                         }
                     }


### PR DESCRIPTION
An alternative fix for #3043.

When deleting/adding a node that points at a config node, we were correctly updating the config node's `users` array, but we weren't emitting the `nodes:change` event for the config node.

That was letting the Outliner display of a config node's user count to get out of sync.