### PR TITLE
Allow a node to specify a filter for the config nodes it can pick from

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -242,7 +242,7 @@ RED.editor = (function() {
      * @param property - the name of the field
      * @param type - the type of the config-node
      */
-    function prepareConfigNodeSelect(node,property,type,prefix) {
+    function prepareConfigNodeSelect(node,property,type,prefix,filter) {
         var input = $("#"+prefix+"-"+property);
         if (input.length === 0 ) {
             return;
@@ -265,12 +265,12 @@ RED.editor = (function() {
         select.css({
             'flex-grow': 1
         });
-        updateConfigNodeSelect(property,type,node[property],prefix);
+        updateConfigNodeSelect(property,type,node[property],prefix,filter);
         $('<a id="'+prefix+'-lookup-'+property+'" class="red-ui-button"><i class="fa fa-pencil"></i></a>')
             .css({"margin-left":"10px"})
             .appendTo(outerWrap);
         $('#'+prefix+'-lookup-'+property).on("click", function(e) {
-            showEditConfigNodeDialog(property,type,select.find(":selected").val(),prefix);
+            showEditConfigNodeDialog(property,type,select.find(":selected").val(),prefix,node);
             e.preventDefault();
         });
         var label = "";
@@ -304,7 +304,7 @@ RED.editor = (function() {
         }
 
         button.on("click", function(e) {
-            showEditConfigNodeDialog(property,type,input.val()||"_ADD_",prefix);
+            showEditConfigNodeDialog(property,type,input.val()||"_ADD_",prefix,node);
             e.preventDefault();
         });
     }
@@ -476,7 +476,7 @@ RED.editor = (function() {
                                 if (configTypeDef.exclusive) {
                                     prepareConfigNodeButton(node,d,definition.defaults[d].type,prefix);
                                 } else {
-                                    prepareConfigNodeSelect(node,d,definition.defaults[d].type,prefix);
+                                    prepareConfigNodeSelect(node,d,definition.defaults[d].type,prefix,definition.defaults[d].filter);
                                 }
                             } else {
                                 console.log("Unknown type:", definition.defaults[d].type);
@@ -694,7 +694,7 @@ RED.editor = (function() {
         return 0;
     }
 
-    function updateConfigNodeSelect(name,type,value,prefix) {
+    function updateConfigNodeSelect(name,type,value,prefix,filter) {
         // if prefix is null, there is no config select to update
         if (prefix) {
             var button = $("#"+prefix+"-edit-"+name);
@@ -717,12 +717,16 @@ RED.editor = (function() {
                 }
 
                 var configNodes = [];
-
+                if (typeof filter !== 'function') {
+                    filter = null;
+                }
                 RED.nodes.eachConfig(function(config) {
                     if (config.type == type && (!config.z || config.z === activeWorkspace.id)) {
-                        var label = RED.utils.getNodeLabel(config,config.id);
-                        config.__label__ = label+(config.d?" ["+RED._("workspace.disabled")+"]":"");
-                        configNodes.push(config);
+                        if (!filter || filter.call(null,config)) {
+                            var label = RED.utils.getNodeLabel(config,config.id);
+                            config.__label__ = label+(config.d?" ["+RED._("workspace.disabled")+"]":"");
+                            configNodes.push(config);
+                        }
                     }
                 });
                 var configSortFn = defaultConfigNodeSort;
@@ -1038,8 +1042,9 @@ RED.editor = (function() {
      * type - type of config node
      * id - id of config node to edit. _ADD_ for a new one
      * prefix - the input prefix of the parent property
+     * editContext - the node that was being edited that triggered editing this node
      */
-    function showEditConfigNodeDialog(name,type,id,prefix) {
+    function showEditConfigNodeDialog(name,type,id,prefix,editContext) {
         if (buildingEditDialog) { return }
         buildingEditDialog = true;
         var adding = (id == "_ADD_");
@@ -1342,7 +1347,13 @@ RED.editor = (function() {
                         RED.events.emit("nodes:change",editing_config_node);
                     }
                     RED.tray.close(function() {
-                        updateConfigNodeSelect(configProperty,configType,editing_config_node.id,prefix);
+                        var filter = null;
+                        if (editContext && typeof editContext._def.defaults[configProperty].filter === 'function') {
+                            filter = function(n) {
+                                return editContext._def.defaults[configProperty].filter.call(editContext,n);
+                            }
+                        }
+                        updateConfigNodeSelect(configProperty,configType,editing_config_node.id,prefix,filter);
                     });
                 }
             }
@@ -1399,7 +1410,13 @@ RED.editor = (function() {
                     RED.view.redraw(true);
                     RED.history.push(historyEvent);
                     RED.tray.close(function() {
-                        updateConfigNodeSelect(configProperty,configType,"",prefix);
+                        var filter = null;
+                        if (editContext && typeof editContext._def.defaults[configProperty].filter === 'function') {
+                            filter = function(n) {
+                                return editContext._def.defaults[configProperty].filter.call(editContext,n);
+                            }
+                        }
+                        updateConfigNodeSelect(configProperty,configType,"",prefix,filter);
                     });
                 }
             });


### PR DESCRIPTION
- [X] New feature (non-breaking change which adds functionality)

When a node depends on a config node it does so by specifying the `type` property in its `defaults` object:

```
    broker: {type:"mqtt-broker", required:true},
```

There was a requirement raised some time ago to be able to provide a filter for what config nodes the user is able to pick from  - rather than listing all of them.

This PR adds support for that.

I will admit it is a bit of an edge case, but it is one that is hard to work around if we don't so something like this.

So, for example, if the select box should only show broker nodes configured to use port 1883:
```
    broker: {type:"mqtt-broker", required:true, filter: function(n) { return n.port == 1883 } },
```

The `filter` function is called for each config node of the given type. It should return `true` if the config node should be listed. Inside the function `this` is the node instance (ie the `mqtt-in` node that lists the broker nodes).

