### PR TITLE
Avoid adding empty env properties to tabs/groups

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/envVarProperties.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/envVarProperties.js
@@ -55,7 +55,9 @@
                         }
                     });
                 }
-                if (!isSameObj(old_env, new_env)) {
+                if (!old_env && new_env.length === 0) {
+                    delete node.env;
+                } else if (!isSameObj(old_env, new_env)) {
                     editState.changes.env = node.env;
                     if (new_env.length === 0) {
                         delete node.env;


### PR DESCRIPTION
Fixes #3306

