### PR TITLE
switch node - add check for NaN in is of type number to be false

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.js
@@ -55,6 +55,7 @@ module.exports = function(RED) {
                 catch(e) { return false;}
             }
             else if (b === "null") { return a === null; }
+            else if (b === "number") { return typeof a === b && !isNaN(a) }
             else { return typeof a === b && !Array.isArray(a) && !Buffer.isBuffer(a) && a !== null; }
         },
         'head': function(a, b, c, d, parts) {

--- a/test/nodes/core/function/10-switch_spec.js
+++ b/test/nodes/core/function/10-switch_spec.js
@@ -310,6 +310,12 @@ describe('switch Node', function() {
     it('should check if payload if of type number 0', function(done) {
         genericSwitchTest("istype", "number", true, true, 0, done);
     });
+    it('should check if payload if of type number NaN', function(done) {
+        genericSwitchTest("istype", "number", true, false, parseInt("banana"), done);
+    });
+    it('should check if payload if of type number Infinity', function(done) {
+        genericSwitchTest("istype", "number", true, true, 1/0, done);
+    });
     it('should check if payload if of type boolean true', function(done) {
         genericSwitchTest("istype", "boolean", true, true, true, done);
     });


### PR DESCRIPTION
and add test
to fix issue #3408

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
This PR - addresses #3408 and makes NaN input to the is of type number test report as false - which is what most humans would expect.

Technically this is a slight change in behaviour and so should be flagged in the v3 release notes - but is very much an edge case that is caused by the weirdness of javascript types.

This does not alter the handling of infinity but does add a test case for it.

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
