### PR TITLE
resume focus after import/export dialog close

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -71,6 +71,7 @@ RED.clipboard = (function() {
                         text: RED._("common.label.cancel"),
                         click: function() {
                             $( this ).dialog( "close" );
+                            RED.view.focus();
                         }
                     },
                     { // red-ui-clipboard-dialog-download
@@ -81,6 +82,7 @@ RED.clipboard = (function() {
                             var data = $("#red-ui-clipboard-dialog-export-text").val();
                             downloadData("flows.json", data);
                             $( this ).dialog( "close" );
+                            RED.view.focus();
                         }
                     },
                     { // red-ui-clipboard-dialog-export
@@ -95,6 +97,7 @@ RED.clipboard = (function() {
                                 $( this ).dialog( "close" );
                                 copyText(flowData);
                                 RED.notify(RED._("clipboard.nodesExported"),{id:"clipboard"});
+                                RED.view.focus();
                             } else {
                                 var flowToExport = $("#red-ui-clipboard-dialog-export-text").val();
                                 var selectedPath = activeLibraries[activeTab].getSelected();
@@ -110,6 +113,7 @@ RED.clipboard = (function() {
                                         contentType: "application/json; charset=utf-8"
                                     }).done(function() {
                                         $(dialog).dialog( "close" );
+                                        RED.view.focus();
                                         RED.notify(RED._("library.exportedToLibrary"),"success");
                                     }).fail(function(xhr,textStatus,err) {
                                         if (xhr.status === 401) {
@@ -171,6 +175,7 @@ RED.clipboard = (function() {
                                 }
                             }
                             $( this ).dialog( "close" );
+                            RED.view.focus();
                         }
                     },
                     { // red-ui-clipboard-dialog-import-conflict
@@ -203,6 +208,7 @@ RED.clipboard = (function() {
                             // console.table(pendingImportConfig.importNodes.map(function(n) { return {id:n.id,type:n.type,result:importMap[n.id]}}))
                             RED.view.importNodes(newNodes, pendingImportConfig.importOptions);
                             $( this ).dialog( "close" );
+                            RED.view.focus();
                         }
                     }
                 ],


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Can not delete selected nodes by delete key after following operations:
1. select nodes,
2. open import/export dialog from menu,
3. close the dialog,
4. press `DEL` key.

This is because focus is lost after opening the dialog.  This PR tries to resolve this issue.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
