### PR TITLE
Add allowUpdate feature to externalModules.palette

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -333,10 +333,8 @@ RED.palette.editor = (function() {
                 nodeEntry.versionSpan.html(moduleInfo.version+' <i class="fa fa-long-arrow-right"></i> '+moduleInfo.pending_version).appendTo(nodeEntry.metaRow)
                 nodeEntry.updateButton.text(RED._('palette.editor.updated')).addClass('disabled').css('display', 'inline-block');
             } else if (loadedIndex.hasOwnProperty(module)) {
-                if (updateAllowed
-                    &&
-                    semVerCompare(loadedIndex[module].version,moduleInfo.version) > 0
-                    &&
+                if (updateAllowed &&
+                    semVerCompare(loadedIndex[module].version,moduleInfo.version) > 0 &&
                     RED.utils.checkModuleAllowed(module,null,updateAllowList,updateDenyList)
                 ) {
                     nodeEntry.updateButton.show();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -333,7 +333,12 @@ RED.palette.editor = (function() {
                 nodeEntry.versionSpan.html(moduleInfo.version+' <i class="fa fa-long-arrow-right"></i> '+moduleInfo.pending_version).appendTo(nodeEntry.metaRow)
                 nodeEntry.updateButton.text(RED._('palette.editor.updated')).addClass('disabled').css('display', 'inline-block');
             } else if (loadedIndex.hasOwnProperty(module)) {
-                if (semVerCompare(loadedIndex[module].version,moduleInfo.version) > 0) {
+                if (updateAllowed
+                    &&
+                    semVerCompare(loadedIndex[module].version,moduleInfo.version) > 0
+                    &&
+                    RED.utils.checkModuleAllowed(module,null,updateAllowList,updateDenyList)
+                ) {
                     nodeEntry.updateButton.show();
                     nodeEntry.updateButton.text(RED._('palette.editor.update',{version:loadedIndex[module].version}));
                 } else {
@@ -484,6 +489,9 @@ RED.palette.editor = (function() {
 
     var installAllowList = ['*'];
     var installDenyList = [];
+    var updateAllowed = true;
+    var updateAllowList = ['*'];
+    var updateDenyList = [];
 
     function init() {
         if (RED.settings.get('externalModules.palette.allowInstall', true) === false) {
@@ -497,6 +505,17 @@ RED.palette.editor = (function() {
         }
         installAllowList = RED.utils.parseModuleList(installAllowList);
         installDenyList = RED.utils.parseModuleList(installDenyList);
+
+        var settingsUpdateAllowList = RED.settings.get("externalModules.palette.allowUpdateList")
+        var settingsUpdateDenyList = RED.settings.get("externalModules.palette.denyUpdateList")
+        if (settingsUpdateAllowList || settingsUpdateDenyList) {
+            updateAllowList = settingsUpdateAllowList;
+            updateDenyList = settingsUpdateDenyList;
+        }
+        updateAllowList = RED.utils.parseModuleList(updateAllowList);
+        updateDenyList = RED.utils.parseModuleList(updateDenyList);
+        updateAllowed = RED.settings.get("externalModules.palette.allowUpdate",true);
+
 
         createSettingsPane();
 

--- a/packages/node_modules/@node-red/registry/lib/installer.js
+++ b/packages/node_modules/@node-red/registry/lib/installer.js
@@ -40,15 +40,42 @@ let installDenyList = [];
 let installAllAllowed = true;
 let installVersionRestricted = false;
 
+let updateAllowed = true;
+let updateAllowList = ['*'];
+let updateDenyList = [];
+let updateAllAllowed = true;
+
 function init(_settings) {
     settings = _settings;
     // TODO: This is duplicated in localfilesystem.js
     //       Should it *all* be managed by util?
+
+    installAllowList = ['*'];
+    installDenyList = [];
+    installAllAllowed = true;
+    installVersionRestricted = false;
+
+    updateAllowed = true;
+    updateAllowList = ['*'];
+    updateDenyList = [];
+    updateAllAllowed = true;
+
     if (settings.externalModules && settings.externalModules.palette) {
+
         if (settings.externalModules.palette.allowList || settings.externalModules.palette.denyList) {
             installAllowList = settings.externalModules.palette.allowList;
             installDenyList = settings.externalModules.palette.denyList;
         }
+
+        if (settings.externalModules.palette.hasOwnProperty('allowUpdate')) {
+            updateAllowed = !!settings.externalModules.palette.allowUpdate;
+        }
+        if (settings.externalModules.palette.allowUpdateList || settings.externalModules.palette.denyUpdateList) {
+            updateAllowList = settings.externalModules.palette.allowUpdateList;
+            updateDenyList = settings.externalModules.palette.denyUpdateList;
+        }
+
+
     }
     installAllowList = registryUtil.parseModuleList(installAllowList);
     installDenyList = registryUtil.parseModuleList(installDenyList);
@@ -64,6 +91,10 @@ function init(_settings) {
 
         }
     }
+
+    updateAllowList = registryUtil.parseModuleList(updateAllowList);
+    updateDenyList = registryUtil.parseModuleList(updateDenyList);
+    updateAllAllowed = updateAllowed ? updateDenyList.length === 0 : false;
 }
 
 var activePromise = Promise.resolve();
@@ -161,6 +192,15 @@ async function installModule(module,version,url) {
             isUpgrade = false;
         }
 
+        if (isUpgrade && !updateAllAllowed) {
+            // Check this module is allowed to be upgraded...
+            if (!updateAllowed || !registryUtil.checkModuleAllowed(module,null,updateAllowList,updateDenyList)) {
+                const e = new Error("Update not allowed");
+                e.code = "update_not_allowed";
+                throw e;
+            }
+        }
+
         if (!isUpgrade) {
             log.info(log._("server.install.installing",{name: module,version: version||"latest"}));
         } else {
@@ -238,6 +278,7 @@ async function installModule(module,version,url) {
                     e = new Error("Module not found");
                     e.code = 404;
                 } else {
+                    console.log(err);
                     log.warn(log._("server.install.install-failed-long",{name:module}));
                     log.warn("------------------------------------------");
                     log.warn(output);

--- a/packages/node_modules/@node-red/registry/lib/installer.js
+++ b/packages/node_modules/@node-red/registry/lib/installer.js
@@ -278,7 +278,6 @@ async function installModule(module,version,url) {
                     e = new Error("Module not found");
                     e.code = 404;
                 } else {
-                    console.log(err);
                     log.warn(log._("server.install.install-failed-long",{name:module}));
                     log.warn("------------------------------------------");
                     log.warn(output);


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

As described in https://github.com/node-red/node-red/pull/3131 adds a new set of flags to `externalModules.palette` to allow finer control over what can be upgraded via the admin API and palette manager.

(renamed to `allowUpdate` from the original proposed `allowUpgrade`)

```
externalModules: {
    autoInstall: true/false,
    autoInstallRetry: 30,
    palette: {
        allowInstall: true/false,
        allowUpload: true/false,
        allowUpdate: true/false,  // NEW, default: true
        allowList: [],
        denyList: [],
        allowUpdateList: [],  // NEW, default: '*' (allow all)
        denyUpdateList: []   // NEW, default: null (do not deny any)
    }
}
```

Works in the same way as the install allow/deny lists. Blocks upgrades to denied modules on the admin api and hides the 'update' button in the palette manager.

### TODO:

 - [x] add unit tests.


<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
