### PR TITLE
Add log logging

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -83,6 +83,7 @@ function createNode(flow,config) {
                 }
             }
             try {
+                Object.defineProperty(conf,'_module', {value: typeRegistry.getNodeInfo(type), enumerable: false, writable: true })
                 Object.defineProperty(conf,'_flow', {value: flow, enumerable: false, writable: true })
                 newNode = new nodeTypeConstructor(conf);
             } catch (err) {

--- a/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
@@ -487,7 +487,6 @@ function log_helper(self, level, msg) {
         level: level,
         id: self.id,
         type: self.type,
-        module: self._module,
         msg: msg
     };
     if (self._alias) {
@@ -500,7 +499,12 @@ function log_helper(self, level, msg) {
     if (self.name) {
         o.name = self.name;
     }
-    self._flow.log(o);
+    // See https://github.com/node-red/node-red/issues/3327
+    try {
+        self._flow.log(o);
+    } catch(err) {
+        logUnexpectedError(self, err)
+    }
 }
 /**
  * Log an INFO level message
@@ -579,5 +583,60 @@ Node.prototype.status = function(status) {
     }
     this._flow.handleStatus(this,status);
 };
+
+
+function inspectObject(flow) {
+    try {
+        let properties = new Set()
+        let currentObj = flow
+        do {
+            if (!Object.getPrototypeOf(currentObj)) { break }
+            Object.getOwnPropertyNames(currentObj).map(item => properties.add(item))
+        } while ((currentObj = Object.getPrototypeOf(currentObj)))
+        let propList = [...properties.keys()].map(item => `${item}[${(typeof flow[item])[0]}]`)
+        propList.sort();
+        let result = [];
+        let line = "";
+        while (propList.length > 0) {
+            let prop = propList.shift()
+            if (line.length+prop.length > 80) {
+                result.push(line)
+                line = "";
+            } else {
+                line += " "+prop
+            }
+        }
+        if (line.length > 0) {
+            result.push(line);
+        }
+        return result.join("\n  ")
+
+    } catch(err) {
+        return "Failed to capture object properties: "+err.toString()
+    }
+}
+
+function logUnexpectedError(node, error) {
+    let moduleInfo = node._module?`${node._module.module}@${node._module.version}`:"undefined"
+    Log.error(`
+********************************************************************
+Unexpected Node Error
+${error.stack}
+Node:
+ Type: ${node.type}
+ Module: ${moduleInfo}
+ ID: ${node._alias||node.id}
+ Properties:
+  ${inspectObject(node)}
+Flow: ${node._flow?node._flow.path:'undefined'}
+ Type: ${node._flow?node._flow.TYPE:'undefined'}
+ Properties:
+  ${node._flow?inspectObject(node._flow):'undefined'}
+
+Please report this issue, including the information logged above:
+https://github.com/node-red/node-red/issues/
+********************************************************************
+`)
+}
 
 module.exports = Node;

--- a/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
@@ -59,6 +59,9 @@ function Node(n) {
         // which we can tolerate as they are the same object.
         Object.defineProperty(this,'_flow', {value: n._flow, enumerable: false, writable: true })
     }
+    if (n._module) {
+        Object.defineProperty(this,'_module', {value: n._module, enumerable: false, writable: true })
+    }
     this.updateWires(n.wires);
 }
 
@@ -484,6 +487,7 @@ function log_helper(self, level, msg) {
         level: level,
         id: self.id,
         type: self.type,
+        module: self._module,
         msg: msg
     };
     if (self._alias) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

## Proposed changes

This adds some comprehensive logging if a call to `Node.log` itself throws an error.

That should not happen - but we have #3327 telling us it *can* happen. This logging should capture more information about the state of the node and its flow object. It will also tell us the type/id/module of the node that hit the error.

A side-effect of this PR is nodes now have a `_module` property that is information about the module that provided the node - including name and version.

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] I have run `grunt` to verify the unit tests pass

