### PR TITLE
Group diff fix

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1097,6 +1097,11 @@ RED.nodes = (function() {
             // Until we know how that can happen, add a filter here to remove them
             node.nodes = node.nodes.filter(function(n) { return !!n }).map(function(n) { return n.id });
         }
+        if (n.type === "tab" || n.type === "group") {
+            if (node.env && node.env.length === 0) {
+                delete node.env;
+            }
+        }
         if (n._def.category != "config") {
             node.x = n.x;
             node.y = n.y;

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
@@ -554,6 +554,8 @@ RED.diff = (function() {
                     color: "#DDAA99",
                     defaults:{name:{value:""}}
                 }
+            } else if (node.type === "group") {
+                def = RED.group.def;
             } else {
                 def = {};
             }
@@ -763,16 +765,15 @@ RED.diff = (function() {
             }
         }
 
-
         if (node.hasOwnProperty('x')) {
             if (localNode) {
-                if (localNode.x !== node.x || localNode.y !== node.y) {
+                if (localNode.x !== node.x || localNode.y !== node.y || localNode.w !== node.w || localNode.h !== node.h ) {
                     localChanged = true;
                     localChanges++;
                 }
             }
             if (remoteNode) {
-                if (remoteNode.x !== node.x || remoteNode.y !== node.y) {
+                if (remoteNode.x !== node.x || remoteNode.y !== node.y|| remoteNode.w !== node.w || remoteNode.h !== node.h) {
                     remoteChanged = true;
                     remoteChanges++;
                 }
@@ -790,7 +791,12 @@ RED.diff = (function() {
                 localCell.addClass("red-ui-diff-status-"+(localChanged?"changed":"unchanged"));
                 $('<span class="red-ui-diff-status">'+(localChanged?'<i class="fa fa-square"></i>':'')+'</span>').appendTo(localCell);
                 element = $('<span class="red-ui-diff-list-element"></span>').appendTo(localCell);
-                propertyElements['local.position'] = RED.utils.createObjectElement({x:localNode.x,y:localNode.y},
+                var localPosition = {x:localNode.x,y:localNode.y};
+                if (localNode.hasOwnProperty('w')) {
+                    localPosition.w = localNode.w;
+                    localPosition.h = localNode.h;
+                }
+                propertyElements['local.position'] = RED.utils.createObjectElement(localPosition,
                     {
                         path: "position",
                         exposeApi: true,
@@ -811,7 +817,12 @@ RED.diff = (function() {
                 if (remoteNode) {
                     $('<span class="red-ui-diff-status">'+(remoteChanged?'<i class="fa fa-square"></i>':'')+'</span>').appendTo(remoteCell);
                     element = $('<span class="red-ui-diff-list-element"></span>').appendTo(remoteCell);
-                    propertyElements['remote.position'] = RED.utils.createObjectElement({x:remoteNode.x,y:remoteNode.y},
+                    var remotePosition = {x:remoteNode.x,y:remoteNode.y};
+                    if (remoteNode.hasOwnProperty('w')) {
+                        remotePosition.w = remoteNode.w;
+                        remotePosition.h = remoteNode.h;
+                    }
+                    propertyElements['remote.position'] = RED.utils.createObjectElement(remotePosition,
                         {
                             path: "position",
                             exposeApi: true,
@@ -883,11 +894,11 @@ RED.diff = (function() {
                 }
             }
         }
-        var properties = Object.keys(node).filter(function(p) { return p!='inputLabels'&&p!='outputLabels'&&p!='z'&&p!='wires'&&p!=='x'&&p!=='y'&&p!=='id'&&p!=='type'&&(!def.defaults||!def.defaults.hasOwnProperty(p))});
+        var properties = Object.keys(node).filter(function(p) { return p!='inputLabels'&&p!='outputLabels'&&p!='z'&&p!='wires'&&p!=='x'&&p!=='y'&&p!=='w'&&p!=='h'&&p!=='id'&&p!=='type'&&(!def.defaults||!def.defaults.hasOwnProperty(p))});
         if (def.defaults) {
             properties = properties.concat(Object.keys(def.defaults));
         }
-        if (node.type !== 'tab') {
+        if (node.type !== 'tab' && node.type !== "group") {
             properties = properties.concat(['inputLabels','outputLabels']);
         }
         if ( ((localNode && localNode.hasOwnProperty('icon')) || (remoteNode && remoteNode.hasOwnProperty('icon'))) &&

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/envVarProperties.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/envVarProperties.js
@@ -56,8 +56,12 @@
                     });
                 }
                 if (!isSameObj(old_env, new_env)) {
-                    node.env = new_env;
                     editState.changes.env = node.env;
+                    if (new_env.length === 0) {
+                        delete node.env;
+                    } else {
+                        node.env = new_env;
+                    }
                     editState.changed = true;
                 }
             }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

This fixes a few things with Groups and the diff view.

 - when editing flow/group env vars, this fixes undoing changes
 - if a flow/group has no env vars, we do not include an empty `env` property on the node
 - the diff view of a group now includes `env` and `w`/`h` properties

Related to #3232