### PR TITLE
Fix generating flow name with incrementing number

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -66,7 +66,7 @@ RED.workspaces = (function() {
             var tabId = RED.nodes.id();
             do {
                 workspaceIndex += 1;
-            } while ($("#red-ui-workspace-tabs a[title='"+RED._('workspace.defaultName',{number:workspaceIndex})+"']").size() !== 0);
+            } while ($("#red-ui-workspace-tabs li[flowname='"+RED._('workspace.defaultName',{number:workspaceIndex})+"']").size() !== 0);
 
             ws = {
                 type: "tab",
@@ -79,12 +79,15 @@ RED.workspaces = (function() {
             };
             RED.nodes.addWorkspace(ws,targetIndex);
             workspace_tabs.addTab(ws,targetIndex);
+
             workspace_tabs.activateTab(tabId);
             if (!skipHistoryEntry) {
                 RED.history.push({t:'add',workspaces:[ws],dirty:RED.nodes.dirty()});
                 RED.nodes.dirty(true);
             }
         }
+        $("#red-ui-tab-"+(ws.id.replace(".","-"))).attr("flowname",ws.label)
+
         RED.view.focus();
         return ws;
     }
@@ -583,7 +586,7 @@ RED.workspaces = (function() {
         refresh: function() {
             RED.nodes.eachWorkspace(function(ws) {
                 workspace_tabs.renameTab(ws.id,ws.label);
-
+                $("#red-ui-tab-"+(ws.id.replace(".","-"))).attr("flowname",ws.label)
             })
             RED.nodes.eachSubflow(function(sf) {
                 if (workspace_tabs.contains(sf.id)) {


### PR DESCRIPTION
Fixes #3295

- [x] Bugfix (non-breaking change which fixes an issue)

## Proposed changes

The logic around generating the name of a newly added tab was broken a while ago so you could end up with multiple tabs called `Flow 1`.

This PR fixes the logic around detecting if a candidate name already exists.

