### PR TITLE
fix datatype in node config not used. fixes #3215

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -1040,7 +1040,7 @@ module.exports = function(RED) {
 
                             //subscribe to sub.topic & hook up subscriptionHandler
                             node.brokerConn.subscribe(sub.topic, options, function (topic, payload, packet) {
-                                subscriptionHandler(node, sub.datatype, topic, payload, packet);
+                                subscriptionHandler(node, sub.datatype || node.datatype, topic, payload, packet);
                             }, node.id);
                             node.dynamicSubs[sub.topic] = sub; //save for later unsubscription & 'list' action
                         })


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)


## Proposed changes

As discussed in #3215 

This modification defaults `datatype` to `node.datatype` (set in config)
NOTE: If `datatype` is specified in the dynamic subscription, it will take precedence over  `node.datatype`. 



## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
