### PR TITLE
Dynamic MQTT connections

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
@@ -54,6 +54,18 @@
         width: 15px;
         height: 15px;
     }
+    .form-row-mqtt5 {
+        display: none;
+    }
+    .form-row-mqtt5.form-row-mqtt5-active:not(.form-row-mqtt-static-disabled) {
+        display: block
+    }
+    .form-row-mqtt-static-disabled {
+        display: none;
+        /* opacity: 0.3;
+        pointer-events: none; */
+    }
+
 </style>
 
 <script type="text/html" data-template-name="mqtt in">
@@ -62,9 +74,16 @@
         <input type="text" id="node-input-broker">
     </div>
     <div class="form-row">
+        <label for="node-input-topicType" data-i18n="mqtt.label.action"></label>
+        <select id="node-input-topicType" style="width: 70%">
+            <option value="topic" data-i18n="mqtt.label.staticTopic"></option>
+            <option value="dynamic" data-i18n="mqtt.label.dynamicTopic"></option>
+        </select>
+        <input type="hidden" id="node-input-inputs">
+    </div>
+    <div class="form-row form-row-mqtt-static">
         <label for="node-input-topic"><i class="fa fa-tasks"></i> <span data-i18n="common.label.topic"></span></label>
-        <input type="hidden" id="node-input-topicType">
-        <input type="text" id="node-input-topic" style="width:70%;" data-i18n="[placeholder]common.label.topic">
+        <input type="text" id="node-input-topic" data-i18n="[placeholder]common.label.topic">
     </div>
     <div class="form-row form-row-mqtt-static">
         <label for="node-input-qos"><i class="fa fa-empire"></i> <span data-i18n="mqtt.label.qos"></span></label>
@@ -74,17 +93,7 @@
             <option value="2">2</option>
         </select>
     </div>
-    <div class="form-row form-row-mqtt-static">
-        <label for="node-input-datatype"><i class="fa fa-sign-out"></i> <span data-i18n="mqtt.label.output"></span></label>
-        <select id="node-input-datatype" style="width:70%;">
-            <option value="auto" data-i18n="mqtt.output.auto"></option>
-            <option value="buffer" data-i18n="mqtt.output.buffer"></option>
-            <option value="utf8" data-i18n="mqtt.output.string"></option>
-            <option value="json" data-i18n="mqtt.output.json"></option>
-            <option value="base64" data-i18n="mqtt.output.base64"></option>
-        </select>
-    </div>
-    <div class="form-row mqtt-flags-row mqtt5 form-row-mqtt-static">
+    <div class="form-row mqtt-flags-row form-row-mqtt5 form-row-mqtt-static">
         <label for="node-input-nl" ><i class="fa fa-flag"></i> <span data-i18n="mqtt.label.flags">Flags</span></label>
         <div class="mqtt-flags">
             <div class="mqtt-flag">
@@ -101,12 +110,22 @@
             </div>
         </div>
     </div>
-    <div class="form-row mqtt5 form-row-mqtt-static">
+    <div class="form-row form-row-mqtt5 form-row-mqtt-static">
         <label for="node-input-rh" style="width:100%"><i class="fa fa-tag"></i> <span data-i18n="mqtt.label.rh"></span></label>
         <select id="node-input-rh" style="margin-left: 104px; width: 70%">
             <option value="0" data-i18n="mqtt.label.rh0"></option>
             <option value="1" data-i18n="mqtt.label.rh1"></option>
             <option value="2" data-i18n="mqtt.label.rh2"></option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-datatype"><i class="fa fa-sign-out"></i> <span data-i18n="mqtt.label.output"></span></label>
+        <select id="node-input-datatype" style="width:70%;">
+            <option value="auto" data-i18n="mqtt.output.auto"></option>
+            <option value="buffer" data-i18n="mqtt.output.buffer"></option>
+            <option value="utf8" data-i18n="mqtt.output.string"></option>
+            <option value="json" data-i18n="mqtt.output.json"></option>
+            <option value="base64" data-i18n="mqtt.output.base64"></option>
         </select>
     </div>
     <div class="form-row">
@@ -186,9 +205,9 @@
                 <label for="node-config-input-port" style="margin-left:20px; width:43px; "> <span data-i18n="mqtt.label.port"></span></label>
                 <input type="text" id="node-config-input-port" data-i18n="[placeholder]mqtt.label.port" style="width:55px">
             </div>
-            <div class="form-row">
-                <input type="checkbox" id="node-config-input-autoConnect" style="height: 34px; margin: 0 5px 0 104px; display: inline-block; width: auto; vertical-align: top;">
-                <label for="node-config-input-autoConnect" style="width: 100px; line-height: 34px;"><span data-i18n="mqtt.label.auto-connect">Auto connect</span></label>
+            <div class="form-row" style="margin-bottom:0">
+                <input type="checkbox" id="node-config-input-autoConnect" style="margin: 0 5px 0 104px; display: inline-block; width: auto;">
+                <label for="node-config-input-autoConnect" style="width: auto"><span data-i18n="mqtt.label.auto-connect"></span></label>
             </div>
             <div class="form-row" style="height: 34px;">
                 <input type="checkbox" id="node-config-input-usetls" style="height: 34px; margin: 0 5px 0 104px; display: inline-block; width: auto; vertical-align: top;">
@@ -714,27 +733,20 @@
 
         }
     });
-    
+
     RED.nodes.registerType('mqtt in',{
         category: 'network',
         defaults: {
             name: {value:""},
-            topicType: {value:"str"},
             topic: {
                 value:"",
-                validate: function() {
-                    var topic;
-                    var $topic = $("#node-input-topic");
-                    var domReady = $topic.length > 0;
-                    var isDynamic = false;
-                    if(domReady) {
-                        isDynamic = ($topic.typedInput("type") == "dynamic");
-                        topic = $topic.typedInput("value");
-                    } else {
-                        isDynamic = (this.topicType == "dynamic");
-                        topic = this.topic;
+                validate: function(v) {
+                    var isDynamic = this.inputs === 1;
+                    var topicTypeSelect = $("#node-input-topicType");
+                    if (topicTypeSelect.length) {
+                        isDynamic = topicTypeSelect.val()==='dynamic'
                     }
-                    return isDynamic || ((!!topic) && RED.validators.regex(/^(#$|(\+|[^+#]*)(\/(\+|[^+#]*))*(\/(\+|#|[^+#]*))?$)/)(topic));
+                    return isDynamic || ((!!v) && RED.validators.regex(/^(#$|(\+|[^+#]*)(\/(\+|[^+#]*))*(\/(\+|#|[^+#]*))?$)/)(v));
                 }
             },
             qos: {value: "2"},
@@ -760,54 +772,51 @@
         labelStyle: function() {
             return this.name?"node_label_italic":"";
         },
-        isDynamic: function() {
-            return $("#node-input-topic").typedInput("type") == "dynamic"
-        },
         oneditprepare: function() {
             const node = this;
             const isV5Broker = function() {
                 var confNode = RED.nodes.node($("#node-input-broker").val());
-                return confNode && confNode.protocolVersion == "5";
+                return confNode && confNode.protocolVersion === "5";
             }
             const isDynamic = function() {
-                return $("#node-input-topic").typedInput("type") == "dynamic";
+                return $('#node-input-topicType').val() === "dynamic";
             }
             const updateVisibility = function() {
                 var v5 = isV5Broker();
                 var dynamic = isDynamic();
-                if(v5) {
-                    $("div.form-row.mqtt5").show();
-                } else {
-                    $("div.form-row.mqtt5").hide();
-                }
-                if(dynamic) {
-                    $("div.form-row.form-row-mqtt-static").hide();
-                } else {
-                    $("div.form-row.form-row-mqtt-static:not(.mqtt5)").show();
-                }
+                $("div.form-row-mqtt5").toggleClass("form-row-mqtt5-active",!!v5);
+                $("div.form-row.form-row-mqtt-static").toggleClass("form-row-mqtt-static-disabled", !!dynamic)
             }
             $("#node-input-broker").on("change",function(d){
                 updateVisibility();
             });
-            var $topic = $("#node-input-topic").typedInput({
-                default: 'str',
-                typeField: $("#node-input-topicType"),
-                types: [ 'str', { value: 'dynamic', label: this._("node-red:mqtt.label.dynamic"), hasValue: false }],
-            });
-            $topic.on("change", function () {
-                node.inputs = isDynamic() ? 1 : 0;
+
+            $('#node-input-topicType').on("change", function () {
+                $("#node-input-inputs").val(isDynamic() ? 1 : 0);
                 updateVisibility();
             });
-            $topic.trigger("change");
+
+            if (this.inputs === 1) {
+                $('#node-input-topicType').val('dynamic')
+            } else {
+                $('#node-input-topicType').val('topic')
+            }
+            $('#node-input-topicType').trigger("change");
+
             if (this.qos === undefined) {
                 $("#node-input-qos").val("2");
             }
             if (this.datatype === undefined) {
                 $("#node-input-datatype").val("auto");
             }
+        },
+        oneditsave: function() {
+            if ($('#node-input-topicType').val() === "dynamic") {
+                $('#node-input-topic').val("");
+            }
         }
     });
-  
+
     RED.nodes.registerType('mqtt out',{
         category: 'network',
         defaults: {

--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -69,7 +69,7 @@ module.exports = function(RED) {
 
     /**
      * Test a topic string is valid
-     * @param {string} topic 
+     * @param {string} topic
      * @returns `true` if it is a valid topic
      */
     function isValidSubscriptionTopic(topic) {
@@ -246,7 +246,7 @@ module.exports = function(RED) {
             msg.qos = Number(node.qos || msg.qos || 0);
             msg.retain = node.retain || msg.retain || false;
             msg.retain = ((msg.retain === true) || (msg.retain === "true")) || false;
-            
+
             if (v5) {
                 if (node.userProperties) {
                     msg.userProperties = node.userProperties;
@@ -273,9 +273,9 @@ module.exports = function(RED) {
 
             if (hasProperty(msg, "payload")) {
 
-                //check & sanitise topic 
+                //check & sanitise topic
                 let topicOK = hasProperty(msg, "topic") && (typeof msg.topic === "string") && (msg.topic !== "");
-                
+
                 if (!topicOK && v5) {
                     //NOTE: A value of 0 (in server props topicAliasMaximum) indicates that the Server does not accept any Topic Aliases on this connection
                     if (hasProperty(msg, "topicAlias") && !isNaN(msg.topicAlias) && msg.topicAlias >= 0 && bsp.topicAliasMaximum && bsp.topicAliasMaximum >= msg.topicAlias) {
@@ -339,6 +339,43 @@ module.exports = function(RED) {
             node.status({ fill: "green", shape: "dot", text: "node-red:common.status.connected" });
         }
     }
+
+    function handleConnectAction(node, msg, done) {
+        let actionData = typeof msg.broker === 'object' ? msg.broker : null;
+        if (node.brokerConn.canConnect()) {
+            // Not currently connected/connecting - trigger the connect
+            if (actionData) {
+                node.brokerConn.setOptions(actionData);
+            }
+            node.brokerConn.connect(function () {
+                done();
+            });
+        } else {
+            // Already Connected/Connecting
+            if (!actionData) {
+                // All is good - already connected and no broker override provided
+                done()
+            } else if (actionData.force) {
+                // The force flag tells us to cycle the connection.
+                node.brokerConn.disconnect(function() {
+                    node.brokerConn.setOptions(actionData);
+                    node.brokerConn.connect(function () {
+                        done();
+                    });
+                })
+            } else {
+                // Without force flag, we will refuse to cycle an active connection
+                done(new Error(RED._('mqtt.errors.invalid-action-alreadyconnected')));
+            }
+        }
+    }
+
+    function handleDisconnectAction(node, done) {
+        node.brokerConn.disconnect(function () {
+            done();
+        });
+    }
+
     //#endregion  "Supporting functions"
 
     //#region  "Broker node"
@@ -356,7 +393,7 @@ module.exports = function(RED) {
         node.subscriptions = {};
         /** @type {mqtt.MqttClient}*/ this.client;
         node.setOptions = function(opts, init) {
-            if(!opts || typeof opts !== "object") { 
+            if(!opts || typeof opts !== "object") {
                 return; //nothing to change, simply return
             }
             const originalBrokerURL = node.brokerurl;
@@ -396,7 +433,7 @@ module.exports = function(RED) {
                             v5Properties = message[v5SubPropName] = {};
                         }
                         //re-align local prop name to mqttjs std
-                        if(hasProperty(v5opts, "respTopic")) { v5opts.responseTopic = v5opts.respTopic; } 
+                        if(hasProperty(v5opts, "respTopic")) { v5opts.responseTopic = v5opts.respTopic; }
                         if(hasProperty(v5opts, "correl")) { v5opts.correlationData = v5opts.correl; }
                         if(hasProperty(v5opts, "expiry")) { v5opts.messageExpiryInterval = v5opts.expiry; }
                         if(hasProperty(v5opts, "delay")) { v5opts.willDelayInterval = v5opts.delay; }
@@ -420,10 +457,10 @@ module.exports = function(RED) {
             }
 
             if(init) {
-                if(hasProperty(opts, "birthTopic")) { 
+                if(hasProperty(opts, "birthTopic")) {
                     node.birthMessage = createLWT(opts.birthTopic, opts.birthPayload, opts.birthQos, opts.birthRetain, opts.birthMsg, "");
                 };
-                if(hasProperty(opts, "closeTopic")) { 
+                if(hasProperty(opts, "closeTopic")) {
                     node.closeMessage = createLWT(opts.closeTopic, opts.closePayload, opts.closeQos, opts.closeRetain, opts.closeMsg, "");
                 };
                 if(hasProperty(opts, "willTopic")) {
@@ -451,10 +488,10 @@ module.exports = function(RED) {
                 node.username = node.credentials.user;
                 node.password = node.credentials.password;
             }
-            if(!init & hasProperty(opts, "username")) { 
+            if(!init & hasProperty(opts, "username")) {
                 node.username  = opts.username;
             };
-            if(!init & hasProperty(opts, "password")) { 
+            if(!init & hasProperty(opts, "password")) {
                 node.password  = opts.password;
             };
 
@@ -480,7 +517,7 @@ module.exports = function(RED) {
 
             //use url or build a url from usetls://broker:port
             if (node.url && node.brokerurl !== node.url) {
-                node.brokerurl = node.url; 
+                node.brokerurl = node.url;
             } else {
                 // if the broker is ws:// or wss:// or tcp://
                 if (node.broker.indexOf("://") > -1) {
@@ -576,7 +613,7 @@ module.exports = function(RED) {
                     tlsNode.addTLSOptions(node.options);
                 }
             }
-    
+
             // If there's no rejectUnauthorized already, then this could be an
             // old config where this option was provided on the broker node and
             // not the tls node
@@ -587,7 +624,7 @@ module.exports = function(RED) {
 
         n.autoConnect = n.autoConnect === "false" || n.autoConnect === false ? false : true;
         node.setOptions(n, true);
-        
+
         // Define functions called by MQTT in and out nodes
         node.register = function(mqttNode) {
             node.users[mqttNode.id] = mqttNode;
@@ -875,7 +912,8 @@ module.exports = function(RED) {
         /**@type {MQTTBrokerNode}*/node.brokerConn = RED.nodes.getNode(node.broker);
 
         node.dynamicSubs = {};
-        node.topicType = n.topicType;
+        node.isDynamic = n.hasOwnProperty("inputs") && n.inputs == 1
+        node.inputs = n.inputs;
         node.topic = n.topic;
         node.qos = parseInt(n.qos);
         node.subscriptionIdentifier = n.subscriptionIdentifier;//https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901117
@@ -883,9 +921,6 @@ module.exports = function(RED) {
         node.rap = n.rap;
         node.rh = n.rh;
 
-        const isDynamic = function() {
-            return node.topicType == "dynamic";
-        }
         const Actions = {
             CONNECT: 'connect',
             DISCONNECT: 'disconnect',
@@ -898,16 +933,16 @@ module.exports = function(RED) {
         if (isNaN(node.qos) || node.qos < 0 || node.qos > 2) {
             node.qos = 2;
         }
-        if (!isDynamic() && !isValidSubscriptionTopic(node.topic)) {
+        if (!node.isDynamic && !isValidSubscriptionTopic(node.topic)) {
             return node.warn(RED._("mqtt.errors.invalid-topic"));
         }
         node.datatype = n.datatype || "utf8";
         if (node.brokerConn) {
             const v5 = node.brokerConn.options && node.brokerConn.options.protocolVersion == 5;
             setStatusDisconnected(node);
-            if (node.topic || node.topicType == "dynamic") {
+            if (node.topic || node.isDynamic) {
                 node.brokerConn.register(node);
-                if (node.topicType != "dynamic") {
+                if (!node.isDynamic) {
                     let options = { qos: node.qos };
                     if(v5) {
                         setIntProp(node, options, "rh", 0, 2, 0);
@@ -916,7 +951,7 @@ module.exports = function(RED) {
                         if(node.rap === "true" || node.rap === true) options.rap = true;
                         else if(node.rap === "false" || node.rap === false) options.rap = false;
                     }
-                    
+
                     node.brokerConn.subscribe(node.topic,options,function(topic, payload, packet) {
                         subscriptionHandler(node, node.datatype, topic, payload, packet);
                     },node.id);
@@ -938,26 +973,14 @@ module.exports = function(RED) {
                 }
 
                 if (action === Actions.CONNECT) {
-                    let actionData = typeof msg.broker === 'object' ? msg.broker : null;
-                    if (node.brokerConn.canConnect()) {
-                        if (actionData) {
-                            node.brokerConn.setOptions(actionData);
-                        }
-                        node.brokerConn.connect(function () {
-                            done();
-                        });
-                    } else {
-                        done(new Error(RED._('mqtt.errors.invalid-action-alreadyconnected')));
-                    }
+                    handleConnectAction(node, msg, done)
                 } else if (action === Actions.DISCONNECT) {
-                    node.brokerConn.disconnect(function () {
-                        done();
-                    });
+                    handleDisconnectAction(node, done)
                 } else if (action === Actions.SUBSCRIBE || action === Actions.UNSUBSCRIBE) {
                     const subscriptions = [];
                     let actionData;
                     //coerce msg.topic into an array of strings or objects (for later iteration)
-                    if(msg.topic === true) {
+                    if(action === Actions.UNSUBSCRIBE && msg.topic === true) {
                         actionData = Object.values(node.dynamicSubs);
                     } else if (Array.isArray(msg.topic)) {
                         actionData = msg.topic;
@@ -1027,15 +1050,16 @@ module.exports = function(RED) {
                     }
                 } else if (action === Actions.GETSUBS) {
                     //send list of subscriptions in payload
+                    msg.topic = "subscriptions";
                     msg.payload = Object.values(node.dynamicSubs);
                     send(msg);
                     done();
-                } 
+                }
             });
 
             node.on('close', function(removed, done) {
                 if (node.brokerConn) {
-                    if(isDynamic()) {
+                    if(node.isDynamic) {
                         Object.keys(node.dynamicSubs).forEach(function (topic) {
                             node.brokerConn.unsubscribe(topic, node.id, removed);
                         });
@@ -1087,21 +1111,9 @@ module.exports = function(RED) {
             node.on("input",function(msg,send,done) {
                 if (msg.action) {
                     if (msg.action === Actions.CONNECT) {
-                        let actionData = typeof msg.broker === 'object' ? msg.broker : null;
-                        if (node.brokerConn.canConnect()) {
-                            if (actionData) {
-                                node.brokerConn.setOptions(actionData);
-                            }
-                            node.brokerConn.connect(function() {
-                                done();
-                            });
-                        } else {
-                            done(new Error(RED._('mqtt.errors.invalid-action-alreadyconnected')));
-                        }
+                        handleConnectAction(node, msg, done)
                     } else if (msg.action === Actions.DISCONNECT) {
-                        node.brokerConn.disconnect(function () {
-                            done();
-                        });
+                        handleDisconnectAction(node, done)
                     } else {
                         done(new Error(RED._('mqtt.errors.invalid-action-action')));
                         return;
@@ -1125,5 +1137,3 @@ module.exports = function(RED) {
     RED.nodes.registerType("mqtt out",MQTTOutNode);
     //#endregion "MQTTOut node"
 };
-
-

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -413,17 +413,9 @@
             "session": "Session",
             "delay": "Delay",
             "action": "Action",
-            "dynamic": "Dynamic"
-        },
-        "action-setby": "- set by msg.action -",
-        "action-tip": {
-            "connect": "Tip: connect to the selected broker. Optionally, you can override connection options by setting msg.options. See help for additional info.",
-            "disconnect": "Tip: disconnect from the selected broker",
-            "subscribe": "Tip: subscribe to 1 or more topics by sending a msg with msg.subscription set. See help for additional info.",
-            "unsubscribe": "Tip: unsubscribe to 1 or more topics by sending a msg with msg.subscription set. See help for additional info.",
-            "publish": "Tip: publish to MQTT by sending a msg with a topic and payload. See help for additional info.",
-            "list": "Tip: Get a list of current subscriptions",
-            "setby": "Tip: set action by msg.action"
+            "staticTopic": "Subscribe to single topic",
+            "dynamicTopic": "Dynamic subscription",
+            "auto-connect": "Connect automatically"
         },
         "sections-label":{
             "birth-message": "Message sent on connection (birth message)",
@@ -467,7 +459,7 @@
             "invalid-json-parse": "Failed to parse JSON string",
             "invalid-action-action": "Invalid action specified",
             "invalid-action-alreadyconnected": "Disconnect from broker before connecting",
-            "invalid-action-badsubscription": "msg.subscriptions is missing or invalid"
+            "invalid-action-badsubscription": "msg.topic is missing or invalid"
         }
     },
     "httpin": {

--- a/packages/node_modules/@node-red/nodes/locales/en-US/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/network/10-mqtt.html
@@ -40,163 +40,38 @@
     <p>This node requires a connection to a MQTT broker to be configured. This is configured by clicking
     the pencil icon.</p>
     <p>Several MQTT nodes (in or out) can share the same broker connection if required.</p>
-</script>
+    <h4>Dynamic Subscription</h4>
+    The node can be configured to dynamically control the MQTT connection and its subscriptions. When
+    enabled, the node will have an input and can be controlled by passing it messages.
+    <h3>Inputs</h3>
+    <p>These only apply when the node has been configured for dynamic subscriptions.</p>
+    <dl class="message-properties">
+       <dt>action <span class="property-type">string</span></dt>
+       <dd>the name of the action the node should perform. Available actions are: <code>"connect"</code>,
+       <code>"disconnect"</code>, <code>"subscribe"</code> and <code>"unsubscribe"</code>.</dd>
+       <dt class="optional">topic <span class="property-type">string|object|array</span></dt>
+       <dd>For the <code>"subscribe"</code> and <code>"unsubscribe"</code> actions, this property
+           provides the topic. It can be set as either:<ul>
+           <li>a String continaing the topic filter</li>
+           <li>an Object containing <code>topic</code> and <code>qos</code> properties</li>
+           <li>an array of either strings or objects to handle multiple topics in one</li>
+            </ul>
+        </dd>
+       <dt class="optional">broker <span class="property-type">broker</span> </dt>
+       <dd>For the <code>"connect"</code> action, this property can override any
+           of the individual broker configuration settings, including: <ul>
+               <li><code>broker</code></li>
+               <li><code>port</code></li>
+               <li><code>url</code> - overrides broker/port to provide a complete connection url</li>
+               <li><code>username</code></li>
+               <li><code>password</code></li>
+           </ul>
+           <p>If this property is set and the broker is already connected an error
+              will be logged unless it has the <code>force</code> property set - in which case it will
+              disconnect from the broker, apply the new settings and reconnect.</p>
+       </dd>
+    </dl>
 
-<script type="text/html" data-help-name="mqtt control">
-   <p>Advanced MQTT Control to connect, disconnect, subscribe, unsubscribe and publish to the selected MQTT broker.</p>
-   <h3>Inputs</h3>
-   <dl class="message-properties">
-      <dt>action <span class="property-type">string</span></dt>
-      <dd>
-         The action property specifies which operation to perform. <br>
-         If not configured in the node, this optional property sets the action to perform.  
-         <code>msg.action</code> must be one of <code>connect</code> <code>disconnect</code> <code>subscribe</code> <code>unsubscribe</code> or <code>list</code>.
-      </dd>
-
-      <hr style="margin: 8px">
-
-      <h4 style="font-size: medium;font-style: italic;"><b>connect</b> action message properties...</h4>
-      <dt class="optional">options <span class="property-type">object</span></dt>
-      <dd>
-         The <code>msg.options</code> object is an optional msg parameter that permits you to override settings on the broker before connecting.<br>
-         * All properties of <code>msg.options</code> are optional.<br>
-         * Exclude properties you do not want to change.<br>
-         * To clear or default the value of a property, set it to null.<br>
-         * This property is only valid when action is "connect"
-         <h5>example...</h5>
-         <pre style="font-size: smaller;white-space: pre;">msg.options = {
-   url: "tcp://xxxxxxx",   //Alternatively, set *broker and *port
-   broker: "192.168.0.x",  //*broker IP or hostname
-   port: "1883",           //*broker port
-   clientid: "",           //string client ID
-   usetls: false,
-   usews: false,
-   verifyservercert: false,
-   protocolVersion: 5,     //3: Legacy mode, 4: V3.11 or 5: MQTT V5
-   keepalive: 0,           //seconds, set to 0 to disable
-   cleansession: true,
-   sessionExpiry: "",      //(MQTTv5)representing the Session Expiry Interval in seconds number
-   userProperties: {},     //(MQTTv5)object containing key/string values
-   "birth": {},            //see "will" for available properties
-   "close": {},            //see "will" for available properties
-   "will": {
-      "payload": "", 
-      "topic":"",
-      "qos": 2,            //(optional) 0: fire and forget, 1: at least once, 2: once and once only
-      "retain": false,     //(optional) 
-      "contentType": "",   //(optional) (MQTTv5) describing the content of the Message
-      "responseTopic": "", //(optional) (MQTTv5) the Topic Name for a response message
-      "correlationData": "", //(optional) (MQTTv5) Correlation Data
-      "messageExpiryInterval": "", //(optional) (MQTTv5) lifetime of the Message in seconds
-      "willDelayInterval": 0 //(optional) (MQTTv5) Will Delay Interval in seconds 
-   }
-}</pre> 
-      NOTE: Inclusion of <code>userProperties</code>, <code>birth</code>, <code>close</code> or <code>will</code> properties will replace the full property and all of its sub properties.<br>
-      NOTE: If <code>url</code> is set, it will override any values in <code>broker</code> and <code>port</code>.
-      </dd>
-
-      <hr style="margin: 8px">
-
-      <h4 style="font-size: medium;font-style: italic;"><b>disconnect</b> action message properties...</h4>
-      <dd>The "disconnect" action requires no additional properties</dd>
-
-      <hr style="margin: 8px">
-
-      <h4 style="font-size: medium;font-style: italic;"><b>subscribe</b> action message properties...</h4>
-      <dt>subscription <span class="property-type">string | object | array</span></dt>
-      <dd>
-         <code>msg.subscription</code> should contain the topic, an array of topics, an object containing topic and properties or an array of objects containing topic and properties<br>
-         * This property is only valid when <code>action</code> is "subscribe" or "unsubscribe"</code>
-         <h5>example 1...</h5>
-         <pre style="font-size: smaller;white-space: pre;">msg.subscription = "topic/subtopic1"</pre> 
-         <h5>example 2...</h5>
-         <pre style="font-size: smaller;white-space: pre;">msg.subscription = ["topic/subtopic1", "topic/subtopic2"];</pre>  
-         <h5>example 3...</h5>
-         <pre style="font-size: smaller;white-space: pre;">msg.subscription = [
-   {
-      "topic": "topic/subtopic1", 
-      "qos": 2,           //(optional) 0: fire and forget, 1: at least once, 2: once and once only
-      "retain": false,    //(optional) true indicates the message was retained and may be old
-      "nl": false,        //(optional) (MQTTv5) No local - Do not receive messages published by this client
-      "rap": false,       //(optional) (MQTTv5) Retain publish - Keep retain flag of original publish
-      "rh": 1,            //(optional) (MQTTv5) Retain Handling 
-                          // - 0: Send retained messages
-                          // - 1: Only send for new subscriptions
-                          // - 2: Do not send
-      "datatype": "auto", //(optional) Output Data Type - valid values are
-                          // "auto", "buffer", "utf8", "json" or "base64"
-   }
-];</pre> 
-      </dd>
-
-      <hr style="margin: 8px">
-
-      <h4 style="font-size: medium;font-style: italic;"><b>publish</b> action message properties...</h4>
-      <dt>payload <span class="property-type">string | buffer</span></dt>
-      <dd>the payload to publish. If this property is not set, no message will be sent. To send a blank message, set this property to an empty String.</dd>
-      <dt>topic <span class="property-type">string</span></dt>
-      <dd>the MQTT topic, uses / as a hierarchy separator. Only used for action "publish"</dd>
-      <dt class="optional">qos <span class="property-type">number</span> </dt>
-      <dd>0, fire and forget - 1, at least once - 2, once and once only.</dd>
-      <dt class="optional">retain <span class="property-type">boolean</span></dt>
-      <dd>true indicates the message was retained and may be old.</dd>
-      <dt class="optional">responseTopic <span class="property-type">string</span></dt>
-      <dd><b>MQTTv5</b>: the MQTT response topic for the message</dd>
-      <dt class="optional">correlationData <span class="property-type">Buffer</span></dt>
-      <dd><b>MQTTv5</b>: the correlation data for the message</dd>
-      <dt class="optional">contentType <span class="property-type">string</span></dt>
-      <dd><b>MQTTv5</b>: the content-type of the payload</dd>
-      <dt class="optional">userProperties <span class="property-type">object</span></dt>
-      <dd><b>MQTTv5</b>: any user properties of the message</dd>
-      <dt class="optional">messageExpiryInterval <span class="property-type">number</span></dt>
-      <dd><b>MQTTv5</b>: the expiry time, in seconds, of the message</dd>
-
-      <hr style="margin: 8px">
-
-      <h4 style="font-size: medium;font-style: italic;"><b>list</b> action message properties...</h4>
-      <dd>The "list" action requires no additional properties</dd>
-
-   </dl>
-
-   <h3>Output 1</h3>
-   <dl class="message-properties">
-      <h4 style="font-size: medium;font-style: italic;">messages from the subscribed topics</h4>
-      <dt>payload <span class="property-type">string | buffer | object</span></dt>
-      <dd>the MQTT payload received from broker.</dd>
-      <dt>topic <span class="property-type">string</span></dt>
-      <dd>the MQTT topic, uses / as a hierarchy separator.</dd>
-      <dt>qos <span class="property-type">number</span> </dt>
-      <dd>0, fire and forget - 1, at least once - 2, once and once only.</dd>
-      <dt>retain <span class="property-type">boolean</span></dt>
-      <dd>true indicates the message was retained and may be old.</dd>
-
-      <dt class="optional">responseTopic <span class="property-type">string</span></dt>
-      <dd><b>MQTTv5</b>: the MQTT response topic for the message</dd>
-      <dt class="optional">correlationData <span class="property-type">Buffer</span></dt>
-      <dd><b>MQTTv5</b>: the correlation data for the message</dd>
-      <dt class="optional">contentType <span class="property-type">string</span></dt>
-      <dd><b>MQTTv5</b>: the content-type of the payload</dd>
-      <dt class="optional">userProperties <span class="property-type">object</span></dt>
-      <dd><b>MQTTv5</b>: any user properties of the message</dd>
-      <dt class="optional">messageExpiryInterval <span class="property-type">number</span></dt>
-      <dd><b>MQTTv5</b>: the expiry time, in seconds, of the message</dd>
-   </dl>
-   
-   <h3>Output 2</h3>
-   <dl class="message-properties">
-      <h4 style="font-size: medium;font-style: italic;">messages in response to a "subscribe", "unsubscribe" or "list" action...</h4>
-      <dt>payload <span class="property-type">array</span></dt>
-      <dd>an array containing the dynamic subscriptions this node will respond to.</dd>
-      <hr style="margin: 8px">
-      <h4 style="font-size: medium;font-style: italic;">messages in response to a "connect" and "disconnect" action...</h4>
-      <dd>the original msg</dd>
-   </dl>   
-   <h3>Details</h3>
-   <p>A subscription topic can include MQTT wildcards, + for one level, # for multiple levels.</p>
-   <p>This node requires a connection to a MQTT broker to be configured. This is configured by clicking
-   the pencil icon.</p>
-   <p>To make a dynamic connection, you can turn off the broker option "auto connect" then run the "connect" action with a new broker connection url.</p>
-   <p>Several MQTT nodes (in or out) can share the same broker connection if required.</p>
 </script>
 
 <script type="text/html" data-help-name="mqtt out">
@@ -235,6 +110,30 @@
     <p>This node requires a connection to a MQTT broker to be configured. This is configured by clicking
     the pencil icon.</p>
     <p>Several MQTT nodes (in or out) can share the same broker connection if required.</p>
+
+    <h4>Dynamic Control</h4>
+    The connection shared by the node can be controlled dynamically. If the node receives
+    one of the following control messages, it will not publish the message payload as well.
+    <h3>Inputs</h3>
+    <dl class="message-properties">
+       <dt>action <span class="property-type">string</span></dt>
+       <dd>the name of the action the node should perform. Available actions are: <code>"connect"</code>,
+       and <code>"disconnect"</code>.</dd>
+       <dt class="optional">broker <span class="property-type">broker</span> </dt>
+       <dd>For the <code>"connect"</code> action, this property can override any
+           of the individual broker configuration settings, including: <ul>
+               <li><code>broker</code></li>
+               <li><code>port</code></li>
+               <li><code>url</code> - overrides broker/port to provide a complete connection url</li>
+               <li><code>username</code></li>
+               <li><code>password</code></li>
+           </ul>
+           <p>If this property is set and the broker is already connected an error
+              will be logged unless it has the <code>force</code> property set - in which case it will
+              disconnect from the broker, apply the new settings and reconnect.</p>
+       </dd>
+    </dl>
+
 </script>
 
 <script type="text/html" data-help-name="mqtt-broker">


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Includes all the changes from  #2989, plus a final polish.

To summarise (as the previous PR covers a lot of discussion and changes in direction...)

1. MQTT In node now has an option for 'Dynamic Subscription'. When selected, the topic/qos fields (plus relevant v5 ones) are hidden. The node also gains an input.
2. The node can be passed messages to trigger actions

    `msg.action` | other properties | behaviour
    --------------|-----------------|----------
    `"connect"`       | `msg.broker` - optional | connects the broker. If `msg.broker` is provided, it can override any individual connection setting. If it is already connected and `msg.broker` is provided, it will error unless `msg.broker.force` is set - in which case it will disconnect, apply changes, reconnect.
    `"disconnect"` | | disconnects from the broker
    `"subscribe"`  | `msg.topic` | subscribe to the provided topic. In this instance topic can be a string, and object (`{topic:"", qos:0}`) or array of strings/objects to allow multiple topics in one request. The node will subscribe and start emitted received messages.
    `"unsubscribe"` | `msg.topic` | unsubscribe from the provided topic(s). Note this only unsubscribes *this* node - it does not affect any other MQTT In node that may be subscribed to the same topic.

3. The MQTT Out node can be passed a `connect` or `disconnect` message.
4. The MQTT Broker config node has a new 'connect automatically' option (default=true) - so you can prevent it connecting straight away and to wait for a `connect` control message.