### PR TITLE
Handle reporting error location when stack is truncated

### DIFF
--- a/packages/node_modules/@node-red/util/lib/events.js
+++ b/packages/node_modules/@node-red/util/lib/events.js
@@ -32,8 +32,14 @@ function wrapEventFunction(obj,func) {
     return function(eventName, listener) {
         if (deprecatedEvents.hasOwnProperty(eventName)) {
             const log = require("@node-red/util").log;
-            const stack = (new Error().stack).split("\n")[2].split("(")[1].slice(0,-1);
-            log.warn(`[RED.events] Deprecated use of "${eventName}" event from "${stack}". Use "${deprecatedEvents[eventName]}" instead.`)
+
+            const stack = (new Error().stack).split("\n");
+            let location = "(unknown)"
+            // See https://github.com/node-red/node-red/issues/3292
+            if (stack.length > 2) {
+                location = stack[2].split("(")[1].slice(0,-1);
+            }
+            log.warn(`[RED.events] Deprecated use of "${eventName}" event from "${location}". Use "${deprecatedEvents[eventName]}" instead.`)
         }
         return events["_"+func].call(events,eventName,listener)
     }


### PR DESCRIPTION
Fixes #3292

- [x] Bugfix (non-breaking change which fixes an issue)

## Proposed changes

If someone is running node with the `--stack_trace_limit` parameter to limit stack trace lengths, then this fix removes an assumption that the stack is at least a certain length.

It does mean we aren't able to report the location of code making a deprecated call - but nothing we can do about that if the user has chosen to limit stack sizes.

