### PR TITLE
Only setup ws client heartbeat once it is connected

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
@@ -105,22 +105,24 @@ module.exports = function(RED) {
             if (node.isServer) {
                 node._clients[id] = socket;
                 node.emit('opened',{count:Object.keys(node._clients).length,id:id});
-            } else {
-                if (node.heartbeat) {
-                    node.heartbeatInterval = setInterval(function() {
-                        if (socket.nrPendingHeartbeat) {
-                            // No pong received
-                            socket.terminate();
-                            socket.nrErrorHandler(new Error("timeout"));
-                            return;
-                        }
-                        socket.nrPendingHeartbeat = true;
-                        socket.ping();
-                    },node.heartbeat);
-                }
             }
             socket.on('open',function() {
                 if (!node.isServer) {
+                    if (node.heartbeat) {
+                        clearInterval(node.heartbeatInterval);
+                        node.heartbeatInterval = setInterval(function() {
+                            if (socket.nrPendingHeartbeat) {
+                                // No pong received
+                                socket.terminate();
+                                socket.nrErrorHandler(new Error("timeout"));
+                                return;
+                            }
+                            socket.nrPendingHeartbeat = true;
+                            try {
+                                socket.ping();
+                            } catch(err) {}
+                        },node.heartbeat);
+                    }
                     node.emit('opened',{count:'',id:id});
                 }
             });


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

## Proposed changes

Fixes #3264

The WebSocket Client heartbeat interval was being setup before the socket's `open` event fired - meaning it could try to send a ping before the client connected.

This fix moves the setup of the heartbeat to the `open` event handler and adds error handling around the `ping()` call to ensure it can't error if it hits a timing window of triggering whilst the socket is closing.

