### PR TITLE
Add option to deep-clone properties in Change node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/15-change.html
+++ b/packages/node_modules/@node-red/nodes/core/function/15-change.html
@@ -113,6 +113,37 @@
             var search = this._("change.action.search");
             var replace = this._("change.action.replace");
             var regex = this._("change.label.regex");
+            var deepCopyLabel = this._("change.label.deepCopy");
+
+            function createPropertyValue(row2_1,row2_2) {
+                var propValInput = $('<input/>',{class:"node-input-rule-property-value",type:"text"})
+                    .appendTo(row2_1)
+                    .typedInput({default:'str',types:['msg','flow','global','str','num','bool','json','bin','date','jsonata','env']});
+
+                var dcLabel = $('<label style="padding-left: 130px; display: flex; align-items: center "></label>').appendTo(row2_2);
+                var deepCopy = $('<input type="checkbox" class="node-input-rule-property-deepCopy" style="width: auto; margin: 0 6px 0 0">').appendTo(dcLabel)
+                $('<span>').text(deepCopyLabel).appendTo(dcLabel)
+
+                propValInput.on("change", function(evt,type,val) {
+                    row2_2.toggle(type === "msg" || type === "flow" || type === "global" || type === "env");
+                })
+                return [propValInput, deepCopy];
+            }
+            function createFromValue(row3_1) {
+                return $('<input/>',{class:"node-input-rule-property-search-value",type:"text"})
+                .appendTo(row3_1)
+                .typedInput({default:'str',types:['msg','flow','global','str','re','num','bool','env']});
+            }
+            function createToValue(row3_2) {
+                return $('<input/>',{class:"node-input-rule-property-replace-value",type:"text"})
+                .appendTo(row3_2)
+                .typedInput({default:'str',types:['msg','flow','global','str','num','bool','json','bin','env']});
+            }
+            function createMoveValue(row4) {
+                return $('<input/>',{class:"node-input-rule-property-move-value",type:"text"})
+                .appendTo(row4)
+                .typedInput({default:'msg',types:['msg','flow','global']});
+            }
 
             $('#node-input-rule-container').css('min-height','150px').css('min-width','450px').editableList({
                 addItem: function(container,i,opt) {
@@ -141,8 +172,8 @@
                     });
                     let fragment = document.createDocumentFragment();
                     var row1 = $('<div/>',{style:"display:flex; align-items: baseline"}).appendTo(fragment);
-                    var row2 = $('<div/>',{style:"display:flex;margin-top:8px; align-items: baseline"}).appendTo(fragment);
-                    var row3 = $('<div/>',{style:"margin-top:8px;align-items: baseline"}).appendTo(fragment);
+                    var row2 = $('<div/>',{style:"margin-top:8px;"}).appendTo(fragment);
+                    var row3 = $('<div/>',{style:"margin-top:8px;"}).appendTo(fragment);
                     var row4 = $('<div/>',{style:"display:flex;margin-top:8px;align-items: baseline"}).appendTo(fragment);
 
                     var selectField = $('<select/>',{class:"node-input-rule-type",style:"width:110px; margin-right:10px;"}).appendTo(row1);
@@ -155,47 +186,26 @@
                         .appendTo(row1)
                         .typedInput({types:['msg','flow','global']});
 
+                    var row2_1 = $('<div/>', {style:"display:flex;align-items: baseline"}).appendTo(row2);
                     $('<div/>',{style:"display:inline-block;text-align:right; width:120px; padding-right:10px; box-sizing:border-box;"})
                         .text(toValueLabel)
-                        .appendTo(row2);
+                        .appendTo(row2_1);
 
-                    function createPropertyValue() {
-                        return $('<input/>',{class:"node-input-rule-property-value",type:"text"})
-                        .appendTo(row2)
-                        .typedInput({default:'str',types:['msg','flow','global','str','num','bool','json','bin','date','jsonata','env']});
-                    }
+                    var row2_2 = $('<div/>', {style:"margin-top: 4px;"}).appendTo(row2);
 
                     var row3_1 = $('<div/>', {style:"display:flex;align-items: baseline"}).appendTo(row3);
                     $('<div/>',{style:"display:inline-block;text-align:right; width:120px; padding-right:10px; box-sizing:border-box;"})
                         .text(search)
                         .appendTo(row3_1);
 
-                    function createFromValue() {
-                        return $('<input/>',{class:"node-input-rule-property-search-value",type:"text"})
-                        .appendTo(row3_1)
-                        .typedInput({default:'str',types:['msg','flow','global','str','re','num','bool','env']});
-                    }
-
                     var row3_2 = $('<div/>',{style:"display:flex;margin-top:8px;align-items: baseline"}).appendTo(row3);
                     $('<div/>',{style:"display:inline-block;text-align:right; width:120px; padding-right:10px; box-sizing:border-box;"})
                         .text(replace)
                         .appendTo(row3_2);
 
-                    function createToValue() {
-                        return $('<input/>',{class:"node-input-rule-property-replace-value",type:"text"})
-                        .appendTo(row3_2)
-                        .typedInput({default:'str',types:['msg','flow','global','str','num','bool','json','bin','env']});
-                    }
-
                     $('<div/>',{style:"display:inline-block;text-align:right; width:120px; padding-right:10px; box-sizing:border-box;"})
                         .text(to)
                         .appendTo(row4);
-
-                    function createMoveValue() {
-                        return $('<input/>',{class:"node-input-rule-property-move-value",type:"text"})
-                        .appendTo(row4)
-                        .typedInput({default:'msg',types:['msg','flow','global']});
-                    }
 
                     let propertyValue = null;
                     let fromValue = null;
@@ -219,7 +229,9 @@
 
                         if (type == "set") {
                             if(!propertyValue) {
-                                propertyValue = createPropertyValue();
+                                var parts = createPropertyValue(row2_1, row2_2);
+                                propertyValue = parts[0];
+                                deepCopy = parts[1];
                             }
                             propertyValue.typedInput('show');
                             row2.show();
@@ -227,11 +239,11 @@
                             row4.hide();
                         } else if (type == "change") {
                             if(!fromValue) {
-                                fromValue = createFromValue();
+                                fromValue = createFromValue(row3_1);
                             }
                             fromValue.typedInput('show');
                             if(!toValue) {
-                                toValue = createToValue();
+                                toValue = createToValue(row3_2);
                             }
                             toValue.typedInput('show');
                             row2.hide();
@@ -243,7 +255,7 @@
                             row4.hide();
                         } else if (type == "move") {
                             if(!moveValue) {
-                                moveValue = createMoveValue();
+                                moveValue = createMoveValue(row4);
                             }
                             moveValue.typedInput('show');
                             row2.hide();
@@ -257,26 +269,29 @@
                     propertyName.typedInput('type',rule.pt);
                     if (rule.t == "set") {
                         if(!propertyValue) {
-                            propertyValue = createPropertyValue();
+                            var parts = createPropertyValue(row2_1, row2_2);
+                            propertyValue = parts[0];
+                            deepCopy = parts[1];
                         }
                         propertyValue.typedInput('value',rule.to);
                         propertyValue.typedInput('type',rule.tot);
+                        deepCopy.prop("checked", !!rule.dc);
                     }
                     if (rule.t == "move") {
                         if(!moveValue) {
-                            moveValue = createMoveValue();
+                            moveValue = createMoveValue(row4);
                         }
                         moveValue.typedInput('value',rule.to);
                         moveValue.typedInput('type',rule.tot);
                     }
                     if (rule.t == "change") {
                         if(!fromValue) {
-                            fromValue = createFromValue();
+                            fromValue = createFromValue(row3_1);
                         }
                         fromValue.typedInput('value',rule.from);
                         fromValue.typedInput('type',rule.fromt);
                         if (!toValue) {
-                            toValue = createToValue();
+                            toValue = createToValue(row3_2);
                         }
                         toValue.typedInput('value',rule.to);
                         toValue.typedInput('type',rule.tot);
@@ -332,6 +347,9 @@
                 if (type === "set") {
                     r.to = rule.find(".node-input-rule-property-value").typedInput('value');
                     r.tot = rule.find(".node-input-rule-property-value").typedInput('type');
+                    if (rule.find(".node-input-rule-property-deepCopy").prop("checked")) {
+                        r.dc = true;
+                    }
                 } else if (type === "move") {
                     r.to = rule.find(".node-input-rule-property-move-value").typedInput('value');
                     r.tot = rule.find(".node-input-rule-property-move-value").typedInput('type');

--- a/packages/node_modules/@node-red/nodes/core/function/15-change.html
+++ b/packages/node_modules/@node-red/nodes/core/function/15-change.html
@@ -109,6 +109,7 @@
             var del = this._("change.action.delete");
             var move = this._("change.action.move");
             var to = this._("change.action.to");
+            var toValueLabel = this._("change.action.toValue",to);
             var search = this._("change.action.search");
             var replace = this._("change.action.replace");
             var regex = this._("change.label.regex");
@@ -139,10 +140,10 @@
                         whiteSpace: 'nowrap'
                     });
                     let fragment = document.createDocumentFragment();
-                    var row1 = $('<div/>',{style:"display:flex;"}).appendTo(fragment);
-                    var row2 = $('<div/>',{style:"display:flex;margin-top:8px;"}).appendTo(fragment);
-                    var row3 = $('<div/>',{style:"margin-top:8px;"}).appendTo(fragment);
-                    var row4 = $('<div/>',{style:"display:flex;margin-top:8px;"}).appendTo(fragment);
+                    var row1 = $('<div/>',{style:"display:flex; align-items: baseline"}).appendTo(fragment);
+                    var row2 = $('<div/>',{style:"display:flex;margin-top:8px; align-items: baseline"}).appendTo(fragment);
+                    var row3 = $('<div/>',{style:"margin-top:8px;align-items: baseline"}).appendTo(fragment);
+                    var row4 = $('<div/>',{style:"display:flex;margin-top:8px;align-items: baseline"}).appendTo(fragment);
 
                     var selectField = $('<select/>',{class:"node-input-rule-type",style:"width:110px; margin-right:10px;"}).appendTo(row1);
                     var selectOptions = [{v:"set",l:set},{v:"change",l:change},{v:"delete",l:del},{v:"move",l:move}];
@@ -155,7 +156,7 @@
                         .typedInput({types:['msg','flow','global']});
 
                     $('<div/>',{style:"display:inline-block;text-align:right; width:120px; padding-right:10px; box-sizing:border-box;"})
-                        .text(to)
+                        .text(toValueLabel)
                         .appendTo(row2);
 
                     function createPropertyValue() {
@@ -164,7 +165,7 @@
                         .typedInput({default:'str',types:['msg','flow','global','str','num','bool','json','bin','date','jsonata','env']});
                     }
 
-                    var row3_1 = $('<div/>', {style:"display:flex;"}).appendTo(row3);
+                    var row3_1 = $('<div/>', {style:"display:flex;align-items: baseline"}).appendTo(row3);
                     $('<div/>',{style:"display:inline-block;text-align:right; width:120px; padding-right:10px; box-sizing:border-box;"})
                         .text(search)
                         .appendTo(row3_1);
@@ -175,7 +176,7 @@
                         .typedInput({default:'str',types:['msg','flow','global','str','re','num','bool','env']});
                     }
 
-                    var row3_2 = $('<div/>',{style:"display:flex;margin-top:8px;"}).appendTo(row3);
+                    var row3_2 = $('<div/>',{style:"display:flex;margin-top:8px;align-items: baseline"}).appendTo(row3);
                     $('<div/>',{style:"display:inline-block;text-align:right; width:120px; padding-right:10px; box-sizing:border-box;"})
                         .text(replace)
                         .appendTo(row3_2);

--- a/packages/node_modules/@node-red/nodes/core/function/15-change.js
+++ b/packages/node_modules/@node-red/nodes/core/function/15-change.js
@@ -206,6 +206,9 @@ module.exports = function(RED) {
                         node.error(err, msg);
                         return done(undefined,null);
                     } else {
+                        if (rule.dc) {
+                            value = RED.util.cloneMessage(value);
+                        }
                         getFromValue(msg,rule,(err,fromParts) => {
                             if (err) {
                                 node.error(err, msg);

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -712,6 +712,7 @@
             "change": "Change",
             "delete": "Delete",
             "move": "Move",
+            "toValue": "to the value",
             "to": "to",
             "search": "Search for",
             "replace": "Replace with"

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -705,7 +705,8 @@
             "delete": "delete __property__",
             "move": "move __property__",
             "changeCount": "change: __count__ rules",
-            "regex": "Use regular expressions"
+            "regex": "Use regular expressions",
+            "deepCopy": "Deep copy value"
         },
         "action": {
             "set": "Set",

--- a/test/nodes/core/function/15-change_spec.js
+++ b/test/nodes/core/function/15-change_spec.js
@@ -98,7 +98,7 @@ describe('change Node', function() {
     });
 
     describe('#set' , function() {
-        
+
         it('sets the value of the message property', function(done) {
             var flow = [{"id":"changeNode1","type":"change","action":"replace","property":"payload","from":"","to":"changed","reg":false,"name":"changeNode","wires":[["helperNode1"]]},
                         {id:"helperNode1", type:"helper", wires:[]}];
@@ -615,7 +615,6 @@ describe('change Node', function() {
 
         });
 
-
         it('changes the value using jsonata', function(done) {
             var flow = [{"id":"changeNode1","type":"change",rules:[{"t":"set","p":"payload","to":"$length(payload)","tot":"jsonata"}],"name":"changeNode","wires":[["helperNode1"]]},
                         {id:"helperNode1", type:"helper", wires:[]}];
@@ -847,7 +846,36 @@ describe('change Node', function() {
             });
         })
 
+        it('deep copies the property if selected', function(done) {
 
+            var flow = [{"id":"changeNode1","type":"change","rules":[{"t":"set","p":"payload","pt":"msg","to":"source","tot":"msg","dc":true}],"name":"changeNode","wires":[["helperNode1"]]},
+            {id:"helperNode1", type:"helper", wires:[]}];
+            helper.load(changeNode, flow, function() {
+                var changeNode1 = helper.getNode("changeNode1");
+                var helperNode1 = helper.getNode("helperNode1");
+                helperNode1.on("input", function(msg) {
+                    try {
+                        // Check payload has been set to a clone of original object
+                        // - the JSON should match
+                        JSON.stringify(msg.payload).should.equal(JSON.stringify(originalObject))
+                        // - but they must be different objects
+                        msg.payload.should.not.equal(originalObject);
+
+                        // Modify nested property of original object
+                        originalObject.a.c = 3;
+                        // Check that modification hasn't happened on cloned prop
+                        msg.payload.a.should.not.have.property('c');
+
+                        done();
+                    } catch(err) {
+                        done(err);
+                    }
+                });
+                var originalObject = { a: { b: 2 } }
+                changeNode1.receive({source:originalObject});
+            });
+
+        })
     });
     describe('#change', function() {
         it('changes the value of the message property', function(done) {


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

A common gotcha with the Change node is that when setting object properties it doesn't clone the value - so you end up with a reference to the original property. Any modifications to the 'new' property also applies to the original one. This happens with  both setting from a msg property and context property.

This PR adds an option to the 'set' action of the Change node to make a 'deep copy' of the value. 

The option is only shown for the 'set' rule when the 'source' is `msg` `flow` `global` or `env` - as those are the ones that can set a value that could be referenced elsewhere.

I have also changed the text of the `set` rule - where it used to just say `to` it now says `to the value` which hopefully helps make it clearer the 'direction' of the action.

![image](https://user-images.githubusercontent.com/51083/135421907-950bec0e-3c12-4a5a-acb4-fbad0ec898e7.png)

This will also help address #3144 

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
