### PR TITLE
Widen Inject interval box for >1 digit

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.html
@@ -143,7 +143,8 @@
         margin-bottom: 8px;
     }
     .inject-time-count {
-        width: 40px !important;
+        padding-left: 3px !important;
+        width: 80px !important;
     }
 </style>
 


### PR DESCRIPTION
The Inject interval spinner is tiny and barely holds more than 1 digit before overflowing.

This widens the input to a more reasonable size.

I dislike the jQuery Spinner widget a lot - the buttons overlap the input so content can be hidden behind them. But not going to overhaul it that much right now. Just note its days are numbered in its current form.