### PR TITLE
Fix copy buttons on the debug window

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -940,6 +940,7 @@ RED.clipboard = (function() {
         if (truncated) {
             msg += "_truncated";
         }
+        var clipboardHidden = $('<textarea type="text" id="red-ui-clipboard-hidden" tabIndex="-1">').appendTo(document.body);
         $("#red-ui-clipboard-hidden").val(value).focus().select();
         var result =  document.execCommand("copy");
         if (result && element) {
@@ -954,7 +955,7 @@ RED.clipboard = (function() {
             },1000);
             popover.open();
         }
-        $("#red-ui-clipboard-hidden").val("");
+        clipboardHidden.remove();
         if (currentFocus) {
             $(currentFocus).focus();
         }
@@ -1235,8 +1236,6 @@ RED.clipboard = (function() {
     return {
         init: function() {
             setupDialogs();
-
-            $('<textarea type="text" id="red-ui-clipboard-hidden" tabIndex="-1">').appendTo("#red-ui-editor");
 
             RED.actions.add("core:show-export-dialog",showExportNodes);
             RED.actions.add("core:show-import-dialog",showImportNodes);


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I fixed the issue, #3328. This problem occurred due to no textarea defined as `red-ui-clipboard-hidden` on the debug window. Therefore, I modified the code to add and remove the `red-ui-clipboard-hidden` on demand. (To solve this problem by another method, I thought that the `navigator.clipboard.writeText(value)` may be better than `document.execCommand("copy")` which is already deprecated.)

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
