### PR TITLE
Correlation log for precise message tracing on Join/Split node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -157,10 +157,10 @@ module.exports = function(RED) {
                                 if (a[a.length-1] == '') {
                                     swapIdThenDone({done,msg,msgid:origMsgid}, corrIds); 
                                 } else {
-                                    node.pendingDones.push({done,msg,msgid:origMsgid,corrMsgId:corrIds});
+                                    node.pendingDones.push({done,msg,msgid:origMsgid,corrMsgids:corrIds});
                                 }
                             } else {
-                                node.pendingDones.push({done,msg,msgid:origMsgid,corrMsgId:corrIds});
+                                node.pendingDones.push({done,msg,msgid:origMsgid,corrMsgids:corrIds});
                             }
                         } else {
                             swapIdThenDone({done,msg,msgid:origMsgid}, corrIds);

--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -18,20 +18,26 @@ module.exports = function(RED) {
     "use strict";
 
     function sendArray(node,msg,array,send) {
+        const corrIds = [];
         for (var i = 0; i < array.length-1; i++) {
             msg.payload = array[i];
             msg.parts.index = node.c++;
             if (node.stream !== true) { msg.parts.count = array.length; }
+            msg._msgid = RED.util.generateId();
+            corrIds.push(msg._msgid);
             send(RED.util.cloneMessage(msg));
         }
         if (node.stream !== true) {
             msg.payload = array[i];
             msg.parts.index = node.c++;
             msg.parts.count = array.length;
+            msg._msgid = RED.util.generateId();
+            corrIds.push(msg._msgid);
             send(RED.util.cloneMessage(msg));
             node.c = 0;
         }
         else { node.remainder = array[i]; }
+        return corrIds;
     }
 
     function SplitNode(n) {
@@ -69,15 +75,28 @@ module.exports = function(RED) {
         node.buffer = Buffer.from([]);
         node.pendingDones = [];
         this.on("input", function(msg, send, done) {
+            function swapIdThenDone(msgInfo, sentMsgIds) {
+                const currentMsgid = msgInfo.msg._msgid;
+                msgInfo.msg._msgid = msgInfo.msgid;
+                msgInfo.done();
+                let c = [];
+                if (msgInfo.corrMsgids) { Array.prototype.push.apply(c, msgInfo.corrMsgids); }
+                if (sentMsgIds) { Array.prototype.push.apply(c, sentMsgIds); }
+                if (c.length > 0) { node.metric("correlate",msgInfo.msg,{split: c}); }
+                msgInfo.msg._msgid = currentMsgid;
+            }
+
             if (msg.hasOwnProperty("payload")) {
                 if (msg.hasOwnProperty("parts")) { msg.parts = { parts:msg.parts }; } // push existing parts to a stack
                 else { msg.parts = {}; }
                 msg.parts.id = RED.util.generateId();  // generate a random id
+                const origMsgid = msg._msgid;
                 delete msg._msgid;
                 if (typeof msg.payload === "string") { // Split String into array
                     msg.payload = (node.remainder || "") + msg.payload;
                     msg.parts.type = "string";
                     if (node.spltType === "len") {
+                        const corrIds = [];
                         msg.parts.ch = "";
                         msg.parts.len = node.splt;
                         var count = msg.payload.length/node.splt;
@@ -94,23 +113,28 @@ module.exports = function(RED) {
                             msg.payload = data.substring(pos,pos+node.splt);
                             msg.parts.index = node.c++;
                             pos += node.splt;
+                            msg._msgid = RED.util.generateId();
+                            corrIds.push(msg._msgid);
                             send(RED.util.cloneMessage(msg));
                         }
                         if (count > 1) {
-                            node.pendingDones.forEach(d => d());
+                            node.pendingDones.forEach(msgInfo => swapIdThenDone(msgInfo, [corrIds[0]]));
                             node.pendingDones = [];
                         }
                         node.remainder = data.substring(pos);
                         if ((node.stream !== true) || (node.remainder.length === node.splt)) {
                             msg.payload = node.remainder;
                             msg.parts.index = node.c++;
+                            msg._msgid = RED.util.generateId();
+                            corrIds.push(msg._msgid);
                             send(RED.util.cloneMessage(msg));
-                            node.pendingDones.forEach(d => d());
+                            node.pendingDones.push({done,msg,msgid:origMsgid});
+                            node.pendingDones.forEach(msgInfo => swapIdThenDone(msgInfo, corrIds));
                             node.pendingDones = [];
-                            done();
                             node.remainder = "";
                         } else {
-                            node.pendingDones.push(done);
+                            node.pendingDones.push({done,msg,msgid:origMsgid,
+                                corrMsgids: corrIds});
                         }
                     }
                     else {
@@ -125,8 +149,22 @@ module.exports = function(RED) {
                             a = msg.payload.split(node.splt);
                             msg.parts.ch = node.splt; // pass the split char to other end for rejoin
                         }
-                        sendArray(node,msg,a,send);
-                        done();
+                        const corrIds = sendArray(node,msg,a,send);
+                        if (node.stream) {
+                            if (a.length > 1) {
+                                node.pendingDones.forEach(msgInfo => swapIdThenDone(msgInfo, [corrIds[0]]));
+                                node.pendingDones = [];
+                                if (a[a.length-1] == '') {
+                                    swapIdThenDone({done,msg,msgid:origMsgid}, corrIds); 
+                                } else {
+                                    node.pendingDones.push({done,msg,msgid:origMsgid,corrMsgId:corrIds});
+                                }
+                            } else {
+                                node.pendingDones.push({done,msg,msgid:origMsgid,corrMsgId:corrIds});
+                            }
+                        } else {
+                            swapIdThenDone({done,msg,msgid:origMsgid}, corrIds);
+                        }
                     }
                 }
                 else if (Array.isArray(msg.payload)) { // then split array into messages
@@ -139,6 +177,7 @@ module.exports = function(RED) {
                     var pos = 0;
                     var data = msg.payload;
                     msg.parts.len = node.arraySplt;
+                    const corrIds = []
                     for (var i=0; i<count; i++) {
                         msg.payload = data.slice(pos,pos+node.arraySplt);
                         if (node.arraySplt === 1) {
@@ -146,15 +185,18 @@ module.exports = function(RED) {
                         }
                         msg.parts.index = i;
                         pos += node.arraySplt;
+                        msg._msgid = RED.util.generateId();
+                        corrIds.push(msg._msgid);
                         send(RED.util.cloneMessage(msg));
                     }
-                    done();
+                    swapIdThenDone({done,msg,msgid:origMsgid}, corrIds);
                 }
                 else if ((typeof msg.payload === "object") && !Buffer.isBuffer(msg.payload)) {
                     var j = 0;
                     var l = Object.keys(msg.payload).length;
                     var pay = msg.payload;
                     msg.parts.type = "object";
+                    const corrIds = [];
                     for (var p in pay) {
                         if (pay.hasOwnProperty(p)) {
                             msg.payload = pay[p];
@@ -164,17 +206,20 @@ module.exports = function(RED) {
                             msg.parts.key = p;
                             msg.parts.index = j;
                             msg.parts.count = l;
+                            msg._msgid = RED.util.generateId();
+                            corrIds.push(msg._msgid);
                             send(RED.util.cloneMessage(msg));
                             j += 1;
                         }
                     }
-                    done();
+                    swapIdThenDone({done,msg,msgid:origMsgid}, corrIds);
                 }
                 else if (Buffer.isBuffer(msg.payload)) {
                     var len = node.buffer.length + msg.payload.length;
                     var buff = Buffer.concat([node.buffer, msg.payload], len);
                     msg.parts.type = "buffer";
                     if (node.spltType === "len") {
+                        const corrIds = [];
                         var count = buff.length/node.splt;
                         if (Math.floor(count) !== count) {
                             count = Math.ceil(count);
@@ -189,26 +234,31 @@ module.exports = function(RED) {
                             msg.payload = buff.slice(pos,pos+node.splt);
                             msg.parts.index = node.c++;
                             pos += node.splt;
+                            msg._msgid = RED.util.generateId();
+                            corrIds.push(msg._msgid);
                             send(RED.util.cloneMessage(msg));
                         }
                         if (count > 1) {
-                            node.pendingDones.forEach(d => d());
+                            node.pendingDones.forEach(msgInfo => swapIdThenDone(msgInfo, [corrIds[0]]));
                             node.pendingDones = [];
                         }
                         node.buffer = buff.slice(pos);
                         if ((node.stream !== true) || (node.buffer.length === node.splt)) {
                             msg.payload = node.buffer;
                             msg.parts.index = node.c++;
+                            msg._msgid = RED.util.generateId();
+                            corrIds.push(msg._msgid);
                             send(RED.util.cloneMessage(msg));
-                            node.pendingDones.forEach(d => d());
+                            node.pendingDones.push({done,msg,msgid:origMsgid});
+                            node.pendingDones.forEach(msgInfo => swapIdThenDone(msgInfo, corrIds));
                             node.pendingDones = [];
-                            done();
                             node.buffer = Buffer.from([]);
                         } else {
-                            node.pendingDones.push(done);
+                            node.pendingDones.push({done,msg,msgid:origMsgid,corrMsgids:corrIds});
                         }
                     }
                     else {
+                        const corrIds = [];
                         var count = 0;
                         if (node.spltType === "bin") {
                             msg.parts.ch = node.spltBuffer;
@@ -232,33 +282,37 @@ module.exports = function(RED) {
                         while (pos > -1) {
                             msg.payload = buff.slice(p,pos);
                             msg.parts.index = node.c++;
+                            msg._msgid = RED.util.generateId();
+                            corrIds.push(msg._msgid);
                             send(RED.util.cloneMessage(msg));
                             i++;
                             p = pos+node.splt.length;
                             pos = buff.indexOf(node.splt,p);
                         }
                         if (count > 1) {
-                            node.pendingDones.forEach(d => d());
+                            node.pendingDones.forEach(msgInfo => swapIdThenDone(msgInfo, [corrIds[0]]));
                             node.pendingDones = [];
                         }
                         if ((node.stream !== true) && (p < buff.length)) {
                             msg.payload = buff.slice(p,buff.length);
                             msg.parts.index = node.c++;
                             msg.parts.count = node.c++;
+                            msg._msgid = RED.util.generateId();
+                            corrIds.push(msg._msgid);
                             send(RED.util.cloneMessage(msg));
-                            node.pendingDones.forEach(d => d());
+                            node.pendingDones.forEach(msgInfo => swapIdThenDone(msgInfo, corrIds));
                             node.pendingDones = [];
                         }
                         else {
                             node.buffer = buff.slice(p,buff.length);
-                            node.pendingDones.push(done);
+                            node.pendingDones.push({done,msg,msgid:origMsgid,corrMsgids:corrIds});
                         }
                         if (node.buffer.length == 0) {
-                            done();
+                            swapIdThenDone({done,msg,msgid:origMsgid},corrIds);
                         }
                     }
                 } else { // otherwise drop the message.
-                    done();
+                    swapIdThenDone({done,msg,msgid:origMsgid});
                 }
             }
         });
@@ -304,7 +358,7 @@ module.exports = function(RED) {
         exp.assign("A", accumulator);
         RED.util.evaluateJSONataExpression(exp, msgInfo.msg, (err,result) => {
             if (err) {
-                return done(err);
+                return done(err, null);
             }
             if (msgInfos.length === 0) {
                 if (fixup) {
@@ -312,14 +366,16 @@ module.exports = function(RED) {
                     fixup.assign("A", result);
                     RED.util.evaluateJSONataExpression(fixup, {}, (err, result) => {
                         if (err) {
-                            return done(err);
+                            return done(err, null);
                         }
-                        msgInfo.send({payload: result});
-                        done();
+                        const _msgid = RED.util.generateId()
+                        msgInfo.send({payload: result, _msgid});
+                        done(null, _msgid);
                     });
                 } else {
-                    msgInfo.send({payload: result});
-                    done();
+                    const _msgid = RED.util.generateId()
+                    msgInfo.send({payload: result, _msgid});
+                    done(null, _msgid);
                 }
             } else {
                 reduceMessageGroup(node,msgInfos,exp,fixup,count,result,done);
@@ -350,7 +406,9 @@ module.exports = function(RED) {
                         done(err);
                         return;
                     } else {
-                        preservedMsgInfos.forEach(mInfo => mInfo.done());
+                        const corrIds = [];
+                        preservedMsgInfos.forEach(mInfo => { corrIds.push(mInfo.msg._msgid); mInfo.done()});
+                        if (corrIds.length > 0) { node.metric("correlate", {_msgid:result}, {join: corrIds}); }
                         done();
                     }
                 })
@@ -529,6 +587,7 @@ module.exports = function(RED) {
             group.send(RED.util.cloneMessage(group.msg));
             group.dones.forEach(f => f());
             group.dones = [];
+            node.metric("correlate",group.msg,{join: group.corrIds});
         }
 
         var pendingMessages = [];
@@ -675,7 +734,8 @@ module.exports = function(RED) {
                             type:"object",
                             msg:RED.util.cloneMessage(msg),
                             send: send,
-                            dones: []
+                            dones: [],
+                            corrIds: []
                         };
                     }
                     else {
@@ -686,7 +746,8 @@ module.exports = function(RED) {
                             type:payloadType,
                             msg:RED.util.cloneMessage(msg),
                             send: send,
-                            dones: []
+                            dones: [],
+                            corrIds: []
                         };
                         if (payloadType === 'string') {
                             inflight[partId].joinChar = joinChar;
@@ -704,6 +765,7 @@ module.exports = function(RED) {
                     }
                 }
                 inflight[partId].dones.push(done);
+                inflight[partId].corrIds.push(msg._msgid);
 
                 var group = inflight[partId];
                 if (payloadType === 'buffer') {

--- a/test/nodes/core/sequence/17-split_spec.js
+++ b/test/nodes/core/sequence/17-split_spec.js
@@ -1893,11 +1893,11 @@ describe('JOIN node', function() {
             });
 
         }
-        it('should emit correlate log when message is splitted (string, mode=len)', function(done) {
+        it('should emit correlation log when message is splitted (string, mode=len)', function(done) {
             // "abcdefg" -> "ab", "cd", "ef", "g":  "abcdefg" - ["ab","cd","ef","g"]
             nonStreamSplit(done, "abcdefg", {splt:2, spltType:"len"});
         });
-        it('should emit correlate logs when messages are splitted/joined (string, mode=len, stream)', function(done) {
+        it('should emit correlation logs when messages are splitted/joined (string, mode=len, stream)', function(done) {
             // "a","b","c","d" -> "ab","cd": "a" - ["ab"], "b" - ["ab"], "c" - ["cd"], "d" - ["cd"]
             const flow = [{ id: "n1", type: "split", splt: 2, spltType: "len", stream: true, wires: [["n2"]]},
                           { id: "n2", type: "helper"}]; 
@@ -1928,11 +1928,11 @@ describe('JOIN node', function() {
                 }, 20);
             });
         });
-        it('should emit correlate logs when message are splitted (string, mode=str)', function (done) {
+        it('should emit a correlation logs when message are splitted (string, mode=str)', function (done) {
             // "a-b-c-d" -> "a","b","c","d": "a-b-c-d": ["a","b","c","d"]
             nonStreamSplit(done, "a-b-c-d", {splt:"-", spliType:"str"});
         });
-        it('should emit correlate logs when messages are splitted/joined (string, mode=str, stream)', function(done) {
+        it('should emit correlation logs when messages are splitted/joined (string, mode=str, stream)', function(done) {
             // "a","b-c","-" -> "ab","c": "a" - ["ab"], "b-c" - ["ab","c"], "-" - ["c"]
             const flow = [{ id: "n1", type: "split", splt: "-", spltType: "str", stream: true, wires: [["n2"]]},
                           { id: "n2", type: "helper"}]; 
@@ -1961,19 +1961,19 @@ describe('JOIN node', function() {
                 }, 20);
             });
         });
-        it('should emit correlate log when a message is splitted (array)', function(done) {
+        it('should emit a correlation log when a message is splitted (array)', function(done) {
             // "[1,2,3]" -> "1","2","3": "[1,2,3]" - ["1","2","3"]
             nonStreamSplit(done, [1,2,3], {arraySplt:1, arraySpltType:"len"});
         });
-        it('should emit correlate log when a message is splitted (object)', function(done) {
+        it('should emit a correlation log when a message is splitted (object)', function(done) {
             // "{a:1,b:2,c:3}" -> "1","2","3": "{a:1,b:2,c:3}" - ["1","2","3"]
             nonStreamSplit(done, {a:1,b:2,c:3}, {});
         });
-        it('should emit correlate log when a message is splitted (buffer, mode=len)', function(done) {
+        it('should emit a correlation log when a message is splitted (buffer, mode=len)', function(done) {
             // Buffer([1,2,3]) -> Buffer([1]),Buffer([2]),Buffer([3])
             nonStreamSplit(done, Buffer.from([1,2,3]), {splt:1, spltType: "len"});
         });
-        it('should emit correlate logs when messages are splitted/joined (buffer, mode=len, stream)', function(done) {
+        it('should emit correlation logs when messages are splitted/joined (buffer, mode=len, stream)', function(done) {
             // Buffer([1,2,3]),Buffer([4,5,6]) -> Buffer([1,2]),Buffer([3,4]),Buffer([5,6]):
             // [1,2,3] -> [1,2],[3,4], [4,5,6]->[3,4],[5,6]
             const flow = [{ id: "n1", type: "split", splt: 2, spltType: "len", stream: true, wires: [["n2"]]},
@@ -2001,11 +2001,11 @@ describe('JOIN node', function() {
                 }, 20);
             });
         });
-        it('should emit correlate log when a message is splitted (buffer, mode=bin)', function(done) {
+        it('should emit a correlation log when a message is splitted (buffer, mode=bin)', function(done) {
             // Buffer([1,2,3]) -> Buffer([1]),Buffer([2]),Buffer([3])
             nonStreamSplit(done, Buffer.from([1,2,3]), {splt:"[2]", spltType: "bin"});
         });
-        it('should emit correlate logs when messages are splitted/joined (buffer, mode=bin, stream)', function(done) {
+        it('should emit correlation logs when messages are splitted/joined (buffer, mode=bin, stream)', function(done) {
             // Buffer([1]),Buffer([1,2,3]),Buffer([2]) -> Buffer([1,1]),Buffer([3]):
             // [1] - [1,2], [1,2,3] - [1,1],[3], [2] -> [3] 
             const flow = [{ id: "n1", type: "split", splt: "[2]", spltType: "bin", stream: true, wires: [["n2"]]},
@@ -2037,7 +2037,7 @@ describe('JOIN node', function() {
         });
     });
     describe('Correlation log (JOIN node)', function() {
-        it('should emit correlate log when messages are joined (automatic)', function(done) {
+        it('should a emit correlation log when messages are joined (automatic)', function(done) {
             const flow = [ { id: "n1", type: "join", mode: "auto"}];
             helper.load(joinNode, flow, function() {
                 const n1 = helper.getNode("n1");
@@ -2057,7 +2057,7 @@ describe('JOIN node', function() {
                 }, 20);
             })
         });
-        it('should emit correlate log when messages are joined (reduce)', function(done) {
+        it('should emit a correlation log when messages are joined (reduce)', function(done) {
             const flow = [ { id: "n1", type: "join", mode: "reduce",
                              reduceRight:false, reduceExp: "$A+payload", reduceInit: "0",
                              reduceInitType: "num", reduceFixup: "$A/$N" }];


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

For precise tracing for nodes which splitting or joining the messages, these nodes should emit a correlation log to provide information of which message is depend on another message.
This PR add a new `correlate` metric event to Join/Split node.

For detailed information, see [design note](https://github.com/node-red/designs/blob/c6687c8ab5d04e6c6eaafee23910b8cda82fecf1/designs/message-trace/README.md) (not yet merged).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
