### PR TITLE
fix 2nd output when in rate limit per topic modes

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.js
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.js
@@ -372,6 +372,7 @@ module.exports = function(RED) {
                 hit = false;
                 for (var b in node.buffer) { // check if already in queue
                     if (msg.topic === node.buffer[b].msg.topic) {
+                        if (node.outputs === 2) { send([null,node.buffer[b].msg]) }
                         node.buffer[b].done();
                         node.buffer[b] = {msg, send, done}; // if so - replace existing entry
                         hit = true;


### PR DESCRIPTION

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

to fix issue found in #3260
When in rate limit per topic mode nothing gets sent to the 2nd output if that is selected.
The way those mode work is that if a new msg arrives on a topic then the new one replaces the old one in the queue (so only the most recent gets sent) - so the old one gets discarded... This fix sends the one that would have been be discarded to the 2nd output if that is enabled.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
