### PR TITLE
Enable functionExternalModules by default

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.html
@@ -329,7 +329,7 @@
 
     function getLibsList() {
         var _libs = [];
-        if (RED.settings.functionExternalModules === true) {
+        if (RED.settings.functionExternalModules !== false) {
             var libs = $("#node-input-libs-container").editableList("items");
             libs.each(function(i) {
                 var item = $(this);

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -100,7 +100,7 @@ module.exports = function(RED) {
         node.fin = n.finalize ? n.finalize.trim() : "";
         node.libs = n.libs || [];
 
-        if (RED.settings.functionExternalModules !== true && node.libs.length > 0) {
+        if (RED.settings.functionExternalModules === false && node.libs.length > 0) {
             throw new Error(RED._("function.error.externalModuleNotAllowed"));
         }
 
@@ -500,7 +500,7 @@ module.exports = function(RED) {
     RED.nodes.registerType("function",FunctionNode, {
         dynamicModuleList: "libs",
         settings: {
-            functionExternalModules: { value: false, exportable: true }
+            functionExternalModules: { value: true, exportable: true }
         }
     });
     RED.library.register("functions");

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -396,7 +396,7 @@ module.exports = {
     //fileWorkingDirectory: "",
 
     /** Allow the Function node to load additional npm modules directly */
-    functionExternalModules: false,
+    functionExternalModules: true,
 
     /** The following property can be used to set predefined values in Global Context.
      * This allows extra node modules to be made available with in Function node.

--- a/test/nodes/core/function/10-function_spec.js
+++ b/test/nodes/core/function/10-function_spec.js
@@ -1461,11 +1461,12 @@ describe('function node', function() {
         afterEach(function() {
             delete RED.settings.functionExternalModules;
         })
-        it('should fail if using OS module without functionExternalModules set to true', function(done) {
+        it('should fail if using OS module with functionExternalModules set to false', function(done) {
             var flow = [
                 {id:"n1",type:"function",wires:[["n2"]],func:"msg.payload = os.type(); return msg;", "libs": [{var:"os", module:"os"}]},
                 {id:"n2", type:"helper"}
             ];
+            RED.settings.functionExternalModules = false;
             helper.load(functionNode, flow, function() {
                 var n1 = helper.getNode("n1");
                 should.not.exist(n1);
@@ -1478,7 +1479,6 @@ describe('function node', function() {
                 {id:"n1",type:"function",wires:[["n2"]],func:"msg.payload = os.type(); return msg;"},
                 {id:"n2", type:"helper"}
             ];
-            RED.settings.functionExternalModules = true;
             helper.load(functionNode, flow, function() {
                 var n1 = helper.getNode("n1");
                 var n2 = helper.getNode("n2");
@@ -1502,7 +1502,6 @@ describe('function node', function() {
                 {id:"n1",type:"function",wires:[["n2"]],func:"msg.payload = os.type(); return msg;", "libs": [{var:"os", module:"os"}]},
                 {id:"n2", type:"helper"}
             ];
-            RED.settings.functionExternalModules = true;
             helper.load(functionNode, flow, function() {
                 var n1 = helper.getNode("n1");
                 var n2 = helper.getNode("n2");
@@ -1523,7 +1522,6 @@ describe('function node', function() {
                 {id:"n1",type:"function",wires:[["n2"]],func:"msg.payload = os.type(); return msg;", "libs": [{var:"flow", module:"os"}]},
                 {id:"n2", type:"helper"}
             ];
-            RED.settings.functionExternalModules = true;
             helper.load(functionNode, flow, function() {
                 var n1 = helper.getNode("n1");
                 should.not.exist(n1);


### PR DESCRIPTION
## Proposed changes

Enable `functionExternalModules` by default for new installs.

