### PR TITLE
Improved regex for markdown renderer

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -27,7 +27,7 @@ RED.utils = (function() {
         level: 'block',                                     // Is this a block-level or inline-level tokenizer?
         start(src) {
             if (!src) { return null; }
-            let m = src.match(/:[^:\n]/);
+            let m = src.match(/:[^:\n]/g);
             return m && m.index; // Hint to Marked.js to stop and check for a match
         },
         tokenizer(src, tokens) {
@@ -53,7 +53,7 @@ RED.utils = (function() {
         level: 'inline',           // Is this a block-level or inline-level tokenizer?
         start(src) {
             if (!src) { return null; }
-            let m = src.match(/:/);
+            let m = src.match(/:/g);
             return m && m.index;   // Hint to Marked.js to stop and check for a match
         },
         tokenizer(src, tokens) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

After the recent changes it was not possible anymore to use images in node-red markdown. The renderer would put a space between `:` and `//` when using markdown urls like `![](https://url.png)`. 

With this change the image will render like it is supposed to.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
