### PR TITLE
Pallet Label (if different to type) should be indexed for search

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
@@ -53,10 +53,22 @@ RED.search = (function() {
         }
         l = l||n.label||n.name||n.id||"";
 
-
         var properties = ['id','type','name','label','info'];
-        if (n._def && n._def.defaults) {
-            properties = properties.concat(Object.keys(n._def.defaults));
+        const node_def = n && n._def;
+        if (node_def) {
+            if (node_def.defaults) {
+                properties = properties.concat(Object.keys(node_def.defaults));
+            }
+            if (n.type !== "group" && node_def.paletteLabel && node_def.paletteLabel !== node_def.type) {
+                try {
+                    const label = ("" + (typeof node_def.paletteLabel === "function" ? node_def.paletteLabel.call(node_def) : node_def.paletteLabel)).toLowerCase();
+                    if(label && label !== (""+node_def.type).toLowerCase()) {
+                        indexProperty(n, l, label);
+                    }
+                } catch(err) {
+                    console.warn(`error indexing ${l}`, err);
+                }
+            }
         }
         for (var i=0;i<properties.length;i++) {
             if (n.hasOwnProperty(properties[i])) {


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

fixes #3297

As the file node and file in node now have different palette label to type name, the search does not reveal them.
this modification adds the palletLabel (when different to  type name) to the search index.

![chrome_pAAPFL9p5l](https://user-images.githubusercontent.com/44235289/151202552-32ce29c5-8aa6-4829-9c27-d0d16eb1cc3b.gif)



## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
