### PR TITLE
New Feature: Add ability to find modified nodes/flows.

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -674,7 +674,8 @@
                 "invalidNodes": "Invalid nodes",
                 "uknownNodes": "Unknown nodes",
                 "unusedSubflows": "Unused subflows",
-                "hiddenFlows": "Hidden flows"
+                "hiddenFlows": "Hidden flows",
+                "modifiedNodes": "Modified nodes and flows"
             }
         },
         "help": {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
@@ -119,6 +119,7 @@ RED.search = (function() {
         val = extractFlag(val,"config",flags);
         val = extractFlag(val,"subflow",flags);
         val = extractFlag(val,"hidden",flags);
+        val = extractFlag(val,"modified",flags);
         // uses:<node-id>
         val = extractValue(val,"uses",flags);
 
@@ -161,6 +162,11 @@ RED.search = (function() {
                         }
                         if (flags.hasOwnProperty("subflow")) {
                             if (flags.subflow !== (node.node.type === 'subflow')) {
+                                continue;
+                            }
+                        }
+                        if (flags.hasOwnProperty("modified")) {
+                            if (!node.node.changed && !node.node.moved) {
                                 continue;
                             }
                         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
@@ -271,6 +271,7 @@ RED.sidebar.info.outliner = (function() {
             options: [
                 {label:RED._("sidebar.info.search.configNodes"), value:"is:config"},
                 {label:RED._("sidebar.info.search.unusedConfigNodes"), value:"is:config is:unused"},
+                {label:RED._("sidebar.info.search.modifiedNodes"), value:"is:modified"},
                 {label:RED._("sidebar.info.search.invalidNodes"), value: "is:invalid"},
                 {label:RED._("sidebar.info.search.uknownNodes"), value: "type:unknown"},
                 {label:RED._("sidebar.info.search.unusedSubflows"), value:"is:subflow is:unused"},

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -428,6 +428,9 @@ RED.workspaces = (function() {
                 }
             }
         })
+        RED.actions.add("core:list-modified-nodes",function() {
+            RED.actions.invoke("core:search","is:modified ");
+        })
         RED.actions.add("core:list-hidden-flows",function() {
             RED.actions.invoke("core:search","is:hidden ");
         })


### PR DESCRIPTION


- [x] New feature (non-breaking change which adds functionality)



## Proposed changes
Add `is:modified` feature to permit user to find all changed nodes

This addresses the issue where by a user cannot find (due to potentially hundreds of nodes) what has changed. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
