### PR TITLE
Give passport verfiy callback wrapper the same arity as the original callback

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/auth/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/index.js
@@ -173,27 +173,30 @@ function genericStrategy(adminApp,strategy) {
     adminApp.use(passport.session());
 
     var options = strategy.options;
+    var verify = function() {
+        var originalDone = arguments[arguments.length-1];
+        if (options.verify) {
+            var args = Array.from(arguments);
+            args[args.length-1] = function(err,profile) {
+                if (err) {
+                    return originalDone(err);
+                } else {
+                    return completeVerify(profile,originalDone);
+                }
+            };
 
-    passport.use(new strategy.strategy(options,
-        function() {
-            var originalDone = arguments[arguments.length-1];
-            if (options.verify) {
-                var args = Array.from(arguments);
-                args[args.length-1] = function(err,profile) {
-                    if (err) {
-                        return originalDone(err);
-                    } else {
-                        return completeVerify(profile,originalDone);
-                    }
-                };
-                options.verify.apply(null,args);
-            } else {
-                var profile = arguments[arguments.length - 2];
-                return completeVerify(profile,originalDone);
-            }
-
+            options.verify.apply(null,args);
+        } else {
+            var profile = arguments[arguments.length - 2];
+            return completeVerify(profile,originalDone);
         }
-    ));
+    };
+    // Give our callback the same arity as the original one from options
+    if (options.verify) {
+        Object.defineProperty(verify, "length", { value: options.verify.length })
+    }
+
+    passport.use(new strategy.strategy(options, verify));
 
     adminApp.get('/auth/strategy',
         passport.authenticate(strategy.name, {session:false, failureRedirect: settings.httpAdminRoot }),


### PR DESCRIPTION
… passed in via options

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This sets the arity of the node-red verify callback wrapper function to the arity of the verify callback provided via options.
This is useful when the passport strategy inspects the arity to determine which data is passed to the function, like this one e.g.:
https://github.com/jaredhanson/passport-openidconnect/blob/master/lib/strategy.js#L220


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
