### PR TITLE
Remember Zoom level and Sidebar tab selection between sessions

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -75,6 +75,8 @@
             "view": {
                 "view": "View",
                 "grid": "Grid",
+                "storeZoom": "Restore zoom level on load",
+                "storePosition": "Restore scroll position on load",
                 "showGrid": "Show grid",
                 "snapGrid": "Snap to grid",
                 "gridSize": "Grid size",

--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -556,8 +556,7 @@ var RED = (function() {
 
         $(".red-ui-header-toolbar").show();
 
-
-        RED.sidebar.show(":first");
+        RED.sidebar.show(":first", true);
 
         setTimeout(function() {
             loader.end();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
@@ -19,6 +19,15 @@ RED.sidebar = (function() {
     var sidebar_tabs;
     var knownTabs = {};
 
+    // We store the current sidebar tab id in localStorage as 'last-sidebar-tab'
+    // This is restored when the editor is reloaded.
+    // We use sidebar_tabs.onchange to update localStorage. However that will
+    // also get triggered when the first tab gets added to the tabs - typically
+    // the 'info' tab. So we use the following variable to store the retrieved
+    // value from localStorage before we start adding the actual tabs
+    var lastSessionSelectedTab = null;
+
+
     function addTab(title,content,closeable,visible) {
         var options;
         if (typeof title === "string") {
@@ -194,16 +203,16 @@ RED.sidebar = (function() {
         RED.events.emit("sidebar:resize");
     }
 
-    function showSidebar(id) {
+    function showSidebar(id, skipShowSidebar) {
         if (id === ":first") {
-            id = RED.settings.get("editor.sidebar.order",["info", "help", "version-control", "debug"])[0]
+            id = lastSessionSelectedTab || RED.settings.get("editor.sidebar.order",["info", "help", "version-control", "debug"])[0]
         }
         if (id) {
             if (!containsTab(id) && knownTabs[id]) {
                 sidebar_tabs.addTab(knownTabs[id]);
             }
             sidebar_tabs.activateTab(id);
-            if (!RED.menu.isSelected("menu-item-sidebar")) {
+            if (!skipShowSidebar && !RED.menu.isSelected("menu-item-sidebar")) {
                 RED.menu.setSelected("menu-item-sidebar",true);
             }
         }
@@ -227,6 +236,7 @@ RED.sidebar = (function() {
                 if (tab.toolbar) {
                     $(tab.toolbar).show();
                 }
+                RED.settings.setLocal("last-sidebar-tab", tab.id)
             },
             onremove: function(tab) {
                 $(tab.wrapper).hide();
@@ -255,7 +265,9 @@ RED.sidebar = (function() {
             }
         });
         RED.popover.tooltip($("#red-ui-sidebar-separator").find(".red-ui-sidebar-control-right"),RED._("keyboard.toggleSidebar"),"core:toggle-sidebar");
-        showSidebar();
+
+        lastSessionSelectedTab = RED.settings.getLocal("last-sidebar-tab")
+
         RED.sidebar.info.init();
         RED.sidebar.help.init();
         RED.sidebar.config.init();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
@@ -122,6 +122,13 @@ RED.userSettings = (function() {
         //     ]
         // },
         {
+            title: "menu.label.view.view",
+            options: [
+                {setting:"view-store-zoom",label:"menu.label.view.storeZoom", default: false, toggle:true, onchange: function(val) { if (!val) { RED.settings.removeLocal("zoom-level")}}},
+                {setting:"view-store-position",label:"menu.label.view.storePosition", default: false, toggle:true, onchange: function(val) { if (!val) { RED.settings.removeLocal("scroll-positions")}}},
+            ]
+        },
+        {
             title: "menu.label.view.grid",
             options: [
                 {setting:"view-show-grid",oldSetting:"menu-menu-item-view-show-grid",label:"menu.label.view.showGrid", default: true, toggle:true,onchange:"core:toggle-show-grid"},

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -678,10 +678,38 @@ RED.view = (function() {
             show: function(n) { return !n.valid }
         })
 
+        if (RED.settings.get("editor.view.view-store-zoom")) {
+            var  userZoomLevel = parseFloat(RED.settings.getLocal('zoom-level'))
+            if (!isNaN(userZoomLevel)) {
+                scaleFactor = userZoomLevel
+            }
+        }
 
-        var  userZoomLevel = parseFloat(RED.settings.getLocal('zoom-level'))
-        if (!isNaN(userZoomLevel)) {
-            scaleFactor = userZoomLevel
+        var onScrollTimer = null;
+        function storeScrollPosition() {
+            workspaceScrollPositions[RED.workspaces.active()] = {
+                left:chart.scrollLeft(),
+                top:chart.scrollTop()
+            };
+            RED.settings.setLocal('scroll-positions', JSON.stringify(workspaceScrollPositions) )
+        }
+        chart.on("scroll", function() {
+            if (RED.settings.get("editor.view.view-store-position")) {
+                if (onScrollTimer) {
+                    clearTimeout(onScrollTimer)
+                }
+                onScrollTimer = setTimeout(storeScrollPosition, 200);
+            }
+        })
+
+        if (RED.settings.get("editor.view.view-store-position")) {
+            var scrollPositions = RED.settings.getLocal('scroll-positions')
+            if (scrollPositions) {
+                try {
+                    workspaceScrollPositions = JSON.parse(scrollPositions)
+                } catch(err) {
+                }
+            }
         }
     }
 
@@ -1983,7 +2011,9 @@ RED.view = (function() {
 
         RED.view.navigator.resize();
         redraw();
-        RED.settings.setLocal('zoom-level', factor.toFixed(1))
+        if (RED.settings.get("editor.view.view-store-zoom")) {
+            RED.settings.setLocal('zoom-level', factor.toFixed(1))
+        }
     }
 
     function selectNone() {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -678,6 +678,11 @@ RED.view = (function() {
             show: function(n) { return !n.valid }
         })
 
+
+        var  userZoomLevel = parseFloat(RED.settings.getLocal('zoom-level'))
+        if (!isNaN(userZoomLevel)) {
+            scaleFactor = userZoomLevel
+        }
     }
 
 
@@ -1965,6 +1970,7 @@ RED.view = (function() {
     }
     function zoomZero() { zoomView(1); }
 
+
     function zoomView(factor) {
         var screenSize = [chart.width(),chart.height()];
         var scrollPos = [chart.scrollLeft(),chart.scrollTop()];
@@ -1977,6 +1983,7 @@ RED.view = (function() {
 
         RED.view.navigator.resize();
         redraw();
+        RED.settings.setLocal('zoom-level', factor.toFixed(1))
     }
 
     function selectNone() {


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

This PR causes the zoom level of the editor to be stored in localStorage and restored when the editor is reloaded.

It also fixes remember if the sidebar had been closed or not, and also restores the view to the last sidebar tab the user had selected.