### PR TITLE
Don't let themes change flow port label color

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
@@ -197,6 +197,7 @@ $view-select-mode-background: $secondary-background-selected;
 $view-grid-color: #eee;
 
 $node-label-color: #333;
+$node-port-label-color: #888;
 $node-border: #999;
 $node-border-unknown: #f33;
 $node-border-placeholder: #aaa;

--- a/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
@@ -47,7 +47,7 @@
 
 .red-ui-flow-port-label {
     stroke-width: 0;
-    fill: $secondary-text-color;
+    fill: $node-port-label-color;
     font-size: 16px;
     dominant-baseline: middle;
     text-anchor: middle;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
The selector `.red-ui-flow-port-label` currently uses `$secondary-text-color` to define its text color, but that variable usually has its value changed by the themes.

I noticed this issue with the Dracula theme. Here's how it looks when using that variable.

<img width="200" alt="Screen Shot 2021-11-22 at 4 35 04 PM" src="https://user-images.githubusercontent.com/29807944/142939652-4635e0ba-b17f-4f53-b7c7-09b1f2cfa130.png">

And here's how it looks with the proposed change.

<img width="200" alt="Screen Shot 2021-11-22 at 4 33 43 PM" src="https://user-images.githubusercontent.com/29807944/142939670-c8cf3437-baa5-4035-aa06-d347122a8946.png">

This uses the same color value defined for `$secondary-text-color` in the default vanilla theme.

It's like Nick said on Slack some time ago.

<img width="371" alt="Screen Shot 2021-11-22 at 4 41 24 PM" src="https://user-images.githubusercontent.com/29807944/142939511-49edaea9-62e2-41c4-a284-5e7823b57fc3.png">

This PR tries to fix that.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
