### PR TITLE
Use a nodes palette label in help tree

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-help.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-help.js
@@ -265,7 +265,7 @@ RED.sidebar.help = (function() {
             }
         }
         label = label || n.type;
-        $('<div>',{class:"red-ui-node-label"}).text(n.name||n.type).appendTo(icon);
+        $('<div>',{class:"red-ui-node-label"}).text(label).appendTo(icon);
         return div;
     }
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-help.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-help.js
@@ -64,15 +64,17 @@ RED.sidebar.help = (function() {
             style: "compact",
             delay: 100,
             change: function() {
-                var val = $(this).val().toLowerCase();
-                if (val) {
+                const searchFor = $(this).val().toLowerCase();
+                if (searchFor) {
                     showTOC();
-                    var c = treeList.treeList('filter',function(item) {
+                    treeList.treeList('filter',function(item) {
                         if (item.depth === 0) {
                             return true;
                         }
-                        return (item.nodeType &&  item.nodeType.indexOf(val) > -1) ||
-                               (item.subflowLabel && item.subflowLabel.indexOf(val) > -1)
+                        let found = item.nodeType && item.nodeType.toLowerCase().indexOf(searchFor) > -1;
+                        found = found || item.subflowLabel && item.subflowLabel.toLowerCase().indexOf(searchFor) > -1;
+                        found = found || item.palleteLabel && item.palleteLabel.toLowerCase().indexOf(searchFor) > -1;
+                        return found;
                     },true)
                 } else {
                     treeList.treeList('filter',null);
@@ -224,17 +226,21 @@ RED.sidebar.help = (function() {
 
 
         moduleNames.forEach(function(moduleName) {
-            var module = modules[moduleName];
-            var nodeTypes = [];
-
-            var setNames = Object.keys(module.sets);
+            const module = modules[moduleName];
+            const nodeTypes = [];
+            const moduleSets = module.sets;
+            const setNames = Object.keys(moduleSets);
             setNames.forEach(function(setName) {
-                module.sets[setName].types.forEach(function(nodeType) {
+                const moduleSet = moduleSets[setName];
+                moduleSet.types.forEach(function(nodeType) {
                     if ($("script[data-help-name='"+nodeType+"']").length) {
+                        const n =  {_def:RED.nodes.getType(nodeType),type:nodeType}
+                        n.name = getNodePaletteLabel(n);
                         nodeTypes.push({
                             id: "node-type:"+nodeType,
                             nodeType: nodeType,
-                            element:getNodeLabel({_def:RED.nodes.getType(nodeType),type:nodeType})
+                            palleteLabel: n.name,
+                            element: getNodeLabel(n)
                         })
                     }
                 })
@@ -254,18 +260,21 @@ RED.sidebar.help = (function() {
         treeList.treeList("data",helpData);
     }
 
-    function getNodeLabel(n) {
-        var div = $('<div>',{class:"red-ui-node-list-item"});
-        var icon = RED.utils.createNodeIcon(n).appendTo(div);
-        var label = n.name;
+    function getNodePaletteLabel(n) {
+        let label = n.name;
         if (!label && n._def && n._def.paletteLabel) {
             try {
                 label = (typeof n._def.paletteLabel === "function" ? n._def.paletteLabel.call(n._def) : n._def.paletteLabel)||"";
             } catch (err) {
             }
         }
-        label = label || n.type;
-        $('<div>',{class:"red-ui-node-label"}).text(label).appendTo(icon);
+        return label || n.type;
+    }
+
+    function getNodeLabel(n) {
+        const div = $('<div>',{class:"red-ui-node-list-item"});
+        const icon = RED.utils.createNodeIcon(n).appendTo(div);
+        $('<div>',{class:"red-ui-node-label"}).text(getNodePaletteLabel(n)).appendTo(icon);
         return div;
     }
 


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes
Fixes #3369 

* Uses palleteLabel for the help sidebar
* Ensures items with upper case chars are found



## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
