### PR TITLE
HTTP Basic Auth should always add : between username and password even if empty

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
@@ -298,18 +298,14 @@ in your Node-RED user directory (${RED.settings.userDir}).
             }
             if (Object.keys(this.credentials).length != 0) {
                 if (this.authType === "basic") {
-                    // Workaround for https://github.com/sindresorhus/got/issues/1169
-                    var cred = ""
-                    if (this.credentials.user) {
-                        // opts.username = this.credentials.user;
-                        cred = this.credentials.user + ":"
-                    }
-                    if (this.credentials.password) {
-                        // opts.password = this.credentials.password;
-                        cred += this.credentials.password
+                    // Workaround for https://github.com/sindresorhus/got/issues/1169 (fixed in got v12)
+                    // var cred = ""
+                    if (this.credentials.user || this.credentials.password) {
+                        // cred = `${this.credentials.user}:${this.credentials.password}`;
+                        opts.headers.Authorization = "Basic " + Buffer.from(`${this.credentials.user}:${this.credentials.password}`).toString("base64");
                     }
                     // build own basic auth header
-                    opts.headers.Authorization = "Basic " + Buffer.from(cred).toString("base64");
+                    // opts.headers.Authorization = "Basic " + Buffer.from(cred).toString("base64");
                 } else if (this.authType === "digest") {
                     let digestCreds = this.credentials;
                     let sentCreds = false;


### PR DESCRIPTION
fix for #3235

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Make sure that `:` is always between the username and password for basic auth and not just if a password is present.
This appears to be inline with the rfc https://datatracker.ietf.org/doc/html/rfc2617#page-5

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
