### PR TITLE
Restore tab selection after merging conflicts

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
@@ -1376,7 +1376,7 @@ RED.diff = (function() {
 
     function mergeDiff(diff) {
         //console.log(diff);
-        var selected = RED.workspaces.active();
+        var selectedTab = RED.workspaces.active();
         var appliedDiff = applyDiff(diff);
 
         var newConfig = appliedDiff.config;
@@ -1427,7 +1427,7 @@ RED.diff = (function() {
         RED.view.redraw(true);
         RED.palette.refresh();
         RED.workspaces.refresh();
-        RED.workspaces.show(selected, true);
+        RED.workspaces.show(selectedTab, true);
         RED.sidebar.config.refresh();
     }
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
@@ -1376,6 +1376,7 @@ RED.diff = (function() {
 
     function mergeDiff(diff) {
         //console.log(diff);
+        var selected = RED.workspaces.active();
         var appliedDiff = applyDiff(diff);
 
         var newConfig = appliedDiff.config;
@@ -1426,6 +1427,7 @@ RED.diff = (function() {
         RED.view.redraw(true);
         RED.palette.refresh();
         RED.workspaces.refresh();
+        RED.workspaces.show(selected, true);
         RED.sidebar.config.refresh();
     }
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Restore tab selection when merging flows that have changed on the server. Right now the user will be send to the first tab.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
