### PR TITLE
Redraw hook for displaying comments inline

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4261,6 +4261,10 @@ RED.view = (function() {
 
                 RED.hooks.trigger("viewRedrawNode",{node:d,el:this})
             });
+
+            // give each node a chance to redraw itself
+            node.each(function(d, i) { if (d._def.redrawhook) { d._def.redrawhook.apply(d, [d3.select(this)]);}});
+
             var link = linkLayer.selectAll(".red-ui-flow-link").data(
                 activeLinks,
                 function(d) {

--- a/packages/node_modules/@node-red/nodes/core/common/90-comment.html
+++ b/packages/node_modules/@node-red/nodes/core/common/90-comment.html
@@ -4,11 +4,34 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
     </div>
+    <div class="form-row">
+        <input type="checkbox" id="node-input-inline" style="display:inline-block; width:15px; vertical-align:baseline;">
+        <span data-i18n="comment.inline">Display inline</span>
+    </div>
     <div class="form-row node-text-editor-row">
         <input type="hidden" id="node-input-info" autofocus="autofocus">
         <div style="height: 250px; min-height:150px;" class="node-text-editor" id="node-input-info-editor"></div>
     </div>
 </script>
+
+<style>
+    .comment h1,
+    .comment h2,
+    .comment h3,
+    .comment h4,
+    .comment h5,
+    .comment h6 {
+        font-weight: 300;
+        bottom: 7px;
+        position: relative;
+    }
+    .comment {
+        font-size: 1.3em;
+    }
+    .comment div {
+        position: fixed;
+    }
+</style>
 
 <script type="text/javascript">
     RED.nodes.registerType('comment',{
@@ -16,7 +39,8 @@
         color:"#ffffff",
         defaults: {
             name: {value:""},
-            info: {value:""}
+            info: {value:""},
+            inline: {value: true}
         },
         inputs:0,
         outputs:0,
@@ -58,6 +82,36 @@
             height -= (parseInt(editorRow.css("marginTop"))+parseInt(editorRow.css("marginBottom")));
             $(".node-text-editor").css("height",height+"px");
             this.editor.resize();
+        },
+        redrawhook(svg) {
+            var node = this;
+            if (this.inline) {
+                var width = 700;
+                var _info = this.info || "## Double-click to edit";
+                svg.select("rect").style("fill", "transparent").style("stroke", "transparent");
+                svg.selectAll(".red-ui-flow-node-icon-group, .red-ui-flow-node-label").classed("hide", true);
+
+                if (!svg.select(".comment").node()) {
+                svg
+                  .append("foreignObject")
+                  .attr("class", "comment")
+                  .attr("width", width)
+                  .attr("height", 1)
+                  .attr("pointer-events", "none")
+                  .style("overflow", "visible");
+                }
+                svg
+                .select(".comment")
+                .html("<div>" + RED.utils.renderMarkdown(_info) + "</div>");
+
+                var rect = svg.select("foreignObject").select("div").node().getBoundingClientRect();
+                svg.select("rect").attr("width", rect.width).attr("height", rect.height);
+            } else {
+                // revert to default node appearance
+                svg.select("rect").attr("style", null);
+                svg.selectAll(".red-ui-flow-node-icon-group, .red-ui-flow-node-label").classed("hide", false);
+                svg.select(".comment").remove();
+            }
         }
     });
 </script>


### PR DESCRIPTION
Optionally (check box) display comments inline in the flow interface.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

This change allows comment nodes to display their content as formatted markdown inside the workspace: ![inline-comments](https://user-images.githubusercontent.com/4451499/130797067-a7948bb1-fe04-404a-8ef7-b7127e74837a.gif)

### Discussion

> https://node-red.slack.com/archives/C024S4W7M8D/p1629889747346000?thread_ts=1625521362.168100&cid=C024S4W7M8D

The discussion needs some consensus before a proper merger can take place. In short, giving component developers free hands as to the _appearance_ of nodes would ultimately take a toll on user experience. In order to adhere to node-red's goal of general consistency, we need to establish a set of Design Guidelines that both developers and maintainers can lean towards. Such guidelines could conclude that:

* a node must have a clear label
* a node must have a clear border
* a node's appearance must be color-blind friendly
* a node must have clear and recognizable input and output ports
* a node's appearance must be respecful to end-users as well as other nodes

### Potential improvements

A better implementation, perhaps as a future refactorization, would be to add a `_redraw` function as an internal prototype on the Node object, and have `src/ui/view.js` tell each node to update itself. A node could then choose to implement its own `_redraw` function, effectively overloading its inherited prototype. That way, nodes could handle their drawing without hooks. In addition, a developer could choose to create a custom `_redraw` that invokes the prototype `_redraw` and further extend it with custom drawing code.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
