### PR TITLE
Let JSON node attempt to parse buffer if it contains a valid string

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/parsers/70-JSON.js
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-JSON.js
@@ -49,7 +49,11 @@ module.exports = function(RED) {
             }
             var value = RED.util.getMessageProperty(msg,node.property);
             if (value !== undefined) {
-                if (typeof value === "string") {
+                if (typeof value === "string" || Buffer.isBuffer(value)) {
+                    // if (Buffer.isBuffer(value) && node.action !== "obj") {
+                    //     node.warn(RED._("json.errors.dropped")); done();
+                    // }
+                    // else
                     if (node.action === "" || node.action === "obj") {
                         try {
                             RED.util.setMessageProperty(msg,node.property,JSON.parse(value));

--- a/test/nodes/core/parsers/70-JSON_spec.js
+++ b/test/nodes/core/parsers/70-JSON_spec.js
@@ -50,6 +50,24 @@ describe('JSON node', function() {
         });
     });
 
+    it('should convert a buffer of a valid json string to a javascript object', function(done) {
+        var flow = [{id:"jn1",type:"json",action:"obj",wires:[["jn2"]]},
+                    {id:"jn2", type:"helper"}];
+        helper.load(jsonNode, flow, function() {
+            var jn1 = helper.getNode("jn1");
+            var jn2 = helper.getNode("jn2");
+            jn2.on("input", function(msg) {
+                msg.should.have.property('topic', 'bar');
+                msg.payload.should.have.property('employees');
+                msg.payload.employees[0].should.have.property('firstName', 'John');
+                msg.payload.employees[0].should.have.property('lastName', 'Smith');
+                done();
+            });
+            var jsonString = Buffer.from('{"employees":[{"firstName":"John", "lastName":"Smith"}]}');
+            jn1.receive({payload:jsonString,topic: "bar"});
+        });
+    });
+
     it('should convert a javascript object to a json string', function(done) {
         var flow = [{id:"jn1",type:"json",wires:[["jn2"]]},
                     {id:"jn2", type:"helper"}];
@@ -166,28 +184,54 @@ describe('JSON node', function() {
         });
     });
 
-    it('should log an error if asked to parse something thats not json or js', function(done) {
-        var flow = [{id:"jn1",type:"json",wires:[["jn2"]]},
+    it('should log an error if asked to parse an invalid json string in a buffer', function(done) {
+        var flow = [{id:"jn1",type:"json",action:"obj",wires:[["jn2"]]},
                     {id:"jn2", type:"helper"}];
         helper.load(jsonNode, flow, function() {
-            var jn1 = helper.getNode("jn1");
-            var jn2 = helper.getNode("jn2");
-            setTimeout(function() {
-                try {
-                    var logEvents = helper.log().args.filter(function(evt) {
-                        return evt[0].type == "json";
-                    });
-                    logEvents.should.have.length(1);
-                    logEvents[0][0].should.have.a.property('msg');
-                    logEvents[0][0].msg.toString().should.eql('json.errors.dropped-object');
-                    done();
-                } catch(err) {
-                    done(err);
-                }
-            },50);
-            jn1.receive({payload:Buffer.from("a")});
+            try {
+                var jn1 = helper.getNode("jn1");
+                var jn2 = helper.getNode("jn2");
+                jn1.receive({payload:Buffer.from('{"name":foo}'),topic: "bar"});
+                setTimeout(function() {
+                    try {
+                        var logEvents = helper.log().args.filter(function(evt) {
+                            return evt[0].type == "json";
+                        });
+                        logEvents.should.have.length(1);
+                        logEvents[0][0].should.have.a.property('msg');
+                        logEvents[0][0].msg.should.startWith("Unexpected token o");
+                        logEvents[0][0].should.have.a.property('level',helper.log().ERROR);
+                        done();
+                    } catch(err) { done(err) }
+                },20);
+            } catch(err) {
+                done(err);
+            }
         });
     });
+
+    // it('should log an error if asked to parse something thats not json or js and not in force object mode', function(done) {
+    //     var flow = [{id:"jn1",type:"json",wires:[["jn2"]]},
+    //                 {id:"jn2", type:"helper"}];
+    //     helper.load(jsonNode, flow, function() {
+    //         var jn1 = helper.getNode("jn1");
+    //         var jn2 = helper.getNode("jn2");
+    //         setTimeout(function() {
+    //             try {
+    //                 var logEvents = helper.log().args.filter(function(evt) {
+    //                     return evt[0].type == "json";
+    //                 });
+    //                 logEvents.should.have.length(1);
+    //                 logEvents[0][0].should.have.a.property('msg');
+    //                 logEvents[0][0].msg.toString().should.eql('json.errors.dropped');
+    //                 done();
+    //             } catch(err) {
+    //                 done(err);
+    //             }
+    //         },50);
+    //         jn1.receive({payload:Buffer.from("abcd")});
+    //     });
+    // });
 
     it('should pass straight through if no payload set', function(done) {
         var flow = [{id:"jn1",type:"json",wires:[["jn2"]]},


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Currently the JSON parse node ignores (and drops) any buffers it sees - This PR changes that behaviour to attempt to parse them as if they contain a string... (and then fails if not).

Another option is to only do this when set in always "convert to javascript object" mode. Though if we don't make that clear I'm sure someone will trip up and wonder why the difference at some point.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
