### PR TITLE
Link in and Link out to show label

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.html
@@ -230,7 +230,7 @@
         outputLabels: function(i) {
             return this.name||this._("link.linkIn");
         },
-        showLabel: false,
+        showLabel: true,
         label: function() {
             return this.name||this._("link.linkIn");
         },
@@ -310,7 +310,7 @@
         inputLabels: function(i) {
             return this.name||(this.mode === "return" ?this._("link.linkOutReturn"):this._("link.linkOut"));
         },
-        showLabel: false,
+        showLabel: true,
         label: function() {
             return this.name||(this.mode === "return" ?this._("link.linkOutReturn"):this._("link.linkOut"));
         },


### PR DESCRIPTION
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

This PR adds the label to the `link in` and `link out` nodes so the flows can be more readable (currently you need to hover your mouse in order to see the name of the node)

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
