### PR TITLE
Prevent function scrollbar from obscuring expand button

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.html
@@ -91,21 +91,21 @@
         <div id="func-tab-init" style="display:none">
             <div class="form-row node-text-editor-row" style="position:relative">
                 <div style="height: 250px; min-height:150px;" class="node-text-editor" id="node-input-init-editor" ></div>
-                <div style="position: absolute; right:0; bottom: calc(100% - 20px); z-Index: 5;"><button id="node-init-expand-js" class="red-ui-button red-ui-button-small"><i class="fa fa-expand"></i></button></div>
+                <div style="position: absolute; right:0; bottom: calc(100% - 20px); z-Index: 10;"><button id="node-init-expand-js" class="red-ui-button red-ui-button-small"><i class="fa fa-expand"></i></button></div>
             </div>
         </div>
 
         <div id="func-tab-body" style="display:none">
             <div class="form-row node-text-editor-row" style="position:relative">
                 <div style="height: 220px; min-height:150px;" class="node-text-editor" id="node-input-func-editor" ></div>
-                <div style="position: absolute; right:0; bottom: calc(100% - 20px); z-Index: 5;"><button id="node-function-expand-js" class="red-ui-button red-ui-button-small"><i class="fa fa-expand"></i></button></div>
+                <div style="position: absolute; right:0; bottom: calc(100% - 20px); z-Index: 10;"><button id="node-function-expand-js" class="red-ui-button red-ui-button-small"><i class="fa fa-expand"></i></button></div>
             </div>
         </div>
 
         <div id="func-tab-finalize" style="display:none">
             <div class="form-row node-text-editor-row" style="position:relative">
                 <div style="height: 250px; min-height:150px;" class="node-text-editor" id="node-input-finalize-editor" ></div>
-                <div style="position: absolute; right:0; bottom: calc(100% - 20px); z-Index: 5;"><button id="node-finalize-expand-js" class="red-ui-button red-ui-button-small"><i class="fa fa-expand"></i></button></div>
+                <div style="position: absolute; right:0; bottom: calc(100% - 20px); z-Index: 10;"><button id="node-finalize-expand-js" class="red-ui-button red-ui-button-small"><i class="fa fa-expand"></i></button></div>
             </div>
         </div>
 


### PR DESCRIPTION
Fixes #2955

Gives the expand button in the Function node code editor a higher z-index then the text area so it appears over the top of the scrollbar.
