### PR TITLE
Allow colouring of tab icon svg

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -24,7 +24,10 @@ var defaultContext = {
     page: {
         title: "Node-RED",
         favicon: "favicon.ico",
-        tabicon: "red/images/node-red-icon-black.svg"
+        tabicon: {
+            icon: "red/images/node-red-icon-black.svg",
+            colour: "#8f0000"
+        }
     },
     header: {
         title: "Node-RED",
@@ -123,9 +126,13 @@ module.exports = {
             }
 
             if (theme.page.tabicon) {
-                url = serveFile(themeApp,"/tabicon/",theme.page.tabicon)
+                let icon = theme.page.tabicon.icon || theme.page.tabicon
+                url = serveFile(themeApp,"/tabicon/", icon)
                 if (url) {
-                    themeContext.page.tabicon = url;
+                    themeContext.page.tabicon.icon = url;
+                }
+                if (theme.page.tabicon.colour) {
+                    themeContext.page.tabicon.colour = theme.page.tabicon.colour
                 }
             }
 

--- a/packages/node_modules/@node-red/editor-client/templates/index.mst
+++ b/packages/node_modules/@node-red/editor-client/templates/index.mst
@@ -23,7 +23,7 @@
 -->
 <title>{{ page.title }}</title>
 <link rel="icon" type="image/png" href="{{ page.favicon }}">
-<link rel="mask-icon" href="{{ page.tabicon }}" color="#8f0000">
+<link rel="mask-icon" href="{{ page.tabicon.icon }}" color="{{ page.tabicon.colour }}">
 <link rel="stylesheet" href="vendor/jquery/css/base/jquery-ui.min.css">
 <link rel="stylesheet" href="vendor/font-awesome/css/font-awesome.min.css">
 <link rel="stylesheet" href="red/style.min.css">

--- a/test/unit/@node-red/editor-api/lib/editor/theme_spec.js
+++ b/test/unit/@node-red/editor-api/lib/editor/theme_spec.js
@@ -41,7 +41,9 @@ describe("api/editor/theme", function () {
         context.should.have.a.property("page");
         context.page.should.have.a.property("title", "Node-RED");
         context.page.should.have.a.property("favicon", "favicon.ico");
-        context.page.should.have.a.property("tabicon", "red/images/node-red-icon-black.svg");
+        context.page.should.have.a.property("tabicon");
+        context.page.tabicon.should.have.a.property("icon", "red/images/node-red-icon-black.svg");
+        context.page.tabicon.should.have.a.property("colour", "#8f0000");
         context.should.have.a.property("header");
         context.header.should.have.a.property("title", "Node-RED");
         context.header.should.have.a.property("image", "red/images/node-red.svg");
@@ -58,7 +60,10 @@ describe("api/editor/theme", function () {
                 page: {
                     title: "Test Page Title",
                     favicon: "/absolute/path/to/theme/favicon",
-                    tabicon: "/absolute/path/to/theme/tabicon",
+                    tabicon: {
+                        icon: "/absolute/path/to/theme/tabicon",
+                        colour: "#8f008f"
+                    },
                     css: "/absolute/path/to/custom/css/file.css",
                     scripts: "/absolute/path/to/script.js"
                 },
@@ -108,7 +113,9 @@ describe("api/editor/theme", function () {
         context.should.have.a.property("page");
         context.page.should.have.a.property("title", "Test Page Title");
         context.page.should.have.a.property("favicon", "theme/favicon/favicon");
-        context.page.should.have.a.property("tabicon", "theme/tabicon/tabicon");
+        context.page.should.have.a.property("tabicon")
+        context.page.tabicon.should.have.a.property("icon", "theme/tabicon/tabicon");
+        context.page.tabicon.should.have.a.property("colour", "#8f008f")
         context.should.have.a.property("header");
         context.header.should.have.a.property("title", "Test Header Title");
         context.header.should.have.a.property("url", "http://nodered.org");
@@ -140,6 +147,27 @@ describe("api/editor/theme", function () {
         settings.palette.should.have.a.property("theme", [{ category: ".*", type: ".*", color: "#f0f" }]);
         settings.should.have.a.property("projects");
         settings.projects.should.have.a.property("enabled", false);
+    });
+
+    it("picks up backwards compatible tabicon setting", async function () {
+        theme.init({
+            editorTheme: {
+                page: {
+                    tabicon: "/absolute/path/to/theme/tabicon",
+                }
+            }
+        });
+
+        theme.app();
+
+        var context = await theme.context();
+        context.should.have.a.property("page");
+        context.page.should.have.a.property("tabicon");
+        context.page.tabicon.should.have.a.property("icon", "theme/tabicon/tabicon");
+        // The colour property should remain as default in this case as the
+        // legacy format for defining tabicon doesn't allow specifying a colour
+        context.page.tabicon.should.have.a.property("colour", "#8f0000");
+
     });
 
     it("test explicit userMenu set to true in theme setting", function () {


### PR DESCRIPTION


<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
<!-- Describe the nature of this change. What problem does it address? -->

I came across an issue where it was possible to change the browser tab icon on safari, but not the colour used to render the svg.

I've therefore made a very small enhancement which allows you to adjust this in the `settings.js`.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
