### PR TITLE
Add option to only send http response errors to Catch node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.html
@@ -87,6 +87,12 @@
     </div>
 
     <div class="form-row">
+        <input type="checkbox" id="node-input-senderr" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-senderr" style="width: auto" data-i18n="httpin.senderr"></label>
+    </div>
+
+
+    <div class="form-row">
         <label for="node-input-ret"><i class="fa fa-arrow-left"></i> <span data-i18n="httpin.label.return"></span></label>
         <select type="text" id="node-input-ret" style="width:70%;">
         <option value="txt" data-i18n="httpin.utf8"></option>
@@ -114,7 +120,8 @@
             tls: {type:"tls-config",required: false},
             persist: {value:false},
             proxy: {type:"http proxy",required: false},
-            authType: {value: ""}
+            authType: {value: ""},
+            senderr: {value: false}
         },
         credentials: {
             user: {type:"text"},

--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
@@ -72,6 +72,7 @@ in your Node-RED user directory (${RED.settings.userDir}).
         var paytoqs = false;
         var paytobody = false;
         var redirectList = [];
+        var sendErrorsToCatch = n.senderr;
 
         var nodeHTTPPersistent = n["persist"];
         if (n.tls) {
@@ -537,10 +538,16 @@ in your Node-RED user directory (${RED.settings.userDir}).
                 nodeSend(msg);
                 nodeDone();
             }).catch(err => {
-                if(err.code === 'ETIMEDOUT' || err.code === 'ESOCKETTIMEDOUT') {
+                // Pre 2.1, any errors would be sent to both Catch node and sent on as normal.
+                // This is not ideal but is the legacy behaviour of the node.
+                // 2.1 adds the 'senderr' option, if set to true, will *only* send errors
+                // to Catch nodes. If false, it still does both behaviours.
+                // TODO: 3.0 - make it one or the other.
+
+                if (err.code === 'ETIMEDOUT' || err.code === 'ESOCKETTIMEDOUT') {
                     node.error(RED._("common.notification.errors.no-response"), msg);
                     node.status({fill:"red", shape:"ring", text:"common.notification.errors.no-response"});
-                }else{
+                } else {
                     node.error(err,msg);
                     node.status({fill:"red", shape:"ring", text:err.code});
                 }
@@ -549,7 +556,9 @@ in your Node-RED user directory (${RED.settings.userDir}).
                 if (node.metric() && timingLog) {
                     emitTimingMetricLog(err.timings, msg);
                 }
-                nodeSend(msg);
+                if (!sendErrorsToCatch) {
+                    nodeSend(msg);
+                }
                 nodeDone();
             });
         });

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -486,6 +486,7 @@
         "proxy-config": "Proxy Configuration",
         "use-proxyauth": "Use proxy authentication",
         "noproxy-hosts": "Ignore hosts",
+        "senderr": "Only send non-2xx responses to Catch node",
         "utf8": "a UTF-8 string",
         "binary": "a binary buffer",
         "json": "a parsed JSON object",


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

The legacy behaviour of the HTTP Request node is, in the case of a non-2xx response, to both trigger any Catch nodes (`node.error(...)`) and send on the response (`node.send(...)`).

This double counting of the response isn't helpful, but is the long held behaviour of the node.

This PR adds an option to the HTTP Request node to send non-2xx responses *only* to the Catch node. Without that option selected, the legacy behaviour remains - the message is passed to both Catch and Send.

In 3.0 we should change the default to be Catch-only.