### PR TITLE
Improve handling of long labels in TreeList

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
@@ -537,6 +537,7 @@
             var labelPaddingWidth = (item.gutter ? item.gutter[0].offsetWidth + 2 : 0) + (depth * 20)
             item.treeList.labelPadding = $('<span>').css({
                 display: "inline-block",
+                "flex-shrink": 0,
                 width:  labelPaddingWidth+'px'
             }).appendTo(label);
 

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-info.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-info.scss
@@ -16,6 +16,7 @@
 
 .red-ui-sidebar-info {
     height: 100%;
+    overflow: hidden;
 }
 .red-ui-sidebar-info  hr {
     margin: 10px 0;

--- a/packages/node_modules/@node-red/editor-client/src/sass/ui/common/treeList.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/ui/common/treeList.scss
@@ -102,6 +102,8 @@
 }
 .red-ui-treeList-label-text {
     margin-left: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
     &:empty {
         min-height: 20px;
     }
@@ -121,6 +123,7 @@
 
 .red-ui-treeList-icon {
     display: inline-block;
+    flex-shrink: 0;
     width: 20px;
     text-align: center;
 }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

Long labels in the TreeList (such as Help Table of Contents) were causing the layout to get compressed.

This now sets the css properly to allow the labels to overflow, and prevents the icon/handle/gutter from shrinking.
