### PR TITLE
Fix fade colors when hovering over tabs

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
@@ -664,6 +664,8 @@ RED.tabs = (function() {
                 link.on("dblclick", function(evt) { evt.stopPropagation(); evt.preventDefault(); })
 
 
+                $('<span class="red-ui-tabs-fade"></span>').appendTo(li);
+
                 if (tab.closeable) {
                     li.addClass("red-ui-tabs-closeable")
                     var closeLink = $("<a/>",{href:"#",class:"red-ui-tab-close"}).appendTo(li);
@@ -673,8 +675,6 @@ RED.tabs = (function() {
                         removeTab(tab.id);
                     });
                 }
-
-                $('<span class="red-ui-tabs-fade"></span>').appendTo(li);
 
                 var badges = $('<span class="red-ui-tabs-badges"></span>').appendTo(li);
                 if (options.onselect) {

--- a/packages/node_modules/@node-red/editor-client/src/sass/tabs.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tabs.scss
@@ -131,6 +131,9 @@
             &:not(.active) a:hover {
                 color: $workspace-button-color-hover;
                 background: $tab-background-hover;
+                &+.red-ui-tabs-fade {
+                    background-image: linear-gradient(to right, change-color($tab-background-hover, $alpha: 0.001), $tab-background-hover);
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
When hovering over an inactive tab, the fade becomes visible due to the background color change. A similar issue happens in subflow tabs.

This PR fixes the issues by changing the fade colors of inactive tabs when hovering and bringing the close tab link to the front.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
