### PR TITLE
Class per updatable node, allowing filtering

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -681,7 +681,7 @@ RED.palette.editor = (function() {
                     var setCount = $('<span>').appendTo(setButton);
                     var buttonGroup = $('<div>',{class:"red-ui-palette-module-button-group"}).appendTo(buttonRow);
 
-                    var updateButton = $('<a href="#" class="red-ui-button red-ui-button-small"></a>').text(RED._('palette.editor.update')).appendTo(buttonGroup);
+                    var updateButton = $('<a href="#" class="red-ui-button red-ui-button-small red-update'+entry.name.replace(/@|\/|^/g,'-')+'"></a>').text(RED._('palette.editor.update')).appendTo(buttonGroup);
                     updateButton.attr('id','up_'+Math.floor(Math.random()*1000000000));
                     updateButton.on("click", function(evt) {
                         evt.preventDefault();


### PR DESCRIPTION

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
See also https://github.com/victronenergy/node-red-contrib-victron/issues/87, where we would like to be able to lock a module to a specific version. This patch allow to do this, by hiding the update button for the package on the Venus OS. Reason is that the module for Venus OS resides on a read-only filesystem, where an update always fails.

This patch adds an extra class to each updatable package (in our case `red-update-victronenergy-node-red-client-victron`) and allows to set a `display: none` for this class in the css file. This also works for nodes that don't have the @-sign and don't reside in directories.

See https://discourse.nodered.org/t/adding-extra-modules-specific-class-to-update-button/50276 for the (not so busy) discourse discussion.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
