### PR TITLE
Add paletteLabel to file nodes to make read/write more obvious

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.html
@@ -210,9 +210,10 @@
             if (this.overwriteFile === "delete") {
                 return this.name||this._("file.label.deletelabel",{file:this.filename});
             } else {
-                return this.name||this.filename||this._("file.label.filelabel");
+                return this.name||this.filename||this._("file.label.write");
             }
         },
+        paletteLabel: RED._("node-red:file.label.write"),
         labelStyle: function() {
             return this.name?"node_label_italic":"";
         },
@@ -290,8 +291,9 @@
         },
         icon: "file-in.svg",
         label: function() {
-            return this.name||this.filename||this._("file.label.filelabel");
+            return this.name||this.filename||this._("file.label.read");
         },
+        paletteLabel: RED._("node-red:file.label.read"),
         labelStyle: function() {
             return this.name?"node_label_italic":"";
         },

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -853,6 +853,8 @@
     },
     "file": {
         "label": {
+            "write": "write file",
+            "read": "read file",
             "filename": "Filename",
             "action": "Action",
             "addnewline": "Add newline (\\n) to each payload?",
@@ -860,7 +862,6 @@
             "outputas": "Output",
             "breakchunks": "Break into chunks",
             "breaklines": "Break into lines",
-            "filelabel": "file",
             "sendError": "Send message on error (legacy mode)",
             "encoding": "Encoding",
             "deletelabel": "delete __file__",


### PR DESCRIPTION
Changes the palette labels of the file nodes to `read file` and `write file` to make it clearer which is which.