### PR TITLE
Include full user object on login audit events

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/auth/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/index.js
@@ -141,7 +141,7 @@ function completeVerify(profile,done) {
     Users.authenticate(profile).then(function(user) {
         if (user) {
             Tokens.create(user.username,"node-red-editor",user.permissions).then(function(tokens) {
-                log.audit({event: "auth.login",username:user.username,scope:user.permissions});
+                log.audit({event: "auth.login",user,username:user.username,scope:user.permissions});
                 user.tokens = tokens;
                 done(null,user);
             });

--- a/packages/node_modules/@node-red/editor-api/lib/auth/strategies.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/strategies.js
@@ -93,7 +93,7 @@ var passwordTokenExchange = function(client, username, password, scope, done) {
                     return logEntry.user !== username;
                 });
                 Tokens.create(username,client.id,scope).then(function(tokens) {
-                    log.audit({event: "auth.login",username:username,client:client.id,scope:scope});
+                    log.audit({event: "auth.login",user,username:username,client:client.id,scope:scope});
                     done(null,tokens.accessToken,null,{expires_in:tokens.expires_in});
                 });
             } else {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

The audit log events for when a user logs in to the editor included the `username` of the user, but not their full profile object - which other audit events have.

This brings these events into line with the others.