### PR TITLE
Extend HTTP request node to log detailed timing information

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
@@ -99,6 +99,11 @@ in your Node-RED user directory (${RED.settings.userDir}).
             noprox = proxyConfig.noproxy;
         }
 
+        let timingLog = false;
+        if (RED.settings.hasOwnProperty("httpRequestTimingLog")) {
+            timingLog = RED.settings.httpRequestTimingLog;
+        }
+
         this.on("input",function(msg,nodeSend,nodeDone) {
             checkNodeAgentPatch();
             //reset redirectList on each request
@@ -514,7 +519,9 @@ in your Node-RED user directory (${RED.settings.userDir}).
                     if (res.client && res.client.bytesRead) {
                         node.metric("size.bytes", msg, res.client.bytesRead);
                     }
-                    emitTimingMetricLog(res.timings, msg);
+                    if (timingLog) {
+                        emitTimingMetricLog(res.timings, msg);
+                    }
                 }
 
                 // Convert the payload to the required return type
@@ -539,7 +546,7 @@ in your Node-RED user directory (${RED.settings.userDir}).
                 }
                 msg.payload = err.toString() + " : " + url;
                 msg.statusCode = err.code || (err.response?err.response.statusCode:undefined);
-                if (node.metric()) {
+                if (node.metric() && timingLog) {
                     emitTimingMetricLog(err.timings, msg);
                 }
                 nodeSend(msg);

--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
@@ -514,6 +514,7 @@ in your Node-RED user directory (${RED.settings.userDir}).
                     if (res.client && res.client.bytesRead) {
                         node.metric("size.bytes", msg, res.client.bytesRead);
                     }
+                    emitTimingMetricLog(res.timings, msg);
                 }
 
                 // Convert the payload to the required return type
@@ -538,6 +539,9 @@ in your Node-RED user directory (${RED.settings.userDir}).
                 }
                 msg.payload = err.toString() + " : " + url;
                 msg.statusCode = err.code || (err.response?err.response.statusCode:undefined);
+                if (node.metric()) {
+                    emitTimingMetricLog(err.timings, msg);
+                }
                 nodeSend(msg);
                 nodeDone();
             });
@@ -546,6 +550,28 @@ in your Node-RED user directory (${RED.settings.userDir}).
         this.on("close",function() {
             node.status({});
         });
+
+        function emitTimingMetricLog(timings, msg) {
+            const props = [
+                "start",
+                "socket",
+                "lookup",
+                "connect",
+                "secureConnect",
+                "upload",
+                "response",
+                "end",
+                "error",
+                "abort"
+            ];
+            if (timings) {
+                props.forEach(p => {
+                    if (timings[p]) {
+                        node.metric(`timings.${p}`, msg, timings[p]);
+                    }
+                });
+            }
+        }
 
         function extractCookies(setCookie) {
             var cookies = {};


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
The current HTTP request node output the time spent on HTTP requests as a metric log(`node.http request.duration.mills`), but it does not provide a breakdown of the time spent on HTTP request, such as DNS resolution, and TCP connection establishment, which hinders failure analysis.

The got package, used in HTTP request node, [can obtain these detailed timing information as a result of HTTP requests](https://www.npmjs.com/package/got#timings).  This PR use this feature to add a function to output the detailed timing information as a metric log.

An example of metric log is shown below: 
```
    23 Aug 11:52:27 - [metric] {"level":99,"nodeid":"15576e5393f5cb94","event":"node.http request.duration.millis","msgid":"11c38881d7cf926f","value":"215.305","timestamp":1629687147857}
    23 Aug 11:52:27 - [metric] {"level":99,"nodeid":"15576e5393f5cb94","event":"node.http request.size.bytes","msgid":"11c38881d7cf926f","value":15079,"timestamp":1629687147857}
    23 Aug 11:52:27 - [metric] {"level":99,"nodeid":"15576e5393f5cb94","event":"node.http request.timings.start","msgid":"11c38881d7cf926f","value":1629687147645,"timestamp":1629687147857}
    23 Aug 11:52:27 - [metric] {"level":99,"nodeid":"15576e5393f5cb94","event":"node.http request.timings.socket","msgid":"11c38881d7cf926f","value":1629687147712,"timestamp":1629687147857}
    23 Aug 11:52:27 - [metric] {"level":99,"nodeid":"15576e5393f5cb94","event":"node.http request.timings.lookup","msgid":"11c38881d7cf926f","value":1629687147712,"timestamp":1629687147857}
    23 Aug 11:52:27 - [metric] {"level":99,"nodeid":"15576e5393f5cb94","event":"node.http request.timings.connect","msgid":"11c38881d7cf926f","value":1629687147712,"timestamp":1629687147857}
    23 Aug 11:52:27 - [metric] {"level":99,"nodeid":"15576e5393f5cb94","event":"node.http request.timings.secureConnect","msgid":"11c38881d7cf926f","value":1629687147762,"timestamp":1629687147857}
    23 Aug 11:52:27 - [metric] {"level":99,"nodeid":"15576e5393f5cb94","event":"node.http request.timings.upload","msgid":"11c38881d7cf926f","value":1629687147762,"timestamp":1629687147857}
    23 Aug 11:52:27 - [metric] {"level":99,"nodeid":"15576e5393f5cb94","event":"node.http request.timings.response","msgid":"11c38881d7cf926f","value":1629687147846,"timestamp":1629687147858}
    23 Aug 11:52:27 - [metric] {"level":99,"nodeid":"15576e5393f5cb94","event":"node.http request.timings.end","msgid":"11c38881d7cf926f","value":1629687147856,"timestamp":1629687147858}
```

[Related discussion in PR#2952](https://github.com/node-red/node-red/pull/2952#discussion_r627108032)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
