### PR TITLE
Update file node examples according to node name change

### DIFF
--- a/packages/node_modules/@node-red/nodes/examples/storage/read file/01 - Read string from a file.json
+++ b/packages/node_modules/@node-red/nodes/examples/storage/read file/01 - Read string from a file.json
@@ -1,8 +1,8 @@
 [
     {
-        "id": "8997398f.c5d628",
+        "id": "84222b92.d65d18",
         "type": "inject",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "props": [
             {
@@ -18,30 +18,30 @@
         "once": false,
         "onceDelay": 0.1,
         "topic": "",
-        "payload": "😀",
+        "payload": "Hello, World!",
         "payloadType": "str",
-        "x": 210,
-        "y": 480,
+        "x": 190,
+        "y": 180,
         "wires": [
             [
-                "56e32d23.050f44"
+                "b4b9f603.739598"
             ]
         ]
     },
     {
-        "id": "4e598e65.1799d",
+        "id": "7b014430.dfd94c",
         "type": "comment",
-        "z": "194a3e4f.a92772",
-        "name": "Read data in specified encoding",
-        "info": "File-in node can specify encoding of data read from a file.",
-        "x": 230,
-        "y": 400,
+        "z": "6312c0588348b2d4",
+        "name": "Write string to a file, then read from the file",
+        "info": "Read file node can read string from a file.",
+        "x": 220,
+        "y": 100,
         "wires": []
     },
     {
-        "id": "56e32d23.050f44",
+        "id": "b4b9f603.739598",
         "type": "file",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "filename": "/tmp/hello.txt",
         "appendNewline": true,
@@ -49,17 +49,17 @@
         "overwriteFile": "true",
         "encoding": "none",
         "x": 380,
-        "y": 480,
+        "y": 180,
         "wires": [
             [
-                "38fa0579.f2cd8a"
+                "6dc01cac.5c4bf4"
             ]
         ]
     },
     {
-        "id": "d28c8994.99c0a8",
+        "id": "2587adb9.7e60f2",
         "type": "debug",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "active": true,
         "tosidebar": true,
@@ -69,45 +69,45 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 770,
-        "y": 480,
+        "y": 180,
         "wires": []
     },
     {
-        "id": "38fa0579.f2cd8a",
+        "id": "6dc01cac.5c4bf4",
         "type": "file in",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "filename": "/tmp/hello.txt",
         "format": "utf8",
         "chunk": false,
         "sendError": false,
-        "encoding": "base64",
+        "encoding": "none",
         "x": 580,
-        "y": 480,
+        "y": 180,
         "wires": [
             [
-                "d28c8994.99c0a8"
+                "2587adb9.7e60f2"
             ]
         ]
     },
     {
-        "id": "fa22ca20.ae4528",
+        "id": "f4b4309a.3b78a",
         "type": "comment",
-        "z": "194a3e4f.a92772",
-        "name": "↑read data from file as base64 string",
+        "z": "6312c0588348b2d4",
+        "name": "↑read result from file",
         "info": "",
-        "x": 640,
-        "y": 520,
+        "x": 590,
+        "y": 220,
         "wires": []
     },
     {
-        "id": "148e25ad.98891a",
+        "id": "672d3693.3cabd8",
         "type": "comment",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "↓write to /tmp/hello.txt",
         "info": "",
         "x": 400,
-        "y": 440,
+        "y": 140,
         "wires": []
     }
 ]

--- a/packages/node_modules/@node-red/nodes/examples/storage/read file/02 - Read data in specified encoding.json
+++ b/packages/node_modules/@node-red/nodes/examples/storage/read file/02 - Read data in specified encoding.json
@@ -1,8 +1,8 @@
 [
     {
-        "id": "e4ef1f5e.7cd82",
+        "id": "8997398f.c5d628",
         "type": "inject",
-        "z": "4b63452d.672afc",
+        "z": "6312c0588348b2d4",
         "name": "",
         "props": [
             {
@@ -18,48 +18,48 @@
         "once": false,
         "onceDelay": 0.1,
         "topic": "",
-        "payload": "8J+YgA==",
+        "payload": "😀",
         "payloadType": "str",
-        "x": 220,
-        "y": 820,
+        "x": 170,
+        "y": 260,
         "wires": [
             [
-                "72b37cc8.177054"
+                "56e32d23.050f44"
             ]
         ]
     },
     {
-        "id": "f5997af4.5a9298",
+        "id": "4e598e65.1799d",
         "type": "comment",
-        "z": "4b63452d.672afc",
-        "name": "Specify encoding of written data",
-        "info": "File node can specify encoding of data.",
-        "x": 230,
-        "y": 740,
+        "z": "6312c0588348b2d4",
+        "name": "Read data in specified encoding",
+        "info": "Read file node can specify encoding of data read from a file.",
+        "x": 190,
+        "y": 180,
         "wires": []
     },
     {
-        "id": "72b37cc8.177054",
+        "id": "56e32d23.050f44",
         "type": "file",
-        "z": "4b63452d.672afc",
+        "z": "6312c0588348b2d4",
         "name": "",
         "filename": "/tmp/hello.txt",
         "appendNewline": true,
         "createDir": false,
         "overwriteFile": "true",
-        "encoding": "base64",
-        "x": 400,
-        "y": 820,
+        "encoding": "none",
+        "x": 340,
+        "y": 260,
         "wires": [
             [
-                "2da33ec.f45cac2"
+                "38fa0579.f2cd8a"
             ]
         ]
     },
     {
-        "id": "2e814354.278c8c",
+        "id": "d28c8994.99c0a8",
         "type": "debug",
-        "z": "4b63452d.672afc",
+        "z": "6312c0588348b2d4",
         "name": "",
         "active": true,
         "tosidebar": true,
@@ -68,46 +68,47 @@
         "complete": "false",
         "statusVal": "",
         "statusType": "auto",
-        "x": 790,
-        "y": 820,
+        "x": 730,
+        "y": 260,
         "wires": []
     },
     {
-        "id": "2da33ec.f45cac2",
+        "id": "38fa0579.f2cd8a",
         "type": "file in",
-        "z": "4b63452d.672afc",
+        "z": "6312c0588348b2d4",
         "name": "",
         "filename": "/tmp/hello.txt",
         "format": "utf8",
         "chunk": false,
         "sendError": false,
-        "encoding": "none",
-        "x": 600,
-        "y": 820,
+        "encoding": "base64",
+        "allProps": false,
+        "x": 540,
+        "y": 260,
         "wires": [
             [
-                "2e814354.278c8c"
+                "d28c8994.99c0a8"
             ]
         ]
     },
     {
-        "id": "ec754c99.84bfd",
+        "id": "fa22ca20.ae4528",
         "type": "comment",
-        "z": "4b63452d.672afc",
-        "name": "↓write string with base64 encoding",
+        "z": "6312c0588348b2d4",
+        "name": "↑read data from file as base64 string",
         "info": "",
-        "x": 460,
-        "y": 780,
+        "x": 600,
+        "y": 300,
         "wires": []
     },
     {
-        "id": "3e6704ff.4ce25c",
+        "id": "148e25ad.98891a",
         "type": "comment",
-        "z": "4b63452d.672afc",
-        "name": "↑read result from file",
+        "z": "6312c0588348b2d4",
+        "name": "↓write to /tmp/hello.txt",
         "info": "",
-        "x": 610,
-        "y": 860,
+        "x": 360,
+        "y": 220,
         "wires": []
     }
 ]

--- a/packages/node_modules/@node-red/nodes/examples/storage/read file/03 - Read data breaking lines into messages.json
+++ b/packages/node_modules/@node-red/nodes/examples/storage/read file/03 - Read data breaking lines into messages.json
@@ -2,7 +2,7 @@
     {
         "id": "6a0b1d03.d4cee4",
         "type": "inject",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "props": [
             {
@@ -20,8 +20,8 @@
         "topic": "",
         "payload": "",
         "payloadType": "date",
-        "x": 220,
-        "y": 740,
+        "x": 160,
+        "y": 220,
         "wires": [
             [
                 "d4b00cb7.a5a23"
@@ -31,25 +31,25 @@
     {
         "id": "f17ea1d1.8ecc3",
         "type": "comment",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "Read data breaking lines into individual messages",
-        "info": "File-in node can break read text into messages with individual lines",
-        "x": 290,
-        "y": 660,
+        "info": "Read file node can break read text into messages with individual lines",
+        "x": 230,
+        "y": 140,
         "wires": []
     },
     {
         "id": "99ae7806.1d6428",
         "type": "file",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "filename": "/tmp/hello.txt",
         "appendNewline": true,
         "createDir": false,
         "overwriteFile": "true",
         "encoding": "none",
-        "x": 540,
-        "y": 740,
+        "x": 480,
+        "y": 220,
         "wires": [
             [
                 "70d7892f.d27db8"
@@ -59,7 +59,7 @@
     {
         "id": "7ed8282c.92b338",
         "type": "debug",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "active": true,
         "tosidebar": true,
@@ -68,22 +68,22 @@
         "complete": "false",
         "statusVal": "",
         "statusType": "auto",
-        "x": 810,
-        "y": 800,
+        "x": 750,
+        "y": 280,
         "wires": []
     },
     {
         "id": "70d7892f.d27db8",
         "type": "file in",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "filename": "/tmp/hello.txt",
         "format": "lines",
         "chunk": false,
         "sendError": false,
         "encoding": "none",
-        "x": 620,
-        "y": 800,
+        "x": 560,
+        "y": 280,
         "wires": [
             [
                 "7ed8282c.92b338"
@@ -93,27 +93,27 @@
     {
         "id": "c1b7e05.1d94b2",
         "type": "comment",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "↑read data from file breaking lines into messages",
         "info": "",
-        "x": 720,
-        "y": 840,
+        "x": 660,
+        "y": 320,
         "wires": []
     },
     {
         "id": "a5f647b2.cf27a8",
         "type": "comment",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "↓write to /tmp/hello.txt",
         "info": "",
-        "x": 560,
-        "y": 700,
+        "x": 500,
+        "y": 180,
         "wires": []
     },
     {
         "id": "d4b00cb7.a5a23",
         "type": "template",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "data",
         "field": "payload",
         "fieldType": "msg",
@@ -121,8 +121,8 @@
         "syntax": "plain",
         "template": "one\ntwo\nthree!",
         "output": "str",
-        "x": 370,
-        "y": 740,
+        "x": 310,
+        "y": 220,
         "wires": [
             [
                 "99ae7806.1d6428"

--- a/packages/node_modules/@node-red/nodes/examples/storage/read file/04 - Create a message stream.json
+++ b/packages/node_modules/@node-red/nodes/examples/storage/read file/04 - Create a message stream.json
@@ -2,7 +2,7 @@
     {
         "id": "bdd57acc.2edc48",
         "type": "inject",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "props": [
             {
@@ -20,8 +20,8 @@
         "topic": "",
         "payload": "",
         "payloadType": "date",
-        "x": 220,
-        "y": 1040,
+        "x": 180,
+        "y": 220,
         "wires": [
             [
                 "7a069b01.0c2324"
@@ -31,25 +31,25 @@
     {
         "id": "1fd12220.33953e",
         "type": "comment",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "Creating a message stream from lines of data",
-        "info": "File-in node can break read text into messages with individual lines.  The messages creates a stream of messages.",
-        "x": 270,
-        "y": 960,
+        "info": "Read file node can break read text into messages with individual lines.  The messages creates a stream of messages.",
+        "x": 230,
+        "y": 140,
         "wires": []
     },
     {
         "id": "ab6eb213.2a08d",
         "type": "file",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "filename": "/tmp/hello.txt",
         "appendNewline": true,
         "createDir": false,
         "overwriteFile": "true",
         "encoding": "none",
-        "x": 540,
-        "y": 1040,
+        "x": 500,
+        "y": 220,
         "wires": [
             [
                 "b7ed49b0.649fb8"
@@ -59,7 +59,7 @@
     {
         "id": "c48d8ae0.9ff3a8",
         "type": "debug",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "active": true,
         "tosidebar": true,
@@ -68,22 +68,22 @@
         "complete": "false",
         "statusVal": "",
         "statusType": "auto",
-        "x": 810,
-        "y": 1140,
+        "x": 770,
+        "y": 320,
         "wires": []
     },
     {
         "id": "b7ed49b0.649fb8",
         "type": "file in",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "filename": "/tmp/hello.txt",
         "format": "lines",
         "chunk": false,
         "sendError": false,
         "encoding": "none",
-        "x": 280,
-        "y": 1140,
+        "x": 240,
+        "y": 320,
         "wires": [
             [
                 "83073ebe.fcce4"
@@ -93,27 +93,27 @@
     {
         "id": "3c33e69f.6a04ba",
         "type": "comment",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "↑read data from file breaking lines into messages",
         "info": "",
-        "x": 380,
-        "y": 1180,
+        "x": 340,
+        "y": 360,
         "wires": []
     },
     {
         "id": "3598bf7d.5712a",
         "type": "comment",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "↓write to /tmp/hello.txt",
         "info": "",
-        "x": 560,
-        "y": 1000,
+        "x": 520,
+        "y": 180,
         "wires": []
     },
     {
         "id": "7a069b01.0c2324",
         "type": "template",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "data",
         "field": "payload",
         "fieldType": "msg",
@@ -121,8 +121,8 @@
         "syntax": "plain",
         "template": "Apple\nBanana\nGrape\nOrange",
         "output": "str",
-        "x": 370,
-        "y": 1040,
+        "x": 330,
+        "y": 220,
         "wires": [
             [
                 "ab6eb213.2a08d"
@@ -132,7 +132,7 @@
     {
         "id": "8d4ed1d0.821fe",
         "type": "join",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "mode": "auto",
         "build": "string",
@@ -145,8 +145,8 @@
         "timeout": "",
         "count": "",
         "reduceRight": false,
-        "x": 630,
-        "y": 1140,
+        "x": 590,
+        "y": 320,
         "wires": [
             [
                 "c48d8ae0.9ff3a8"
@@ -156,7 +156,7 @@
     {
         "id": "83073ebe.fcce4",
         "type": "switch",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "< D",
         "property": "payload",
         "propertyType": "msg",
@@ -170,8 +170,8 @@
         "checkall": "true",
         "repair": true,
         "outputs": 1,
-        "x": 470,
-        "y": 1140,
+        "x": 430,
+        "y": 320,
         "wires": [
             [
                 "8d4ed1d0.821fe"
@@ -181,21 +181,21 @@
     {
         "id": "2088e195.f7aebe",
         "type": "comment",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "↓filter data before \"D\"",
         "info": "",
-        "x": 520,
-        "y": 1100,
+        "x": 480,
+        "y": 280,
         "wires": []
     },
     {
         "id": "b848cdc7.61e06",
         "type": "comment",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "↑join to single string",
         "info": "",
-        "x": 670,
-        "y": 1180,
+        "x": 630,
+        "y": 360,
         "wires": []
     }
 ]

--- a/packages/node_modules/@node-red/nodes/examples/storage/write file/01 - Write string to a file.json
+++ b/packages/node_modules/@node-red/nodes/examples/storage/write file/01 - Write string to a file.json
@@ -1,17 +1,12 @@
 [
     {
-        "id": "704479e1.399388",
+        "id": "84222b92.d65d18",
         "type": "inject",
-        "z": "4b63452d.672afc",
+        "z": "5132b95f037524f9",
         "name": "",
         "props": [
             {
                 "p": "payload"
-            },
-            {
-                "p": "filename",
-                "v": "/tmp/hello.txt",
-                "vt": "str"
             },
             {
                 "p": "topic",
@@ -25,46 +20,46 @@
         "topic": "",
         "payload": "Hello, World!",
         "payloadType": "str",
-        "x": 230,
-        "y": 400,
+        "x": 150,
+        "y": 220,
         "wires": [
             [
-                "402f3b7e.988014"
+                "b4b9f603.739598"
             ]
         ]
     },
     {
-        "id": "8e876a75.e9beb8",
+        "id": "7b014430.dfd94c",
         "type": "comment",
-        "z": "4b63452d.672afc",
-        "name": "Write string to a file specied by filename property, the read from the file",
-        "info": "File node can target file using `filename` property.",
-        "x": 350,
-        "y": 320,
+        "z": "5132b95f037524f9",
+        "name": "Write string to a file, then read from the file",
+        "info": "Write file node can write string from a file.",
+        "x": 180,
+        "y": 140,
         "wires": []
     },
     {
-        "id": "402f3b7e.988014",
+        "id": "b4b9f603.739598",
         "type": "file",
-        "z": "4b63452d.672afc",
+        "z": "5132b95f037524f9",
         "name": "",
-        "filename": "",
+        "filename": "/tmp/hello.txt",
         "appendNewline": true,
         "createDir": false,
         "overwriteFile": "true",
         "encoding": "none",
-        "x": 390,
-        "y": 400,
+        "x": 340,
+        "y": 220,
         "wires": [
             [
-                "26e077d6.bbcd98"
+                "6dc01cac.5c4bf4"
             ]
         ]
     },
     {
-        "id": "97b6b6b2.a54b38",
+        "id": "2587adb9.7e60f2",
         "type": "debug",
-        "z": "4b63452d.672afc",
+        "z": "5132b95f037524f9",
         "name": "",
         "active": true,
         "tosidebar": true,
@@ -73,46 +68,46 @@
         "complete": "false",
         "statusVal": "",
         "statusType": "auto",
-        "x": 770,
-        "y": 400,
+        "x": 730,
+        "y": 220,
         "wires": []
     },
     {
-        "id": "26e077d6.bbcd98",
+        "id": "6dc01cac.5c4bf4",
         "type": "file in",
-        "z": "4b63452d.672afc",
+        "z": "5132b95f037524f9",
         "name": "",
         "filename": "/tmp/hello.txt",
         "format": "utf8",
         "chunk": false,
         "sendError": false,
         "encoding": "none",
-        "x": 580,
-        "y": 400,
+        "x": 540,
+        "y": 220,
         "wires": [
             [
-                "97b6b6b2.a54b38"
+                "2587adb9.7e60f2"
             ]
         ]
     },
     {
-        "id": "85062297.da79",
+        "id": "f4b4309a.3b78a",
         "type": "comment",
-        "z": "4b63452d.672afc",
+        "z": "5132b95f037524f9",
         "name": "↑read result from file",
         "info": "",
-        "x": 590,
-        "y": 440,
+        "x": 550,
+        "y": 260,
         "wires": []
     },
     {
-        "id": "7316c4fc.b1dcdc",
+        "id": "672d3693.3cabd8",
         "type": "comment",
-        "z": "4b63452d.672afc",
-        "name": "↓write to file specified by filename property",
+        "z": "5132b95f037524f9",
+        "name": "↓write to /tmp/hello.txt",
         "info": "",
-        "x": 500,
-        "y": 360,
+        "x": 360,
+        "y": 180,
         "wires": []
     }
 ]

--- a/packages/node_modules/@node-red/nodes/examples/storage/write file/02 - Write string to a file specified by property.json
+++ b/packages/node_modules/@node-red/nodes/examples/storage/write file/02 - Write string to a file specified by property.json
@@ -1,12 +1,17 @@
 [
     {
-        "id": "84222b92.d65d18",
+        "id": "704479e1.399388",
         "type": "inject",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "props": [
             {
                 "p": "payload"
+            },
+            {
+                "p": "filename",
+                "v": "/tmp/hello.txt",
+                "vt": "str"
             },
             {
                 "p": "topic",
@@ -20,46 +25,46 @@
         "topic": "",
         "payload": "Hello, World!",
         "payloadType": "str",
-        "x": 230,
-        "y": 220,
+        "x": 190,
+        "y": 260,
         "wires": [
             [
-                "b4b9f603.739598"
+                "402f3b7e.988014"
             ]
         ]
     },
     {
-        "id": "7b014430.dfd94c",
+        "id": "8e876a75.e9beb8",
         "type": "comment",
-        "z": "194a3e4f.a92772",
-        "name": "Write string to a file, then read from the file",
-        "info": "File-in node can read string from a file.",
-        "x": 260,
-        "y": 140,
+        "z": "6312c0588348b2d4",
+        "name": "Write string to a file specied by filename property, the read from the file",
+        "info": "Write file node can target file using `filename` property.",
+        "x": 310,
+        "y": 180,
         "wires": []
     },
     {
-        "id": "b4b9f603.739598",
+        "id": "402f3b7e.988014",
         "type": "file",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
-        "filename": "/tmp/hello.txt",
+        "filename": "",
         "appendNewline": true,
         "createDir": false,
         "overwriteFile": "true",
         "encoding": "none",
-        "x": 420,
-        "y": 220,
+        "x": 350,
+        "y": 260,
         "wires": [
             [
-                "6dc01cac.5c4bf4"
+                "26e077d6.bbcd98"
             ]
         ]
     },
     {
-        "id": "2587adb9.7e60f2",
+        "id": "97b6b6b2.a54b38",
         "type": "debug",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "active": true,
         "tosidebar": true,
@@ -68,46 +73,46 @@
         "complete": "false",
         "statusVal": "",
         "statusType": "auto",
-        "x": 810,
-        "y": 220,
+        "x": 730,
+        "y": 260,
         "wires": []
     },
     {
-        "id": "6dc01cac.5c4bf4",
+        "id": "26e077d6.bbcd98",
         "type": "file in",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "",
         "filename": "/tmp/hello.txt",
         "format": "utf8",
         "chunk": false,
         "sendError": false,
         "encoding": "none",
-        "x": 620,
-        "y": 220,
+        "x": 540,
+        "y": 260,
         "wires": [
             [
-                "2587adb9.7e60f2"
+                "97b6b6b2.a54b38"
             ]
         ]
     },
     {
-        "id": "f4b4309a.3b78a",
+        "id": "85062297.da79",
         "type": "comment",
-        "z": "194a3e4f.a92772",
+        "z": "6312c0588348b2d4",
         "name": "↑read result from file",
         "info": "",
-        "x": 630,
-        "y": 260,
+        "x": 550,
+        "y": 300,
         "wires": []
     },
     {
-        "id": "672d3693.3cabd8",
+        "id": "7316c4fc.b1dcdc",
         "type": "comment",
-        "z": "194a3e4f.a92772",
-        "name": "↓write to /tmp/hello.txt",
+        "z": "6312c0588348b2d4",
+        "name": "↓write to file specified by filename property",
         "info": "",
-        "x": 440,
-        "y": 180,
+        "x": 460,
+        "y": 220,
         "wires": []
     }
 ]

--- a/packages/node_modules/@node-red/nodes/examples/storage/write file/03 - Delete a file.json
+++ b/packages/node_modules/@node-red/nodes/examples/storage/write file/03 - Delete a file.json
@@ -2,7 +2,7 @@
     {
         "id": "4ac00fb0.d5f52",
         "type": "inject",
-        "z": "4b63452d.672afc",
+        "z": "6312c0588348b2d4",
         "name": "",
         "props": [
             {
@@ -20,8 +20,8 @@
         "topic": "",
         "payload": "",
         "payloadType": "date",
-        "x": 220,
-        "y": 600,
+        "x": 180,
+        "y": 220,
         "wires": [
             [
                 "542cc2f4.92857c"
@@ -31,25 +31,25 @@
     {
         "id": "671f8295.0e6f6c",
         "type": "comment",
-        "z": "4b63452d.672afc",
+        "z": "6312c0588348b2d4",
         "name": "Delete a file",
-        "info": "File node can delete a file.",
-        "x": 170,
-        "y": 540,
+        "info": "Write file node can delete a file.",
+        "x": 130,
+        "y": 160,
         "wires": []
     },
     {
         "id": "542cc2f4.92857c",
         "type": "file",
-        "z": "4b63452d.672afc",
+        "z": "6312c0588348b2d4",
         "name": "",
         "filename": "/tmp/hello.txt",
         "appendNewline": true,
         "createDir": false,
         "overwriteFile": "delete",
         "encoding": "none",
-        "x": 420,
-        "y": 600,
+        "x": 380,
+        "y": 220,
         "wires": [
             [
                 "a24da523.5babe8"
@@ -59,7 +59,7 @@
     {
         "id": "a24da523.5babe8",
         "type": "debug",
-        "z": "4b63452d.672afc",
+        "z": "6312c0588348b2d4",
         "name": "",
         "active": true,
         "tosidebar": true,
@@ -68,18 +68,18 @@
         "complete": "false",
         "statusVal": "",
         "statusType": "auto",
-        "x": 630,
-        "y": 600,
+        "x": 590,
+        "y": 220,
         "wires": []
     },
     {
         "id": "51157051.2f62",
         "type": "comment",
-        "z": "4b63452d.672afc",
+        "z": "6312c0588348b2d4",
         "name": "↓delete a file",
         "info": "",
-        "x": 390,
-        "y": 560,
+        "x": 350,
+        "y": 180,
         "wires": []
     }
 ]

--- a/packages/node_modules/@node-red/nodes/examples/storage/write file/04 - Specify encoding of written data.json
+++ b/packages/node_modules/@node-red/nodes/examples/storage/write file/04 - Specify encoding of written data.json
@@ -1,9 +1,9 @@
 [
     {
-        "id": "84222b92.d65d18",
+        "id": "e4ef1f5e.7cd82",
         "type": "inject",
-        "z": "4b63452d.672afc",
-        "name": "",
+        "z": "6312c0588348b2d4",
+        "name": "Base64 encoded string",
         "props": [
             {
                 "p": "payload"
@@ -18,48 +18,48 @@
         "once": false,
         "onceDelay": 0.1,
         "topic": "",
-        "payload": "Hello, World!",
+        "payload": "8J+YgA==",
         "payloadType": "str",
-        "x": 230,
-        "y": 200,
+        "x": 200,
+        "y": 220,
         "wires": [
             [
-                "b4b9f603.739598"
+                "72b37cc8.177054"
             ]
         ]
     },
     {
-        "id": "7b014430.dfd94c",
+        "id": "f5997af4.5a9298",
         "type": "comment",
-        "z": "4b63452d.672afc",
-        "name": "Write string to a file, then read from the file",
-        "info": "File node can write string to a file.",
-        "x": 260,
-        "y": 120,
+        "z": "6312c0588348b2d4",
+        "name": "Specify encoding of written data",
+        "info": "Write file node can specify encoding of data.",
+        "x": 170,
+        "y": 140,
         "wires": []
     },
     {
-        "id": "b4b9f603.739598",
+        "id": "72b37cc8.177054",
         "type": "file",
-        "z": "4b63452d.672afc",
+        "z": "6312c0588348b2d4",
         "name": "",
         "filename": "/tmp/hello.txt",
         "appendNewline": true,
         "createDir": false,
         "overwriteFile": "true",
-        "encoding": "none",
+        "encoding": "base64",
         "x": 420,
-        "y": 200,
+        "y": 220,
         "wires": [
             [
-                "6dc01cac.5c4bf4"
+                "2da33ec.f45cac2"
             ]
         ]
     },
     {
-        "id": "2587adb9.7e60f2",
+        "id": "2e814354.278c8c",
         "type": "debug",
-        "z": "4b63452d.672afc",
+        "z": "6312c0588348b2d4",
         "name": "",
         "active": true,
         "tosidebar": true,
@@ -69,13 +69,13 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 810,
-        "y": 200,
+        "y": 220,
         "wires": []
     },
     {
-        "id": "6dc01cac.5c4bf4",
+        "id": "2da33ec.f45cac2",
         "type": "file in",
-        "z": "4b63452d.672afc",
+        "z": "6312c0588348b2d4",
         "name": "",
         "filename": "/tmp/hello.txt",
         "format": "utf8",
@@ -83,31 +83,31 @@
         "sendError": false,
         "encoding": "none",
         "x": 620,
-        "y": 200,
+        "y": 220,
         "wires": [
             [
-                "2587adb9.7e60f2"
+                "2e814354.278c8c"
             ]
         ]
     },
     {
-        "id": "f4b4309a.3b78a",
+        "id": "ec754c99.84bfd",
         "type": "comment",
-        "z": "4b63452d.672afc",
-        "name": "↑read result from file",
+        "z": "6312c0588348b2d4",
+        "name": "↓write string with base64 encoding",
         "info": "",
-        "x": 630,
-        "y": 240,
+        "x": 480,
+        "y": 180,
         "wires": []
     },
     {
-        "id": "672d3693.3cabd8",
+        "id": "3e6704ff.4ce25c",
         "type": "comment",
-        "z": "4b63452d.672afc",
-        "name": "↓write to /tmp/hello.txt",
+        "z": "6312c0588348b2d4",
+        "name": "↑read result from file",
         "info": "",
-        "x": 440,
-        "y": 160,
+        "x": 630,
+        "y": 260,
         "wires": []
     }
 ]


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->
In recent Node-RED release, name of `file` and `file-in` node changed to `read file` and `write file`.  But examples of these nodes uses old name.  This PR fixes these node names.
This PR also fixes minor typo in examples.

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
