### PR TITLE
Support Mustache path in copy button on debug tab

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -280,6 +280,7 @@
             "conflictNotification2": "Select which nodes to import and whether to replace the existing nodes, or to import a copy of them."
         },
         "copyMessagePath": "Path copied",
+        "copyMessagePathForMustache": "Path copied for Mustache",
         "copyMessageValue": "Value copied",
         "copyMessageValue_truncated": "Truncated value copied"
     },

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -280,6 +280,7 @@
             "conflictNotification2": "読み込むノードを選択し、また既存のノードを置き換えるか、もしくはそれらのコピーを読み込むかも選択してください。"
         },
         "copyMessagePath": "パスをコピーしました",
+        "copyMessagePathForMustache": "Mustache向けのパスをコピーしました",
         "copyMessageValue": "値をコピーしました",
         "copyMessageValue_truncated": "切り捨てられた値をコピーしました"
     },

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -226,20 +226,21 @@ RED.utils = (function() {
         var tools = $('<span class="red-ui-debug-msg-tools"></span>').appendTo(obj);
         var copyTools = $('<span class="red-ui-debug-msg-tools-copy button-group"></span>').appendTo(tools);
         if (!!key) {
+            var mustachePath = key.replace(/\["([^\]]+)"\]/g,'.$1').replace(/\[([0-9]+)\]/g,'.$1');
             var copyPath = $('<button class="red-ui-button red-ui-button-small"><i class="fa fa-terminal"></i></button>').appendTo(copyTools).on("click", function(e) {
                 e.preventDefault();
                 e.stopPropagation();
-                var mustachePath;
-                if (e.ctrlKey || e.metaKey) {
-                    mustachePath = key.replace(/\["([^\]]+)"\]/g,'.$1').replace(/\[([0-9]+)\]/g,'.$1');
-                }
-                if (!mustachePath || key === mustachePath) {
-                    RED.clipboard.copyText(key,copyPath,"clipboard.copyMessagePath");
-                } else {
+                if ((e.ctrlKey || e.metaKey) && key !== mustachePath) {
                     RED.clipboard.copyText(mustachePath,copyPath,"clipboard.copyMessagePathForMustache");
+                } else {
+                    RED.clipboard.copyText(key,copyPath,"clipboard.copyMessagePath");
                 }
             })
-            RED.popover.tooltip(copyPath,RED._("node-red:debug.sidebar.copyPath"));
+            if (key !== mustachePath) {
+                RED.popover.tooltip(copyPath,RED._("node-red:debug.sidebar.copyPathForMustache"));
+            } else {
+                RED.popover.tooltip(copyPath,RED._("node-red:debug.sidebar.copyPath"));
+            }
         }
         var copyPayload = $('<button class="red-ui-button red-ui-button-small"><i class="fa fa-clipboard"></i></button>').appendTo(copyTools).on("click", function(e) {
             e.preventDefault();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -229,7 +229,15 @@ RED.utils = (function() {
             var copyPath = $('<button class="red-ui-button red-ui-button-small"><i class="fa fa-terminal"></i></button>').appendTo(copyTools).on("click", function(e) {
                 e.preventDefault();
                 e.stopPropagation();
-                RED.clipboard.copyText(key,copyPath,"clipboard.copyMessagePath");
+                var mustachePath;
+                if (e.ctrlKey || e.metaKey) {
+                    mustachePath = key.replace(/\["([^\]]+)"\]/g,'.$1').replace(/\[([0-9]+)\]/g,'.$1');
+                }
+                if (!mustachePath || key === mustachePath) {
+                    RED.clipboard.copyText(key,copyPath,"clipboard.copyMessagePath");
+                } else {
+                    RED.clipboard.copyText(mustachePath,copyPath,"clipboard.copyMessagePathForMustache");
+                }
             })
             RED.popover.tooltip(copyPath,RED._("node-red:debug.sidebar.copyPath"));
         }

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -148,6 +148,7 @@
             "filterLog": "Filter messages",
             "openWindow": "Open in new window",
             "copyPath": "Copy path",
+            "copyPathForMustache": "Copy path (Mustache path by ctrl+click)",
             "copyPayload": "Copy value",
             "pinPath": "Pin open",
             "selectAll": "select all",

--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -148,6 +148,7 @@
             "filterLog": "ログのフィルタリング",
             "openWindow": "新しいウィンドウで開く",
             "copyPath": "パスをコピー",
+            "copyPathForMustache": "パスをコピー(Ctrl+クリックでMustacheパス)",
             "copyPayload": "値をコピー",
             "pinPath": "展開を固定",
             "selectAll": "全てを選択",


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes
I tried to implement the copy button enhancement which we discussed on [the Node-RED forum](https://discourse.nodered.org/t/support-bracket-name-to-specify-array-index-in-mustache/57585/6). Using this implementation, users can copy the dot-style path by left click with the Ctrl key for the Mustache template.

[ **Copy dot-style path** ]

<img src="https://user-images.githubusercontent.com/20310935/152482339-de349026-6ff4-4d38-a54e-9d57c89a50a1.png" width="300px">

Of course, when users click the button without the Ctrl key, the button copies the bracket-style path as same as the default. We can use the copied path for function and change nodes as usual.

[ **Copy bracket-style path** ]

<img src="https://user-images.githubusercontent.com/20310935/152482371-9f23eda9-d325-406f-b6f9-c0b1666a8f19.png" width="300px">

I think that it's useful when we copy and paste paths between debug tab and template node.

### Flow to test
```
[{"id":"2aa8ec36da9c7a0b","type":"inject","z":"43fab81c88fde8bf","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"{\"array\":[\"a\",\"b\",\"c\"]}","payloadType":"json","x":190,"y":1300,"wires":[["6ca294772571dbc6","c279b8ed158729d7"]]},{"id":"6ca294772571dbc6","type":"debug","z":"43fab81c88fde8bf","name":"output array","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"payload","targetType":"msg","statusVal":"","statusType":"auto","x":410,"y":1300,"wires":[]},{"id":"c279b8ed158729d7","type":"template","z":"43fab81c88fde8bf","name":"","field":"payload","fieldType":"msg","format":"handlebars","syntax":"mustache","template":"This is the payload: {{payload.array.0}} !","output":"str","x":240,"y":1380,"wires":[["e4d9a8e67f4153ad"]]},{"id":"e4d9a8e67f4153ad","type":"debug","z":"43fab81c88fde8bf","name":"output 1st character in array","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"payload","targetType":"msg","statusVal":"","statusType":"auto","x":460,"y":1380,"wires":[]}]
```

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality