### PR TITLE
Refresh editor settings whenever a node is added or enabled

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -475,31 +475,33 @@ var RED = (function() {
             var typeList;
             var info;
             if (topic == "notification/node/added") {
-                var addedTypes = [];
-                msg.forEach(function(m) {
-                    var id = m.id;
-                    RED.nodes.addNodeSet(m);
-                    addedTypes = addedTypes.concat(m.types);
-                    RED.i18n.loadNodeCatalog(id, function() {
-                        var lang = localStorage.getItem("editor-language")||RED.i18n.detectLanguage();
-                        $.ajax({
-                            headers: {
-                                "Accept":"text/html",
-                                "Accept-Language": lang
-                            },
-                            cache: false,
-                            url: 'nodes/'+id,
-                            success: function(data) {
-                                appendNodeConfig(data);
-                            }
+                RED.settings.refreshSettings(function(err, data) {
+                    var addedTypes = [];
+                    msg.forEach(function(m) {
+                        var id = m.id;
+                        RED.nodes.addNodeSet(m);
+                        addedTypes = addedTypes.concat(m.types);
+                        RED.i18n.loadNodeCatalog(id, function() {
+                            var lang = localStorage.getItem("editor-language")||RED.i18n.detectLanguage();
+                            $.ajax({
+                                headers: {
+                                    "Accept":"text/html",
+                                    "Accept-Language": lang
+                                },
+                                cache: false,
+                                url: 'nodes/'+id,
+                                success: function(data) {
+                                    appendNodeConfig(data);
+                                }
+                            });
                         });
                     });
-                });
-                if (addedTypes.length) {
-                    typeList = "<ul><li>"+addedTypes.map(RED.utils.sanitize).join("</li><li>")+"</li></ul>";
-                    RED.notify(RED._("palette.event.nodeAdded", {count:addedTypes.length})+typeList,"success");
-                }
-                loadIconList();
+                    if (addedTypes.length) {
+                        typeList = "<ul><li>"+addedTypes.map(RED.utils.sanitize).join("</li><li>")+"</li></ul>";
+                        RED.notify(RED._("palette.event.nodeAdded", {count:addedTypes.length})+typeList,"success");
+                    }
+                    loadIconList();
+                })
             } else if (topic == "notification/node/removed") {
                 for (i=0;i<msg.length;i++) {
                     m = msg[i];
@@ -512,27 +514,29 @@ var RED = (function() {
                 loadIconList();
             } else if (topic == "notification/node/enabled") {
                 if (msg.types) {
-                    info = RED.nodes.getNodeSet(msg.id);
-                    if (info.added) {
-                        RED.nodes.enableNodeSet(msg.id);
-                        typeList = "<ul><li>"+msg.types.map(RED.utils.sanitize).join("</li><li>")+"</li></ul>";
-                        RED.notify(RED._("palette.event.nodeEnabled", {count:msg.types.length})+typeList,"success");
-                    } else {
-                        var lang = localStorage.getItem("editor-language")||RED.i18n.detectLanguage();
-                        $.ajax({
-                            headers: {
-                                "Accept":"text/html",
-                                "Accept-Language": lang
-                            },
-                            cache: false,
-                            url: 'nodes/'+msg.id,
-                            success: function(data) {
-                                appendNodeConfig(data);
-                                typeList = "<ul><li>"+msg.types.map(RED.utils.sanitize).join("</li><li>")+"</li></ul>";
-                                RED.notify(RED._("palette.event.nodeAdded", {count:msg.types.length})+typeList,"success");
-                            }
-                        });
-                    }
+                    RED.settings.refreshSettings(function(err, data) {
+                        info = RED.nodes.getNodeSet(msg.id);
+                        if (info.added) {
+                            RED.nodes.enableNodeSet(msg.id);
+                            typeList = "<ul><li>"+msg.types.map(RED.utils.sanitize).join("</li><li>")+"</li></ul>";
+                            RED.notify(RED._("palette.event.nodeEnabled", {count:msg.types.length})+typeList,"success");
+                        } else {
+                            var lang = localStorage.getItem("editor-language")||RED.i18n.detectLanguage();
+                            $.ajax({
+                                headers: {
+                                    "Accept":"text/html",
+                                    "Accept-Language": lang
+                                },
+                                cache: false,
+                                url: 'nodes/'+msg.id,
+                                success: function(data) {
+                                    appendNodeConfig(data);
+                                    typeList = "<ul><li>"+msg.types.map(RED.utils.sanitize).join("</li><li>")+"</li></ul>";
+                                    RED.notify(RED._("palette.event.nodeAdded", {count:msg.types.length})+typeList,"success");
+                                }
+                            });
+                        }
+                    });
                 }
             } else if (topic == "notification/node/disabled") {
                 if (msg.types) {

--- a/packages/node_modules/@node-red/editor-client/src/js/settings.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/settings.js
@@ -125,7 +125,7 @@ RED.settings = (function () {
         load(done);
     }
 
-    var load = function(done) {
+    var refreshSettings = function(done) {
         $.ajax({
             headers: {
                 "Accept": "application/json"
@@ -135,6 +135,23 @@ RED.settings = (function () {
             url: 'settings',
             success: function (data) {
                 setProperties(data);
+                done(null, data);
+            },
+            error: function(jqXHR,textStatus,errorThrown) {
+                if (jqXHR.status === 401) {
+                    if (/[?&]access_token=(.*?)(?:$|&)/.test(window.location.search)) {
+                        window.location.search = "";
+                    }
+                    RED.user.login(function() { refreshSettings(done); });
+                } else {
+                    console.log("Unexpected error loading settings:",jqXHR.status,textStatus);
+                }
+            }
+        });
+    }
+    var load = function(done) {
+        refreshSettings(function(err, data) {
+            if (!err) {
                 if (!RED.settings.user || RED.settings.user.anonymous) {
                     RED.settings.remove("auth-tokens");
                 }
@@ -147,18 +164,8 @@ RED.settings = (function () {
                 console.log("D3",d3.version);
                 console.groupEnd();
                 loadUserSettings(done);
-            },
-            error: function(jqXHR,textStatus,errorThrown) {
-                if (jqXHR.status === 401) {
-                    if (/[?&]access_token=(.*?)(?:$|&)/.test(window.location.search)) {
-                        window.location.search = "";
-                    }
-                    RED.user.login(function() { load(done); });
-                } else {
-                    console.log("Unexpected error loading settings:",jqXHR.status,textStatus);
-                }
             }
-        });
+        })
     };
 
     function loadUserSettings(done) {
@@ -234,6 +241,7 @@ RED.settings = (function () {
         init: init,
         load: load,
         loadUserSettings: loadUserSettings,
+        refreshSettings: refreshSettings,
         set: set,
         get: get,
         remove: remove,


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

Fixes #3217

This ensures any node-provided settings are loaded and ready
for use by the nodes

