### PR TITLE
Add string option to TCP request node output

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
@@ -197,8 +197,8 @@
     <div class="form-row">
         <label for="node-input-out"><i class="fa fa-sign-out"></i> <span data-i18n="tcpin.label.return"></span></label>
         <select type="text" id="node-input-ret" style="width:54%;">
-            <option value="buffer" data-i18n="tcpin.return.buffer"></option>
-            <option value="string" data-i18n="tcpin.return.string"></option>
+            <option value="buffer" data-i18n="tcpin.output.buffer"></option>
+            <option value="string" data-i18n="tcpin.output.string"></option>
         </select>
     </div>
     <div class="form-row">

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -598,9 +598,7 @@
             "character": "when character received is",
             "number": "a fixed number of chars",
             "never": "never - keep connection open",
-            "immed": "immediately - don't wait for reply",
-            "buffer": "a Buffer",
-            "string": "a String"
+            "immed": "immediately - don't wait for reply"
         },
         "status": {
             "connecting": "connecting to __host__:__port__",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

adds an option to select a string type output to the TCP request node. (The TCP In node already has it)
Defaults to Buffer as per existing.
![image](https://user-images.githubusercontent.com/5375409/137986569-1feed379-b168-483e-a3c8-e9f4b922e380.png)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
