### PR TITLE
Include `hasUser=false` config nodes when exporting whole flow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -701,6 +701,13 @@ RED.clipboard = (function() {
                 var activeWorkspace = RED.workspaces.active();
                 nodes = RED.nodes.groups(activeWorkspace);
                 nodes = nodes.concat(RED.nodes.filterNodes({z:activeWorkspace}));
+                RED.nodes.eachConfig(function(n) {
+                    if (n.z === RED.workspaces.active() && n._def.hasUsers === false) {
+                        // Grab any config nodes scoped to this flow that don't
+                        // require any flow-nodes to use them
+                        nodes.push(n);
+                    }
+                });
                 var parentNode = RED.nodes.workspace(activeWorkspace)||RED.nodes.subflow(activeWorkspace);
                 nodes.unshift(parentNode);
                 nodes = RED.nodes.createExportableNodeSet(nodes);


### PR DESCRIPTION
When exporting a whole flow, it selects the flow nodes and pulls in any referenced config nodes.

However some config nodes (such as `ui_spacer`) can be scoped to a flow without any references. These nodes have `hasUser` set to false in their definition.

This fix ensures those config nodes get included in an export.