### PR TITLE
bug fix: Dont add wires to undo buffer twice

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -2338,14 +2338,21 @@ RED.view = (function() {
             var removedSubflowStatus;
             var subflowInstances = [];
             var historyEvents = [];
-
+            var addToRemovedLinks = function(links) {
+                if(!links) { return; }
+                var _links = Array.isArray(links) ? links : [links];
+                _links.forEach(function(l) {
+                    removedLinks.push(l);
+                    selectedLinks.remove(l);
+                })
+            }
             if (reconnectWires) {
                 var reconnectResult = RED.nodes.detachNodes(movingSet.nodes())
                 var addedLinks = reconnectResult.newLinks;
                 if (addedLinks.length > 0) {
                     historyEvents.push({ t:'add', links: addedLinks })
                 }
-                removedLinks = removedLinks.concat(reconnectResult.removedLinks)
+                addToRemovedLinks(reconnectResult.removedLinks)
             }
 
             var startDirty = RED.nodes.dirty();
@@ -2377,7 +2384,7 @@ RED.view = (function() {
                         var removedEntities = RED.nodes.remove(node.id);
                         removedNodes.push(node);
                         removedNodes = removedNodes.concat(removedEntities.nodes);
-                        removedLinks = removedLinks.concat(removedEntities.links);
+                        addToRemovedLinks(removedNodes.removedLinks);
                         if (node.g) {
                             var group = RED.nodes.group(node.g);
                             if (selectedGroups.indexOf(group) === -1) {
@@ -2410,20 +2417,20 @@ RED.view = (function() {
                 if (removedSubflowOutputs.length > 0) {
                     result = RED.subflow.removeOutput(removedSubflowOutputs);
                     if (result) {
-                        removedLinks = removedLinks.concat(result.links);
+                        addToRemovedLinks(result.links);
                     }
                 }
                 // Assume 0/1 inputs
                 if (removedSubflowInputs.length == 1) {
                     result = RED.subflow.removeInput();
                     if (result) {
-                        removedLinks = removedLinks.concat(result.links);
+                        addToRemovedLinks(result.links);
                     }
                 }
                 if (removedSubflowStatus) {
                     result = RED.subflow.removeStatus();
                     if (result) {
-                        removedLinks = removedLinks.concat(result.links);
+                        addToRemovedLinks(result.links);
                     }
                 }
 


### PR DESCRIPTION
Fixes #3433


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)


## Proposed changes
wrap the push to `removedLinks` array to ensure removed links are removed from `selectedLinks` (to avoid duplicate additions to undo history

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
