### PR TITLE
bug: merge issue. fixes #3364

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
@@ -557,23 +557,19 @@ RED.tabs = (function() {
                 }
             }
 
-            li.one("transitionend", function(evt) {
-                li.remove();
-                if (tabs[id].pinned) {
-                    pinnedTabsCount--;
-                }
-                if (options.onremove) {
-                    options.onremove(tabs[id]);
-                }
-                delete tabs[id];
-                updateTabWidths();
-                if (collapsibleMenu) {
-                    collapsibleMenu.remove();
-                    collapsibleMenu = null;
-                }
-            })
-            li.addClass("hide-tab");
-            li.width(0);
+            li.remove();
+            if (tabs[id].pinned) {
+                pinnedTabsCount--;
+            }
+            if (options.onremove) {
+                options.onremove(tabs[id]);
+            }
+            delete tabs[id];
+            updateTabWidths();
+            if (collapsibleMenu) {
+                collapsibleMenu.remove();
+                collapsibleMenu = null;
+            }
         }
 
         function findPreviousVisibleTab(li) {


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)



## Proposed changes

Fixes #3364 

As discussed, for now, remove the close animation causing the UI glitch

The async nature of `li.one("transitionend", function(evt) {` was causing the problem. 


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
