### PR TITLE
Wiring shortcut

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
@@ -725,6 +725,90 @@ RED.view.tools = (function() {
         }
     }
 
+
+    function wireSeriesOfNodes() {
+        var selection = RED.view.selection();
+        if (selection.nodes) {
+            if (selection.nodes.length > 1) {
+                var i = 0;
+                var newLinks = [];
+                while (i < selection.nodes.length - 1) {
+                    var nodeA = selection.nodes[i];
+                    var nodeB = selection.nodes[i+1];
+                    if (nodeA.outputs > 0 && nodeB.inputs > 0) {
+                        var existingLinks = RED.nodes.filterLinks({
+                            source: nodeA,
+                            target: nodeB,
+                            sourcePort: 0
+                        })
+                        if (existingLinks.length === 0) {
+                            var newLink = {
+                                source: nodeA,
+                                target: nodeB,
+                                sourcePort: 0
+                            }
+                            RED.nodes.addLink(newLink);
+                            newLinks.push(newLink);
+                        }
+                    }
+                    i++;
+                }
+                if (newLinks.length > 0) {
+                    RED.history.push({
+                        t: 'add',
+                        links: newLinks,
+                        dirty: RED.nodes.dirty()
+                    })
+                    RED.nodes.dirty(true);
+                    RED.view.redraw(true);
+                }
+            }
+        }
+    }
+
+    function wireNodeToMultiple() {
+        var selection = RED.view.selection();
+        if (selection.nodes) {
+            if (selection.nodes.length > 1) {
+                var sourceNode = selection.nodes[0];
+                if (sourceNode.outputs === 0) {
+                    return;
+                }
+                var i = 1;
+                var newLinks = [];
+                while (i < selection.nodes.length) {
+                    var targetNode = selection.nodes[i];
+                    if (targetNode.inputs > 0) {
+                        var existingLinks = RED.nodes.filterLinks({
+                            source: sourceNode,
+                            target: targetNode,
+                            sourcePort: Math.min(sourceNode.outputs-1,i-1)
+                        })
+                        if (existingLinks.length === 0) {
+                            var newLink = {
+                                source: sourceNode,
+                                target: targetNode,
+                                sourcePort: Math.min(sourceNode.outputs-1,i-1)
+                            }
+                            RED.nodes.addLink(newLink);
+                            newLinks.push(newLink);
+                        }
+                    }
+                    i++;
+                }
+                if (newLinks.length > 0) {
+                    RED.history.push({
+                        t: 'add',
+                        links: newLinks,
+                        dirty: RED.nodes.dirty()
+                    })
+                    RED.nodes.dirty(true);
+                    RED.view.redraw(true);
+                }
+            }
+        }
+    }
+
     return {
         init: function() {
             RED.actions.add("core:show-selected-node-labels", function() { setSelectedNodeLabelState(true); })
@@ -783,7 +867,8 @@ RED.view.tools = (function() {
             RED.actions.add("core:distribute-selection-horizontally", function() { distributeSelection('h') })
             RED.actions.add("core:distribute-selection-vertically", function() { distributeSelection('v') })
 
-
+            RED.actions.add("core:wire-series-of-nodes", function() { wireSeriesOfNodes() })
+            RED.actions.add("core:wire-node-to-multiple", function() { wireNodeToMultiple() })
 
             // RED.actions.add("core:add-node", function() { addNode() })
         },


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

Adds a pair of new actions for wiring nodes.

 - `core:wire-series-of-nodes` - for a selection of nodes, add a wire (if necessary) between each node pair in the order they exist in the selection
 - `core:wire-node-to-multiple` - for a selection of nodes, wires the *first* node (the source) in the selection to all of the remaining nodes. If the source node has multiple outputs, they are wired in turn.


No default keyboard shortcut assigned to them (yet)... something to consider adding.
