### PR TITLE
Detect if agent-base has patch https.request and undo it

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
@@ -28,8 +28,43 @@ module.exports = function(RED) {
     var cookie = require("cookie");
     var hashSum = require("hash-sum");
 
+
+    // Cache a reference to the existing https.request function
+    // so we can compare later to see if an old agent-base instance
+    // has been required.
+    // This is generally okay as the core nodes are required before
+    // any contrib nodes. Where it will fail is if the agent-base module
+    // is required via the settings file or outside of Node-RED before it
+    // is started.
+    // If there are other modules that patch the function, they will get undone
+    // as well. Not much we can do about that right now. Patching core
+    // functions is bad.
+    const HTTPS_MODULE = require("https");
+    const HTTPS_REQUEST = HTTPS_MODULE.request;
+
+    function checkNodeAgentPatch() {
+        if (HTTPS_MODULE.request !== HTTPS_REQUEST) {
+            RED.log.warn(`
+
+---------------------------------------------------------------------
+Patched https.request function detected. This will break the
+HTTP Request node. The original code has now been restored.
+
+This is likely caused by a contrib node including an old version of
+the 'agent-base@<5.0.0' module.
+
+You can identify what node is at fault by running:
+   npm list agent-base
+in your Node-RED user directory (${RED.settings.userDir}).
+---------------------------------------------------------------------
+`);
+            HTTPS_MODULE.request = HTTPS_REQUEST
+        }
+    }
+
     function HTTPRequest(n) {
         RED.nodes.createNode(this,n);
+        checkNodeAgentPatch();
         var node = this;
         var nodeUrl = n.url;
         var isTemplatedUrl = (nodeUrl||"").indexOf("{{") != -1;
@@ -65,6 +100,7 @@ module.exports = function(RED) {
         }
 
         this.on("input",function(msg,nodeSend,nodeDone) {
+            checkNodeAgentPatch();
             //reset redirectList on each request
             redirectList = [];
             var preRequestTimestamp = process.hrtime();


### PR DESCRIPTION
Fixes #3072

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

Attempt to detect if an old agent-base instance has been required that has patched the core https.request function, and undo the patching if found.

Not ideal, but will keep the core working and quickly identify nodes that need updating.