### PR TITLE
Render node documentation to node-red style guide when written in markdown.

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -84,15 +84,14 @@ RED.utils = (function() {
 
     //override list creation - add node-ports to order lists
     renderer.list = function (body, ordered, start) {
-        let temp = body;
-        if (enable && ordered) {
-            temp = `<ol class="node-ports">${body}</ol>`;
+        let addClass = /dl.*?class.*?message-properties.*/.test(body);
+        if (addClass && ordered) {
+            return '<ol class="node-ports">' + body + '</ol>';
         } else if (ordered) {
-            temp = `<ol>${body}</ol>`;
+            return '<ol>' + body + '</ol>';
         } else {
-            temp = `<ul>${body}</ul>`;
+            return '<ul>' + body + '</ul>'
         }
-        return temp;
     }
 
     window._marked.setOptions({

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -22,8 +22,82 @@ RED.utils = (function() {
         return renderMarkdown(txt);
     }
 
-    _marked.setOptions({
-        renderer: new _marked.Renderer(),
+    let enable = true;
+    const descriptionList = {
+        name: 'descriptionList',
+        level: 'block',                                     // Is this a block-level or inline-level tokenizer?
+        start(src) {
+            if (!src) return null
+            return src.match(/:[^:\n]/)?.index; // Hint to Marked.js to stop and check for a match
+        },
+        tokenizer(src, tokens) {
+            if (!src) return null;
+            const rule = /^(?::[^:\n]+:[^:\n]*(?:\n|$))+/;    // Regex for the complete token
+            const match = rule.exec(src);
+            if (match) {
+                return {                                        // Token to generate
+                    type: 'descriptionList',                      // Should match "name" above
+                    raw: match[0],                                // Text to consume from the source
+                    text: match[0].trim(),                        // Additional custom properties
+                    tokens: this.inlineTokens(match[0].trim())    // inlineTokens to process **bold**, *italics*, etc.
+                };
+            }
+        },
+        renderer(token) {
+            return `<dl class="message-properties">${this.parseInline(token.tokens)}\n</dl>`; // parseInline to turn child tokens into HTML
+        }
+    };
+
+    const description = {
+        name: 'description',
+        level: 'inline',           // Is this a block-level or inline-level tokenizer?
+        start(src) {
+            if (!enable) return null
+            src.match(/:/)?.index; // Hint to Marked.js to stop and check for a match
+        },
+        tokenizer(src, tokens) {
+            if (!enable) return null;
+            const rule = /^:([^:\n]+)\(([^:\n]+)\).*?:([^:\n]*)(?:\n|$)/;  // Regex for the complete token
+            const match = rule.exec(src);
+            if (match) {
+                return {                                       // Token to generate
+                    type: 'description',                       // Should match "name" above
+                    raw: match[0],                             // Text to consume from the source
+                    dt: this.inlineTokens(match[1].trim()),    // Additional custom properties
+                    types: this.inlineTokens(match[2].trim()),
+                    dd: this.inlineTokens(match[3].trim()),
+                };
+            }
+        },
+        renderer(token) {
+            return `\n<dt>${this.parseInline(token.dt)}<span class="property-type">${this.parseInline(token.types)}</span></dt><dd>${this.parseInline(token.dd)}</dd>`;
+        },
+        childTokens: ['dt', 'dd'],                 // Any child tokens to be visited by walkTokens
+        walkTokens(token) {                        // Post-processing on the completed token tree
+            if (token.type === 'strong') {
+                token.text += ' walked';
+            }
+        }
+    };
+
+
+    const renderer = new window._marked.Renderer();
+
+    //override list creation - add node-ports to order lists
+    renderer.list = function (body, ordered, start) {
+        let temp = body;
+        if (enable && ordered) {
+            temp = `<ol class="node-ports">${body}</ol>`;
+        } else if (ordered) {
+            temp = `<ol>${body}</ol>`;
+        } else {
+            temp = `<ul>${body}</ul>`;
+        }
+        return temp;
+    }
+
+    window._marked.setOptions({
+        renderer: renderer,
         gfm: true,
         tables: true,
         breaks: false,
@@ -31,6 +105,8 @@ RED.utils = (function() {
         smartLists: true,
         smartypants: false
     });
+
+    window._marked.use({extensions: [descriptionList, description] } );
 
     function renderMarkdown(txt) {
         var rendered = _marked(txt);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -26,11 +26,12 @@ RED.utils = (function() {
         name: 'descriptionList',
         level: 'block',                                     // Is this a block-level or inline-level tokenizer?
         start(src) {
-            if (!src) return null
-            return src.match(/:[^:\n]/)?.index; // Hint to Marked.js to stop and check for a match
+            if (!src) { return null; }
+            let m = src.match(/:[^:\n]/);
+            return m && m.index; // Hint to Marked.js to stop and check for a match
         },
         tokenizer(src, tokens) {
-            if (!src) return null;
+            if (!src) { return null; }
             const rule = /^(?::[^:\n]+:[^:\n]*(?:\n|$))+/;    // Regex for the complete token
             const match = rule.exec(src);
             if (match) {
@@ -51,11 +52,12 @@ RED.utils = (function() {
         name: 'description',
         level: 'inline',           // Is this a block-level or inline-level tokenizer?
         start(src) {
-            if (!src) return null
-            src.match(/:/)?.index; // Hint to Marked.js to stop and check for a match
+            if (!src) { return null; }
+            let m = src.match(/:/);
+            return m & m.index; // Hint to Marked.js to stop and check for a match
         },
         tokenizer(src, tokens) {
-            if (!src) return null;
+            if (!src) { return null; }
             const rule = /^:([^:\n]+)\(([^:\n]+)\).*?:([^:\n]*)(?:\n|$)/;  // Regex for the complete token
             const match = rule.exec(src);
             if (match) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -22,7 +22,6 @@ RED.utils = (function() {
         return renderMarkdown(txt);
     }
 
-    let enable = true;
     const descriptionList = {
         name: 'descriptionList',
         level: 'block',                                     // Is this a block-level or inline-level tokenizer?
@@ -52,11 +51,11 @@ RED.utils = (function() {
         name: 'description',
         level: 'inline',           // Is this a block-level or inline-level tokenizer?
         start(src) {
-            if (!enable) return null
+            if (!src) return null
             src.match(/:/)?.index; // Hint to Marked.js to stop and check for a match
         },
         tokenizer(src, tokens) {
-            if (!enable) return null;
+            if (!src) return null;
             const rule = /^:([^:\n]+)\(([^:\n]+)\).*?:([^:\n]*)(?:\n|$)/;  // Regex for the complete token
             const match = rule.exec(src);
             if (match) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -54,7 +54,7 @@ RED.utils = (function() {
         start(src) {
             if (!src) { return null; }
             let m = src.match(/:/);
-            return m & m.index; // Hint to Marked.js to stop and check for a match
+            return m && m.index;   // Hint to Marked.js to stop and check for a match
         },
         tokenizer(src, tokens) {
             if (!src) { return null; }

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-info.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-info.scss
@@ -212,6 +212,9 @@ div.red-ui-info-table {
                 border: none;
             }
         }
+        p {
+            display: inline;
+        }
     }
     .red-ui-help-info-header {
         i {

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-info.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-info.scss
@@ -233,7 +233,32 @@ div.red-ui-info-table {
             }
         }
     }
-
+    table {
+        border-collapse: collapse;
+        margin         : 8px 0 8px 0;
+        min-width      : 300px;
+        box-shadow     : 0 0 2px rgb(0 0 0 / 15%);
+        overflow       : hidden;
+        border-radius  : 4px;
+    }
+    table thead tr {
+        background-color: var(--red-ui-primary-text-color); //$primary-text-color;
+        color: var(--red-ui-primary-background); //$primary-background
+        text-align: left;
+    }
+    table th,
+    table td {
+        padding: 6px 8px;
+    }
+    table tbody tr {
+        border-bottom: 1px solid var(--red-ui-tertiary-background); //$tertiary-background
+    }
+    table tbody tr:nth-of-type(even) {
+        background-color: var(--red-ui-primary-background); //$primary-background;
+    }
+    table tbody tr:last-of-type {
+        border-bottom: 2px solid var(--red-ui-primary-text-color); //$primary-text-color;
+    }
 }
 .red-ui-sidebar-info-stack {
     height: 100%;


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

* Add a custom marked extension to convert markup from markdown text to generate HTML that adheres to the [Node help style guide](https://nodered.org/docs/creating-nodes/help-style-guide)
* markup kept simple to leave un-rendered markdown human readable

As discussed in the [design note](https://github.com/node-red/designs/discussions/60) and in forum [here](https://discourse.nodered.org/t/using-markdown-directly-to-document-the-nodes/49592/12?u=steve-mcl)

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
