### PR TITLE
fix to hide tooltip after removing subflow tab

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
@@ -350,6 +350,15 @@ RED.popover = (function() {
             }
         }
 
+        target.on("remove", function (ev) {
+            if (timer) {
+                clearTimeout(timer);
+            }
+            if (active) {
+                active = false;
+                setTimeout(closePopup,delay.hide);
+            }
+        });
         if (trigger === 'hover') {
             target.on('mouseenter',function(e) {
                 clearTimeout(timer);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Closing subflow template tab while *Hide flow* tooltip is shown, leaves the tooltip shown.
This PR try to fix this issue by handling remove target event.

![スクリーンショット 2022-02-02 11 45 20](https://user-images.githubusercontent.com/30289092/152085882-d6bd7927-b3cf-4094-bda6-0e323ab93bea.png)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
