### PR TITLE
Update Function to use correct api to access env vars

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -234,8 +234,7 @@ module.exports = function(RED) {
             },
             env: {
                 get: function(envVar) {
-                    var flow = node._flow;
-                    return flow.getSetting(envVar);
+                    return RED.util.getSetting(node, envVar);
                 }
             },
             setTimeout: function () {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

Fixes #3299

The Function node was not using the right utility function to access env vars - so the group level env vars were being ignored.