### PR TITLE
Fix import notification message when importing config nodes

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4957,7 +4957,7 @@ RED.view = (function() {
                     counts.push(RED._("clipboard.group",{count:newGroupCount}));
                 }
                 if (newConfigNodeCount > 0) {
-                    counts.push(RED._("clipboard.configNode",{count:newNodeCount}));
+                    counts.push(RED._("clipboard.configNode",{count:newConfigNodeCount}));
                 }
                 if (new_subflows.length > 0) {
                     counts.push(RED._("clipboard.subflow",{count:new_subflows.length}));


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

When importing a flow including Config nodes, the notification of import was using the number of flow nodes as the number of config nodes... something that gave me a minor heart attach when importing a flow that claimed to contain 20 config nodes.