### PR TITLE
OAuth/OpenID logout with Keycloak - Forum 57492

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/auth/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/index.js
@@ -185,7 +185,7 @@ function genericStrategy(adminApp,strategy) {
                 }
             };
 
-            options.verify.apply(null,args);
+            options.verify.apply(this,args);
         } else {
             var profile = arguments[arguments.length - 2];
             return completeVerify(profile,originalDone);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
tldr; 
get passport strategy in verify function to allow redirects

### Context
When using an authentication provider with a single-sign-on login session like (none exclusive!) keycloak, you login once and as long as your login session is valid every auth-client get its tokens without further user interaction. To switch your identity you have to terminate your login session. 

### Node-Red relationship
There are two situations where this affects Node-Red as an auth-client:
1. Logout a valid user session with active editor access
    To achieve a login-session termination on logout you can configure settings.editorTheme.logout.redirect to hit the logout URL and redirect back to your httpAdminRoot. See https://discourse.nodered.org/t/oauth-openid-logout-with-keycloak/57492
1. Change your identity when your current login session does not have node-red permissions
    In this case you get trapped in loop: 
    - without permissions you get Node-Red Login modal 
    - on Button click you are redirected to your authentication provider
    - the authentication provider detects an active login session and redirects you back to Node-Red with a new token
    - without Node-Red permissions in your valid user context you get the Node-Red Login modal

### Approach
Inside the settings.adminAuth.strategy.options you can configure a verify function to check if a valid user context also has Node-Red permssions. See https://nodered.org/docs/user-guide/runtime/securing-node-red#oauthopenid-based-authentication . This function has currently no access to the Express-request/response objects or the authentication provider strategy and i could not find a proper way to terminate a valid login session on my authentication provider. With the provided change the strategy is passed as this-context to the verify function and when the configured logic detects a valid session without Node-Red permissions it terminates this session by calling
`this.redirect("\<auth-provider-logout-url>?redirect_uri="+encodeURI("\<httpAdminRoot>?session_message=Unauthorized"));`
for example in my keycloak setup:
```
    adminAuth: {
      type:"strategy",
      strategy: {
          name: "keycloak",
          label: 'Login',
          icon:"fa-lock",
          strategy: require("passport-keycloak-oauth2-oidc").Strategy,
          options: {
              clientID: "node-red",
              realm: 'myRealm',
              publicClient: "false",
              clientSecret: "Secret",
              sslRequired: "external",
              authServerURL: "https://<keycloak-host>/auth",
              callbackURL: "<httpAdminRoot>/auth/strategy/callback",
              verify: function(token, tokenSecret, profile, done) {
                if( profile._json
                 && profile._json.realm_access
                 && profile._json.realm_access.roles
                 && profile._json.realm_access.roles.indexOf("flow-designer")!==-1){
                  profile.username="Flow-Designer";
                  done(null,profile);
                }else{
                  this.redirect("http://<keycloak-host>/auth/realms/myRalm/protocol/openid-connect/logout?redirect_uri="+encodeURI("<httpAdminRoot>?session_message=Unauthorized"));
                }
              }
          },
      },
```

### side effects
Because verify was executed without a this-context at all, the change is without side effects.

### alternatives
If the httpAdminMiddleware had access to the profile information provided by the authentication layer, it would be an option to set the username to a keyword like "__no_node_red_permission__" and redirect from the middleware in that case. Unfortunately this middleware seems to run in an independent middleware chain and i can't get a user context before or after the next() call.

By reviewing the code i discovered that settings.adminAuth.users can be a function. I could not find any documentation, did't stepped in deeper and have no clue if this could be used.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
