### PR TITLE
Remove use of verbose flag in core nodes - and use node.debug level instead

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.js
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.js
@@ -144,10 +144,8 @@ module.exports = function(RED) {
         }
         if (this.interval_id != null) {
             clearInterval(this.interval_id);
-            this.debug(RED._("inject.stopped"));
         } else if (this.cronjob != null) {
             this.cronjob.stop();
-            this.debug(RED._("inject.stopped"));
             delete this.cronjob;
         }
     };

--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.js
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.js
@@ -75,16 +75,12 @@ module.exports = function(RED) {
         node.repeaterSetup = function () {
             if (this.repeat && !isNaN(this.repeat) && this.repeat > 0) {
                 this.repeat = this.repeat * 1000;
-                if (RED.settings.verbose) {
-                    this.log(RED._("inject.repeat", this));
-                }
+                this.debug(RED._("inject.repeat", this));
                 this.interval_id = setInterval(function() {
                     node.emit("input", {});
                 }, this.repeat);
             } else if (this.crontab) {
-                if (RED.settings.verbose) {
-                    this.log(RED._("inject.crontab", this));
-                }
+                this.debug(RED._("inject.crontab", this));
                 this.cronjob = scheduleTask(this.crontab,() => { node.emit("input", {})});
             }
         };
@@ -148,10 +144,10 @@ module.exports = function(RED) {
         }
         if (this.interval_id != null) {
             clearInterval(this.interval_id);
-            if (RED.settings.verbose) { this.log(RED._("inject.stopped")); }
+            this.debug(RED._("inject.stopped"));
         } else if (this.cronjob != null) {
             this.cronjob.stop();
-            if (RED.settings.verbose) { this.log(RED._("inject.stopped")); }
+            this.debug(RED._("inject.stopped"));
             delete this.cronjob;
         }
     };

--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.js
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.js
@@ -86,7 +86,7 @@ module.exports = function(RED) {
                     });
                     var cmd = arg.shift();
                     /* istanbul ignore else  */
-                    if (RED.settings.verbose) { node.log(cmd+" ["+arg+"]"); }
+                    node.debug(cmd+" ["+arg+"]");
                     child = spawn(cmd,arg,node.spawnOpt);
                     node.status({fill:"blue",shape:"dot",text:"pid:"+child.pid});
                     var unknownCommand = (child.pid === undefined);
@@ -136,7 +136,7 @@ module.exports = function(RED) {
                 }
                 else {
                     /* istanbul ignore else  */
-                    if (RED.settings.verbose) { node.log(arg); }
+                    node.debug(arg);
                     child = exec(arg, node.execOpt, function (error, stdout, stderr) {
                         var msg2, msg3;
                         delete msg.payload;
@@ -155,7 +155,7 @@ module.exports = function(RED) {
                             if (error.signal) { msg3.payload.signal = error.signal; }
                             if (error.code === null) { node.status({fill:"red",shape:"dot",text:"killed"}); }
                             else { node.status({fill:"red",shape:"dot",text:"error:"+error.code}); }
-                            if (RED.settings.verbose) { node.log('error:' + error); }
+                            node.debug('error:' + error);
                         }
                         else if (node.oldrc === "false") {
                             msg3 = RED.util.cloneMessage(msg);

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.js
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.js
@@ -71,9 +71,7 @@ module.exports = function(RED) {
                         node.error(RED._("file.errors.deletefail",{error:err.toString()}),msg);
                     }
                     else {
-                        if (RED.settings.verbose) {
-                            node.log(RED._("file.status.deletedfile",{file:filename}));
-                        }
+                        node.debug(RED._("file.status.deletedfile",{file:filename}));
                         nodeSend(msg);
                     }
                     done();


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This PR - tidies up the core exec, file and inject nodes to use node.debug rather than the old -v / verbose flag from settings or command line.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
