### PR TITLE
Fix switching projects

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2384,7 +2384,6 @@ RED.nodes = (function() {
     }
 
     function clear() {
-        allNodes.clear();
         links = [];
         linkTabMap = {};
         nodeLinks = {};
@@ -2404,6 +2403,8 @@ RED.nodes = (function() {
         defaultWorkspace = null;
         initialLoad = null;
         workspaces = {};
+
+        allNodes.clear();
 
         RED.nodes.dirty(false);
         RED.view.redraw(true, true);

--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -251,6 +251,9 @@ var RED = (function() {
                         if (/^#flow\/.+$/.test(currentHash)) {
                             RED.workspaces.show(currentHash.substring(6),true);
                         }
+                        if (RED.workspaces.active() === 0 && RED.workspaces.count() > 0) {
+                            RED.workspaces.show(RED.nodes.getWorkspaceOrder()[0])
+                        }
                     } catch(err) {
                         console.warn(err);
                         RED.notify(


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

An error in `RED.nodes.clear()` was causing project switching to fail. This would also have impacted merging diffs.

Also ensures the first tab is shown after switching projects - rather than leave workspace blank (a result of the hiding tabs work).