### PR TITLE
Improve node install error reporting

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -545,7 +545,7 @@
             "nodeDisabled": "Node disabled:",
             "nodeDisabled_plural": "Nodes disabled:",
             "nodeUpgraded": "Node module __module__ upgraded to version __version__",
-            "unknownNodeRegistered": "Unrecognised node type registered: <ul><li>__type__</li></ul>"
+            "unknownNodeRegistered": "Error loading node: <ul><li>__type__<br>__error__</li></ul>"
         },
         "editor": {
             "title": "Manage palette",

--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -544,7 +544,8 @@
             "nodeEnabled_plural": "Nodes enabled:",
             "nodeDisabled": "Node disabled:",
             "nodeDisabled_plural": "Nodes disabled:",
-            "nodeUpgraded": "Node module __module__ upgraded to version __version__"
+            "nodeUpgraded": "Node module __module__ upgraded to version __version__",
+            "unknownNodeRegistered": "Unrecognised node type registered: <ul><li>__type__</li></ul>"
         },
         "editor": {
             "title": "Manage palette",

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -142,9 +142,12 @@ RED.nodes = (function() {
                 RED.events.emit("registry:node-set-disabled",ns);
             },
             registerNodeType: function(nt,def) {
-                nodeDefinitions[nt] = def;
-                def.type = nt;
                 if (nt.substring(0,8) != "subflow:") {
+                    if (!nodeSets[typeToId[nt]]) {
+                        var fullType = (RED._loadingModule?("["+RED._loadingModule+"] "):"")+nt
+                        RED.notify(RED._("palette.event.unknownNodeRegistered",{type:fullType}), "error");
+                        return;
+                    }
                     def.set = nodeSets[typeToId[nt]];
                     nodeSets[typeToId[nt]].added = true;
                     nodeSets[typeToId[nt]].enabled = true;
@@ -167,9 +170,13 @@ RED.nodes = (function() {
                         }
                         return result;
                     }
-
                     // TODO: too tightly coupled into palette UI
                 }
+
+                def.type = nt;
+                nodeDefinitions[nt] = def;
+
+
                 if (def.defaults) {
                     for (var d in def.defaults) {
                         if (def.defaults.hasOwnProperty(d)) {

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -144,8 +144,17 @@ RED.nodes = (function() {
             registerNodeType: function(nt,def) {
                 if (nt.substring(0,8) != "subflow:") {
                     if (!nodeSets[typeToId[nt]]) {
-                        var fullType = (RED._loadingModule?("["+RED._loadingModule+"] "):"")+nt
-                        RED.notify(RED._("palette.event.unknownNodeRegistered",{type:fullType}), "error");
+                        var error = "";
+                        var fullType = nt;
+                        if (RED._loadingModule) {
+                            fullType = "["+RED._loadingModule+"] "+nt;
+                            if (nodeSets[RED._loadingModule]) {
+                                error = nodeSets[RED._loadingModule].err || "";
+                            } else {
+                                error = "Unknown error";
+                            }
+                        }
+                        RED.notify(RED._("palette.event.unknownNodeRegistered",{type:fullType, error:error}), "error");
                         return;
                     }
                     def.set = nodeSets[typeToId[nt]];

--- a/packages/node_modules/@node-red/registry/lib/installer.js
+++ b/packages/node_modules/@node-red/registry/lib/installer.js
@@ -299,15 +299,28 @@ async function installModule(module,version,url) {
 
 function reportAddedModules(info) {
     if (info.nodes.length > 0) {
-        log.info(log._("server.added-types"));
+        const installedTypes = [];
+        const errorSets = [];
         for (var i=0;i<info.nodes.length;i++) {
-            for (var j=0;j<info.nodes[i].types.length;j++) {
-                log.info(" - "+
-                    (info.nodes[i].module?info.nodes[i].module+":":"")+
-                    info.nodes[i].types[j]+
-                    (info.nodes[i].err?" : "+info.nodes[i].err:"")
-                );
+            const typeCount = info.nodes[i].types.length;
+            if (typeCount > 0) {
+                for (var j=0;j<typeCount;j++) {
+                    installedTypes.push(" - "+
+                        (info.nodes[i].module?info.nodes[i].module+":":"")+
+                        info.nodes[i].types[j]+
+                        (info.nodes[i].err?" : "+info.nodes[i].err:"")
+                    );
+                }
+            } else if (info.nodes[i].err) {
+                errorSets.push(`[${info.nodes[i].id}] ${info.nodes[i].err}`)
             }
+        }
+        if (errorSets.length > 0) {
+            errorSets.forEach(l => log.warn(l))
+        }
+        if (installedTypes.length > 0) {
+            log.info(log._("server.added-types"));
+            installedTypes.forEach(l => log.info(l))
         }
     }
     return info;


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

Improves the error reporting if a 'bad' node module is installed. This is specifically if the module is installed via the Palette Manager, rather than just loaded at startup.

In this instance, 'bad' means the node's .js file throws an error whilst being required. If that error is thrown before any node types are registered, we would log the following:

```
    30 Sep 15:25:38 - [info] Installing module: broken-node, version: 1.0.0
    30 Sep 15:25:41 - [info] Installed module: broken-node
    30 Sep 15:25:41 - [info] Adding node types:
```

With this PR, we now log the following:

```
    30 Sep 15:25:38 - [info] Installing module: broken-node, version: 1.0.0
    30 Sep 15:25:41 - [info] Installed module: broken-node
    30 Sep 15:25:41 - [warn] [broken-node/index] Error: Bish bash bosh(line:3)
```

In this scenario, within the editor, no notification would appear after the install appears to complete. This is because the runtime side did not register any types. However the node's html would still get loaded and try to register its types. That would lead to an error because the those types aren't known.

We now display a notification for that scenario:


![image](https://user-images.githubusercontent.com/51083/135476528-1a65213f-bc80-4503-9c69-901f884dc982.png)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
