### PR TITLE
Fix issue with old inject nodes that migrated topic to 'string' type

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -846,7 +846,10 @@
         },
         value: function(value) {
             var that = this;
-            var opt = this.typeMap[this.propertyType];
+            // If the default type has been set to an invalid type, then on first
+            // creation, the current propertyType will not exist. Default to an
+            // empty object on the assumption the corrent type will be set shortly
+            var opt = this.typeMap[this.propertyType] || {};
             if (!arguments.length) {
                 var v = this.input.val();
                 if (opt.export) {

--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.html
@@ -539,7 +539,7 @@
                     var propertyValue = $('<input/>',{class:"node-input-prop-property-value",type:"text"})
                         .css("width","calc(70% - 30px)")
                         .appendTo(row)
-                        .typedInput({default:prop.vt,types:['flow','global','str','num','bool','json','bin','date','jsonata','env','msg']});
+                        .typedInput({default:prop.vt || 'str',types:['flow','global','str','num','bool','json','bin','date','jsonata','env','msg']});
 
                     propertyName.typedInput('value',prop.p);
                     propertyValue.typedInput('value',prop.v);
@@ -562,7 +562,7 @@
                 var topic = {
                     p:'topic',
                     v: node.topic ? node.topic : '',
-                    vt:'string'
+                    vt:'str'
                 }
                 node.props = [payload,topic];
             }
@@ -577,6 +577,11 @@
                     } else if (prop.p === 'topic' && prop.vt === "str") {
                         newProp.v =  node.topic ? node.topic : '';
                     }
+                }
+                if (newProp.vt === "string") {
+                    // Fix bug in pre 2.1 where an old Inject node might have
+                    // a migrated rule with type 'string' not 'str'
+                    newProp.vt = "str";
                 }
                 eList.editableList('addItem',newProp);
             }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

When the Inject node was updated to support a list of properties code was added to migrate the Payload/Topic properties of the node into the node's `props` array.

However the `topic` property was migrated with a type of `string`, not `str`. This meant the typedInput wasn't being initialised with a valid type.

Pre 2.1 that didn't cause a problem, but due to other changes, the TI was unhappy setting the value on an input with an invalid type.

This PR does the following:

 - fixes the Inject node to migrate to `str` not `string`
 - fixes any properties it finds with the bad value
 - fixes the TypedInput to handle setting its value whilst it has an invalid/missing type.