### PR TITLE
Add search history to main search box

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -890,6 +890,8 @@
         "addTitle": "add an item"
     },
     "search": {
+        "history": "Search history",
+        "clear": "clear all",
         "empty": "No matches found",
         "addNode": "add a node..."
     },

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
@@ -22,6 +22,7 @@ RED.search = (function() {
     var selected = -1;
     var visible = false;
 
+    var searchHistory = [];
     var index = {};
     var currentResults = [];
     var previousActiveElement;
@@ -196,6 +197,20 @@ RED.search = (function() {
         }
     }
 
+    function populateSearchHistory() {
+        if (searchHistory.length > 0) {
+            searchResults.editableList('addItem',{
+                historyHeader: true
+            });
+            searchHistory.forEach(function(entry) {
+                searchResults.editableList('addItem',{
+                    history: true,
+                    value: entry
+                });
+            })
+        }
+
+    }
     function createDialog() {
         dialog = $("<div>",{id:"red-ui-search",class:"red-ui-search"}).appendTo("#red-ui-main-container");
         var searchDiv = $("<div>",{class:"red-ui-search-container"}).appendTo(dialog);
@@ -204,7 +219,12 @@ RED.search = (function() {
             change: function() {
                 searchResults.editableList('empty');
                 selected = -1;
-                currentResults = search($(this).val());
+                var value = $(this).val();
+                if (value === "") {
+                    populateSearchHistory();
+                    return;
+                }
+                currentResults = search(value);
                 if (currentResults.length > 0) {
                     for (i=0;i<Math.min(currentResults.length,25);i++) {
                         searchResults.editableList('addItem',currentResults[i])
@@ -276,7 +296,12 @@ RED.search = (function() {
                                 })
                             }
                         }
-                    } else {
+                    } if ($(children[selected]).hasClass("red-ui-search-history")) {
+                        var object = $(children[selected]).find(".red-ui-editableList-item-content").data('data');
+                        if (object) {
+                            searchInput.searchBox('value',object.value)
+                        }
+                    } else if (!$(children[selected]).hasClass("red-ui-search-historyHeader")) {
                         if (currentResults.length > 0) {
                             reveal(currentResults[Math.max(0,selected)].node);
                         }
@@ -292,7 +317,32 @@ RED.search = (function() {
             addItem: function(container,i,object) {
                 var node = object.node;
                 var div;
-                if (object.more) {
+                if (object.historyHeader) {
+                    container.parent().addClass("red-ui-search-historyHeader")
+                    $('<div>',{class:"red-ui-search-empty"}).text(RED._("search.history")).appendTo(container);
+                    $('<button type="button" class="red-ui-button red-ui-button-small"></button>').text(RED._("search.clear")).appendTo(container).on("click", function(evt) {
+                        evt.preventDefault();
+                        searchHistory = [];
+                        searchResults.editableList('empty');
+                    });
+                } else if (object.history) {
+                    container.parent().addClass("red-ui-search-history")
+                    div = $('<a>',{href:'#',class:"red-ui-search-result"}).appendTo(container);
+                    div.text(object.value);
+                    div.on("click", function(evt) {
+                        evt.preventDefault();
+                        searchInput.searchBox('value',object.value)
+                        searchInput.focus();
+                    })
+                    $('<button type="button" class="red-ui-button red-ui-button-small"><i class="fa fa-remove"></i></button>').appendTo(container).on("click", function(evt) {
+                        evt.preventDefault();
+                        var index = searchHistory.indexOf(object.value);
+                        searchHistory.splice(index,1);
+                        searchResults.editableList('removeItem', object);
+                    });
+
+
+                } else if (object.more) {
                     container.parent().addClass("red-ui-search-more")
                     div = $('<a>',{href:'#',class:"red-ui-search-result red-ui-search-empty"}).appendTo(container);
                     div.text(RED._("palette.editor.more",{count:object.more.results.length-object.more.start}));
@@ -347,6 +397,12 @@ RED.search = (function() {
     }
 
     function reveal(node) {
+        var searchVal = searchInput.val();
+        var existingIndex = searchHistory.indexOf(searchVal);
+        if (existingIndex > -1) {
+            searchHistory.splice(existingIndex,1);
+        }
+        searchHistory.unshift(searchInput.val());
         hide();
         RED.view.reveal(node.id);
     }
@@ -365,9 +421,14 @@ RED.search = (function() {
 
             if (dialog === null) {
                 createDialog();
+            } else {
+                searchResults.editableList('empty');
             }
             dialog.slideDown(300);
             searchInput.searchBox('value',v)
+            if (!v || v === "") {
+                populateSearchHistory();
+            }
             RED.events.emit("search:open");
             visible = true;
         }

--- a/packages/node_modules/@node-red/editor-client/src/sass/search.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/search.scss
@@ -204,6 +204,28 @@
     font-style: italic;
     color: $form-placeholder-color;
 }
+.red-ui-search-history {
+    button {
+        display: none;
+        position: absolute;
+        top: 8px;
+        right: 7px;
+    }
+
+    &:hover button {
+        display: inline;
+    }
+}
+.red-ui-search-historyHeader {
+    button {
+        position: absolute;
+        top: 10px;
+        right: 7px;
+    }
+}
+.red-ui-search-history-result {
+
+}
 
 .red-ui-search-result-action {
     color: $primary-text-color;


### PR DESCRIPTION
- [X] New feature (non-breaking change which adds functionality)

## Proposed changes

Adds a history of search terms to the main search dialog. This history entries are shown if the search field is empty:

![image](https://user-images.githubusercontent.com/51083/141868633-01c16973-5b35-41bd-9256-6f17964289c9.png)

 - A search term is only added to the history if one of its results is selected
 - The terms are listed with most-recent at the top
 - If an older term is reused, it is brought to the top of the list, rather than being duplicated
 - Hovering over any entry reviews a remove button


## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
