### PR TITLE
Fix bug in debug node due to msg.hasOwnProperty construct

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.js
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.js
@@ -107,7 +107,7 @@ module.exports = function(RED) {
             }
         })
         this.on("input", function(msg, send, done) {
-            if (msg.hasOwnProperty("status") && msg.status.hasOwnProperty("source") && msg.status.source.hasOwnProperty("id") && (msg.status.source.id === node.id)) {
+            if (Object.prototype.hasOwnProperty.call(msg, "status") && Object.prototype.hasOwnProperty.call(msg.status, "source") && Object.prototype.hasOwnProperty.call(msg.status.source, "id") && (msg.status.source.id === node.id)) {
                 done();
                 return;
             }
@@ -118,17 +118,17 @@ module.exports = function(RED) {
                     var st = (typeof output === 'string') ? output : util.inspect(output);
                     var fill = "grey";
                     var shape = "dot";
-                    if (typeof output === 'object' && output.hasOwnProperty("fill") && output.hasOwnProperty("shape") && output.hasOwnProperty("text")) {
+                    if (typeof output === 'object' && Object.prototype.hasOwnProperty.call(output, "fill") && Object.prototype.hasOwnProperty.call(output, "shape") && Object.prototype.hasOwnProperty.call(output, "text")) {
                         fill = output.fill;
                         shape = output.shape;
                         st = output.text;
                     }
                     if (node.statusType === "auto") {
-                        if (msg.hasOwnProperty("error")) {
+                        if (Object.prototype.hasOwnProperty.call(msg, "error")) {
                             fill = "red";
                             st = msg.error.message;
                         }
-                        if (msg.hasOwnProperty("status")) {
+                        if (Object.prototype.hasOwnProperty.call(msg, "status")) {
                             fill = msg.status.fill || "grey";
                             shape = msg.status.shape || "ring";
                             st = msg.status.text || "";
@@ -194,7 +194,7 @@ module.exports = function(RED) {
 
     function sendDebug(msg) {
         // don't put blank errors in sidebar (but do add to logs)
-        //if ((msg.msg === "") && (msg.hasOwnProperty("level")) && (msg.level === 20)) { return; }
+        //if ((msg.msg === "") && (Object.prototype.hasOwnProperty.call(msg, "level")) && (msg.level === 20)) { return; }
         msg = RED.util.encodeObject(msg,{maxLength:debuglength});
         RED.comms.publish("debug",msg);
     }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

`msg.hasOwnProperty("status")` might make the debug node crash/produce an error if the payload was created with `Object.create(null)`.

This is the case e.g. for `ini` (to parse INI files), an official NPM node:
https://github.com/npm/ini/blob/4f289946b3bf95f144e849d771f64e4f2aa2737c/lib/ini.js#L63

My Node-RED node `node-red-contrib-parser-ini`, which is using that library, was hit by this bug and I had to ship a workaround
https://github.com/alexandrainst/node-red-contrib-parser-ini/blob/fe6b1eb4b18fd54459e2505b1c2f54eb0a9c9fec/parser-ini.js#L14 to make it work with the default output `msg.payload` of the debug node.

The `msg.hasOwnProperty("xxx")` construct should not be used since ECMAScript 5.1.

ESLint advises in the same direction https://eslint.org/docs/rules/no-prototype-builtins

This patch was produced using the following regex:
Search: `\b([\w.]+).hasOwnProperty\(`
Replace: `Object.prototype.hasOwnProperty.call($1, `

This could be applied more globally if desired.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
