### PR TITLE
Fix i18n handling of namespaces with spaces in

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/i18n.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/i18n.js
@@ -38,6 +38,8 @@ RED.i18n = (function() {
                 defaultNS: "editor",
                 fallbackLng: ['en-US'],
                 returnObjects: true,
+                keySeparator: ".",
+                nsSeparator: ":",
                 interpolation: {
                     unescapeSuffix: 'HTML',
                     escapeValue: false,

--- a/packages/node_modules/@node-red/util/lib/i18n.js
+++ b/packages/node_modules/@node-red/util/lib/i18n.js
@@ -136,8 +136,6 @@ function getCurrentLocale() {
 
 function init(settings) {
     if (!initPromise) {
-        // Keep this as a 'when' promise as top-level red.js uses 'otherwise'
-        // and embedded users of NR may have copied that.
         initPromise = new Promise((resolve,reject) => {
             i18n.use(MessageFileLoader);
             var opt = {
@@ -146,6 +144,8 @@ function init(settings) {
                 defaultNS: "runtime",
                 ns: [],
                 fallbackLng: defaultLang,
+                keySeparator: ".",
+                nsSeparator: ":",
                 interpolation: {
                     unescapeSuffix: 'HTML',
                     escapeValue: false,


### PR DESCRIPTION
i18next recently added a 'natural language detection' feature that, whilst the details are irrelevant, broken the ability to have message catalog namespaces that contain a space.

This was introduced in a major version change on their part, but unfortunately their migration guide did little to highlight the impact of this feature. It did at least, once the dots were joined, point to the config options needed to disable the behaviour and get back to how it used to work.