### PR TITLE
Improve jsonata legacy mode detection regex

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/expression.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/expression.js
@@ -247,7 +247,7 @@
                         var currentExpression = expressionEditor.getValue();
                         var expr;
                         var usesContext = false;
-                        var legacyMode = /(^|[^a-zA-Z0-9_'"])msg([^a-zA-Z0-9_'"]|$)/.test(currentExpression);
+                        var legacyMode = /(^|[^a-zA-Z0-9_'".])msg([^a-zA-Z0-9_'"]|$)/.test(currentExpression);
                         $(".red-ui-editor-type-expression-legacy").toggle(legacyMode);
                         try {
                             expr = jsonata(currentExpression);

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -686,7 +686,7 @@ function prepareJSONataExpression(value,node) {
         return moment(arg1, arg2, arg3, arg4);
     });
     expr.registerFunction('clone', cloneMessage, '<(oa)-:o>');
-    expr._legacyMode = /(^|[^a-zA-Z0-9_'"])msg([^a-zA-Z0-9_'"]|$)/.test(value);
+    expr._legacyMode = /(^|[^a-zA-Z0-9_'".])msg([^a-zA-Z0-9_'"]|$)/.test(value);
     expr._node = node;
     return expr;
 }


### PR DESCRIPTION
Fixes #3290

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

The current regex used to spot if `msg` is used in a JSONata expression has been updated to ignore case where it appears as `.msg`. For example, if `msg.payload` had a property called `msg` - `msg.payload.msg`.
