### PR TITLE
load extralibs when expanding monaco. fixes #3319

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/js.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/js.js
@@ -81,7 +81,8 @@
                             clearTimeout: true,
                             setInterval: true,
                             clearInterval: true
-                        }
+                        },
+                        extraLibs: options.extraLibs
                     });
                     if (options.cursor) {
                         expressionEditor.gotoLine(options.cursor.row+1,options.cursor.column,false);

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.html
@@ -512,6 +512,7 @@
                 return function(e) {
                     e.preventDefault();
                     var value = editor.getValue();
+                    var extraLibs = that.libs || [];
                     RED.editor.editJavaScript({
                         value: value,
                         width: "Infinity",
@@ -523,7 +524,8 @@
                             setTimeout(function() {
                                 editor.focus();
                             },300);
-                        }
+                        },
+                        extraLibs: extraLibs
                     })
                 }
             }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Ensure extra libs are declared in monaco to prevent red error underline on libraries declared in setup tab.

See issue #3319 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
