### PR TITLE
Delay node: add option to send intermediate messages on separate output

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/jquery.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/jquery.scss
@@ -137,10 +137,10 @@
     padding: 0;
     border: 1px solid $form-input-border-color;
 }
-.ui-spinner input {
+.ui-spinner input[type=text] {
     background: $form-input-background;
     margin: 0 17px 0 0;
-    padding: 6px;
+    padding: 8px;
     border: none;
     border-top-right-radius: 0px;
     border-bottom-right-radius: 0px;

--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.html
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.html
@@ -78,11 +78,17 @@
               <option value="day" data-i18n="delay.label.units.day.singular"></option>
             </select>
         </div>
-        <div class="form-row" id="rate-override">
-            <label></label><input style="width:30px; vertical-align:baseline;" type="checkbox" id="node-input-allowrate"><label style="width: 250px;" for="node-input-allowrate" data-i18n="delay.allowrate"></label>
+        <div class="form-row" id="rate-override" style="display: flex; align-items: center">
+            <label></label><input style="width:30px; margin:0" type="checkbox" id="node-input-allowrate"><label style="margin:0;width: auto;" for="node-input-allowrate" data-i18n="delay.allowrate"></label>
         </div>
         <div class="form-row" id="rate-details-drop">
-            <label></label><input style="width:30px;; vertical-align:baseline;" type="checkbox" id="node-input-drop"><label style="width: 250px;" for="node-input-drop" data-i18n="delay.dropmsg"></label>
+            <input type="hidden" id="node-input-outputs" value="1">
+            <label></label>
+            <select id="node-input-drop-select" style="width: 70%">
+                <option id="node-input-drop-select-queue" value="queue" data-i18n="delay.queuemsg"></option>
+                <option value="drop" data-i18n="delay.dropmsg"></option>
+                <option value="emit" data-i18n="delay.sendmsg"></option>
+            </select>
         </div>
         <div class="form-row" id="rate-details-per-topic">
             <label></label>
@@ -114,7 +120,8 @@
             randomLast: {value:"5", required:true, validate:function(v) { return RED.validators.number(v) && (v >= 0); }},
             randomUnits: {value: "seconds"},
             drop: {value:false},
-            allowrate: {value:false}
+            allowrate: {value:false},
+            outputs: { value: 1},
         },
         inputs:1,
         outputs:1,
@@ -234,12 +241,23 @@
                 }
             }).trigger("change");
 
+            if (this.outputs === 2) {
+                $("#node-input-drop-select").val("emit");
+            } else if (this.drop) {
+                $("#node-input-drop-select").val("drop");
+            } else {
+                $("#node-input-drop-select").val("queue");
+            }
+
             $("#node-input-rate-type").on("change", function() {
                 if (this.value === "all") {
-                    $("#node-input-drop").attr('disabled',false).next().css("opacity",1)
                     $("#rate-details-per-topic").hide();
+                    $("#node-input-drop-select-queue").attr('disabled', false);
                 } else if (this.value === "topic") {
-                    $("#node-input-drop").prop('checked',true).attr('disabled',true).next().css("opacity",0.5)
+                    if ($("#node-input-drop-select").val() === "queue") {
+                        $("#node-input-drop-select").val("drop");
+                    }
+                    $("#node-input-drop-select-queue").attr('disabled', true);
                     $("#rate-details-per-topic").show();
                 }
             }).trigger("change");
@@ -248,6 +266,7 @@
             var action = $("#node-input-delay-action").val();
             if (action === "delay") {
                 this.pauseType = $("#node-input-delay-type").val();
+                $("#node-input-outputs").val(1);
             } else if (action === "rate") {
                 action = $("#node-input-rate-type").val();
                 if (action === "all") {
@@ -255,6 +274,9 @@
                 } else {
                     this.pauseType = $("#node-input-rate-topic-type").val();
                 }
+                var dropType = $("#node-input-drop-select").val();
+                this.drop = dropType !== "queue";
+                $("#node-input-outputs").val(dropType === "emit"?2:1);
             }
         }
     });

--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.js
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.js
@@ -95,6 +95,7 @@ module.exports = function(RED) {
         this.droppedMsgs = 0;
         this.allowrate = n.allowrate|| false;
         this.fixedrate = this.rate;
+        this.outputs = n.outputs;
         var node = this;
 
         function ourTimeout(handler, delay, clearHandler) {
@@ -324,6 +325,8 @@ module.exports = function(RED) {
                         else if ( ( (timeSinceLast[0] * SECONDS_TO_NANOS) + timeSinceLast[1] ) > (node.rate * MILLIS_TO_NANOS) ) {
                             node.lastSent = process.hrtime();
                             send(msg);
+                        } else if (node.outputs === 2) {
+                            send([null,msg])
                         }
                     }
                     done();

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -290,7 +290,9 @@
         "and": "&",
         "rate": "Rate",
         "msgper": "msg(s) per",
-        "dropmsg": "drop intermediate messages",
+        "queuemsg": "Queue intermediate messages",
+        "dropmsg": "Drop intermediate messages",
+        "sendmsg": "Send intermediate messages on 2nd output",
         "allowrate": "allow msg.rate (in ms) to override rate",
         "label": {
             "delay": "delay",


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)
## Proposed changes

Backlog item: https://trello.com/c/1jAoRESp

This changes the 'drop intermediate messages' checkbox of the Delay node (in rate limit mode) to a select box. The options are:

 - Queue intermediate messages - the default behaviour, equivalent to the old checkbox being unticked
 - Drop intermediate messages - equiv to the old checkbox being ticked
 - Send intermediate messages on 2nd output.

If this last option is selected, the node gains a 2nd output. Any message that would previously have been dropped will now get sent on that output.

This is useful for rate limiting flows that need to do some work with the 'reject' messages. For example, rate limiting an HTTP API, where the 'dropped' requests need to be responded to with a 503.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
