### PR TITLE
Do better remembering TypedInput values whilst switching types

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -428,6 +428,10 @@
 
             this.optionExpandButton = $('<button tabindex="0" class="red-ui-typedInput-option-expand" style="display:inline-block"></button>').appendTo(this.uiSelect);
             this.optionExpandButtonIcon = $('<i class="red-ui-typedInput-icon fa fa-ellipsis-h"></i>').appendTo(this.optionExpandButton);
+
+            // Used to remember selections per-type to restore them when switching between types
+            this.oldValues = {};
+
             this.type(this.options.default||this.typeList[0].value);
         }catch(err) {
             console.log(err.stack);
@@ -767,6 +771,24 @@
                 var that = this;
                 var opt = this.typeMap[type];
                 if (opt && this.propertyType !== type) {
+                    // If previousType is !null, then this is a change of the type, rather than the initialisation
+                    var previousType = this.typeMap[this.propertyType];
+                    var typeChanged = !!previousType;
+
+                    if (typeChanged) {
+                        if (previousType.options) {
+                            this.oldValues[previousType.value] = this.input.val();
+                        } else if (previousType.hasValue === false) {
+                            this.oldValues[previousType.value] = this.input.val();
+                        } else {
+                            this.oldValues["_"] = this.input.val();
+                        }
+                        if (opt.options || opt.hasValue === false) {
+                            this.input.val(this.oldValues.hasOwnProperty(opt.value)?this.oldValues[opt.value]:(opt.default||[]).join(","))
+                        } else {
+                            this.input.val(this.oldValues.hasOwnProperty("_")?this.oldValues["_"]:(opt.default||""))
+                        }
+                    }
                     this.propertyType = type;
                     if (this.typeField) {
                         this.typeField.val(type);
@@ -865,8 +887,10 @@
                                     // Check to see if value is a valid csv of
                                     // options.
                                     var currentValues = {};
+                                    var selected = [];
                                     currentVal.split(",").forEach(function(v) {
                                         if (v) {
+                                            selected.push(v);
                                             currentValues[v] = true;
                                         }
                                     });
@@ -875,9 +899,11 @@
                                         delete currentValues[op.value||op];
                                     }
                                     if (!$.isEmptyObject(currentValues)) {
+                                        selected = opt.default || [];
                                         // Invalid, set to default/empty
-                                        this.value((opt.default||[]).join(","));
+                                        this.value(selected.join(","));
                                     }
+                                    that._updateOptionSelectLabel(selected);
                                 }
                             } else {
                                 var selectedOption = this.optionValue||opt.options[0];
@@ -938,8 +964,6 @@
                             this.input.attr('type',this.defaultInputType)
                         }
                         if (opt.hasValue === false) {
-                            this.oldValue = this.input.val();
-                            this.input.val("");
                             this.elementDiv.hide();
                             this.valueLabelContainer.hide();
                         } else if (opt.valueLabel) {
@@ -952,10 +976,6 @@
                             this.elementDiv.hide();
                             opt.valueLabel.call(this,this.valueLabelContainer,this.input.val());
                         } else {
-                            if (this.oldValue !== undefined) {
-                                this.input.val(this.oldValue);
-                                delete this.oldValue;
-                            }
                             this.valueLabelContainer.hide();
                             this.elementDiv.show();
                         }

--- a/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
@@ -81,7 +81,8 @@
     z-index: 2000;
     a {
         padding: 6px 18px 6px 6px;
-        display: block;
+        display: flex;
+        align-items: center;
         border-bottom: 1px solid $secondary-border-color;
         color: $form-text-color;
         &:hover {
@@ -98,7 +99,7 @@
             background: $workspace-button-background-active;
         }
         input[type="checkbox"] {
-            margin-right: 6px;
+            margin: 0 6px 0 0;
         }
     }
     .red-ui-typedInput-icon {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

When you have a TypedInput with multiple types, we didn't do a good job of remembering previous values whilst switching types.

For example, if you had an input with two types:
1. 'none' with hasValue=false
2. 'select' with multiple options

Then if you picked the 'select' option and chose some options, then switched to 'none' and back to 'select' - all of your previous choices were cleared.

There were also issues with that combination with it not setting the 'select' label properly.

With this PR, the TypedInput now remembers the value when switching between types and restores the previous value when you go back to a previous type.... in some cases.

For this change, there are 3 'classes' of type to consider:
1. types with a value (where the user types in) - `str` `num` `msg` etc
2. types with no value (where the user has no options) - `date`
3. types with options (single or multi select) - `bool`

The TypedInput will now remember the previous value for each 'no value' (2)  and 'options' (3) types, but all 'value'(1) types are lumped together.

This also means when going from a multi-select to a `str` type, you don't get the comma-separated list of selected values in the input box.
