### PR TITLE
fix select menu label of config node to use paletteLabel

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -744,7 +744,16 @@ RED.editor = (function() {
                     delete cn.__label__;
                 });
 
-                select.append('<option value="_ADD_"'+(value===""?" selected":"")+'>'+RED._("editor.addNewType", {type:type})+'</option>');
+                var label = type;
+                if (typeof node_def.paletteLabel !== "undefined") {
+                    try {
+                        label = RED.utils.sanitize((typeof node_def.paletteLabel === "function" ? node_def.paletteLabel.call(node_def) : node_def.paletteLabel)||type);
+                    } catch(err) {
+                        console.log("Definition error: "+type+".paletteLabel",err);
+                    }
+                }
+
+                select.append('<option value="_ADD_"'+(value===""?" selected":"")+'>'+RED._("editor.addNewType", {type:label})+'</option>');
                 window.setTimeout(function() { select.trigger("change");},50);
             }
         }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Currently, config node is shown using node type in config node selection menu ((1) in the following figure).  But, the config node is shown using `paletteLabel` name in settings panel ((2) in the following figure).  

This difference seems ambiguous, so this PR change them to use the same `paletteLabel` expression.

![スクリーンショット 2021-11-24 14 18 19](https://user-images.githubusercontent.com/30289092/143179351-7141fa31-a4f6-43ea-8e3a-2ea065c8cf03.png)

## Checklist
<!-- Put an `x` in the boxes that apply -->


- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
