### PR TITLE
Key and certificate as string or buffer

### DIFF
--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -234,8 +234,13 @@ httpsPromise.then(function(startupHttps) {
                             // Get the result of the function, because createServer doesn't accept functions as input
                             Promise.resolve(settings.https()).then(function(refreshedHttps) {
                                 if (refreshedHttps) {
+                                    // The key/cert needs to be updated in the NodeJs http(s) server, when no key/cert is yet available or when the key/cert has changed. 
+                                    // Note that the refreshed key/cert can be supplied as a string or a buffer.
+                                    var updateKey = (server.key == undefined || (Buffer.isBuffer(server.key) && !server.key.equals(refreshedHttps.key)) || (typeof server.key == "string" && server.key != refreshedHttps.key));
+                                    var updateCert = (server.cert == undefined || (Buffer.isBuffer(server.cert) && !server.cert.equals(refreshedHttps.cert)) || (typeof server.cert == "string" && server.cert != refreshedHttps.cert));
+                                    
                                     // Only update the credentials in the server when key or cert has changed
-                                    if(!server.key || !server.cert || !server.key.equals(refreshedHttps.key) || !server.cert.equals(refreshedHttps.cert)) {
+                                    if(updateKey || updateCert) {
                                         server.setSecureContext(refreshedHttps);
                                         RED.log.info(RED.log._("server.https.settings-refreshed"));
                                     }


### PR DESCRIPTION
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

+ In the current settings.js template the following code snippet is provided:
   ```
   https: function() {
      return {
         key: require("fs").readFileSync('/home/pi/.node-red/certs/privkey.pem'),
         cert: require("fs").readFileSync('/home/pi/.node-red/certs/fullchain.pem')
      }
   },
   ```
   Since no encoding parameter is specified, the readFileSync will return a ***raw buffer***.

+ However it is also possible to read the keypair like this:
   ```
   https: function() {
      return {
         key: require("fs").readFileSync('/home/pi/.node-red/certs/privkey.pem', 'utf8'),
         cert: require("fs").readFileSync('/home/pi/.node-red/certs/fullchain.pem', 'utf8')
      }
   },
   ```
   Since an encoding parameter is specified, the readFileSync will return a ***string***.

However in the case of a string, the current code will fail (as discussed on [Discourse](https://discourse.nodered.org/t/https-refresh-interval-returning-with-an-error/49726/6)):

![image](https://user-images.githubusercontent.com/14224149/130334092-6e934f40-1cbe-4acb-9257-afc95c615757.png)

This pull request fixes the key and certificate equality checks, to support both strings and buffers.

Thanks!
Bart

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
