### PR TITLE
set node width dependent on gridsize

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -46,6 +46,7 @@ RED.view = (function() {
     var workspaceScrollPositions = {};
 
     var gridSize = 20;
+    var widthSize = 20;
     var snapGrid = false;
 
     var activeSpliceLink;
@@ -4025,7 +4026,7 @@ RED.view = (function() {
                         if (hideLabel) {
                             d.w = node_height;
                         } else {
-                            d.w = Math.max(node_width,20*(Math.ceil((labelParts.width+50+(d._def.inputs>0?7:0))/20)) );
+                            d.w = Math.max(node_width,widthSize*(Math.ceil((labelParts.width+50+(d._def.inputs>0?7:0))/widthSize)) );
                         }
                         if (ow !== undefined) {
                             d.x += (d.w-ow)/2;
@@ -4572,9 +4573,9 @@ RED.view = (function() {
                             d.nodes.forEach(function(n) {
                                 groupOpCount++
                                 if (n.type !== "group") {
-                                    minX = Math.min(minX,n.x-n.w/2-margin-((n._def.button && n._def.align!=="right")?20:0));
+                                    minX = Math.min(minX,n.x-n.w/2-margin-((n._def.button && n._def.align!=="right")?widthSize:0));
                                     minY = Math.min(minY,n.y-n.h/2-margin);
-                                    maxX = Math.max(maxX,n.x+n.w/2+margin+((n._def.button && n._def.align=="right")?20:0));
+                                    maxX = Math.max(maxX,n.x+n.w/2+margin+((n._def.button && n._def.align=="right")?widthSize:0));
                                     maxY = Math.max(maxY,n.y+n.h/2+margin);
                                 } else {
                                     minX = Math.min(minX,n.x-margin)
@@ -5084,23 +5085,23 @@ RED.view = (function() {
     function calculateNodeDimensions(node) {
         var result = [node_width,node_height];
         try {
-        var isLink = (node.type === "link in" || node.type === "link out")
-        var hideLabel = node.hasOwnProperty('l')?!node.l : isLink;
-        var label = RED.utils.getNodeLabel(node, node.type);
-        var labelParts = getLabelParts(label, "red-ui-flow-node-label");
-        if (hideLabel) {
-            result[1] = Math.max(node_height,(node.outputs || 0) * 15);
-        } else {
-            result[1] = Math.max(6+24*labelParts.lines.length,(node.outputs || 0) * 15, 30);
+            var isLink = (node.type === "link in" || node.type === "link out")
+            var hideLabel = node.hasOwnProperty('l')?!node.l : isLink;
+            var label = RED.utils.getNodeLabel(node, node.type);
+            var labelParts = getLabelParts(label, "red-ui-flow-node-label");
+            if (hideLabel) {
+                result[1] = Math.max(node_height,(node.outputs || 0) * 15);
+            } else {
+                result[1] = Math.max(6+24*labelParts.lines.length,(node.outputs || 0) * 15, 30);
+            }
+            if (hideLabel) {
+                result[0] = node_height;
+            } else {
+                result[0] = Math.max(node_width,widthSize*(Math.ceil((labelParts.width+50+(node._def.inputs>0?7:0))/widthSize)) );
+            }
+        } catch(err) {
+            console.log("Error",node);
         }
-        if (hideLabel) {
-            result[0] = node_height;
-        } else {
-            result[0] = Math.max(node_width,20*(Math.ceil((labelParts.width+50+(node._def.inputs>0?7:0))/20)) );
-        }
-    }catch(err) {
-        console.log("Error",node);
-    }
         return result;
     }
 
@@ -5241,6 +5242,8 @@ RED.view = (function() {
                 return gridSize;
             } else {
                 gridSize = Math.max(5,v);
+                widthSize = gridSize;
+                while (widthSize > 50) { widthSize = Math.round(widthSize/2); }
                 updateGrid();
             }
         },


### PR DESCRIPTION
(up to 50 - then use half sizes or quarters etc)

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

In order to better help users OCD this PR helps align the right hand side of nodes with the current grid size so both sides are aligned... - but only up to a grid size of 50 (which is quite large - default is 20).... above 50 it uses the grid size/2  (and above 100 it uses grid size/4 etc - so will give half and quarter increments rather than just make massive nodes.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
