### PR TITLE
Add fs-extra module to dependencies in @node-red/util module

### DIFF
--- a/packages/node_modules/@node-red/util/package.json
+++ b/packages/node_modules/@node-red/util/package.json
@@ -16,6 +16,7 @@
     ],
     "dependencies": {
         "clone": "2.1.2",
+        "fs-extra": "10.0.0",
         "i18next": "20.3.2",
         "json-stringify-safe": "5.0.1",
         "jsonata": "1.8.4",


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
When I tried [the electron Node-RED](https://github.com/node-red/node-red-desktop/pull/1) using Node-RED v2.0 beta 2, I encountered a startup error.

<img src="https://user-images.githubusercontent.com/20310935/124418958-94bac380-dd97-11eb-8f83-79047735cec5.png" width="400px">

I found that this problem came from a lack of dependencies in the `@node-red/util` module. Therefore, I added the `fs-extra` module as dependencies in the `@node-red/util` module. (Strangely, this problem didn't occur using Node-RED v1.3.5).

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
