### PR TITLE
Initialize passport when only adminAuth.tokens is set

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/auth/strategies.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/strategies.js
@@ -146,7 +146,7 @@ function authenticateUserToken(req) {
                 } else {
                     reject();
                 }
-            });
+            }).catch(reject);
         } else {
             reject();
         }
@@ -163,6 +163,7 @@ TokensStrategy.prototype.authenticate = function(req) {
     authenticateUserToken(req).then(user => {
         this.success(user,{scope:user.permissions});
     }).catch(err => {
+        log.trace("token authentication failure: "+err.stack)
         this.fail(401);
     });
 }

--- a/packages/node_modules/@node-red/editor-api/lib/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/index.js
@@ -90,6 +90,8 @@ function init(settings,_server,storage,runtimeAPI) {
                     auth.getToken,
                     auth.errorHandler
                 );
+            } else if (settings.adminAuth.tokens) {
+                adminApp.use(passport.initialize());
             }
             adminApp.post("/auth/revoke",auth.needsPermission(""),auth.revoke,apiUtil.errorHandler);
         }


### PR DESCRIPTION
Fixes #3341

If `adminAuth` only contained `tokens` then we were not initialising Passport properly.

This fixes that and also adds some trace level logging if the token-auth fails for any reason.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
