### PR TITLE
Check availability of type of config node on deploy

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -333,6 +333,16 @@ RED.deploy = (function() {
                 var unknownNodes = [];
                 var invalidNodes = [];
 
+                RED.nodes.eachConfig(function(node) {
+                    if (!node.valid && !node.d) {
+                        invalidNodes.push(getNodeInfo(node));
+                    }
+                    if (node.type === "unknown") {
+                        if (unknownNodes.indexOf(node.name) == -1) {
+                            unknownNodes.push(node.name);
+                        }
+                    }                    
+                });
                 RED.nodes.eachNode(function(node) {
                     if (!node.valid && !node.d) {
                         invalidNodes.push(getNodeInfo(node));


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

When importing and deploying a flow, a warning will be displayed if there are undefined nodes.
However, in the case of a config node, no warning is displayed.  So if you deploy a flow containing undefined config node, the flow will stop unintentionally.

![image](https://user-images.githubusercontent.com/30313213/146904679-78186c6e-a8df-449e-a7de-bf1a7ee9b39e.png)

To solve this problem, I added a check to see if the config node is an undefined node at the time of deployment.

![image](https://user-images.githubusercontent.com/30313213/146904723-67517dfa-0d66-431e-b4e3-21ba5246398a.png)

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
