### PR TITLE
Avoid redundant initialisation of TypedInput type

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -556,7 +556,7 @@
             this.optionExpandButton = $('<button tabindex="0" class="red-ui-typedInput-option-expand" style="display:inline-block"></button>').appendTo(this.uiSelect);
             this.optionExpandButtonIcon = $('<i class="red-ui-typedInput-icon fa fa-ellipsis-h"></i>').appendTo(this.optionExpandButton);
 
-            this.type(this.options.default||this.typeList[0].value);
+            this.type(this.typeField.val() || this.options.default||this.typeList[0].value);
             this.typeChanged = !!this.options.default;
         }catch(err) {
             console.log(err.stack);
@@ -805,6 +805,7 @@
             var that = this;
             var currentType = this.type();
             this.typeMap = {};
+            var firstCall = (this.typeList === undefined);
             this.typeList = types.map(function(opt) {
                 var result;
                 if (typeof opt === 'string') {
@@ -829,10 +830,14 @@
             }
             this.menu = this._createMenu(this.typeList,{},function(v) { that.type(v) });
             if (currentType && !this.typeMap.hasOwnProperty(currentType)) {
-                this.type(this.typeList[0].value);
+                if (!firstCall) {
+                    this.type(this.typeList[0].value);
+                }
             } else {
                 this.propertyType = null;
-                this.type(currentType);
+                if (!firstCall) {
+                    this.type(currentType);
+                }
             }
             if (this.typeList.length === 1 && !this.typeList[0].icon && (!this.typeList[0].label || this.typeList[0].showLabel === false)) {
                 this.selectTrigger.hide()


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

[Reported on the forum](https://discourse.nodered.org/t/typefield-problems-in-2-1-3/53832), if a TypedInput is initialised with a list of types where the first type in the list has no value (eg, timestamp), but the node property is a different type with value (eg `str`), then the TI gets the right type, but the value is blank.

This is happening because when the TI is initialised, it first sets the types, which causes the type to be primed as the first in the list (`timestamp`). It then applies the actual type (`str`), which is seen as a change in type from no-value to value - and it restores the 'old' value which is blank - overwriting the right value that was already there.

The fix is to not set the `type` when setting the `types` list if its part of the initialisation of the whole widget - because we know we'll be setting it to the right type a few lines later.