### PR TITLE
Add cache-busting query params to index.mst

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -583,7 +583,7 @@ module.exports = function(grunt) {
     grunt.registerMultiTask('attachCopyright', function() {
         var files = this.data.src;
         var copyright = "/**\n"+
-            " * Copyright JS Foundation and other contributors, http://js.foundation\n"+
+            " * Copyright OpenJS Foundation and other contributors, https://openjsf.org/\n"+
             " *\n"+
             " * Licensed under the Apache License, Version 2.0 (the \"License\");\n"+
             " * you may not use this file except in compliance with the License.\n"+

--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -27,7 +27,8 @@ var defaultContext = {
         tabicon: {
             icon: "red/images/node-red-icon-black.svg",
             colour: "#8f0000"
-        }
+        },
+        version: require(path.join(__dirname,"../../package.json")).version
     },
     header: {
         title: "Node-RED",

--- a/packages/node_modules/@node-red/editor-client/templates/index.mst
+++ b/packages/node_modules/@node-red/editor-client/templates/index.mst
@@ -7,7 +7,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="mobile-web-app-capable" content="yes">
 <!--
-  Copyright JS Foundation and other contributors, http://js.foundation
+  Copyright OpenJS Foundation and other contributors, https://openjsf.org/
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -24,24 +24,24 @@
 <title>{{ page.title }}</title>
 <link rel="icon" type="image/png" href="{{ page.favicon }}">
 <link rel="mask-icon" href="{{ page.tabicon.icon }}" color="{{ page.tabicon.colour }}">
-<link rel="stylesheet" href="vendor/jquery/css/base/jquery-ui.min.css">
-<link rel="stylesheet" href="vendor/font-awesome/css/font-awesome.min.css">
-<link rel="stylesheet" href="red/style.min.css">
+<link rel="stylesheet" href="vendor/jquery/css/base/jquery-ui.min.css?v={{ page.version }}">
+<link rel="stylesheet" href="vendor/font-awesome/css/font-awesome.min.css?v={{ page.version }}">
+<link rel="stylesheet" href="red/style.min.css?v={{ page.version }}">
 {{#page.css}}
 <link rel="stylesheet" href="{{.}}">
 {{/page.css}}
 {{#asset.vendorMonaco}}
-<link rel="stylesheet" href="vendor/monaco/style.css">
+<link rel="stylesheet" href="vendor/monaco/style.css?v={{ page.version }}">
 {{/asset.vendorMonaco}}
 </head>
 <body spellcheck="false">
 <div id="red-ui-editor"></div>
-<script src="vendor/vendor.js"></script>
+<script src="vendor/vendor.js?v={{ page.version }}"></script>
 {{#asset.vendorMonaco}}
-<script src="{{ asset.vendorMonaco }}"></script>
+<script src="{{ asset.vendorMonaco }}?v={{ page.version }}"></script>
 {{/asset.vendorMonaco}}
-<script src="{{ asset.red }}"></script>
-<script src="{{ asset.main }}"></script>
+<script src="{{ asset.red }}?v={{ page.version }}"></script>
+<script src="{{ asset.main }}?v={{ page.version }}"></script>
 {{# page.scripts }}
 <script src="{{.}}"></script>
 {{/ page.scripts }}


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

Adds `?v=<node-red-version>` query params to `index.mst`. This will help ensure the browser doesn't cache old copies when loading a new version of Node-RED.
