### PR TITLE
Add environment variable to enable/disable tours

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -228,6 +228,11 @@ module.exports = {
         if (theme.theme) {
             themeSettings.theme = theme.theme;
         }
+
+        if (theme.hasOwnProperty("tours")) {
+            themeSettings.tours = theme.tours;
+        }
+
         return themeApp;
     },
     context: async function() {

--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -194,6 +194,11 @@ if (process.env.NODE_RED_ENABLE_PROJECTS) {
     settings.editorTheme.projects.enabled = !/^false$/i.test(process.env.NODE_RED_ENABLE_PROJECTS);
 }
 
+if (process.env.NODE_RED_ENABLE_TOURS) {
+    settings.editorTheme = settings.editorTheme || {};
+    settings.editorTheme.tours = !/^false$/i.test(process.env.NODE_RED_ENABLE_TOURS);
+}
+
 
 var defaultServerSettings = {
     "x-powered-by": false


### PR DESCRIPTION
NODE_RED_ENABLE_TOURS

Also had to patch editor-api/lib/editor/themes.js to pass
`editorTheme.tours` to the editor.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Ticked both, because Env Var is new, but needed to fix not passing `editorTheme.tours` to the browser side.

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
