### PR TITLE
Fixes to fs promises so that an electron built version runs

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/library.js
+++ b/packages/node_modules/@node-red/registry/lib/library.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-var fs = require('fs-extra');
+var fs = require('fs');
 var fspath = require('path');
 
 var runtime;
@@ -25,7 +25,7 @@ var exampleFlows = null;
 async function getFlowsFromPath(path) {
     var result = {};
     var validFiles = [];
-    return fs.readdir(path).then(files => {
+    return fs.promises.readdir(path).then(files => {
         var promises = [];
         if (files) {
             files.forEach(function(file) {

--- a/packages/node_modules/@node-red/util/lib/i18n.js
+++ b/packages/node_modules/@node-red/util/lib/i18n.js
@@ -50,7 +50,7 @@ async function registerMessageCatalog(namespace,dir,file) {
     return initPromise.then(function() {
         return new Promise((resolve,reject) => {
             resourceMap[namespace] = { basedir:dir, file:file, lngs: []};
-            fs.promises.readdir(dir,function(err, files) {
+            fs.readdir(dir,function(err, files) {
                 if (err) {
                     resolve();
                 } else {

--- a/packages/node_modules/@node-red/util/lib/i18n.js
+++ b/packages/node_modules/@node-red/util/lib/i18n.js
@@ -23,7 +23,7 @@
 var i18n = require("i18next");
 
 var path = require("path");
-var fs = require("fs-extra");
+var fs = require("fs");
 
 var defaultLang = "en-US";
 
@@ -50,7 +50,7 @@ async function registerMessageCatalog(namespace,dir,file) {
     return initPromise.then(function() {
         return new Promise((resolve,reject) => {
             resourceMap[namespace] = { basedir:dir, file:file, lngs: []};
-            fs.readdir(dir,function(err, files) {
+            fs.promises.readdir(dir,function(err, files) {
                 if (err) {
                     resolve();
                 } else {
@@ -89,7 +89,7 @@ async function readFile(lng, ns) {
         return resourceCache[ns][lng];
     } else if (resourceMap[ns]) {
         const file = path.join(resourceMap[ns].basedir, lng, resourceMap[ns].file);
-        const content = await fs.readFile(file, "utf8");
+        const content = await fs.promises.readFile(file, "utf8");
         resourceCache[ns] = resourceCache[ns] || {};
         resourceCache[ns][lng] = JSON.parse(content.replace(/^\uFEFF/, ''));
         var baseLng = lng.split('-')[0];


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This replaces fs-extra with fs and uses the fs.promises versions for the async calls
This fixes the issue that causes electron to fail to run complaining about Unhandled promise rejection. 

In draft as tests now fail... need to discuss if it's the tests that need fixing or the code...

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
