### PR TITLE
Implemented support for Websocket Subprotocols in WS Client Node.

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.html
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.html
@@ -268,7 +268,7 @@
     </div>
     <div class="form-row">
         <label for="node-config-input-subprotocol"><i class="fa fa-tag"></i> <span data-i18n="websocket.label.subprotocol"></span></label>
-        <input id="node-config-input-subprotocol" type="text" data-i18n="[placeholder]websocket.placeholder.subprotocol">
+        <input type="text" id="node-config-input-subprotocol">
     </div>
     <div class="form-row">
         <label for="node-config-input-wholemsg" data-i18n="websocket.sendrec"></label>

--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.html
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.html
@@ -177,7 +177,8 @@
             path: {value:"",required:true,validate:RED.validators.regex(/^((?!\/debug\/ws).)*$/)},
             tls: {type:"tls-config",required: false},
             wholemsg: {value:"false"},
-            hb: {value: "", validate: RED.validators.number(/*blank allowed*/true) }
+            hb: {value: "", validate: RED.validators.number(/*blank allowed*/true) },
+            subprotocol: {value:"",required: false}
         },
         inputs:0,
         outputs:0,
@@ -265,7 +266,10 @@
         <label for="node-config-input-tls" data-i18n="httpin.tls-config"></label>
         <input type="text" id="node-config-input-tls">
     </div>
-
+    <div class="form-row">
+        <label for="node-config-input-subprotocol"><i class="fa fa-tag"></i> <span data-i18n="websocket.label.subprotocol"></span></label>
+        <input id="node-config-input-subprotocol" type="text" data-i18n="[placeholder]websocket.placeholder.subprotocol">
+    </div>
     <div class="form-row">
         <label for="node-config-input-wholemsg" data-i18n="websocket.sendrec"></label>
         <select type="text" id="node-config-input-wholemsg" style="width: 70%;">

--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
@@ -46,7 +46,12 @@ module.exports = function(RED) {
 
         // Store local copies of the node configuration (as defined in the .html)
         node.path = n.path;
-        node.subprotocol = n.subprotocol; // optional client protocol
+        if (typeof n.subprotocol === "string") {
+            // Split the string on comma and trim each result
+            node.subprotocol = n.subprotocol.split(",").map(v => v.trim())
+        } else {
+            node.subprotocol = [];
+        }
         node.wholemsg = (n.wholemsg === "true");
 
         node._inputNodes = [];    // collection of nodes that want to receive events

--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
@@ -46,6 +46,7 @@ module.exports = function(RED) {
 
         // Store local copies of the node configuration (as defined in the .html)
         node.path = n.path;
+        node.subprotocol = n.subprotocol; // optional client protocol
         node.wholemsg = (n.wholemsg === "true");
 
         node._inputNodes = [];    // collection of nodes that want to receive events
@@ -92,7 +93,7 @@ module.exports = function(RED) {
                     tlsNode.addTLSOptions(options);
                 }
             }
-            var socket = new ws(node.path,options);
+            var socket = new ws(node.path,node.subprotocol,options);
             socket.setMaxListeners(0);
             node.server = socket; // keep for closing
             handleConnection(socket);

--- a/packages/node_modules/@node-red/nodes/locales/de/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/de/messages.json
@@ -499,7 +499,8 @@
         "label": {
             "type": "Typ",
             "path": "Pfad",
-            "url": "URL"
+            "url": "URL",
+            "subprotocol": "Subprotokoll"
         },
         "listenon": "Lauschen (listen on)",
         "connectto": "Verbinden mit",

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -530,7 +530,8 @@
         "label": {
             "type": "Type",
             "path": "Path",
-            "url": "URL"
+            "url": "URL",
+            "subprotocol": "Subprotocol"
         },
         "listenon": "Listen on",
         "connectto": "Connect to",

--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -530,7 +530,8 @@
         "label": {
             "type": "種類",
             "path": "パス",
-            "url": "URL"
+            "url": "URL",
+            "subprotocol": "サブプロトコル"
         },
         "listenon": "待ち受け",
         "connectto": "接続",

--- a/packages/node_modules/@node-red/nodes/locales/ko/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ko/messages.json
@@ -433,7 +433,8 @@
         "label": {
             "type": "종류",
             "path": "패스",
-            "url": "URL"
+            "url": "URL",
+            "subprotocol": "서브 프로토콜"
         },
         "listenon": "대기",
         "connectto": "접속",

--- a/packages/node_modules/@node-red/nodes/locales/ru/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ru/messages.json
@@ -461,7 +461,8 @@
         "label": {
             "type": "Тип",
             "path": "Путь",
-            "url": "URL"
+            "url": "URL",
+            "subprotocol": "Подпротокол"
         },
         "listenon": "Слушать на ...",
         "connectto": "Присоединиться к ...",

--- a/packages/node_modules/@node-red/nodes/locales/zh-CN/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/zh-CN/messages.json
@@ -454,7 +454,8 @@
         "label": {
             "type": "类型",
             "path": "路径",
-            "url": "URL"
+            "url": "URL",
+            "subprotocol": "子协议"
         },
         "listenon": "监听",
         "connectto": "连接",

--- a/packages/node_modules/@node-red/nodes/locales/zh-TW/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/zh-TW/messages.json
@@ -458,7 +458,8 @@
         "label": {
             "type": "類型",
             "path": "路徑",
-            "url": "URL"
+            "url": "URL",
+            "subprotocol": "子协议"
         },
         "listenon": "監聽",
         "connectto": "連接",

--- a/test/nodes/core/network/22-websocket_spec.js
+++ b/test/nodes/core/network/22-websocket_spec.js
@@ -372,8 +372,8 @@ describe('websocket Node', function() {
                 { id: "n1", type: "websocket-client", path: getWsUrl("/ws") },
                 { id: "n2", type: "websocket-client", path: getWsUrl("/ws"), subprotocol: "testprotocol" }];
             helper.load(websocketNode, flow, function() {
-                helper.getNode("n1").should.have.property("protocol", undefined);
-                helper.getNode("n2").should.have.property("protocol", "testprotocol");
+                helper.getNode("n1").should.have.property("subprotocol", undefined);
+                helper.getNode("n2").should.have.property("subprotocol", "testprotocol");
                 done();
             });
         });

--- a/test/nodes/core/network/22-websocket_spec.js
+++ b/test/nodes/core/network/22-websocket_spec.js
@@ -366,6 +366,18 @@ describe('websocket Node', function() {
             });
         });
 
+        it('should handle protocol property', function(done) {
+            var flow = [
+                { id: "server", type: "websocket-listener", path: "/ws" },
+                { id: "n1", type: "websocket-client", path: getWsUrl("/ws") },
+                { id: "n2", type: "websocket-client", path: getWsUrl("/ws"), subprotocol: "testprotocol" }];
+            helper.load(websocketNode, flow, function() {
+                helper.getNode("n1").should.have.property("protocol", undefined);
+                helper.getNode("n2").should.have.property("protocol", "testprotocol");
+                done();
+            });
+        });
+
         it('should connect to server', function(done) {
             var flow = [
                 { id: "server", type: "websocket-listener", path: "/ws" },
@@ -375,6 +387,18 @@ describe('websocket Node', function() {
                     done();
                 });
 
+            });
+        });
+
+        it('should initiate with subprotocol', function(done) {
+            var flow = [
+                { id: "server", type: "websocket-listener", path: "/ws" },
+                { id: "n2", type: "websocket-client", path: getWsUrl("/ws"), subprotocol: "testprotocol" }];
+            helper.load(websocketNode, flow, function() {
+                getSocket('server').on('connection', function (sock) {
+                    sock.should.have.property("protocol", "testprotocol")
+                    done();
+                });
             });
         });
 

--- a/test/nodes/core/network/22-websocket_spec.js
+++ b/test/nodes/core/network/22-websocket_spec.js
@@ -370,10 +370,10 @@ describe('websocket Node', function() {
             var flow = [
                 { id: "server", type: "websocket-listener", path: "/ws" },
                 { id: "n1", type: "websocket-client", path: getWsUrl("/ws") },
-                { id: "n2", type: "websocket-client", path: getWsUrl("/ws"), subprotocol: "testprotocol" }];
+                { id: "n2", type: "websocket-client", path: getWsUrl("/ws"), subprotocol: "testprotocol1, testprotocol2" }];
             helper.load(websocketNode, flow, function() {
-                helper.getNode("n1").should.have.property("subprotocol", undefined);
-                helper.getNode("n2").should.have.property("subprotocol", "testprotocol");
+                helper.getNode("n1").should.have.property("subprotocol", []);
+                helper.getNode("n2").should.have.property("subprotocol", ["testprotocol1","testprotocol2"]);
                 done();
             });
         });


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Implemented support for Websocket Subprotocols [RFC 6455 section 1.9](https://datatracker.ietf.org/doc/html/rfc6455#section-1.9) in the Websocket Client node.

This change is largely based upon PR #1938 by @dpslwk, which was abandoned a couple of years ago. The main changes to the original PR are (based on the orig PR comments):

- Consequently named the var and displayed label 'subprotocol' (conforming to the RFC naming)
- Implemented a test that validates the client functionality by reading out the ws-serverside received subprotocol

This PR was also discussed at https://discourse.nodered.org/t/feature-request-websocket-sub-protocol-support/56315/4.
<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
