### PR TITLE
Ensure tab state updates properly when toggling enable state

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1755,8 +1755,12 @@ RED.editor = (function() {
                             editState.changes.disabled = workspace.disabled;
                             editState.changed = true;
                             workspace.disabled = disabled;
-                        }
 
+                            $("#red-ui-tab-"+(workspace.id.replace(".","-"))).toggleClass('red-ui-workspace-disabled',!!workspace.disabled);
+                            if (workspace.id === RED.workspaces.active()) {
+                                $("#red-ui-workspace").toggleClass("red-ui-workspace-disabled",!!workspace.disabled);
+                            }
+                        }
 
                         if (editState.changed) {
                             var historyEvent = {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -450,7 +450,7 @@ RED.workspaces = (function() {
             var changes = { disabled: workspace.disabled };
             workspace.disabled = disabled;
             $("#red-ui-tab-"+(workspace.id.replace(".","-"))).toggleClass('red-ui-workspace-disabled',!!workspace.disabled);
-            if (id === activeWorkspace) {
+            if (id || activeWorkspace) {
                 $("#red-ui-workspace").toggleClass("red-ui-workspace-disabled",!!workspace.disabled);
             }
             var historyEvent = {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

The tab CSS wasn't being updated properly when toggling the disabled state of a flow.