### PR TITLE
fix env var access using $parent for groups

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -439,8 +439,6 @@ class Flow {
                                 }
                             }
                             return [env.name, env];
-                            
-                            return [env.name, env];
                         });
                         group._env = Object.fromEntries(entries);
                     }
@@ -457,24 +455,24 @@ class Flow {
                                 const val
                                       = ((value === "true") ||
                                          (value === true));
-                                return {
+                                return [{
                                     val: val
-                                };
+                                }, null];
                             }
                             if (type === "cred") {
-                                return {
+                                return [{
                                     val: value
-                                };
+                                }, null];
                             }
                             try {
                                 var val = redUtil.evaluateNodeProperty(value, type, node, null, null);
-                                return {
+                                return [{
                                     val: val
-                                };
+                                }, null];
                             }
                             catch (e) {
                                 this.error(e);
-                                return null;
+                                return [null, null];
                             }
                         }
                     }
@@ -488,7 +486,7 @@ class Flow {
                 return this.getGroupEnvSetting(node, parent, name);
             }
         }
-        return null;
+        return [null, name];
     }
 
 
@@ -544,6 +542,9 @@ class Flow {
                         }
                     }
                 }
+            }
+            else {
+                key = key.substring(8);
             }
         }
         return this.parent.getSetting(key);

--- a/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
@@ -373,10 +373,11 @@ class Subflow extends Flow {
         const node = this.subflowInstance;
         if (node.g) {
             const group = this.getGroupNode(node.g);
-            const result = this.getGroupEnvSetting(node, group, name);
+            const [result, newName] = this.getGroupEnvSetting(node, group, name);
             if (result) {
                 return result.val;
             }
+            name = newName;
         }
         
 

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -526,10 +526,11 @@ function getSetting(node, name, flow_) {
     if (flow) {
         if (node && node.g) {
             const group = flow.getGroupNode(node.g);
-            const result = flow.getGroupEnvSetting(node, group, name);
+            const [result, newName] = flow.getGroupEnvSetting(node, group, name);
             if (result) {
                 return result.val;
             }
+            name = newName;
         }
         return flow.getSetting(name);
     }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
If an environment variable reference is made using `$parent` in a group, the location of the variable reference in the outer environment may become incorrect.  
This is because the `$parent` reference within the group is not reflected in the outside environment.

This PR tries to fix this problem.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
