### PR TITLE
Change tab hide button icon to an eye and add search option

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -59,6 +59,8 @@
         "hideOtherFlows": "Hide other flows",
         "showAllFlows": "Show all flows",
         "hideAllFlows": "Hide all flows",
+        "hiddenFlows": "List __count__ hidden flow",
+        "hiddenFlows_plural": "List __count__ hidden flows",
         "showLastHiddenFlow": "Show last hidden flow",
         "listFlows": "List flows",
         "listSubflows": "List subflows",
@@ -669,7 +671,8 @@
                 "unusedConfigNodes": "Unused configuration nodes",
                 "invalidNodes": "Invalid nodes",
                 "uknownNodes": "Unknown nodes",
-                "unusedSubflows": "Unused subflows"
+                "unusedSubflows": "Unused subflows",
+                "hiddenFlows": "Hidden flows"
             }
         },
         "help": {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
@@ -811,6 +811,7 @@ RED.tabs = (function() {
                         event.preventDefault();
                         removeTab(tab.id);
                     });
+                    RED.popover.tooltip(closeLink,RED._("workspace.hideFlow"));
                 }
                 if (tab.hideable) {
                     li.addClass("red-ui-tabs-closeable")
@@ -821,6 +822,7 @@ RED.tabs = (function() {
                         event.preventDefault();
                         hideTab(tab.id);
                     });
+                    RED.popover.tooltip(closeLink,RED._("workspace.hideFlow"));
                 }
 
                 var badges = $('<span class="red-ui-tabs-badges"></span>').appendTo(li);
@@ -829,7 +831,8 @@ RED.tabs = (function() {
                     $('<i class="red-ui-tabs-badge-selected fa fa-check-circle"></i>').appendTo(badges);
                 }
 
-                link.attr("title",tab.label);
+                // link.attr("title",tab.label);
+                RED.popover.tooltip(link,function() { return tab.label})
 
                 if (options.onadd) {
                     options.onadd(tab);
@@ -948,7 +951,6 @@ RED.tabs = (function() {
             renameTab: function(id,label) {
                 tabs[id].label = label;
                 var tab = ul.find("a[href='#"+id+"']");
-                tab.attr("title",label);
                 tab.find("span.red-ui-text-bidi-aware").text(label).attr('dir', RED.text.bidi.resolveBaseTextDir(label));
                 updateTabWidths();
             },

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
@@ -117,6 +117,8 @@ RED.tabs = (function() {
                     menuOptions = options.menu()
                 } else if (Array.isArray(options.menu)) {
                     menuOptions = options.menu;
+                } else if (typeof options.menu === 'function') {
+                    menuOptions = options.menu();
                 }
                 menu = RED.menu.init({options: menuOptions});
                 menu.attr("id",options.id+"-menu");
@@ -812,8 +814,9 @@ RED.tabs = (function() {
                 }
                 if (tab.hideable) {
                     li.addClass("red-ui-tabs-closeable")
-                    var closeLink = $("<a/>",{href:"#",class:"red-ui-tab-close"}).appendTo(li);
-                    closeLink.append('<i class="fa fa-times" />');
+                    var closeLink = $("<a/>",{href:"#",class:"red-ui-tab-close red-ui-tab-hide"}).appendTo(li);
+                    closeLink.append('<i class="fa fa-eye" />');
+                    closeLink.append('<i class="fa fa-eye-slash" />');
                     closeLink.on("click",function(event) {
                         event.preventDefault();
                         hideTab(tab.id);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
@@ -105,6 +105,7 @@ RED.search = (function() {
         val = extractFlag(val,"unused",flags);
         val = extractFlag(val,"config",flags);
         val = extractFlag(val,"subflow",flags);
+        val = extractFlag(val,"hidden",flags);
         // uses:<node-id>
         val = extractValue(val,"uses",flags);
 
@@ -150,7 +151,15 @@ RED.search = (function() {
                                 continue;
                             }
                         }
-
+                        if (flags.hasOwnProperty("hidden")) {
+                            // Only tabs can be hidden
+                            if (node.node.type !== 'tab') {
+                                continue
+                            }
+                            if (!RED.workspaces.isHidden(node.node.id)) {
+                                continue
+                            }
+                        }
                         if (flags.hasOwnProperty("unused")) {
                             var isUnused = (node.node.type === 'subflow' && node.node.instances.length === 0) ||
                                            (isConfigNode && node.node.users.length === 0)

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
@@ -274,6 +274,7 @@ RED.sidebar.info.outliner = (function() {
                 {label:RED._("sidebar.info.search.invalidNodes"), value: "is:invalid"},
                 {label:RED._("sidebar.info.search.uknownNodes"), value: "type:unknown"},
                 {label:RED._("sidebar.info.search.unusedSubflows"), value:"is:subflow is:unused"},
+                {label:RED._("sidebar.info.search.hiddenFlows"), value:"is:hidden"},
             ]
         });
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -218,55 +218,64 @@ RED.workspaces = (function() {
             scrollable: true,
             addButton: "core:add-flow",
             addButtonCaption: RED._("workspace.addFlow"),
-            menu: [
-                {
-                    id:"red-ui-tabs-menu-option-search-flows",
-                    label: RED._("workspace.listFlows"),
-                    onselect: "core:list-flows"
-                },
-                {
-                    id:"red-ui-tabs-menu-option-search-subflows",
-                    label: RED._("workspace.listSubflows"),
-                    onselect: "core:list-subflows"
-                },
-                null,
-                {
-                    id:"red-ui-tabs-menu-option-add-flow",
-                    label: RED._("workspace.addFlow"),
-                    onselect: "core:add-flow"
-                },
-                {
-                    id:"red-ui-tabs-menu-option-add-flow-right",
-                    label: RED._("workspace.addFlowToRight"),
-                    onselect: "core:add-flow-to-right"
-                },
-                null,
-                {
-                    id:"red-ui-tabs-menu-option-add-hide-flows",
-                    label: RED._("workspace.hideFlow"),
-                    onselect: "core:hide-flow"
-                },
-                {
-                    id:"red-ui-tabs-menu-option-add-hide-other-flows",
-                    label: RED._("workspace.hideOtherFlows"),
-                    onselect: "core:hide-other-flows"
-                },
-                {
-                    id:"red-ui-tabs-menu-option-add-show-all-flows",
-                    label: RED._("workspace.showAllFlows"),
-                    onselect: "core:show-all-flows"
-                },
-                {
-                    id:"red-ui-tabs-menu-option-add-hide-all-flows",
-                    label: RED._("workspace.hideAllFlows"),
-                    onselect: "core:hide-all-flows"
-                },
-                {
-                    id:"red-ui-tabs-menu-option-add-show-last-flow",
-                    label: RED._("workspace.showLastHiddenFlow"),
-                    onselect: "core:show-last-hidden-flow"
+            menu: function() {
+                var menuItems = [
+                    {
+                        id:"red-ui-tabs-menu-option-search-flows",
+                        label: RED._("workspace.listFlows"),
+                        onselect: "core:list-flows"
+                    },
+                    {
+                        id:"red-ui-tabs-menu-option-search-subflows",
+                        label: RED._("workspace.listSubflows"),
+                        onselect: "core:list-subflows"
+                    },
+                    null,
+                    {
+                        id:"red-ui-tabs-menu-option-add-flow",
+                        label: RED._("workspace.addFlow"),
+                        onselect: "core:add-flow"
+                    },
+                    {
+                        id:"red-ui-tabs-menu-option-add-flow-right",
+                        label: RED._("workspace.addFlowToRight"),
+                        onselect: "core:add-flow-to-right"
+                    },
+                    null,
+                    {
+                        id:"red-ui-tabs-menu-option-add-hide-flows",
+                        label: RED._("workspace.hideFlow"),
+                        onselect: "core:hide-flow"
+                    },
+                    {
+                        id:"red-ui-tabs-menu-option-add-hide-other-flows",
+                        label: RED._("workspace.hideOtherFlows"),
+                        onselect: "core:hide-other-flows"
+                    },
+                    {
+                        id:"red-ui-tabs-menu-option-add-show-all-flows",
+                        label: RED._("workspace.showAllFlows"),
+                        onselect: "core:show-all-flows"
+                    },
+                    {
+                        id:"red-ui-tabs-menu-option-add-hide-all-flows",
+                        label: RED._("workspace.hideAllFlows"),
+                        onselect: "core:hide-all-flows"
+                    },
+                    {
+                        id:"red-ui-tabs-menu-option-add-show-last-flow",
+                        label: RED._("workspace.showLastHiddenFlow"),
+                        onselect: "core:show-last-hidden-flow"
+                    }
+                ]
+                if (hideStack.length > 0) {
+                    menuItems.unshift({
+                        label: RED._("workspace.hiddenFlows",{count: hideStack.length}),
+                        onselect: "core:list-hidden-flows"
+                    })
                 }
-            ]
+                return menuItems;
+            }
         });
         workspaceTabCount = 0;
     }
@@ -406,7 +415,9 @@ RED.workspaces = (function() {
                 }
             }
         })
-
+        RED.actions.add("core:list-hidden-flows",function() {
+            RED.actions.invoke("core:search","is:hidden ");
+        })
         RED.actions.add("core:list-flows",function() {
             RED.actions.invoke("core:search","type:tab ");
         })
@@ -535,6 +546,9 @@ RED.workspaces = (function() {
                 hiddenTabs[id] = true;
                 RED.settings.setLocal("hiddenTabs",JSON.stringify(hiddenTabs));
             }
+        },
+        isHidden: function(id) {
+            return hideStack.includes(id)
         },
         show: function(id,skipStack,unhideOnly) {
             if (!workspace_tabs.contains(id)) {

--- a/packages/node_modules/@node-red/editor-client/src/sass/tabs.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tabs.scss
@@ -389,7 +389,19 @@ i.red-ui-tab-icon {
     vertical-align: top;
 
 }
-
+.red-ui-tab-hide {
+    .fa-eye-slash {
+        display: none;
+    }
+    &:hover {
+        .fa-eye-slash {
+            display: inline
+        }
+        .fa-eye {
+            display: none
+        }
+    }
+}
 .red-ui-tab-close {
     display: none;
     background: $tab-background-inactive;


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

This is technically a new feature that addresses a usability concern with the hide-tabs feature. I propose to include this in 2.1.4 rather than wait two months for 2.2.0.

As such, want to get sign-off from @dceejay as this is an exception to our normal way of working.

This PR improves the workflow around hiding tabs a bit. Specifically:

 - the icon is changed from the `x`to by the eye icon. Repeated feedback told us users felt the `x` implied they were deleting the tab rather than hiding. Changing the icon to the more benign eye is less alarming and more related to visibility rather than deletion.
 - moreso, when you hover on the tab the icon is the open eye. When you hover over the eye it closes. This also helps reinforce the purpose of the button.

    ![](http://g.recordit.co/iuhLiNkNPv.gif)

 - The tab dropdown menu has a new option at the top if you have hidden flows that tells you how many hidden tabs there are. Clicking on this option opens the search dialog which will list the hidden flows.
    
    ![image](https://user-images.githubusercontent.com/51083/144288238-ec42bef3-21ee-40cd-8bd6-638a57562bb6.png)


I think this is a much needed improvement to the hide flows workflow.
