### PR TITLE
Fix loading non-default language files leaving runtime in wrong locale

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/locales.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/locales.js
@@ -48,9 +48,10 @@ module.exports = {
         var prevLang = i18n.i.language;
         // Trigger a load from disk of the language if it is not the default
         i18n.i.changeLanguage(lang, function(){
-            var catalog = loadResource(lang, namespace);
-            res.json(catalog||{});
+            i18n.i.changeLanguage(prevLang, function() {
+                var catalog = loadResource(lang, namespace);
+                res.json(catalog||{});
+            });
         });
-        i18n.i.changeLanguage(prevLang);
     }
 }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

https://discourse.nodered.org/t/2-0-6-shows-different-node-errors-in-different-languages/51693

In some rare occasions, the runtime was randomly emitting log messages in the wrong locale.

This could happen if someone requests a message catalog in the a non-default locale (eg http://localhost:1880/locales/node-red?lng=ja). The slightly hacky way these requests were handled, meant the i18n subsystem was switched to the desired language, the catalog loaded, then switched back to the primary runtime language.

However the restore of the language was happening in parallel which could leave it in an inconsistent state.

This improves the sequencing to reduce the chances of this happening. However the overall logic is not ideal and we do need a way to load non-default catalogues without modifying the current default.