### PR TITLE
Ensure tourGuide popover doesn't fall offscreen

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tour/tourGuide.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tour/tourGuide.js
@@ -348,7 +348,12 @@ RED.tourGuide = (function() {
                 maxWidth: maxWidth+"px",
                 direction: direction,
             })
-
+            setTimeout(function() {
+                var pos = popover.element.position()
+                if (pos.left < 0) {
+                    popover.element.css({left: 0});
+                }
+            },100);
             if (nextButton) {
                 setTimeout(function() {
                     nextButton.focus();


### PR DESCRIPTION
- [ x] Bugfix (non-breaking change which fixes an issue)

The Welcome Tour popover can get pushed offscreen if the browser window is narrower than we expect. This pushes it back into view.

Only handles the left hand edge - will need expanding to cover the other edges as needed
