### PR TITLE
Add _path property to nodes and expose as node.path in Function node

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/types/node-red/func.d.ts
+++ b/packages/node_modules/@node-red/editor-client/src/types/node-red/func.d.ts
@@ -31,12 +31,12 @@ interface NodeStatus {
 }
 
 declare class node {
-    /** 
-    * Send 1 or more messages asynchronously 
-    * @param {object | object[]} msg  The msg object 
-    * @param {Boolean} [clone=true]  Flag to indicate the `msg` should be cloned. Default = `true`   
-    * @see node-red documentation [writing-functions: sending messages asynchronously](https://nodered.org/docs/user-guide/writing-functions#sending-messages-asynchronously) 
-    */ 
+    /**
+    * Send 1 or more messages asynchronously
+    * @param {object | object[]} msg  The msg object
+    * @param {Boolean} [clone=true]  Flag to indicate the `msg` should be cloned. Default = `true`
+    * @see node-red documentation [writing-functions: sending messages asynchronously](https://nodered.org/docs/user-guide/writing-functions#sending-messages-asynchronously)
+    */
     static send(msg:object|object[], clone?:Boolean): void;
     /** Inform runtime this instance has completed its operation */
     static done();
@@ -60,6 +60,8 @@ declare class node {
     public readonly id:string;
     /** the name of this node */
     public readonly name:string;
+    /** the path identifier for this node */
+    public readonly path:string;
     /** the number of outputs of this node */
     public readonly outputCount:number;
 }
@@ -93,27 +95,27 @@ declare class context {
     /**
      * Set one or multiple values in context (synchronous).
      * @param name - Name (or array of names) to set in context
-     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed. 
+     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed.
      */
     static set(name: string | string[], value?: any | any[]);
     /**
      * Set one or multiple values in context (asynchronous).
      * @param name - Name (or array of names) to set in context
-     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed. 
+     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed.
      * @param callback - (optional) Callback function (`(err) => {}`)
      */
     static set(name: string | string[], value?: any | any[], callback?: Function);
     /**
      * Set one or multiple values in context (synchronous).
      * @param name - Name (or array of names) to set in context
-     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed. 
+     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed.
      * @param store - (optional) Name of context store
      */
     static set(name: string | string[], value?: any | any[], store?: string);
     /**
      * Set one or multiple values in context (asynchronous).
      * @param name - Name (or array of names) to set in context
-     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed. 
+     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed.
      * @param store - (optional) Name of context store
      * @param callback - (optional) Callback function (`(err) => {}`)
      */
@@ -158,27 +160,27 @@ declare class flow {
     /**
      * Set one or multiple values in context (synchronous).
      * @param name - Name (or array of names) to set in context
-     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed. 
+     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed.
      */
     static set(name: string | string[], value?: any | any[]);
     /**
      * Set one or multiple values in context (asynchronous).
      * @param name - Name (or array of names) to set in context
-     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed. 
+     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed.
      * @param callback - (optional) Callback function (`(err) => {}`)
      */
     static set(name: string | string[], value?: any | any[], callback?: Function);
     /**
      * Set one or multiple values in context (synchronous).
      * @param name - Name (or array of names) to set in context
-     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed. 
+     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed.
      * @param store - (optional) Name of context store
      */
     static set(name: string | string[], value?: any | any[], store?: string);
     /**
      * Set one or multiple values in context (asynchronous).
      * @param name - Name (or array of names) to set in context
-     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed. 
+     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed.
      * @param store - (optional) Name of context store
      * @param callback - (optional) Callback function (`(err) => {}`)
      */
@@ -225,32 +227,32 @@ declare class global {
     /**
      * Set one or multiple values in context (synchronous).
      * @param name - Name (or array of names) to set in context
-     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed. 
+     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed.
      */
     static set(name: string | string[], value?: any | any[]);
     /**
      * Set one or multiple values in context (asynchronous).
      * @param name - Name (or array of names) to set in context
-     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed. 
+     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed.
      * @param callback - (optional) Callback function (`(err) => {}`)
      */
     static set(name: string | string[], value?: any | any[], callback?: Function);
     /**
      * Set one or multiple values in context (synchronous).
      * @param name - Name (or array of names) to set in context
-     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed. 
+     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed.
      * @param store - (optional) Name of context store
      */
     static set(name: string | string[], value?: any | any[], store?: string);
     /**
      * Set one or multiple values in context (asynchronous).
      * @param name - Name (or array of names) to set in context
-     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed. 
+     * @param value - The value (or array of values) to store in context. If the value(s) are null/undefined, the context item(s) will be removed.
      * @param store - (optional) Name of context store
      * @param callback - (optional) Callback function (`(err) => {}`)
      */
     static set(name: string | string[], value?: any | any[], store?: string, callback?: Function);
- 
+
     /** Get an array of the keys in the context store */
     static keys(): Array<string>;
     /** Get an array of the keys in the context store */

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -112,6 +112,7 @@ module.exports = function(RED) {
                 "var node = {"+
                     "id:__node__.id,"+
                     "name:__node__.name,"+
+                    "path:__node__.path,"+
                     "outputCount:__node__.outputCount,"+
                     "log:__node__.log,"+
                     "error:__node__.error,"+
@@ -163,6 +164,7 @@ module.exports = function(RED) {
             __node__: {
                 id: node.id,
                 name: node.name,
+                path: node._path,
                 outputCount: node.outputs,
                 log: function() {
                     node.log.apply(node, arguments);
@@ -344,6 +346,7 @@ module.exports = function(RED) {
                         var node = {
                             id:__node__.id,
                             name:__node__.name,
+                            path:__node__.path,
                             outputCount:__node__.outputCount,
                             log:__node__.log,
                             error:__node__.error,
@@ -366,6 +369,7 @@ module.exports = function(RED) {
                         var node = {
                             id:__node__.id,
                             name:__node__.name,
+                            path:__node__.path,
                             outputCount:__node__.outputCount,
                             log:__node__.log,
                             error:__node__.error,

--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -85,6 +85,7 @@ function createNode(flow,config) {
             try {
                 Object.defineProperty(conf,'_module', {value: typeRegistry.getNodeInfo(type), enumerable: false, writable: true })
                 Object.defineProperty(conf,'_flow', {value: flow, enumerable: false, writable: true })
+                Object.defineProperty(conf,'_path', {value: `${flow.path}/${config._alias||config.id}`, enumerable: false, writable: true })
                 newNode = new nodeTypeConstructor(conf);
             } catch (err) {
                 Log.log({

--- a/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
@@ -62,6 +62,9 @@ function Node(n) {
     if (n._module) {
         Object.defineProperty(this,'_module', {value: n._module, enumerable: false, writable: true })
     }
+    if (n._path) {
+        Object.defineProperty(this,'_path', {value: n._path, enumerable: false, writable: true })
+    }
     this.updateWires(n.wires);
 }
 


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

This PR exposes a new property on the Node object - `node._path`.

This can be used to describe a node's location in the flow - in terms of what Flow/Subflow it is on.

If `node-1` is on `flow-1`, it will have a `_path` of `flow-1/node-1`

That isn't very interesting. Where it does get interesting is when subflows are involved.

Given the following configuration:
 - ​`node-1` is in `subflow-1`,
 - an instance of `subflow-1` has id `subflow-instance-1` and is on `flow-1`

When the runtime starts that flow, it will create `subflow-instance-1` and create an instance of `node-1` and assigned a random id - `node-instance-49876`

When debugging that node instance, having the id `node-instance-49876` isn't very useful as a user cannot relate it back to `node-1`. This is where the `_alias` property comes in - `node-instance-49876` will have an `_alias` of `node-1` - meaning we can easily map it back to the actual node.

It will have a `_path` of: `flow-1/subflow-instance-1/node-1`. That tells you exactly where the node is.



But what happens if there are nested subflows... knowing the 'true' id of a node inside a nested subflow will tell you which subflow its in, but not which *instance* of that subflow its in.

This is where `_path` is useful. Lets look at a nested example:

 - ​`node-2` is in `subflow-inner`,
​ - an instance of `subflow-inner` has id `subflow-instance-inner` and is in `subflow-outer`
 - an instance of `subflow-outer` has id `subflow-instance-outer` and is on `flow-1`

When the runtime starts this flow we will have:

 - `flow-1` creates an instance of `subflow-outer` with id `subflow-instance-outer`.
 - `subflow-instance-outer` contains an instance of `subflow-instance-inner` with a randomly generated id `subflow-instance-inner-98794`
 - `subflow-instance-inner-98794` contains an instance of `node-2` with a randomly generated id `node-2-09375`

Given all of that, `node-2-09375` has:
 - `id` : `node-2-09375`
 - `_alias` : `node-2`
 - `_path` : `flow-1/subflow-instance-outer/subflow-instance-inner-98794/node-2`

The `_path` gives you all the information needed to identify which (nested) subflow on what top-level flow the node is on.

---

This PR also exposes this property as `node.path` inside the Function node (without the underscore). This will allow subflows that are published as NPM modules do better internal logging for their end users.
