### PR TITLE
make `link call` node act as `node out` ui wise

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1991,7 +1991,7 @@ RED.view = (function() {
                 activeLinkNodes = {};
                 for (var i=0;i<movingSet.length();i++) {
                     var msn = movingSet.get(i);
-                    if (((msn.n.type === "link out" && msn.n.mode !== 'return') || msn.n.type === "link in") &&
+                    if (((msn.n.type === "link out" && msn.n.mode !== 'return') || msn.n.type === "link in" || msn.n.type === "link call") &&
                         (msn.n.z === activeWorkspace)) {
                         var linkNode = msn.n;
                         activeLinkNodes[linkNode.id] = linkNode;
@@ -1999,7 +1999,7 @@ RED.view = (function() {
                         linkNode.links.forEach(function(id) {
                             var target = RED.nodes.node(id);
                             if (target) {
-                                if (linkNode.type === "link out") {
+                                if (linkNode.type === "link out" || linkNode.type === "link call") {
                                     if (target.z === linkNode.z) {
                                         if (!addedLinkLinks[linkNode.id+":"+target.id]) {
                                             activeLinks.push({

--- a/packages/node_modules/@node-red/nodes/core/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.html
@@ -68,6 +68,9 @@
                 }
             });
         var candidateNodes = RED.nodes.filterNodes({type:targetType});
+        if (targetType === 'link out'){
+            candidateNodes = candidateNodes.concat(RED.nodes.filterNodes({type:'link call'}));
+        }
         var candidateNodesCount = 0;
 
         var search = $("#node-input-link-target-filter").searchBox({
@@ -168,10 +171,6 @@
         }
         node.oldLinks.sort();
         node.links.sort();
-
-        if (node.type === "link call") {
-            return
-        }
 
         var nodeMap = {};
         var length = Math.max(node.oldLinks.length,node.links.length);
@@ -286,6 +285,7 @@
         oneditsave: function() {
             onEditSave(this);
         },
+        onadd: onAdd,
         oneditresize: resizeNodeList
     });
 


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

The `link call` node will behave the same as `node out` in the UI - added the `link call` nodes the list of links in the `link in` editor and also added a UI path between connected `node call` and `node in` elements.

This will make it easier to see the linkage and usage of different link node

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
