### PR TITLE
fix opening/closing subflow template not to make subflow changed

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/appearance.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/appearance.js
@@ -35,9 +35,10 @@
                     editState.changed = true;
                 }
                 if (!node._def.defaults || !node._def.defaults.hasOwnProperty("icon")) {
-                    var icon = $("#red-ui-editor-node-icon").val()||""
+                    var icon = $("#red-ui-editor-node-icon").val()||"";
                     if (!this.isDefaultIcon) {
-                        if (icon !== node.icon) {
+                        if ((icon !== node.icon) &&
+                            (icon !== "")) {
                             editState.changes.icon = node.icon;
                             node.icon = icon;
                             editState.changed = true;
@@ -101,14 +102,14 @@
                     if (showLabel) {
                         // Default to show label
                         if (node.l !== false) {
-                            editState.changes.l = node.l
+                            editState.changes.l = node.l;
                             editState.changed = true;
                         }
                         node.l = false;
                     } else {
                         // Node has showLabel:false (eg link nodes)
                         if (node.hasOwnProperty('l') && node.l) {
-                            editState.changes.l = node.l
+                            editState.changes.l = node.l;
                             editState.changed = true;
                         }
                         delete node.l;
@@ -118,20 +119,20 @@
                     if (showLabel) {
                         // Default to show label
                         if (node.hasOwnProperty('l') && !node.l) {
-                            editState.changes.l = node.l
+                            editState.changes.l = node.l;
                             editState.changed = true;
                         }
                         delete node.l;
                     } else {
                         if (!node.l) {
-                            editState.changes.l = node.l
+                            editState.changes.l = node.l;
                             editState.changed = true;
                         }
                         node.l = true;
                     }
                 }
             }
-        }
+        };
     });
 
     function buildAppearanceForm(container,node) {
@@ -164,10 +165,10 @@
             var categories = RED.palette.getCategories();
             categories.sort(function(A,B) {
                 return A.label.localeCompare(B.label);
-            })
+            });
             categories.forEach(function(cat) {
                 categorySelector.append($("<option/>").val(cat.id).text(cat.label));
-            })
+            });
             categorySelector.append($("<option/>").attr('disabled',true).text("---"));
             categorySelector.append($("<option/>").val("_custom_").text(RED._("palette.addCategory")));
 
@@ -180,7 +181,7 @@
                     $("#subflow-appearance-input-category").width(250);
                     $("#subflow-appearance-input-custom-category").hide();
                 }
-            })
+            });
 
             $("#subflow-appearance-input-category").val(node.category||"subflows");
             var userCount = 0;
@@ -204,7 +205,7 @@
         $("#node-input-show-label").toggleButton({
             enabledLabel: RED._("editor.show"),
             disabledLabel: RED._("editor.hide")
-        })
+        });
 
         if (!node.hasOwnProperty("l")) {
             // Show label unless def.showLabel set to false
@@ -230,7 +231,7 @@
                 "#E9967A", "#F3B567", "#FDD0A2",
                 "#FDF0C2", "#FFAAAA", "#FFCC66",
                 "#FFF0F0", "#FFFFFF"
-            ]
+            ];
 
             RED.editor.colorPicker.create({
                 id: "red-ui-editor-node-color",
@@ -245,9 +246,9 @@
                 nodeDiv.css('backgroundColor',colour);
                 var borderColor = RED.utils.getDarkerColor(colour);
                 if (borderColor !== colour) {
-                    nodeDiv.css('border-color',borderColor)
+                    nodeDiv.css('border-color',borderColor);
                 }
-            })
+            });
         }
 
 
@@ -264,7 +265,7 @@
             nodeDiv.css('backgroundColor',colour);
             var borderColor = RED.utils.getDarkerColor(colour);
             if (borderColor !== colour) {
-                nodeDiv.css('border-color',borderColor)
+                nodeDiv.css('border-color',borderColor);
             }
 
             var iconContainer = $('<div/>',{class:"red-ui-palette-icon-container"}).appendTo(nodeDiv);
@@ -292,7 +293,7 @@
 
             RED.popover.tooltip(iconButton, function() {
                 return $("#red-ui-editor-node-icon").val() || RED._("editor.default");
-            })
+            });
             $('<input type="hidden" id="red-ui-editor-node-icon">').val(node.icon).appendTo(iconRow);
         }
 
@@ -417,11 +418,11 @@
             });
             rows.sort(function(A,B) {
                 return A.i-B.i;
-            })
+            });
             rows.forEach(function(r,i) {
                 r.r.find("label").text((i+1)+".");
                 r.r.appendTo(outputsDiv);
-            })
+            });
             if (rows.length === 0) {
                 buildLabelRow("output",i,"").appendTo(outputsDiv);
             } else {
@@ -467,7 +468,7 @@
             clear.on("click", function(evt) {
                 evt.preventDefault();
                 input.val("");
-            })
+            });
         }
         return result;
     }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Simply opening and closing subflow template causes subflow instances modified.
This is caused by changing icon property value from `undefined` to `""` when no icon is specified.
This PR try to fix the problem.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
