### PR TITLE
Fix table tokenizer for node help markdown renderer

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -39,12 +39,12 @@ RED.utils = (function() {
                     type: 'descriptionList',                      // Should match "name" above
                     raw: match[0],                                // Text to consume from the source
                     text: match[0].trim(),                        // Additional custom properties
-                    tokens: this.inlineTokens(match[0].trim())    // inlineTokens to process **bold**, *italics*, etc.
+                    tokens: this.lexer.inlineTokens(match[0].trim())    // inlineTokens to process **bold**, *italics*, etc.
                 };
             }
         },
         renderer(token) {
-            return `<dl class="message-properties">${this.parseInline(token.tokens)}\n</dl>`; // parseInline to turn child tokens into HTML
+            return `<dl class="message-properties">${this.parser.parseInline(token.tokens)}\n</dl>`; // parseInline to turn child tokens into HTML
         }
     };
 
@@ -64,14 +64,14 @@ RED.utils = (function() {
                 return {                                       // Token to generate
                     type: 'description',                       // Should match "name" above
                     raw: match[0],                             // Text to consume from the source
-                    dt: this.inlineTokens(match[1].trim()),    // Additional custom properties
-                    types: this.inlineTokens(match[2].trim()),
-                    dd: this.inlineTokens(match[3].trim()),
+                    dt: this.lexer.inlineTokens(match[1].trim()),    // Additional custom properties
+                    types: this.lexer.inlineTokens(match[2].trim()),
+                    dd: this.lexer.inlineTokens(match[3].trim()),
                 };
             }
         },
         renderer(token) {
-            return `\n<dt>${this.parseInline(token.dt)}<span class="property-type">${this.parseInline(token.types)}</span></dt><dd>${this.parseInline(token.dd)}</dd>`;
+            return `\n<dt>${this.parser.parseInline(token.dt)}<span class="property-type">${this.parser.parseInline(token.types)}</span></dt><dd>${this.parser.parseInline(token.dd)}</dd>`;
         },
         childTokens: ['dt', 'dd'],                 // Any child tokens to be visited by walkTokens
         walkTokens(token) {                        // Post-processing on the completed token tree


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

We added the ability to format node help using markdown in #3169 

Shortly later, we updated to the latest `marked` release. This was a major version change and despite testing the basic markdown rendering, we didn't have an explicit test for the new message property table parsing... which promptly broke

We give with one PR, we take with another.

This PR updates the token parsing to the new API.

I have also updated the Node Help Style guide to include Markdown examples alongside the HTML examples 
 https://nodered.org/docs/creating-nodes/help-style-guide

fyi @Steve-Mcl 
