### PR TITLE
Snap nodes on grid using either edge as reference

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -412,25 +412,55 @@ RED.view = (function() {
                 var historyEvent = result.historyEvent;
                 var nn = result.node;
 
+                RED.nodes.add(nn);
+
                 var showLabel = RED.utils.getMessageProperty(RED.settings.get('editor'),"view.view-node-show-label");
                 if (showLabel !== undefined &&  (nn._def.hasOwnProperty("showLabel")?nn._def.showLabel:true) && !nn._def.defaults.hasOwnProperty("l")) {
                     nn.l = showLabel;
                 }
 
                 var helperOffset = d3.touches(ui.helper.get(0))[0]||d3.mouse(ui.helper.get(0));
+                var helperWidth = ui.helper.width();
+                var helperHeight = ui.helper.height();
                 var mousePos = d3.touches(this)[0]||d3.mouse(this);
 
-                mousePos[1] += this.scrollTop + ((nn.h/2)-helperOffset[1]);
-                mousePos[0] += this.scrollLeft + ((nn.w/2)-helperOffset[0]);
+                try {
+                    var isLink = (nn.type === "link in" || nn.type === "link out")
+                    var hideLabel = nn.hasOwnProperty('l')?!nn.l : isLink;
+
+                    var label = RED.utils.getNodeLabel(nn, nn.type);
+                    var labelParts = getLabelParts(label, "red-ui-flow-node-label");
+                    if (hideLabel) {
+                        nn.w = node_height;
+                        nn.h = Math.max(node_height,(nn.outputs || 0) * 15);
+                    } else {
+                        nn.w = Math.max(node_width,20*(Math.ceil((labelParts.width+50+(nn._def.inputs>0?7:0))/20)) );
+                        nn.h = Math.max(6+24*labelParts.lines.length,(nn.outputs || 0) * 15, 30);
+                    }
+                } catch(err) {
+                }
+
+                mousePos[1] += this.scrollTop + ((helperHeight/2)-helperOffset[1]);
+                mousePos[0] += this.scrollLeft + ((helperWidth/2)-helperOffset[0]);
                 mousePos[1] /= scaleFactor;
                 mousePos[0] /= scaleFactor;
 
-                if (snapGrid) {
-                    mousePos[0] = gridSize*(Math.ceil(mousePos[0]/gridSize));
-                    mousePos[1] = gridSize*(Math.ceil(mousePos[1]/gridSize));
-                }
                 nn.x = mousePos[0];
                 nn.y = mousePos[1];
+
+                if (snapGrid) {
+                    var gridOffset = [0,0];
+                    var offsetLeft = nn.x-(gridSize*Math.round((nn.x-nn.w/2)/gridSize)+nn.w/2);
+                    var offsetRight = nn.x-(gridSize*Math.round((nn.x+nn.w/2)/gridSize)-nn.w/2);
+                    if (Math.abs(offsetLeft) < Math.abs(offsetRight)) {
+                        gridOffset[0] = offsetLeft
+                    } else {
+                        gridOffset[0] = offsetRight
+                    }
+                    gridOffset[1] = nn.y-(gridSize*Math.round(nn.y/gridSize));
+                    nn.x -= gridOffset[0];
+                    nn.y -= gridOffset[1];
+                }
 
                 var spliceLink = $(ui.helper).data("splice");
                 if (spliceLink) {
@@ -452,7 +482,6 @@ RED.view = (function() {
                     historyEvent.removedLinks = [spliceLink];
                 }
 
-                RED.nodes.add(nn);
 
                 var group = $(ui.helper).data("group");
                 if (group) {
@@ -1515,8 +1544,16 @@ RED.view = (function() {
                     gridOffset[0] = node.n.x-(gridSize*Math.floor(node.n.x/gridSize))-gridSize/2;
                     gridOffset[1] = node.n.y-(gridSize*Math.floor(node.n.y/gridSize))-gridSize/2;
                 } else {
-                    gridOffset[0] = node.n.x-(gridSize*Math.floor((node.n.x-node.n.w/2)/gridSize)+node.n.w/2);
-                    gridOffset[1] = node.n.y-(gridSize*Math.floor(node.n.y/gridSize));
+                    var offsetLeft = node.n.x-(gridSize*Math.round((node.n.x-node.n.w/2)/gridSize)+node.n.w/2);
+                    var offsetRight = node.n.x-(gridSize*Math.round((node.n.x+node.n.w/2)/gridSize)-node.n.w/2);
+                    // gridOffset[0] = node.n.x-(gridSize*Math.floor((node.n.x-node.n.w/2)/gridSize)+node.n.w/2);
+                    if (Math.abs(offsetLeft) < Math.abs(offsetRight)) {
+                        gridOffset[0] = offsetLeft
+                    } else {
+                        gridOffset[0] = offsetRight
+                    }
+                    gridOffset[1] = node.n.y-(gridSize*Math.round(node.n.y/gridSize));
+                    // console.log(offsetLeft, offsetRight);
                 }
                 if (gridOffset[0] !== 0 || gridOffset[1] !== 0) {
                     for (i = 0; i<movingSet.length(); i++) {


### PR DESCRIPTION
- [X] New feature (non-breaking change which adds functionality)

This PR addresses the whole 'cannot align link nodes properly' issue.

The existing logic is this:
 - The existing snap-to-grid behaviour aligns the left-hand edge of nodes to the grid.
 - Node widths (if the is label shown) are rounded to the nearest 20
 - For the default grid size, this means regular nodes span an exact number of grid cells, so the fact the left-hand edge snaps to the grid means the right-hand edge snaps for 'free'.
 - For non-default grid sizes however, it means the right-hand edge is always 'off' the grid.
 - It also means for Link nodes (hidden label), where the width is not a multiple of 20, the RH edge is off grid.

With this PR, the snap-to-grid logic has been updated to snap to the nearest grid line, whether that is left or right hand edge.

This means nodes that are not a whole number of grid cells wide can be aligned on either edge:

![image](https://user-images.githubusercontent.com/51083/144768329-36c1202f-fb72-4985-8565-b1a9e15016f1.png)

This solves all of the layout issues with the link nodes.

Whilst working on this, I also fixed the positioning of nodes that are dragged in from the palette - they now land much closer to where the mouse drops them and are properly snapped to the grid.
