### PR TITLE
Add proper error handling for 404 errors when serving debug files

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.js
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.js
@@ -280,6 +280,18 @@ module.exports = function(RED) {
             root: path.join(__dirname,"lib","debug"),
             dotfiles: 'deny'
         };
-        res.sendFile(req.params[0], options);
+        try {
+            res.sendFile(
+                req.params[0],
+                options,
+                 err => {
+                    if (err) {
+                        res.sendStatus(404);
+                    }
+                }
+            )
+        } catch(err) {
+            res.sendStatus(404);
+        }
     });
 };


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

This avoids internal errors from being returned to the caller