### PR TITLE
fix removed tab not to cause node conflict

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -805,7 +805,6 @@ RED.nodes = (function() {
         var removedGroups = [];
         if (ws) {
             delete workspaces[id];
-            allNodes.removeTab(id);
             delete linkTabMap[id];
             workspacesOrder.splice(workspacesOrder.indexOf(id),1);
             var i;
@@ -843,6 +842,7 @@ RED.nodes = (function() {
             for (i=removedGroups.length-1; i>=0; i--) {
                 removeGroup(removedGroups[i]);
             }
+            allNodes.removeTab(id);
             RED.events.emit('flows:remove',ws);
         }
         return {nodes:removedNodes,links:removedLinks, groups: removedGroups};


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Following editor operation causes node conflict on importing flow:
1. detele flow tab,
2. import a flow with nodes that was contained in the flow tab of (1)

This is because the tab information is deleted too early, so the deletion is delayed in this PR.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
