### PR TITLE
Fix copy buttons on the debug window (another method)

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -940,6 +940,7 @@ RED.clipboard = (function() {
         if (truncated) {
             msg += "_truncated";
         }
+        var clipboardHidden = $('<textarea type="text" id="red-ui-clipboard-hidden" tabIndex="-1">').appendTo(document.body);
         $("#red-ui-clipboard-hidden").val(value).focus().select();
         var result =  document.execCommand("copy");
         if (result && element) {
@@ -954,7 +955,7 @@ RED.clipboard = (function() {
             },1000);
             popover.open();
         }
-        $("#red-ui-clipboard-hidden").val("");
+        clipboardHidden.remove();
         if (currentFocus) {
             $(currentFocus).focus();
         }
@@ -1235,8 +1236,6 @@ RED.clipboard = (function() {
     return {
         init: function() {
             setupDialogs();
-
-            $('<textarea type="text" id="red-ui-clipboard-hidden" tabIndex="-1">').appendTo("#red-ui-editor");
 
             RED.actions.add("core:show-export-dialog",showExportNodes);
             RED.actions.add("core:show-import-dialog",showImportNodes);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -940,28 +940,24 @@ RED.clipboard = (function() {
         if (truncated) {
             msg += "_truncated";
         }
-        var clipboardHidden = $('<textarea type="text" id="red-ui-clipboard-hidden" tabIndex="-1">').appendTo(document.body);
-        $("#red-ui-clipboard-hidden").val(value).focus().select();
-        var result =  document.execCommand("copy");
-        if (result && element) {
-            var popover = RED.popover.create({
-                target: element,
-                direction: 'left',
-                size: 'small',
-                content: RED._(msg)
-            });
-            setTimeout(function() {
-                popover.close();
-            },1000);
-            popover.open();
-        }
-        clipboardHidden.remove();
-        if (currentFocus) {
-            $(currentFocus).focus();
-        }
-        return result;
+        navigator.clipboard.writeText(value).then(function () {
+            if (element) {
+                var popover = RED.popover.create({
+                    target: element,
+                    direction: 'left',
+                    size: 'small',
+                    content: RED._(msg)
+                });
+                setTimeout(function() {
+                    popover.close();
+                },1000);
+                popover.open();
+            }
+            if (currentFocus) {
+                $(currentFocus).focus();
+            }
+        });
     }
-
 
     function importNodes(nodesStr,addFlow) {
         var newNodes = nodesStr;

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -956,7 +956,7 @@ RED.clipboard = (function() {
             if (currentFocus) {
                 $(currentFocus).focus();
             }
-        });
+        }).catch(err => { console.error("Failed to copy:",err) });
     }
 
     function importNodes(nodesStr,addFlow) {

--- a/packages/node_modules/@node-red/editor-client/src/sass/editor.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/editor.scss
@@ -356,10 +356,6 @@ button.red-ui-button-small
     background: $secondary-background;
 }
 
-#red-ui-clipboard-hidden {
-    position: absolute;
-    top: -3000px;
-}
 .form-row .red-ui-editor-node-label-form-row {
     margin: 5px 0 0 50px;
     label {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
As I mentioned in #3329, the `document.execCommand("copy")` is deprecated. So, in this pull request, I used the `navigator.clipboard.writeText(value)` instead of that. Could you select #3329 or this pull request to merge?

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
