### PR TITLE
SPLIT Join node - support for msg.resetTimeout …

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -631,6 +631,19 @@ module.exports = function(RED) {
                     }
                 }
 
+                if (msg.hasOwnProperty("resetTimeout")) {
+                    if (inflight[partId]) {
+                        if (inflight[partId].timeout) {
+                            clearTimeout(inflight[partId].timeout);
+                        }
+                        if (node.timer > 0) {
+                            inflight[partId].timeout = setTimeout(function() {
+                                completeSend(partId)
+                            }, node.timer)
+                        }
+                    }
+                }
+
                 if (msg.hasOwnProperty("reset")) {
                     if (inflight[partId]) {
                         if (inflight[partId].timeout) {

--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -631,7 +631,7 @@ module.exports = function(RED) {
                     }
                 }
 
-                if (msg.hasOwnProperty("resetTimeout")) {
+                if (msg.hasOwnProperty("restartTimeout")) {
                     if (inflight[partId]) {
                         if (inflight[partId].timeout) {
                             clearTimeout(inflight[partId].timeout);

--- a/packages/node_modules/@node-red/nodes/locales/en-US/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/sequence/17-split.html
@@ -115,10 +115,9 @@
     <p>A <i>count</i> can be set for how many messages should be received before generating the output message.
     For object outputs, once this count has been reached, the node can be configured to send a message for each subsequent message
     received.</p>
-    <p>A <i>timeout</i> can be set to trigger sending the new message using whatever has been received so far.</p>
+    <p>A <i>timeout</i> can be set to trigger sending the new message using whatever has been received so far. This timeout can be restarted and set to its initial value by sending a message with the <code>msg.restartTimeout</code> property set.</p>
     <p>If a message is received with the <code>msg.complete</code> property set, the output message is finalised and sent.
     This resets any part counts.</p>
-    <p>If a message is received with the <code>msg.resetTimeout</code> property set, the timer for the partly complete message is reset to the original time.
     <p>If a message is received with the <code>msg.reset</code> property set, the partly complete message is deleted and not sent.
     This resets any part counts.</p>
 

--- a/packages/node_modules/@node-red/nodes/locales/en-US/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/sequence/17-split.html
@@ -118,6 +118,7 @@
     <p>A <i>timeout</i> can be set to trigger sending the new message using whatever has been received so far.</p>
     <p>If a message is received with the <code>msg.complete</code> property set, the output message is finalised and sent.
     This resets any part counts.</p>
+    <p>If a message is received with the <code>msg.resetTimeout</code> property set, the timer for the partly complete message is reset to the original time.
     <p>If a message is received with the <code>msg.reset</code> property set, the partly complete message is deleted and not sent.
     This resets any part counts.</p>
 


### PR DESCRIPTION
… to restore original timeout

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Adds support for the join node to reset its timer to the original value, by using an input key with the message. Similar to how it already handles _msg.complete_ and _msg.reset_. I chose the name **msg.resetTimeout**.

This is a minor patch and I also created [this forum thread](https://discourse.nodered.org/t/proposal-to-add-payload-resettimeout-support-for-join-node/50156).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
