### PR TITLE
Add push to front of rate limit queue.

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.js
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.js
@@ -337,6 +337,8 @@ module.exports = function(RED) {
                 node.status({});
             });
         }
+
+        // The topic based fair queue and last arrived on all topics queue
         else if ((node.pauseType === "queue") || (node.pauseType === "timed")) {
             node.intervalID = setInterval(function() {
                 if (node.pauseType === "queue") {

--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.js
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.js
@@ -154,6 +154,7 @@ module.exports = function(RED) {
         }, 15 * 1000);
         node.on("close", function() { clearInterval(loggerId); });
 
+        // The delay type modes
         if (node.pauseType === "delay") {
             node.on("input", function(msg, send, done) {
                 var id = ourTimeout(function() {
@@ -199,6 +200,29 @@ module.exports = function(RED) {
             });
             node.on("close", function() { clearDelayList(); });
         }
+        else if (node.pauseType === "random") {
+            node.on("input", function(msg, send, done) {
+                var wait = node.randomFirst + (node.diff * Math.random());
+                var id = ourTimeout(function() {
+                    node.idList.splice(node.idList.indexOf(id),1);
+                    send(msg);
+                    if (node.timeout >= 1000) {
+                        node.status({fill:"blue",shape:"dot",text:node.idList.length});
+                    }
+                    done();
+                }, wait, () => done());
+                if (Object.keys(msg).length === 2 && msg.hasOwnProperty("flush")) { id.clear(); }
+                else { node.idList.push(id); }
+                if (msg.hasOwnProperty("reset")) { clearDelayList(true); }
+                if (msg.hasOwnProperty("flush")) { flushDelayList(msg.flush); done(); }
+                if (node.timeout >= 1000) {
+                    node.status({fill:"blue",shape:"dot",text:node.idList.length});
+                }
+            });
+            node.on("close", function() { clearDelayList(); });
+        }
+
+        // The rate limit/queue type modes
         else if (node.pauseType === "rate") {
             node.on("input", function(msg, send, done) {
                 if (msg.hasOwnProperty("reset")) {
@@ -217,6 +241,7 @@ module.exports = function(RED) {
                 if (!node.drop) {
                     var m = RED.util.cloneMessage(msg);
                     delete m.flush;
+                    delete m.lifo;
                     if (Object.keys(m).length > 1) {
                         if (node.intervalID !== -1) {
                             if (node.allowrate && msg.hasOwnProperty("rate") && !isNaN(parseFloat(msg.rate)) && node.rate !== msg.rate) {
@@ -228,6 +253,9 @@ module.exports = function(RED) {
                             if ((max_msgs > 0) && (node.buffer.length >= max_msgs)) {
                                 node.buffer = [];
                                 node.error(RED._("delay.errors.too-many"), msg);
+                            } else if (msg.lifo) {
+                                node.buffer.unshift({msg: m, send: send, done: done});
+                                node.reportDepth();
                             } else {
                                 node.buffer.push({msg: m, send: send, done: done});
                                 node.reportDepth();
@@ -384,27 +412,6 @@ module.exports = function(RED) {
                 node.buffer = [];
                 node.status({});
             });
-        }
-        else if (node.pauseType === "random") {
-            node.on("input", function(msg, send, done) {
-                var wait = node.randomFirst + (node.diff * Math.random());
-                var id = ourTimeout(function() {
-                    node.idList.splice(node.idList.indexOf(id),1);
-                    send(msg);
-                    if (node.timeout >= 1000) {
-                        node.status({fill:"blue",shape:"dot",text:node.idList.length});
-                    }
-                    done();
-                }, wait, () => done());
-                if (Object.keys(msg).length === 2 && msg.hasOwnProperty("flush")) { id.clear(); }
-                else { node.idList.push(id); }
-                if (msg.hasOwnProperty("reset")) { clearDelayList(true); }
-                if (msg.hasOwnProperty("flush")) { flushDelayList(msg.flush); done(); }
-                if (node.timeout >= 1000) {
-                    node.status({fill:"blue",shape:"dot",text:node.idList.length});
-                }
-            });
-            node.on("close", function() { clearDelayList(); });
         }
     }
     RED.nodes.registerType("delay",DelayNode);

--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.js
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.js
@@ -253,7 +253,7 @@ module.exports = function(RED) {
                             if ((max_msgs > 0) && (node.buffer.length >= max_msgs)) {
                                 node.buffer = [];
                                 node.error(RED._("delay.errors.too-many"), msg);
-                            } else if (msg.lifo) {
+                            } else if (msg.toFront === true) {
                                 node.buffer.unshift({msg: m, send: send, done: done});
                                 node.reportDepth();
                             } else {

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/89-delay.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/89-delay.html
@@ -35,6 +35,11 @@
         <dd>If the received message has this property set to a numeric value then that many messages
             will be released immediately. If set to any other type (e.g. boolean), then all
             outstanding messages held by the node are sent immediately.</dd>
+        <dt class="optional">toFront</dt>
+        <dd>When in rate limit mode, if the received message has this property set to boolean <code>true</code>,
+            then the message is pushed to the front of the queue and will be released next.
+            This can be used in combination with <code>msg.flush=1</code> to resend immediately.
+        </dd>
     </dl>
     <h3>Details</h3>
     <p>When configured to delay messages, the delay interval can be a fixed value,

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/89-delay.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/89-delay.html
@@ -51,7 +51,7 @@
         the configured time period. The status shows the number of messages currently in the queue.
         It can optionally discard intermediate messages as they arrive.</p>
     </p>
-    <p> If set to allow override of the rate, the new rate will be applied immediately,
+    <p>If set to allow override of the rate, the new rate will be applied immediately,
         and will remain in effect until changed again, the node is reset, or the flow is restarted.</p>
     <p>The rate limiting can be applied to all messages, or group them according to
         their <code>msg.topic</code> value. When grouping, intermediate messages are
@@ -59,4 +59,6 @@
         the most recent message for all topics, or release the most recent message
         for the next topic.
     </p>
+    <p><b>Note</b>: In rate limit mode the maximum queue depth can be set by a property in your
+        <i>settings.js</i> file. For example <code>nodeMessageBufferMaxLength: 1000,</code>
 </script>

--- a/test/nodes/core/function/89-delay_spec.js
+++ b/test/nodes/core/function/89-delay_spec.js
@@ -824,7 +824,7 @@ describe('delay Node', function() {
                     }
                     else if (msg.topic === "doo") {
                         msg.payload.should.equal(1);
-                        (Date.now() - t).should.be.approximately(404,50);
+                        (Date.now() - t).should.be.approximately(4,50);
                         c = c + 1;
                     }
                     if (c === 5) { done(); }
@@ -837,7 +837,7 @@ describe('delay Node', function() {
             delayNode1.receive({payload:1,topic:"aoo"});
             setImmediate( function() { delayNode1.receive({payload:1,topic:"boo"}); }  );
             setImmediate( function() { delayNode1.receive({payload:1,topic:"coo",toFront:true}); }  );
-            setImmediate( function() { delayNode1.receive({payload:1,topic:"doo"}); }  );
+            setImmediate( function() { delayNode1.receive({payload:1,topic:"doo",toFront:true,flush:1}); }  );
             setImmediate( function() { delayNode1.receive({payload:1,topic:"eoo",toFront:true}); }  );
             setImmediate( function() { delayNode1.receive({flush:1});  });
             setTimeout( function() { delayNode1.receive({flush:1});  }, 200);

--- a/test/nodes/core/function/89-delay_spec.js
+++ b/test/nodes/core/function/89-delay_spec.js
@@ -789,6 +789,62 @@ describe('delay Node', function() {
         });
     });
 
+    it('can part push to front of rate limit queue', function(done) {
+        this.timeout(2000);
+        var flow = [{"id":"delayNode1","type":"delay","name":"delayNode","pauseType":"rate","timeout":1,"timeoutUnits":"seconds","rate":1,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[["helperNode1"]]},
+                    {id:"helperNode1", type:"helper", wires:[]}];
+        helper.load(delayNode, flow, function() {
+            var delayNode1 = helper.getNode("delayNode1");
+            var helperNode1 = helper.getNode("helperNode1");
+            var t = Date.now();
+            var c = 0;
+            helperNode1.on("input", function(msg) {
+                msg.should.have.a.property('payload');
+                msg.should.have.a.property('topic');
+                try {
+                    if (msg.topic === "aoo") {
+                        msg.payload.should.equal(1);
+                        (Date.now() - t).should.be.approximately(2,50);
+                        c = c + 1;
+                    }
+                    else if (msg.topic === "eoo") {
+                        msg.payload.should.equal(1);
+                        (Date.now() - t).should.be.approximately(4,50);
+                        c = c + 1;
+                    }
+                    else if (msg.topic === "coo") {
+                        msg.payload.should.equal(1);
+                        (Date.now() - t).should.be.approximately(202,50);
+                        c = c + 1;
+                    }
+                    else if (msg.topic === "boo") {
+                        msg.payload.should.equal(1);
+                        (Date.now() - t).should.be.approximately(406,50);
+                        c = c + 1;
+                    }
+                    else if (msg.topic === "doo") {
+                        msg.payload.should.equal(1);
+                        (Date.now() - t).should.be.approximately(404,50);
+                        c = c + 1;
+                    }
+                    if (c === 5) { done(); }
+                } catch(e) {
+                    done(e);
+                }
+            });
+
+            // send test messages
+            delayNode1.receive({payload:1,topic:"aoo"});
+            setImmediate( function() { delayNode1.receive({payload:1,topic:"boo"}); }  );
+            setImmediate( function() { delayNode1.receive({payload:1,topic:"coo",toFront:true}); }  );
+            setImmediate( function() { delayNode1.receive({payload:1,topic:"doo"}); }  );
+            setImmediate( function() { delayNode1.receive({payload:1,topic:"eoo",toFront:true}); }  );
+            setImmediate( function() { delayNode1.receive({flush:1});  });
+            setTimeout( function() { delayNode1.receive({flush:1});  }, 200);
+            setTimeout( function() { delayNode1.receive({flush:4});  }, 400);
+        });
+    });
+
     it('can reset rate limit queue', function(done) {
         this.timeout(2000);
         var flow = [{"id":"delayNode1","type":"delay","name":"delayNode","pauseType":"rate","timeout":1,"timeoutUnits":"seconds","rate":2,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[["helperNode1"]]},


### PR DESCRIPTION
(moved random delay to top to group with other delay types.
Tests and docs to follow

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

This adds (allows) a `msg.lifo` property . If it exists on a msg for a rate limited queue then it adds it to the front of the queue (unshift) rather than the end so it will be first out (Last In First Out). 

This  allow building a stack type queue if required - or a push back in case of failure retry type queue.

 - [x] Add tests
 - [x] Enhance Docs

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
