### PR TITLE
Add TLS option to tcp client nodes

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
@@ -93,10 +93,8 @@
                 var sockettype = $("#node-input-server").val();
                 if (sockettype == "client") {
                     $("#node-input-host-row").show();
-                    $("#node-input-tls-enable").show();
                 } else {
                     $("#node-input-host-row").hide();
-                    $("#node-input-tls-enable").hide();
                 }
                 var datamode = $("#node-input-datamode").val();
                 var datatype = $("#node-input-datatype").val();
@@ -222,7 +220,7 @@
                     $("#node-input-port-row").show();
                     $("#node-input-host-row").hide();
                     $("#node-input-end-row").show();
-                    $("#node-input-tls-enable").hide();
+                    $("#node-input-tls-enable").show();
                 }
             };
             updateOptions();
@@ -269,7 +267,7 @@
         </div>
     </div>
     <div class="form-row">
-        <label for="node-input-out"><i class="fa fa-sign-out"></i> <span data-i18n="tcpin.label.return"></span></label>
+        <label for="node-input-ret"><i class="fa fa-sign-out"></i> <span data-i18n="tcpin.label.return"></span></label>
         <select type="text" id="node-input-ret" style="width:54%;">
             <option value="buffer" data-i18n="tcpin.output.buffer"></option>
             <option value="string" data-i18n="tcpin.output.string"></option>

--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
@@ -23,8 +23,16 @@
         </select>
         <span data-i18n="tcpin.label.port"></span> <input type="text" id="node-input-port" style="width:65px">
     </div>
-    <div class="form-row hidden" id="node-input-host-row" style="padding-left: 110px;">
+    <div class="form-row hidden" id="node-input-host-row" style="padding-left:110px;">
         <span data-i18n="tcpin.label.host"></span> <input type="text" id="node-input-host" placeholder="localhost" style="width: 60%;">
+    </div>
+    <div class="form-row" id="node-input-tls-enable">
+        <label> </label>
+        <input type="checkbox" id="node-input-usetls" style="display: inline-block; width:auto; vertical-align:top;">
+        <label for="node-input-usetls" style="width:auto" data-i18n="httpin.use-tls"></label>
+        <div id="node-row-tls" class="hide">
+            <label style="width:auto; margin-left:20px; margin-right:10px;" for="node-input-tls"><span data-i18n="httpin.tls-config"></span></label><input type="text" style="width: 300px" id="node-input-tls">
+        </div>
     </div>
 
     <div class="form-row">
@@ -58,17 +66,18 @@
 <script type="text/javascript">
     RED.nodes.registerType('tcp in',{
         category: 'network',
-        color:"Silver",
+        color: "Silver",
         defaults: {
             name: {value:""},
-            server: {value:"server",required:true},
-            host: {value:"",validate:function(v) { return (this.server == "server")||v.length > 0;} },
-            port: {value:"",required:true,validate:RED.validators.number()},
+            server: {value:"server", required:true},
+            host: {value:"", validate:function(v) { return (this.server == "server")||v.length > 0;} },
+            port: {value:"", required:true, validate:RED.validators.number()},
             datamode:{value:"stream"},
             datatype:{value:"buffer"},
             newline:{value:""},
             topic: {value:""},
-            base64: {/*deprecated*/ value:false,required:true}
+            base64: {/*deprecated*/ value:false, required:true},
+            tls: {type:"tls-config", value:'', required:false}
         },
         inputs:0,
         outputs:1,
@@ -77,15 +86,17 @@
             return this.name || "tcp:"+(this.host?this.host+":":"")+this.port;
         },
         labelStyle: function() {
-            return this.name?"node_label_italic":"";
+            return this.name ? "node_label_italic" : "";
         },
         oneditprepare: function() {
             var updateOptions = function() {
                 var sockettype = $("#node-input-server").val();
                 if (sockettype == "client") {
                     $("#node-input-host-row").show();
+                    $("#node-input-tls-enable").show();
                 } else {
                     $("#node-input-host-row").hide();
+                    $("#node-input-tls-enable").hide();
                 }
                 var datamode = $("#node-input-datamode").val();
                 var datatype = $("#node-input-datatype").val();
@@ -103,6 +114,27 @@
             $("#node-input-server").change(updateOptions);
             $("#node-input-datatype").change(updateOptions);
             $("#node-input-datamode").change(updateOptions);
+            function updateTLSOptions() {
+                if ($("#node-input-usetls").is(':checked')) {
+                    $("#node-row-tls").show();
+                } else {
+                    $("#node-row-tls").hide();
+                }
+            }
+            if (this.tls) {
+                $('#node-input-usetls').prop('checked', true);
+            } else {
+                $('#node-input-usetls').prop('checked', false);
+            }
+            updateTLSOptions();
+            $("#node-input-usetls").on("click",function() {
+                updateTLSOptions();
+            });
+        },
+        oneditsave: function() {
+            if (!$("#node-input-usetls").is(':checked')) {
+                $("#node-input-tls").val("_ADD_");
+            }
         }
     });
 </script>
@@ -121,6 +153,15 @@
 
     <div class="form-row hidden" id="node-input-host-row" style="padding-left: 110px;">
         <span data-i18n="tcpin.label.host"></span> <input type="text" id="node-input-host" style="width: 60%;">
+    </div>
+
+    <div class="form-row" id="node-input-tls-enable">
+        <label> </label>
+        <input type="checkbox" id="node-input-usetls" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-usetls" style="width: auto" data-i18n="httpin.use-tls"></label>
+        <div id="node-row-tls" class="hide">
+            <label style="width: auto; margin-left: 20px; margin-right: 10px;" for="node-input-tls"><span data-i18n="httpin.tls-config"></span></label><input type="text" style="width: 300px" id="node-input-tls">
+        </div>
     </div>
 
     <div class="form-row hidden" id="node-input-end-row">
@@ -144,14 +185,15 @@
 <script type="text/javascript">
     RED.nodes.registerType('tcp out',{
         category: 'network',
-        color:"Silver",
+        color: "Silver",
         defaults: {
+            name: {value:""},
             host: {value:"",validate:function(v) { return (this.beserver != "client")||v.length > 0;} },
             port: {value:"",validate:function(v) { return (this.beserver == "reply")||RED.validators.number()(v); } },
-            beserver: {value:"client",required:true},
-            base64: {value:false,required:true},
-            end: {value:false,required:true},
-            name: {value:""}
+            beserver: {value:"client", required:true},
+            base64: {value:false, required:true},
+            end: {value:false, required:true},
+            tls: {type:"tls-config", value:'', required:false}
         },
         inputs:1,
         outputs:0,
@@ -170,18 +212,42 @@
                     $("#node-input-port-row").hide();
                     $("#node-input-host-row").hide();
                     $("#node-input-end-row").hide();
+                    $("#node-input-tls-enable").hide();
                 } else if (sockettype == "client"){
                     $("#node-input-port-row").show();
                     $("#node-input-host-row").show();
                     $("#node-input-end-row").show();
+                    $("#node-input-tls-enable").show();
                 } else {
                     $("#node-input-port-row").show();
                     $("#node-input-host-row").hide();
                     $("#node-input-end-row").show();
+                    $("#node-input-tls-enable").hide();
                 }
             };
             updateOptions();
             $("#node-input-beserver").change(updateOptions);
+            function updateTLSOptions() {
+                if ($("#node-input-usetls").is(':checked')) {
+                    $("#node-row-tls").show();
+                } else {
+                    $("#node-row-tls").hide();
+                }
+            }
+            if (this.tls) {
+                $('#node-input-usetls').prop('checked', true);
+            } else {
+                $('#node-input-usetls').prop('checked', false);
+            }
+            updateTLSOptions();
+            $("#node-input-usetls").on("click",function() {
+                updateTLSOptions();
+            });
+        },
+        oneditsave: function() {
+            if (!$("#node-input-usetls").is(':checked')) {
+                $("#node-input-tls").val("_ADD_");
+            }
         }
     });
 </script>
@@ -193,6 +259,14 @@
         <input type="text" id="node-input-server" placeholder="ip.address" style="width:45%">
         <span data-i18n="tcpin.label.port"></span>
         <input type="text" id="node-input-port" style="width:60px">
+    </div>
+    <div class="form-row" id="node-input-tls-enable">
+        <label> </label>
+        <input type="checkbox" id="node-input-usetls" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-usetls" style="width: auto" data-i18n="httpin.use-tls"></label>
+        <div id="node-row-tls" class="hide">
+            <label style="width: auto; margin-left: 20px; margin-right: 10px;" for="node-input-tls"><span data-i18n="httpin.tls-config"></span></label><input type="text" style="width: 300px" id="node-input-tls">
+        </div>
     </div>
     <div class="form-row">
         <label for="node-input-out"><i class="fa fa-sign-out"></i> <span data-i18n="tcpin.label.return"></span></label>
@@ -222,14 +296,15 @@
 <script type="text/javascript">
     RED.nodes.registerType('tcp request',{
         category: 'network',
-        color:"Silver",
+        color: "Silver",
         defaults: {
+            name: {value:""},
             server: {value:""},
-            port: {value:"",validate:RED.validators.regex(/^(\d*|)$/)},
-            out: {value:"time",required:true},
+            port: {value:"", validate:RED.validators.regex(/^(\d*|)$/)},
+            out: {value:"time", required:true},
             ret: {value:"buffer"},
-            splitc: {value:"0",required:true},
-            name: {value:""}
+            splitc: {value:"0", required:true},
+            tls: {type:"tls-config", value:'', required:false}
         },
         inputs:1,
         outputs:1,
@@ -272,6 +347,27 @@
                     $("#node-input-splitc").hide();
                 }
             });
+            function updateTLSOptions() {
+                if ($("#node-input-usetls").is(':checked')) {
+                    $("#node-row-tls").show();
+                } else {
+                    $("#node-row-tls").hide();
+                }
+            }
+            if (this.tls) {
+                $('#node-input-usetls').prop('checked', true);
+            } else {
+                $('#node-input-usetls').prop('checked', false);
+            }
+            updateTLSOptions();
+            $("#node-input-usetls").on("click",function() {
+                updateTLSOptions();
+            });
+        },
+        oneditsave: function() {
+            if (!$("#node-input-usetls").is(':checked')) {
+                $("#node-input-tls").val("_ADD_");
+            }
         }
     });
 </script>

--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
@@ -50,7 +50,7 @@
     </div>
 
     <div id="node-row-newline" class="form-row hidden" style="padding-left:110px;">
-        <span data-i18n="tcpin.label.delimited"></span> <input type="text" id="node-input-newline" style="width:110px;">
+        <span data-i18n="tcpin.label.delimited"></span> <input type="text" id="node-input-newline" style="width:110px;" data-i18n="[placeholder]tcpin.label.optional">
     </div>
 
     <div class="form-row">
@@ -274,7 +274,7 @@
         </select>
     </div>
     <div class="form-row">
-        <label for="node-input-out"> </label>
+        <label for="node-input-out"><i class="fa fa-sign-out fa-rotate-90"></i> <span data-i18n="tcpin.label.close"></span></label>
         <select type="text" id="node-input-out" style="width:54%;">
             <option value="time" data-i18n="tcpin.return.timeout"></option>
             <option value="char" data-i18n="tcpin.return.character"></option>
@@ -284,6 +284,9 @@
         </select>
         <input type="text" id="node-input-splitc" style="width:50px;">
         <span id="node-units"></span>
+    </div>
+    <div id="node-row-newline" class="form-row hidden" style="padding-left:162px;">
+        <span data-i18n="tcpin.label.delimited"></span> <input type="text" id="node-input-newline" style="width:110px;" data-i18n="[placeholder]tcpin.label.optional">
     </div>
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
@@ -302,6 +305,7 @@
             out: {value:"time", required:true},
             ret: {value:"buffer"},
             splitc: {value:"0", required:true},
+            newline: {value:""},
             tls: {type:"tls-config", value:'', required:false}
         },
         inputs:1,
@@ -319,6 +323,14 @@
                 $("#node-input-ret").val("buffer");
                 this.ret = "buffer";
             }
+            $("#node-input-ret").on("change", function() {
+                if ($("#node-input-ret").val() === "string" && $("#node-input-out").val() === "sit") { $("#node-row-newline").show(); }
+                else { $("#node-row-newline").hide(); }
+            });
+            $("#node-input-out").on("change", function() {
+                if ($("#node-input-ret").val() === "string" && $("#node-input-out").val() === "sit") { $("#node-row-newline").show(); }
+                else { $("#node-row-newline").hide(); }
+            });
             $("#node-input-out").on('focus', function () { previous = this.value; }).on("change", function() {
                 $("#node-input-splitc").show();
                 if (previous === null) { previous = $("#node-input-out").val(); }

--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
@@ -517,6 +517,7 @@ module.exports = function(RED) {
         this.port = Number(n.port);
         this.out = n.out;
         this.ret = n.ret || "buffer";
+        this.newline = n.newline;
         this.splitc = n.splitc;
         if (n.tls) {
             var tlsNode = RED.nodes.getNode(n.tls);
@@ -802,7 +803,7 @@ module.exports = function(RED) {
                         if (clients[connection_id].client) {
                             clients[connection_id].connecting = true;
 
-                            var connOpts = {host: host, port: port};
+                            var connOpts = {host:host, port:port};
                             if (n.tls) {
                                 connOpts = tlsNode.addTLSOptions(connOpts);
                             }

--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
@@ -86,7 +86,7 @@ module.exports = function(RED) {
         this.topic = n.topic;
         this.stream = (!n.datamode||n.datamode=='stream'); /* stream,single*/
         this.datatype = n.datatype||'buffer'; /* buffer,utf8,base64 */
-        this.newline = (n.newline||"").replace("\\n","\n").replace("\\r","\r");
+        this.newline = (n.newline||"").replace("\\n","\n").replace("\\r","\r").replace("\\t","\t");
         this.base64 = n.base64;
         this.server = (typeof n.server == 'boolean')?n.server:(n.server == "server");
         this.closing = false;
@@ -517,7 +517,7 @@ module.exports = function(RED) {
         this.port = Number(n.port);
         this.out = n.out;
         this.ret = n.ret || "buffer";
-        this.newline = n.newline;
+        this.newline = (n.newline||"").replace("\\n","\n").replace("\\r","\r").replace("\\t","\t");
         this.splitc = n.splitc;
         if (n.tls) {
             var tlsNode = RED.nodes.getNode(n.tls);

--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
@@ -16,13 +16,46 @@
 
 module.exports = function(RED) {
     "use strict";
-    var reconnectTime = RED.settings.socketReconnectTime||10000;
-    var socketTimeout = RED.settings.socketTimeout||null;
+    let reconnectTime = RED.settings.socketReconnectTime || 10000;
+    let socketTimeout = RED.settings.socketTimeout || null;
     const msgQueueSize = RED.settings.tcpMsgQueueSize || 1000;
     const Denque = require('denque');
-    var net = require('net');
+    const net = require('net');
+    const tls = require('tls');
 
-    var connectionPool = {};
+    let connectionPool = {};
+
+    function normalizeConnectArgs(listArgs) {
+      const args = net._normalizeArgs(listArgs);
+      const options = args[0];
+      const cb = args[1];
+
+      // If args[0] was options, then normalize dealt with it.
+      // If args[0] is port, or args[0], args[1] is host, port, we need to
+      // find the options and merge them in, normalize's options has only
+      // the host/port/path args that it knows about, not the tls options.
+      // This means that options.host overrides a host arg.
+      if (listArgs[1] !== null && typeof listArgs[1] === 'object') {
+        ObjectAssign(options, listArgs[1]);
+      } else if (listArgs[2] !== null && typeof listArgs[2] === 'object') {
+        ObjectAssign(options, listArgs[2]);
+      }
+
+      return cb ? [options, cb] : [options];
+    }
+
+    function getAllowUnauthorized() {
+      const allowUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0';
+
+      if (allowUnauthorized) {
+        process.emitWarning(
+          'Setting the NODE_TLS_REJECT_UNAUTHORIZED ' +
+          'environment variable to \'0\' makes TLS connections ' +
+          'and HTTPS requests insecure by disabling ' +
+          'certificate verification.');
+      }
+      return allowUnauthorized;
+    }
 
     /**
      * Enqueue `item` in `queue`
@@ -60,6 +93,8 @@ module.exports = function(RED) {
         this.connected = false;
         var node = this;
         var count = 0;
+        var nlstr = (this.newline && !this.newline.trim()) ? false : true;
+        if (n.tls) { var tlsNode = RED.nodes.getNode(n.tls); }
 
         if (!node.server) {
             var buffer = null;
@@ -70,13 +105,26 @@ module.exports = function(RED) {
                 node.log(RED._("tcpin.status.connecting",{host:node.host,port:node.port}));
                 node.status({fill:"grey",shape:"dot",text:"common.status.connecting"});
                 var id = RED.util.generateId();
-                client = net.connect(node.port, node.host, function() {
-                    buffer = (node.datatype == 'buffer') ? Buffer.alloc(0) : "";
-                    node.connected = true;
-                    node.log(RED._("tcpin.status.connected",{host:node.host,port:node.port}));
-                    node.status({fill:"green",shape:"dot",text:"common.status.connected",_session:{type:"tcp",id:id}});
-                });
-                client.setKeepAlive(true,120000);
+                var connOpts = {host: node.host
+                };
+                if (n.tls) {
+                    var connOpts = tlsNode.addTLSOptions({host: node.host});
+                    client = tls.connect(node.port, connOpts, function() {
+                        buffer = (node.datatype == 'buffer') ? Buffer.alloc(0) : "";
+                        node.connected = true;
+                        node.log(RED._("status.connected", {host: node.host, port: node.port}));
+                        node.status({fill:"green",shape:"dot",text:"common.status.connected",_session:{type:"tcp",id:id}});
+                    });
+                }
+                else {
+                    client = net.connect(node.port, node.host, function() {
+                        buffer = (node.datatype == 'buffer') ? Buffer.alloc(0) : "";
+                        node.connected = true;
+                        node.log(RED._("tcpin.status.connected",{host:node.host,port:node.port}));
+                        node.status({fill:"green",shape:"dot",text:"common.status.connected",_session:{type:"tcp",id:id}});
+                    });
+                }
+                client.setKeepAlive(true, 120000);
                 connectionPool[id] = client;
 
                 client.on('data', function (data) {
@@ -89,6 +137,7 @@ module.exports = function(RED) {
                             buffer = buffer+data;
                             var parts = buffer.split(node.newline);
                             for (var i = 0; i<parts.length-1; i+=1) {
+                                if (nlstr) { parts[i] += node.newline; }
                                 msg = {topic:node.topic, payload:parts[i]};
                                 msg._session = {type:"tcp",id:id};
                                 node.send(msg);
@@ -269,8 +318,9 @@ module.exports = function(RED) {
         this.closing = false;
         this.connected = false;
         var node = this;
+        if (n.tls) { var tlsNode = RED.nodes.getNode(n.tls); }
 
-        if (!node.beserver||node.beserver=="client") {
+        if (!node.beserver || node.beserver == "client") {
             var reconnectTimeout;
             var client = null;
             var end = false;
@@ -278,11 +328,24 @@ module.exports = function(RED) {
             var setupTcpClient = function() {
                 node.log(RED._("tcpin.status.connecting",{host:node.host,port:node.port}));
                 node.status({fill:"grey",shape:"dot",text:"common.status.connecting"});
-                client = net.connect(node.port, node.host, function() {
-                    node.connected = true;
-                    node.log(RED._("tcpin.status.connected",{host:node.host,port:node.port}));
-                    node.status({fill:"green",shape:"dot",text:"common.status.connected"});
-                });
+                if (n.tls) {
+                    // connOpts = tlsNode.addTLSOptions(connOpts);
+                    // client = tls.connect(connOpts, function() {
+                    var connOpts = tlsNode.addTLSOptions({host: node.host});
+                    client = tls.connect(node.port, connOpts, function() {
+                        // buffer = (node.datatype == 'buffer') ? Buffer.alloc(0) : "";
+                        node.connected = true;
+                        node.log(RED._("status.connected", {host: node.host, port: node.port}));
+                        node.status({fill:"green",shape:"dot",text:"common.status.connected"});
+                    });
+                }
+                else {
+                    client = net.connect(node.port, node.host, function() {
+                        node.connected = true;
+                        node.log(RED._("tcpin.status.connected",{host:node.host,port:node.port}));
+                        node.status({fill:"green",shape:"dot",text:"common.status.connected"});
+                    });
+                }
                 client.setKeepAlive(true,120000);
                 client.on('error', function (err) {
                     node.log(RED._("tcpin.errors.error",{error:err.toString()}));
@@ -446,6 +509,9 @@ module.exports = function(RED) {
         this.out = n.out;
         this.ret = n.ret || "buffer";
         this.splitc = n.splitc;
+        if (n.tls) {
+            var tlsNode = RED.nodes.getNode(n.tls);
+        }
 
         if (this.out === "immed") { this.splitc = -1; this.out = "time"; }
         if (this.out !== "char") { this.splitc = Number(this.splitc); }
@@ -500,12 +566,49 @@ module.exports = function(RED) {
                 }
                 else { buf = Buffer.alloc(65536); } // set it to 64k... hopefully big enough for most TCP packets.... but only hopefully
 
-                clients[connection_id].client = net.Socket();
+                var connOpts = {host: host, port: port};
+                if (n.tls) {
+                    connOpts = tlsNode.addTLSOptions(connOpts);
+                    const allowUnauthorized = getAllowUnauthorized();
+
+                    let options = {
+                        rejectUnauthorized: !allowUnauthorized,
+                        ciphers: tls.DEFAULT_CIPHERS,
+                        checkServerIdentity: tls.checkServerIdentity,
+                        minDHSize: 1024,
+                        ...connOpts
+                    };
+
+                    if (!options.keepAlive)
+                    options.singleUse = true;
+
+                    const context = options.secureContext || tls.createSecureContext(options);
+
+                    clients[connection_id].client = new tls.TLSSocket(options.socket, {
+                        allowHalfOpen: options.allowHalfOpen,
+                        pipe: !!options.path,
+                        secureContext: context,
+                        isServer: false,
+                        requestCert: false, // true,
+                        rejectUnauthorized: false, // options.rejectUnauthorized !== false,
+                        session: options.session,
+                        ALPNProtocols: options.ALPNProtocols,
+                        requestOCSP: options.requestOCSP,
+                        enableTrace: options.enableTrace,
+                        pskCallback: options.pskCallback,
+                        highWaterMark: options.highWaterMark,
+                        onread: options.onread,
+                        signal: options.signal,
+                    });
+                }
+                else {
+                    clients[connection_id].client = net.Socket();
+                }
                 if (socketTimeout !== null) { clients[connection_id].client.setTimeout(socketTimeout);}
 
                 if (host && port) {
                     clients[connection_id].connecting = true;
-                    clients[connection_id].client.connect(port, host, function() {
+                    clients[connection_id].client.connect(connOpts, function() {
                         //node.log(RED._("tcpin.errors.client-connected"));
                         node.status({fill:"green",shape:"dot",text:"common.status.connected"});
                         if (clients[connection_id] && clients[connection_id].client) {
@@ -675,7 +778,13 @@ module.exports = function(RED) {
                         //node.warn(RED._("tcpin.errors.connect-timeout"));
                         if (clients[connection_id].client) {
                             clients[connection_id].connecting = true;
-                            clients[connection_id].client.connect(port, host, function() {
+
+                            var connOpts = {host: host, port: port};
+                            if (n.tls) {
+                                connOpts = tlsNode.addTLSOptions(connOpts);
+                            }
+
+                            clients[connection_id].client.connect(connOpts, function() {
                                 clients[connection_id].connected = true;
                                 clients[connection_id].connecting = false;
                                 node.status({fill:"green",shape:"dot",text:"common.status.connected"});

--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
@@ -229,7 +229,7 @@ module.exports = function(RED) {
                             buffer = buffer+data;
                             var parts = buffer.split(node.newline);
                             for (var i = 0; i<parts.length-1; i+=1) {
-                                msg = {topic:node.topic, payload:parts[i], ip:socket.remoteAddress, port:socket.remotePort};
+                                msg = {topic:node.topic, payload:parts[i] + node.newline.trimEnd(), ip:socket.remoteAddress, port:socket.remotePort};
                                 msg._session = {type:"tcp",id:id};
                                 node.send(msg);
                             }
@@ -575,7 +575,7 @@ module.exports = function(RED) {
                 }
                 else { buf = Buffer.alloc(65536); } // set it to 64k... hopefully big enough for most TCP packets.... but only hopefully
 
-                var connOpts = {host: host, port: port};
+                var connOpts = {host:host, port:port};
                 if (n.tls) {
                     connOpts = tlsNode.addTLSOptions(connOpts);
                     const allowUnauthorized = getAllowUnauthorized();
@@ -588,8 +588,7 @@ module.exports = function(RED) {
                         ...connOpts
                     };
 
-                    if (!options.keepAlive)
-                    options.singleUse = true;
+                    if (!options.keepAlive) { options.singleUse = true; }
 
                     const context = options.secureContext || tls.createSecureContext(options);
 
@@ -640,17 +639,32 @@ module.exports = function(RED) {
                 else {
                     node.warn(RED._("tcpin.errors.no-host"));
                 }
-
+                var chunk = "";
                 clients[connection_id].client.on('data', function(data) {
                     if (node.out === "sit") { // if we are staying connected just send the buffer
                         if (clients[connection_id]) {
                             const msg = clients[connection_id].lastMsg || {};
                             msg.payload = RED.util.cloneMessage(data);
                             if (node.ret === "string") {
-                                try { msg.payload = msg.payload.toString(); }
-                                catch(e) { node.error("Failed to create string", msg); }
+                                try {
+                                    if (node.newline && node.newline !== "" ) {
+                                        chunk += msg.payload.toString();
+                                        let parts = chunk.split(node.newline);
+                                        for (var i=0; i<parts.length-1; i+=1) {
+                                            let m = RED.util.cloneMessage(msg);
+                                            m.payload = parts[i] + node.newline.trimEnd();
+                                            nodeSend(m);
+                                        }
+                                        chunk = parts[parts.length-1];
+                                    }
+                                    else {
+                                        msg.payload = msg.payload.toString();
+                                        nodeSend(msg);
+                                    }
+                                }
+                                catch(e) { node.error(RED._("tcpin.errors.bad-string"), msg); }
                             }
-                            nodeSend(msg);
+                            else { nodeSend(msg); }
                         }
                     }
                     // else if (node.splitc === 0) {

--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
@@ -93,7 +93,6 @@ module.exports = function(RED) {
         this.connected = false;
         var node = this;
         var count = 0;
-        var nlstr = (this.newline && !this.newline.trim()) ? false : true;
         if (n.tls) { var tlsNode = RED.nodes.getNode(n.tls); }
 
         if (!node.server) {
@@ -105,8 +104,7 @@ module.exports = function(RED) {
                 node.log(RED._("tcpin.status.connecting",{host:node.host,port:node.port}));
                 node.status({fill:"grey",shape:"dot",text:"common.status.connecting"});
                 var id = RED.util.generateId();
-                var connOpts = {host: node.host
-                };
+                var connOpts = {host: node.host};
                 if (n.tls) {
                     var connOpts = tlsNode.addTLSOptions({host: node.host});
                     client = tls.connect(node.port, connOpts, function() {
@@ -137,8 +135,7 @@ module.exports = function(RED) {
                             buffer = buffer+data;
                             var parts = buffer.split(node.newline);
                             for (var i = 0; i<parts.length-1; i+=1) {
-                                if (nlstr) { parts[i] += node.newline; }
-                                msg = {topic:node.topic, payload:parts[i]};
+                                msg = {topic:node.topic, payload:parts[i] + node.newline.trimEnd()};
                                 msg._session = {type:"tcp",id:id};
                                 node.send(msg);
                             }
@@ -199,7 +196,13 @@ module.exports = function(RED) {
             });
         }
         else {
-            var server = net.createServer(function (socket) {
+            let srv = net;
+            let connOpts;
+            if (n.tls) {
+                srv = tls;
+                connOpts = tlsNode.addTLSOptions({});
+            }
+            var server = srv.createServer(connOpts, function (socket) {
                 socket.setKeepAlive(true,120000);
                 if (socketTimeout !== null) { socket.setTimeout(socketTimeout); }
                 var id = RED.util.generateId();
@@ -431,7 +434,13 @@ module.exports = function(RED) {
         else {
             var connectedSockets = [];
             node.status({text:RED._("tcpin.status.connections",{count:0})});
-            var server = net.createServer(function (socket) {
+            let srv = net;
+            let connOpts;
+            if (n.tls) {
+                srv = tls;
+                connOpts = tlsNode.addTLSOptions({});
+            }
+            var server = srv.createServer(connOpts, function (socket) {
                 socket.setKeepAlive(true,120000);
                 if (socketTimeout !== null) { socket.setTimeout(socketTimeout); }
                 node.log(RED._("tcpin.status.connection-from",{host:socket.remoteAddress, port:socket.remotePort}));

--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
@@ -650,9 +650,9 @@ module.exports = function(RED) {
                                     if (node.newline && node.newline !== "" ) {
                                         chunk += msg.payload.toString();
                                         let parts = chunk.split(node.newline);
-                                        for (var i=0; i<parts.length-1; i+=1) {
+                                        for (var p=0; p<parts.length-1; p+=1) {
                                             let m = RED.util.cloneMessage(msg);
-                                            m.payload = parts[i] + node.newline.trimEnd();
+                                            m.payload = parts[p] + node.newline.trimEnd();
                                             nodeSend(m);
                                         }
                                         chunk = parts[parts.length-1];

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -579,7 +579,9 @@
             "server": "Server",
             "return": "Return",
             "ms": "ms",
-            "chars": "chars"
+            "chars": "chars",
+            "close": "Close",
+            "optional": "(optional)"
         },
         "type": {
             "listen": "Listen on",
@@ -596,7 +598,7 @@
         "return": {
             "timeout": "after a fixed timeout of",
             "character": "when character received is",
-            "number": "a fixed number of chars",
+            "number": "after a fixed number of characters",
             "never": "never - keep connection open",
             "immed": "immediately - don't wait for reply"
         },
@@ -616,11 +618,11 @@
             "timeout": "timeout closed socket port __port__",
             "cannot-listen": "unable to listen on port __port__, error: __error__",
             "error": "error: __error__",
-
             "socket-error": "socket error from __host__:__port__",
             "no-host": "Host and/or port not set",
             "connect-timeout": "connect timeout",
-            "connect-fail": "connect failed"
+            "connect-fail": "connect failed",
+            "bad-string": "failed to convert to string"
         }
     },
     "udp": {

--- a/test/nodes/core/network/31-tcprequest_spec.js
+++ b/test/nodes/core/network/31-tcprequest_spec.js
@@ -84,9 +84,17 @@ describe('TCP Request Node', function() {
             n2.on("input", msg => {
                 try {
                     if (typeof result === 'object') {
-                        msg.should.have.properties(Object.assign({}, result, {payload: Buffer.from(result.payload)}));
+                        if (flow[0].ret === "string") {
+                            msg.should.have.properties(Object.assign({}, result, {payload: result.payload}));
+                        } else {
+                            msg.should.have.properties(Object.assign({}, result, {payload: Buffer.from(result.payload)}));
+                        }
                     } else {
-                        msg.should.have.property('payload', Buffer.from(result));
+                        if (flow[0].ret === "string") {
+                            msg.should.have.property('payload', result);
+                        } else {
+                            msg.should.have.property('payload', Buffer.from(result));
+                        }
                     }
                     done();
                 } catch(err) {
@@ -245,10 +253,23 @@ describe('TCP Request Node', function() {
             }, done);
         });
 
+        it('should send & receive, then keep connection, and split return strings', function(done) {
+            var flow = [{id:"n1", type:"tcp request", server:"localhost", port:port, out:"sit", ret:"string", newline:"<A>", wires:[["n2"]] },
+                        {id:"n2", type:"helper"}];
+            testTCPMany(flow, [{
+                payload: "foo<A>bar",
+                topic: 'boo'
+            }], {
+                payload: "ACK:foo<A>",
+                topic: 'boo'
+            }, done);
+        });
+
         it('should send & recv data to/from server:port from msg', function(done) {
             var flow = [{id:"n1", type:"tcp request", server:"", port:"", out:"time", splitc: "0", wires:[["n2"]] },
                         {id:"n2", type:"helper"}];
-            testTCPMany(flow, [{
+            testTCPMany(flow, [
+                {
                     payload: "f",
                     host: "localhost",
                     port: port

--- a/test/nodes/core/network/31-tcprequest_spec.js
+++ b/test/nodes/core/network/31-tcprequest_spec.js
@@ -253,14 +253,32 @@ describe('TCP Request Node', function() {
             }, done);
         });
 
-        it('should send & receive, then keep connection, and split return strings', function(done) {
-            var flow = [{id:"n1", type:"tcp request", server:"localhost", port:port, out:"sit", ret:"string", newline:"<A>", wires:[["n2"]] },
+        it('should send & receive, then keep connection, and not split return strings', function(done) {
+            var flow = [{id:"n1", type:"tcp request", server:"localhost", port:port, out:"sit", ret:"string", newline:"", wires:[["n2"]] },
                         {id:"n2", type:"helper"}];
             testTCPMany(flow, [{
-                payload: "foo<A>bar",
+                payload: "foo",
+                topic: 'boo'
+            }, {
+                payload: "bar<A>\nfoo",
                 topic: 'boo'
             }], {
-                payload: "ACK:foo<A>",
+                payload: "ACK:foobar<A>\nfoo",
+                topic: 'boo'
+            }, done);
+        });
+
+        it('should send & receive, then keep connection, and split return strings', function(done) {
+            var flow = [{id:"n1", type:"tcp request", server:"localhost", port:port, out:"sit", ret:"string", newline:"<A>\\n", wires:[["n2"]] },
+                        {id:"n2", type:"helper"}];
+            testTCPMany(flow, [{
+                payload: "foo",
+                topic: 'boo'
+            }, {
+                payload: "bar<A>\nfoo",
+                topic: 'boo'
+            }], {
+                payload: "ACK:foobar<A>",
                 topic: 'boo'
             }, done);
         });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This PR add the TLS config option panel (used in HTTP request nodes) to the TCP nodes in both client and server modes.

It also  makes the TCP request node match the existing TCP in node capability of splitting the input when in receive Strings mode... existing is just the received Buffer or String. This now also allows to split that string on a char or sequence of chars. This then holds any remaining input until the next packet arrives and then tries to split again.  


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
