### PR TITLE
add support of property validation message

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -1156,5 +1156,21 @@
         "ru": "Russian",
         "zh-CN": "Chinese(Simplified)",
         "zh-TW": "Chinese(Traditional)"
+    },
+    "validator": {
+        "errors": {
+	    "invalid-json": "Invalid JSON data: __error__",
+	    "invalid-json-prop": "__prop__: invalid JSON data: __error__",
+	    "invalid-prop": "Invalid property expression",
+	    "invalid-prop-prop": "__prop__: invalid property expression",
+	    "invalid-num": "Invalid number",
+	    "invalid-num-prop": "__prop__: invalid number",
+	    "invalid-regexp": "Invalid input pattern",
+	    "invalid-regex-prop": "__prop__: invalid input pattern",
+	    "missing-required-prop": "__prop__: property value missing",
+	    "invalid-config": "__prop__: invalid configuration node",
+	    "missing-config": "__prop__: missing configuration node",
+	    "validation-error": "__prop__: validation error: __node__, __id__: __error__"
+	}
     }
 }

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -1288,5 +1288,21 @@
         "zoom-out": "ズームアウト",
         "zoom-reset": "ズームリセット",
         "toggle-navigator": "ナビゲータ表示切替"
+    },
+    "validator": {
+        "errors": {
+	    "invalid-json": "JSONデータが不正: __error__",
+	    "invalid-json-prop": "__prop__: JSONデータが不正: __error__",
+	    "invalid-prop": "プロパティ式が不正",
+	    "invalid-prop-prop": "__prop__: プロパティ式が不正",
+	    "invalid-num": "数値が不正",
+	    "invalid-num-prop": "__prop__: 数値が不正",
+	    "invalid-regexp": "入力パターンが不正",
+	    "invalid-regex-prop": "__prop__: 入力パターンが不正",
+	    "missing-required-prop": "__prop__: プロパティが未設定",
+	    "invalid-config": "__prop__: 設定ノードが不正",
+	    "missing-config": "__prop__: 設定ノードが存在しません",
+	    "validation-error": "__prop__: チェックエラー: __node__, __id__: __error__"
+	}
     }
 }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
@@ -349,7 +349,6 @@ RED.popover = (function() {
                 }
             }
         }
-
         if (trigger === 'hover') {
             target.on('mouseenter',function(e) {
                 clearTimeout(timer);
@@ -461,6 +460,10 @@ RED.popover = (function() {
             popover.setAction = function(newAction) {
                 action = newAction;
             }
+            popover.delete = function() {
+                target.off("mouseenter");
+                target.off("mouseleave");
+            };
             return popover;
 
         },

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -110,7 +110,11 @@ RED.editor = (function() {
         var result = [];
         for (var prop in definition) {
             if (definition.hasOwnProperty(prop)) {
-                if (!validateNodeProperty(node, definition, prop, properties[prop])) {
+                var valid = validateNodeProperty(node, definition, prop, properties[prop]);
+                if ((typeof valid) === "string") {
+                    result.push(valid);
+                }
+                else if(!valid) {
                     result.push(prop);
                 }
             }
@@ -136,22 +140,64 @@ RED.editor = (function() {
         if (/^\$\{[a-zA-Z_][a-zA-Z0-9_]*\}$/.test(value)) {
             return true;
         }
+        var label = null;
+        if (("label" in definition[property]) &&
+            ((typeof definition[property].label) == "string")) {
+            label = definition[property].label;
+        }
         if ("required" in definition[property] && definition[property].required) {
             valid = value !== "";
+            if (!valid && label) {
+                return RED._("validator.errors.missing-required-prop", {
+                    prop: label
+                });
+            }
         }
         if (valid && "validate" in definition[property]) {
             try {
-                valid = definition[property].validate.call(node,value);
+                var opt = {};
+                valid = definition[property].validate.call(node,value, opt);
+                if ((typeof valid) === "string") {
+                    return valid;
+                }
             } catch(err) {
                 console.log("Validation error:",node.type,node.id,"property: "+property,"value:",value,err);
+                return RED._("validator.errors.validation-error", {
+                    prop: property,
+                    node: node.type,
+                    id: node.id,
+                    error: err.message
+                });
             }
         }
         if (valid && definition[property].type && RED.nodes.getType(definition[property].type) && !("validate" in definition[property])) {
             if (!value || value == "_ADD_") {
                 valid = definition[property].hasOwnProperty("required") && !definition[property].required;
+                if (!valid && label) {
+                    return RED._("validator.errors.missing-required-prop", {
+                        prop: label
+                    });
+                }
             } else {
                 var configNode = RED.nodes.node(value);
-                valid = (configNode && (configNode.valid == null || configNode.valid));
+                if (configNode) {
+                    if ((configNode.valid == null) || configNode.valid) {
+                        return true;
+                    }
+                    if (label) {
+                        return RED._("validator.errors.invalid-config", {
+                            prop: label
+                        });
+                    }
+                }
+                else {
+                    if (label) {
+                        return RED._("validator.errors.missing-config", {
+                            prop: label
+                        });
+                    }
+                }
+                return false;
             }
         }
         return valid;
@@ -179,10 +225,26 @@ RED.editor = (function() {
             if (defaults[property].hasOwnProperty("format") && defaults[property].format !== "" && input[0].nodeName === "DIV") {
                 value = input.text();
             }
-            if (!validateNodeProperty(node, defaults, property,value)) {
+            var valid = validateNodeProperty(node, defaults, property,value);
+            if (((typeof valid) === "string") || !valid) {
                 input.addClass("input-error");
+                if ((typeof valid) === "string") {
+                    var tooltip = input.data("tooltip");
+                    if (tooltip) {
+                        tooltip.setContent(valid);
+                    }
+                    else {
+                        tooltip = RED.popover.tooltip(input, valid);
+                        input.data("tooltip", tooltip);
+                    }
+                }
             } else {
                 input.removeClass("input-error");
+                var tooltip = input.data("tooltip");
+                if (tooltip) {
+                    input.data("tooltip", null);
+                    tooltip.delete();
+                }
             }
         }
     }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -156,8 +156,14 @@ RED.editor = (function() {
         if (valid && "validate" in definition[property]) {
             try {
                 var opt = {};
+                if (label) {
+                    opt.label = label;
+                }
                 valid = definition[property].validate.call(node,value, opt);
-                if ((typeof valid) === "string") {
+                // If the validator takes two arguments, it is a 3.x validator that
+                // can return a String to mean 'invalid' and provide a reason
+                if ((definition[property].validate.length === 2) &&
+                    ((typeof valid) === "string")) {
                     return valid;
                 }
             } catch(err) {

--- a/packages/node_modules/@node-red/editor-client/src/js/validators.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/validators.js
@@ -19,10 +19,10 @@ RED.validators = {
             if ((blankAllowed&&(v===''||v===undefined)) || (v!=='' && !isNaN(v))) {
                 return true;
             }
-            if (mopt && mopt.label) {
-                return opt ? RED._("validator.errors.invalid-num-prop", {
-                    prop: mopt.label
-                }) : false;
+            if (opt && opt.label) {
+                return RED._("validator.errors.invalid-num-prop", {
+                    prop: opt.label
+                });
             }
             return opt ? RED._("validator.errors.invalid-num") : false;
         };
@@ -32,10 +32,10 @@ RED.validators = {
             if (re.test(v)) {
                 return true;
             }
-            if (mopt && mopt.label) {
-                return opt ? RED._("validator.errors.invalid-regex-prop", {
-                    prop: mopt.label
-                }) : false;
+            if (opt && opt.label) {
+                return RED._("validator.errors.invalid-regex-prop", {
+                    prop: opt.label
+                });
             }
             return opt ? RED._("validator.errors.invalid-regexp") : false;
         };
@@ -48,11 +48,11 @@ RED.validators = {
                     JSON.parse(v);
                     return true;
                 } catch(err) {
-                    if (mopt && mopt.label) {
-                        return opt ? RED._("validator.errors.invalid-json-prop", {
+                    if (opt && opt.label) {
+                        return RED._("validator.errors.invalid-json-prop", {
                             error: err.message,
-                            prop: mopt.label,
-                        }) : false;
+                            prop: opt.label,
+                        });
                     }
                     return opt ? RED._("validator.errors.invalid-json", {
                         error: err.message
@@ -62,20 +62,20 @@ RED.validators = {
                 if (RED.utils.validatePropertyExpression(v)) {
                     return true;
                 }
-                if (mopt && mopt.label) {
-                    return opt ? RED._("validator.errors.invalid-prop-prop", {
-                        prop: mopt.label
-                    }) : false;
+                if (opt && opt.label) {
+                    return RED._("validator.errors.invalid-prop-prop", {
+                        prop: opt.label
+                    });
                 }
                 return opt ? RED._("validator.errors.invalid-prop") : false;
             } else if (ptype === 'num') {
                 if (/^[+-]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?$/.test(v)) {
                     return true;
                 }
-                if (mopt && mopt.label) {
-                    return opt ? RED._("validator.errors.invalid-num-prop", {
-                        prop: mopt.label
-                    }) : false;
+                if (opt && opt.label) {
+                    return RED._("validator.errors.invalid-num-prop", {
+                        prop: opt.label
+                    });
                 }
                 return opt ? RED._("validator.errors.invalid-num") : false;
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/validators.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/validators.js
@@ -14,22 +14,72 @@
  * limitations under the License.
  **/
 RED.validators = {
-    number: function(blankAllowed){return function(v) { return (blankAllowed&&(v===''||v===undefined)) || (v!=='' && !isNaN(v));}},
-    regex: function(re){return function(v) { return re.test(v);}},
-    typedInput: function(ptypeName,isConfig) { return function(v) {
-        var ptype = $("#node-"+(isConfig?"config-":"")+"input-"+ptypeName).val() || this[ptypeName];
-        if (ptype === 'json') {
-            try {
-                JSON.parse(v);
+    number: function(blankAllowed,mopt){
+        return function(v, opt) {
+            if ((blankAllowed&&(v===''||v===undefined)) || (v!=='' && !isNaN(v))) {
                 return true;
-            } catch(err) {
-                return false;
             }
-        } else if (ptype === 'msg' || ptype === 'flow' || ptype === 'global' ) {
-            return RED.utils.validatePropertyExpression(v);
-        } else if (ptype === 'num') {
-            return /^[+-]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?$/.test(v);
-        }
-        return true;
-    }}
+            if (mopt && mopt.property) {
+                return opt ? RED._("validator.errors.invalid-num-prop", {
+                    prop: mopt.property
+                }) : false;
+            }
+            return opt ? RED._("validator.errors.invalid-num") : false;
+        };
+    },
+    regex: function(re, mopt) {
+        return function(v, opt) {
+            if (re.test(v)) {
+                return true;
+            }
+            if (mopt && mopt.property) {
+                return opt ? RED._("validator.errors.invalid-regex-prop", {
+                    prop: mopt.property
+                }) : false;
+            }
+            return opt ? RED._("validator.errors.invalid-regexp") : false;
+        };
+    },
+    typedInput: function(ptypeName,isConfig,mopt) {
+        return function(v, opt) {
+            var ptype = $("#node-"+(isConfig?"config-":"")+"input-"+ptypeName).val() || this[ptypeName];
+            if (ptype === 'json') {
+                try {
+                    JSON.parse(v);
+                    return true;
+                } catch(err) {
+                    if (mopt && mopt.property) {
+                        return opt ? RED._("validator.errors.invalid-json-prop", {
+                            error: err.message,
+                            prop: mopt.property,
+                        }) : false;
+                    }
+                    return opt ? RED._("validator.errors.invalid-json", {
+                        error: err.message
+                    }) : false;
+                }
+            } else if (ptype === 'msg' || ptype === 'flow' || ptype === 'global' ) {
+                if (RED.utils.validatePropertyExpression(v)) {
+                    return true;
+                }
+                if (mopt && mopt.property) {
+                    return opt ? RED._("validator.errors.invalid-prop-prop", {
+                        prop: mopt.property
+                    }) : false;
+                }
+                return opt ? RED._("validator.errors.invalid-prop") : false;
+            } else if (ptype === 'num') {
+                if (/^[+-]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?$/.test(v)) {
+                    return true;
+                }
+                if (mopt && mopt.property) {
+                    return opt ? RED._("validator.errors.invalid-num-prop", {
+                        prop: mopt.property
+                    }) : false;
+                }
+                return opt ? RED._("validator.errors.invalid-num") : false;
+            }
+            return true;
+        };
+    }
 };

--- a/packages/node_modules/@node-red/editor-client/src/js/validators.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/validators.js
@@ -19,9 +19,9 @@ RED.validators = {
             if ((blankAllowed&&(v===''||v===undefined)) || (v!=='' && !isNaN(v))) {
                 return true;
             }
-            if (mopt && mopt.property) {
+            if (mopt && mopt.label) {
                 return opt ? RED._("validator.errors.invalid-num-prop", {
-                    prop: mopt.property
+                    prop: mopt.label
                 }) : false;
             }
             return opt ? RED._("validator.errors.invalid-num") : false;
@@ -32,9 +32,9 @@ RED.validators = {
             if (re.test(v)) {
                 return true;
             }
-            if (mopt && mopt.property) {
+            if (mopt && mopt.label) {
                 return opt ? RED._("validator.errors.invalid-regex-prop", {
-                    prop: mopt.property
+                    prop: mopt.label
                 }) : false;
             }
             return opt ? RED._("validator.errors.invalid-regexp") : false;
@@ -48,10 +48,10 @@ RED.validators = {
                     JSON.parse(v);
                     return true;
                 } catch(err) {
-                    if (mopt && mopt.property) {
+                    if (mopt && mopt.label) {
                         return opt ? RED._("validator.errors.invalid-json-prop", {
                             error: err.message,
-                            prop: mopt.property,
+                            prop: mopt.label,
                         }) : false;
                     }
                     return opt ? RED._("validator.errors.invalid-json", {
@@ -62,9 +62,9 @@ RED.validators = {
                 if (RED.utils.validatePropertyExpression(v)) {
                     return true;
                 }
-                if (mopt && mopt.property) {
+                if (mopt && mopt.label) {
                     return opt ? RED._("validator.errors.invalid-prop-prop", {
-                        prop: mopt.property
+                        prop: mopt.label
                     }) : false;
                 }
                 return opt ? RED._("validator.errors.invalid-prop") : false;
@@ -72,9 +72,9 @@ RED.validators = {
                 if (/^[+-]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?$/.test(v)) {
                     return true;
                 }
-                if (mopt && mopt.property) {
+                if (mopt && mopt.label) {
                     return opt ? RED._("validator.errors.invalid-num-prop", {
-                        prop: mopt.property
+                        prop: mopt.label
                     }) : false;
                 }
                 return opt ? RED._("validator.errors.invalid-num") : false;

--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.html
@@ -261,9 +261,7 @@
             once: {value:false},
             onceDelay: {value:0.1},
             topic: {value:""},
-            payload: {value:"", validate: RED.validators.typedInput("payloadType", false, {
-                property: "payload"
-            }) },
+            payload: {value:"", validate: RED.validators.typedInput("payloadType", false) },
             payloadType: {value:"date"},
         },
         icon: "inject.svg",

--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.html
@@ -225,28 +225,45 @@
         color:"#a6bbcf",
         defaults: {
             name: {value:""},
-            props:{value:[{p:"payload"},{p:"topic",vt:"str"}], validate:function(v) {
+            props:{value:[{p:"payload"},{p:"topic",vt:"str"}], validate:function(v, opt) {
                     if (!v || v.length === 0) { return true }
                     for (var i=0;i<v.length;i++) {
                         if (/msg|flow|global/.test(v[i].vt)) {
                             if (!RED.utils.validatePropertyExpression(v[i].v)) {
-                                return false;
+                                return RED._("node-red:inject.errors.invalid-prop", { prop: v[i].p, error: v[i].v });
                             }
                         } else if (v[i].vt === "jsonata") {
-                            try{jsonata(v[i].v);}catch(e){return false;}
+                            try{ jsonata(v[i].v); }
+                            catch(e){
+                                return RED._("node-red:inject.errors.invalid-jsonata", { prop: v[i].p, error: e.message });
+                            }
                         } else if (v[i].vt === "json") {
-                            try{JSON.parse(v[i].v);}catch(e){return false;}
+                            try{ JSON.parse(v[i].v); }
+                            catch(e){
+                                return RED._("node-red:inject.errors.invalid-json", { prop: v[i].p, error: e.message });
+                            }
                         }
                     }
                     return true;
                 }
             },
-            repeat: {value:"", validate:function(v) { return ((v === "") || (RED.validators.number(v) && (v >= 0) && (v <= 2147483))) }},
+            repeat: {
+                value:"", validate: function(v, opt) {
+                    if ((v === "") ||
+                        (RED.validators.number(v) &&
+                         (v >= 0) && (v <= 2147483))) {
+                        return true;
+                    }
+                    return RED._("node-red:inject.errors.invalid-repeat");
+                }
+            },
             crontab: {value:""},
             once: {value:false},
             onceDelay: {value:0.1},
             topic: {value:""},
-            payload: {value:"", validate: RED.validators.typedInput("payloadType")},
+            payload: {value:"", validate: RED.validators.typedInput("payloadType", false, {
+                property: "payload"
+            }) },
             payloadType: {value:"date"},
         },
         icon: "inject.svg",

--- a/packages/node_modules/@node-red/nodes/core/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.html
@@ -259,7 +259,11 @@
         defaults: {
             name: {value:""},
             links: { value: [], type:"link in[]"},
-            timeout: { value: "30", validate:RED.validators.number(true) }
+            timeout: { value: "30",
+                       validate:RED.validators.number(true, {
+                           property: RED._("node-red:link.timeout")
+                       })
+                     }
         },
         inputs: 1,
         outputs: 1,

--- a/packages/node_modules/@node-red/nodes/core/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.html
@@ -260,9 +260,8 @@
             name: {value:""},
             links: { value: [], type:"link in[]"},
             timeout: { value: "30",
-                       validate:RED.validators.number(true, {
-                           property: RED._("node-red:link.timeout")
-                       })
+                       label: RED._("node-red:link.timeout"),
+                       validate:RED.validators.number(true)
                      }
         },
         inputs: 1,

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.html
@@ -358,24 +358,38 @@
             name: {value:""},
             func: {value:"\nreturn msg;"},
             outputs: {value:1},
-            noerr: {value:0,required:true,validate:function(v) { return !v; }},
+            noerr: {value:0,required:true,
+                    validate: function(v, opt) {
+                        if (!v) {
+                            return true;
+                        }
+                        return RED._("node-red:function.error.invalid-js");
+                    }},
             initialize: {value:""},
             finalize: {value:""},
-            libs: {value: [], validate: function(v) {
+            libs: {value: [], validate: function(v, opt) {
                 if (!v) { return true; }
                 for (var i=0,l=v.length;i<l;i++) {
                     var m = v[i];
                     if (!RED.utils.checkModuleAllowed(m.module,null,installAllowList,installDenyList)) {
-                        return false
+                        return RED._("node-red:function.error.moduleNotAllowed", {
+                            module: m.module
+                        });
                     }
                     if (m.var === "" || / /.test(m.var)) {
-                        return false;
+                        return RED._("node-red:function.error.moduleNameError", {
+                            name: m.var
+                        });
                     }
                     if (missingModules.indexOf(m.module) > -1) {
-                        return false;
+                        return RED._("node-red:function.error.missing-module", {
+                            module: m.module
+                        });
                     }
                     if (invalidModuleVNames.indexOf(m.var) !== -1){
-                        return false;
+                        return RED._("node-red:function.error.moduleNameError", {
+                            name: m.var
+                        });
                     }
                 }
                 return true;

--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.html
@@ -165,9 +165,7 @@
             name: {value:""},
             property: {value:"payload", required:true,
                        label:RED._("node-red:common.label.payload"),
-                       validate: RED.validators.typedInput("propertyType", false, {
-                           property: RED._("node-red:common.label.payload")
-                       })},
+                       validate: RED.validators.typedInput("propertyType", false)},
             propertyType: { value:"msg" },
             rules: {value:[{t:"eq", v:"", vt:"str"}]},
             checkall: {value:"true", required:true},

--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.html
@@ -163,7 +163,11 @@
         category: 'function',
         defaults: {
             name: {value:""},
-            property: {value:"payload", required:true, validate: RED.validators.typedInput("propertyType")},
+            property: {value:"payload", required:true,
+                       label:RED._("node-red:common.label.payload"),
+                       validate: RED.validators.typedInput("propertyType", false, {
+                           property: RED._("node-red:common.label.payload")
+                       })},
             propertyType: { value:"msg" },
             rules: {value:[{t:"eq", v:"", vt:"str"}]},
             checkall: {value:"true", required:true},

--- a/packages/node_modules/@node-red/nodes/core/function/15-change.html
+++ b/packages/node_modules/@node-red/nodes/core/function/15-change.html
@@ -19,38 +19,66 @@
 
 <script type="text/javascript">
 (function() {
-    function validateProperty(v,vt) {
+    function isInvalidProperty(v,vt) {
         if (/msg|flow|global/.test(vt)) {
             if (!RED.utils.validatePropertyExpression(v)) {
-                return false;
+                return RED._("node-red:change.errors.invalid-prop", {
+                    property: v
+                });
             }
         } else if (vt === "jsonata") {
-            try{jsonata(v);}catch(e){return false;}
+            try{ jsonata(v); } catch(e) {
+                return RED._("node-red:change.errors.invalid-expr", {
+                    error: e.message
+                });
+            }
         } else if (vt === "json") {
-            try{JSON.parse(v);}catch(e){return false;}
+            try{ JSON.parse(v); } catch(e) {
+                return RED._("node-red:change.errors.invalid-json-data", {
+                    error: e.message
+                });
+            }
         }
-        return true;
+        return false;
     }
+
     RED.nodes.registerType('change', {
         color: "#E2D96E",
         category: 'function',
         defaults: {
             name: {value:""},
-            rules:{value:[{t:"set",p:"payload",pt:"msg",to:"",tot:"str"}],validate: function(rules) {
+            rules:{value:[{t:"set",p:"payload",pt:"msg",to:"",tot:"str"}],validate: function(rules, opt) {
+                var msg;
                 if (!rules || rules.length === 0) { return true }
                 for (var i=0;i<rules.length;i++) {
                     var r = rules[i];
                     if (r.t === 'set') {
-                        if (!validateProperty(r.p,r.pt) || !validateProperty(r.to,r.tot)) {
-                            return false;
+                        if (msg = isInvalidProperty(r.p,r.pt)) {
+                            return msg;
+                        }
+                        if (msg = isInvalidProperty(r.to,r.tot)) {
+                            return msg;
                         }
                     } else if (r.t === 'change') {
-                        if (!validateProperty(r.p,r.pt) || !validateProperty(r.from,r.fromt) || !validateProperty(r.to,r.tot)) {
-                            return false;
+                        if (msg = isInvalidProperty(r.p,r.pt)) {
+                            return msg;
+                        }
+                        if(msg = isInvalidProperty(r.from,r.fromt)) {
+                            return msg;
+                        }
+                        if(msg = isInvalidProperty(r.to,r.tot)) {
+                            return msg;
+                        }
+                    } else if (r.t === 'delete') {
+                        if (msg = isInvalidProperty(r.p,r.pt)) {
+                            return msg;
                         }
                     } else if (r.t === 'move') {
-                        if (!validateProperty(r.p,r.pt)) {
-                            return false;
+                        if (msg = isInvalidProperty(r.p,r.pt)) {
+                            return msg;
+                        }
+                        if (msg = isInvalidProperty(r.to,r.tot)) {
+                            return msg;
                         }
                     }
                 }

--- a/packages/node_modules/@node-red/nodes/core/function/16-range.html
+++ b/packages/node_modules/@node-red/nodes/core/function/16-range.html
@@ -41,13 +41,30 @@
         color: "#E2D96E",
         category: 'function',
         defaults: {
-            minin: {value:"",required:true,validate:RED.validators.number()},
-            maxin: {value:"",required:true,validate:RED.validators.number()},
-            minout: {value:"",required:true,validate:RED.validators.number()},
-            maxout: {value:"",required:true,validate:RED.validators.number()},
+            minin: {value:"", required: true,
+                    label:RED._("node-red:range.label.minin"),
+                    validate:RED.validators.number(false, {
+                        property: RED._("node-red:range.label.minin")
+                    })},
+            maxin: {value:"", required: true,
+                    label:RED._("node-red:range.label.maxin"),
+                    validate:RED.validators.number(false, {
+                        property: RED._("node-red:range.label.maxin")
+                    })},
+            minout: {value:"", required:true,
+                     label:RED._("node-red:range.label.minout"),
+                     validate:RED.validators.number(false, {
+                        property: RED._("node-red:range.label.minout")
+                     })},
+            maxout: {value:"", required:true,
+                     label:RED._("node-red:range.label.maxout"),
+                     validate:RED.validators.number(false, {
+                        property: RED._("node-red:range.label.maxout")
+                     })},
             action: {value:"scale"},
             round: {value:false},
-            property: {value:"payload",required:true},
+            property: {value:"payload",required:true,
+                       label:RED._("node-red:common.label.property")},
             name: {value:""}
         },
         inputs: 1,

--- a/packages/node_modules/@node-red/nodes/core/function/16-range.html
+++ b/packages/node_modules/@node-red/nodes/core/function/16-range.html
@@ -43,24 +43,16 @@
         defaults: {
             minin: {value:"", required: true,
                     label:RED._("node-red:range.label.minin"),
-                    validate:RED.validators.number(false, {
-                        property: RED._("node-red:range.label.minin")
-                    })},
+                    validate:RED.validators.number(false)},
             maxin: {value:"", required: true,
                     label:RED._("node-red:range.label.maxin"),
-                    validate:RED.validators.number(false, {
-                        property: RED._("node-red:range.label.maxin")
-                    })},
+                    validate:RED.validators.number(false)},
             minout: {value:"", required:true,
                      label:RED._("node-red:range.label.minout"),
-                     validate:RED.validators.number(false, {
-                        property: RED._("node-red:range.label.minout")
-                     })},
+                     validate:RED.validators.number(false)},
             maxout: {value:"", required:true,
                      label:RED._("node-red:range.label.maxout"),
-                     validate:RED.validators.number(false, {
-                        property: RED._("node-red:range.label.maxout")
-                     })},
+                     validate:RED.validators.number(false)},
             action: {value:"scale"},
             round: {value:false},
             property: {value:"payload",required:true,

--- a/packages/node_modules/@node-red/nodes/core/function/80-template.html
+++ b/packages/node_modules/@node-red/nodes/core/function/80-template.html
@@ -56,7 +56,10 @@
         category: 'function',
         defaults: {
             name: {value:""},
-            field: {value:"payload", validate:RED.validators.typedInput("fieldType")},
+            field: {value:"payload",
+                    validate:RED.validators.typedInput("fieldType", false, {
+                        property: "payload"
+                    })},
             fieldType: {value:"msg"},
             format: {value:"handlebars"},
             syntax: {value:"mustache"},

--- a/packages/node_modules/@node-red/nodes/core/function/80-template.html
+++ b/packages/node_modules/@node-red/nodes/core/function/80-template.html
@@ -57,9 +57,8 @@
         defaults: {
             name: {value:""},
             field: {value:"payload",
-                    validate:RED.validators.typedInput("fieldType", false, {
-                        property: "payload"
-                    })},
+                    label:"payload",
+                    validate:RED.validators.typedInput("fieldType", false)},
             fieldType: {value:"msg"},
             format: {value:"handlebars"},
             syntax: {value:"mustache"},

--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.html
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.html
@@ -111,14 +111,52 @@
         defaults: {
             name: {value:""},
             pauseType: {value:"delay", required:true},
-            timeout: {value:"5", required:true, validate:function(v) { return RED.validators.number(v) && (v >= 0); }},
+            timeout: {
+                value:"5", required:true,
+                label:RED._("node-red:delay.label.delay"),
+                validate:function(v,opt) {
+                    if (RED.validators.number(v) && (v >= 0)) {
+                        return true;
+                    }
+                    return RED._("node-red:delay.errors.invalid-timeout");
+                }},
             timeoutUnits: {value:"seconds"},
-            rate: {value:"1", required:true, validate:function(v) { return RED.validators.number(v) && (v >= 0); }},
-            nbRateUnits: {value:"1", required:false,
-                          validate:function(v) { return RED.validators.number(v) && (v >= 0); }},
+            rate: {
+                value:"1", required:true,
+                label:RED._("node-red:delay.label.rate"),
+                validate:function(v,opt) {
+                    if (RED.validators.number(v) && (v >= 0)) {
+                        return true;
+                    }
+                    return RED._("node-red:delay.errors.invalid-rate");
+                }},
+            nbRateUnits: {
+                value:"1", required:false,
+                validate:function(v,opt) {
+                    if (RED.validators.number(v) && (v >= 0)) {
+                        return true;
+                    }
+                    return RED._("node-red:delay.errors.invalid-rate-unit");
+                }},
             rateUnits: {value: "second"},
-            randomFirst: {value:"1", required:true, validate:function(v) { return RED.validators.number(v) && (v >= 0); }},
-            randomLast: {value:"5", required:true, validate:function(v) { return RED.validators.number(v) && (v >= 0); }},
+            randomFirst: {
+                value:"1", required:true,
+                label:RED._("node-red:delay.label.random-first"),
+                validate:function(v,opt) {
+                    if (RED.validators.number(v) && (v >= 0)) {
+                        return true;
+                    }
+                    return RED._("node-red:delay.errors.invalid-random-first");
+                }},
+            randomLast: {
+                value:"5", required:true,
+                label:RED._("node-red:delay.label.random-last"),
+                validate:function(v,opt) {
+                    if (RED.validators.number(v) && (v >= 0)) {
+                        return true;
+                    }
+                    return RED._("node-red:delay.errors.invalid-random-last");
+                }},
             randomUnits: {value: "seconds"},
             drop: {value:false},
             allowrate: {value:false},

--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.html
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.html
@@ -141,7 +141,6 @@
             rateUnits: {value: "second"},
             randomFirst: {
                 value:"1", required:true,
-                label:RED._("node-red:delay.label.random-first"),
                 validate:function(v,opt) {
                     if (RED.validators.number(v) && (v >= 0)) {
                         return true;
@@ -150,7 +149,6 @@
                 }},
             randomLast: {
                 value:"5", required:true,
-                label:RED._("node-red:delay.label.random-last"),
                 validate:function(v,opt) {
                     if (RED.validators.number(v) && (v >= 0)) {
                         return true;

--- a/packages/node_modules/@node-red/nodes/core/function/89-trigger.html
+++ b/packages/node_modules/@node-red/nodes/core/function/89-trigger.html
@@ -87,17 +87,29 @@
         color:"#E6E0F8",
         defaults: {
             name: {value:""},
-            op1: {value:"1", validate: RED.validators.typedInput("op1type")},
-            op2: {value:"0", validate: RED.validators.typedInput("op2type")},
+            op1: {value:"1",
+                  validate: RED.validators.typedInput("op1type", false, {
+                      property: RED._("node-red:trigger.send")
+                  })},
+            op2: {value:"0",
+                  validate: RED.validators.typedInput("op2type", false, {
+                      property: RED._("node-red:trigger.then-send")
+                  })},
             op1type: {value:"val"},
             op2type: {value:"val"},
-            duration: {value:"250",required:true,validate:RED.validators.number()},
+            duration: {
+                value:"250", required:true,
+                label:RED._("node-red:trigger.label.duration"),
+                validate:RED.validators.number(false, {
+                    property: RED._("node-red:trigger.label.duration")
+                })},
             extend: {value:"false"},
             overrideDelay: {value:"false"},
             units: {value:"ms"},
             reset: {value:""},
             bytopic: {value:"all"},
-            topic: {value:"topic",required:true},
+            topic: {value:"topic", required:true,
+                    label:RED._("node-red:trigger.label.topic")},
             outputs: {value:1}
         },
         inputs:1,

--- a/packages/node_modules/@node-red/nodes/core/function/89-trigger.html
+++ b/packages/node_modules/@node-red/nodes/core/function/89-trigger.html
@@ -88,21 +88,17 @@
         defaults: {
             name: {value:""},
             op1: {value:"1",
-                  validate: RED.validators.typedInput("op1type", false, {
-                      property: RED._("node-red:trigger.send")
-                  })},
+                  label: RED._("node-red:trigger.send"),
+                  validate: RED.validators.typedInput("op1type", false)},
             op2: {value:"0",
-                  validate: RED.validators.typedInput("op2type", false, {
-                      property: RED._("node-red:trigger.then-send")
-                  })},
+                  label: RED._("node-red:trigger.then-send"),
+                  validate: RED.validators.typedInput("op2type", false)},
             op1type: {value:"val"},
             op2type: {value:"val"},
             duration: {
                 value:"250", required:true,
                 label:RED._("node-red:trigger.label.duration"),
-                validate:RED.validators.number(false, {
-                    property: RED._("node-red:trigger.label.duration")
-                })},
+                validate:RED.validators.number(false)},
             extend: {value:"false"},
             overrideDelay: {value:"false"},
             units: {value:"ms"},

--- a/packages/node_modules/@node-red/nodes/core/function/rbe.html
+++ b/packages/node_modules/@node-red/nodes/core/function/rbe.html
@@ -50,9 +50,8 @@
             name: {value:""},
             func: {value:"rbe"},
             gap: {value:"",
-                  validate:RED.validators.regex(/^(\d*[.]*\d*|)(%|)$/, {
-                      property: RED._("node-red:rbe.label.gap")
-                  })},
+                  label: RED._("node-red:rbe.label.gap"),
+                  validate:RED.validators.regex(/^(\d*[.]*\d*|)(%|)$/)},
             start: {value:""},
             inout: {value:"out"},
             septopics: {value:true},

--- a/packages/node_modules/@node-red/nodes/core/function/rbe.html
+++ b/packages/node_modules/@node-red/nodes/core/function/rbe.html
@@ -49,12 +49,17 @@
         defaults: {
             name: {value:""},
             func: {value:"rbe"},
-            gap: {value:"",validate:RED.validators.regex(/^(\d*[.]*\d*|)(%|)$/)},
+            gap: {value:"",
+                  validate:RED.validators.regex(/^(\d*[.]*\d*|)(%|)$/, {
+                      property: RED._("node-red:rbe.label.gap")
+                  })},
             start: {value:""},
             inout: {value:"out"},
             septopics: {value:true},
-            property: {value:"payload",required:true},
-            topi: {value:"topic",required:true}
+            property: {value:"payload", required:true,
+                       label:RED._("node-red:rbe.label.property")},
+            topi: {value:"topic", required:true,
+                   label:RED._("node-red:rbe.label.topic")}
         },
         inputs:1,
         outputs:1,

--- a/packages/node_modules/@node-red/nodes/core/network/05-tls.html
+++ b/packages/node_modules/@node-red/nodes/core/network/05-tls.html
@@ -83,19 +83,25 @@
         category: 'config',
         defaults: {
             name: {value:""},
-            cert: {value:"", validate: function(v) {
+            cert: {value:"", validate: function(v,opt) {
                 var currentKey = $("#node-config-input-key").val();
                 if (currentKey === undefined) {
                     currentKey = this.key;
                 }
-                return currentKey === '' || v != '';
+                if (currentKey === '' || v != '') {
+                    return true;
+                }
+                return RED._("node-red:tls.error.invalid-cert");
             }},
-            key: {value:"", validate: function(v) {
+            key: {value:"", validate: function(v,opt) {
                 var currentCert = $("#node-config-input-cert").val();
                 if (currentCert === undefined) {
                     currentCert = this.cert;
                 }
-                return currentCert === '' || v != '';
+                if (currentCert === '' || v != '') {
+                    return true;
+                }
+                return RED._("node-red:tls.error.invalid-key");
             }},
             ca: {value:""},
             certname: {value:""},

--- a/packages/node_modules/@node-red/nodes/core/network/06-httpproxy.html
+++ b/packages/node_modules/@node-red/nodes/core/network/06-httpproxy.html
@@ -50,7 +50,16 @@
         category: 'config',
         defaults: {
             name: {value:''},
-            url: {value:'',validate:function(v) { return (v && (v.indexOf('://') !== -1) && (v.trim().indexOf('http') === 0)); }},
+            url: {
+                value:'',
+                validate:function(v, opt) {
+                    if ((v && (v.indexOf('://') !== -1) &&
+                         (v.trim().indexOf('http') === 0))) {
+                        return true;
+                    }
+                    return RED._("node-red:httpin.errors.invalid-url");
+                }
+            },
             noproxy: {value:[]}
         },
         credentials: {

--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
@@ -450,9 +450,8 @@
             broker: {value:"",required:true},
             port: {
                 value:1883,required:false,
-                validate:RED.validators.number(true, {
-                    property: RED._("node-red:mqtt.label.port")
-                })},
+                label: RED._("node-red:mqtt.label.port"),
+                validate:RED.validators.number(true)},
             tls: {type:"tls-config",required: false,
                   label:RED._("node-red:mqtt.label.use-tls") },
             clientid: {value:"", validate: function(v, opt) {
@@ -475,9 +474,8 @@
             protocolVersion: { value: 4},
             keepalive: {
                 value:60,
-                validate:RED.validators.number(false, {
-                    property: RED._("node-red:mqtt.label.keepalive")
-                })},
+                label: RED._("node-red:mqtt.label.keepalive"),
+                validate:RED.validators.number(false)},
             cleansession: {value: true},
             birthTopic: {value:""},
             birthQos: {value:"0"},

--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
@@ -448,22 +448,36 @@
         defaults: {
             name: {value:""},
             broker: {value:"",required:true},
-            port: {value:1883,required:false,validate:RED.validators.number(true)},
-            tls: {type:"tls-config",required: false},
-            clientid: {value:"", validate: function(v) {
+            port: {
+                value:1883,required:false,
+                validate:RED.validators.number(true, {
+                    property: RED._("node-red:mqtt.label.port")
+                })},
+            tls: {type:"tls-config",required: false,
+                  label:RED._("node-red:mqtt.label.use-tls") },
+            clientid: {value:"", validate: function(v, opt) {
+                var ok = false;
                 if ($("#node-config-input-clientid").length) {
                     // Currently editing the node
-                    return $("#node-config-input-cleansession").is(":checked") || (v||"").length > 0;
+                    ok = $("#node-config-input-cleansession").is(":checked") || (v||"").length > 0;
                 } else {
-                    return (this.cleansession===undefined || this.cleansession) || (v||"").length > 0;
+                    ok = (this.cleansession===undefined || this.cleansession) || (v||"").length > 0;
                 }
+                if (ok) {
+                    return ok;
+                }
+                return RED._("node-red:mqtt.errors.invalid-client-id");
             }},
             autoConnect: {value: true},
             usetls: {value: false},
             verifyservercert: { value: false},
             compatmode: { value: false},
             protocolVersion: { value: 4},
-            keepalive: {value:60,validate:RED.validators.number()},
+            keepalive: {
+                value:60,
+                validate:RED.validators.number(false, {
+                    property: RED._("node-red:mqtt.label.keepalive")
+                })},
             cleansession: {value: true},
             birthTopic: {value:""},
             birthQos: {value:"0"},
@@ -740,18 +754,22 @@
             name: {value:""},
             topic: {
                 value:"",
-                validate: function(v) {
+                validate: function(v, opt) {
                     var isDynamic = this.inputs === 1;
                     var topicTypeSelect = $("#node-input-topicType");
                     if (topicTypeSelect.length) {
                         isDynamic = topicTypeSelect.val()==='dynamic'
                     }
-                    return isDynamic || ((!!v) && RED.validators.regex(/^(#$|(\+|[^+#]*)(\/(\+|[^+#]*))*(\/(\+|#|[^+#]*))?$)/)(v));
+                    if (isDynamic || ((!!v) && RED.validators.regex(/^(#$|(\+|[^+#]*)(\/(\+|[^+#]*))*(\/(\+|#|[^+#]*))?$)/)(v))) {
+                        return true;
+                    }
+                    return RED._("node-red:mqtt.errors.invalid-topic");
                 }
             },
             qos: {value: "2"},
             datatype: {value:"auto",required:true},
-            broker: {type:"mqtt-broker", required:true},
+            broker: {type:"mqtt-broker", required:true,
+                     label:RED._("node-red:mqtt.label.broker")},
             // subscriptionIdentifier: {value:0},
             nl: {value:false},
             rap: {value:true},
@@ -829,7 +847,8 @@
             userProps: {value:''},
             correl: {value:''},
             expiry: {value:''},
-            broker: {type:"mqtt-broker", required:true}
+            broker: {type:"mqtt-broker", required:true,
+                     label:RED._("node-red:mqtt.label.broker") }
         },
         color:"#d8bfd8",
         inputs:1,

--- a/packages/node_modules/@node-red/nodes/core/network/21-httpin.html
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httpin.html
@@ -70,7 +70,8 @@
         color:"rgb(231, 231, 174)",
         defaults: {
             name: {value:""},
-            url: {value:"",required:true},
+            url: {value:"", required:true,
+                  label:RED._("node-red:httpin.label.url")},
             method: {value:"get",required:true},
             upload: {value:false},
             swaggerDoc: {type:"swagger-doc", required:false}
@@ -146,7 +147,11 @@
         color:"rgb(231, 231, 174)",
         defaults: {
             name: {value:""},
-            statusCode: {value:"",validate: RED.validators.number(true)},
+            statusCode: {
+                value:"",
+                validate: RED.validators.number(true,{
+                    property: RED._("node-red:httpin.label.status")
+                })},
             headers: {value:{}}
         },
         inputs:1,

--- a/packages/node_modules/@node-red/nodes/core/network/21-httpin.html
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httpin.html
@@ -149,9 +149,8 @@
             name: {value:""},
             statusCode: {
                 value:"",
-                validate: RED.validators.number(true,{
-                    property: RED._("node-red:httpin.label.status")
-                })},
+                label: RED._("node-red:httpin.label.status"),
+                validate: RED.validators.number(true)},
             headers: {value:{}}
         },
         inputs:1,

--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.html
@@ -116,10 +116,22 @@
             method:{value:"GET"},
             ret: {value:"txt"},
             paytoqs: {value: false},
-            url:{value:"",validate:function(v) { return (v.trim().length === 0) || (v.indexOf("://") === -1) || (v.trim().indexOf("http") === 0)} },
-            tls: {type:"tls-config",required: false},
+            url:{
+                value:"",
+                validate: function(v, opt) {
+                    if ((v.trim().length === 0) ||
+                        (v.indexOf("://") === -1) ||
+                        (v.trim().indexOf("http") === 0)) {
+                        return true;
+                    }
+                    return RED._("node-red:httpin.errors.invalid-url");
+                }
+            },
+            tls: {type:"tls-config",required: false,
+                  label:RED._("node-red:httpin.tls-config") },
             persist: {value:false},
-            proxy: {type:"http proxy",required: false},
+            proxy: {type:"http proxy",required: false,
+                    label:RED._("node-red:httpin.proxy-config") },
             authType: {value: ""},
             senderr: {value: false}
         },

--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.html
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.html
@@ -83,13 +83,19 @@
             return true;
         }
         else {
-            return RED.nodes.node(this.server) != null;
+            if (RED.nodes.node(this.server) != null) {
+                return true;
+            }
+            return RED._("node-red:websocket.errors.missing-server");
         }
     }
 
     function ws_validateclient() {
         if ($("#node-input-mode").val() === 'client' || (this.client && !this.server)) {
-            return RED.nodes.node(this.client) != null;
+            if (RED.nodes.node(this.client) != null) {
+                return true;
+            }
+            return RED._("node-red:websocket.errors.missing-client");
         }
         else {
             return true;
@@ -138,7 +144,10 @@
     RED.nodes.registerType('websocket-listener',{
         category: 'config',
         defaults: {
-            path: {value:"",required:true,validate:RED.validators.regex(/^((?!\/debug\/ws).)*$/)},
+            path: {value:"",required:true,
+                   validate:RED.validators.regex(/^((?!\/debug\/ws).)*$/, {
+                       property:RED._("node-red:websocket.label.path")
+                   })},
             wholemsg: {value:"false"}
         },
         inputs:0,
@@ -174,10 +183,18 @@
     RED.nodes.registerType('websocket-client',{
         category: 'config',
         defaults: {
-            path: {value:"",required:true,validate:RED.validators.regex(/^((?!\/debug\/ws).)*$/)},
+            path: {
+                value:"",required:true,
+                validate:RED.validators.regex(/^((?!\/debug\/ws).)*$/, {
+                    property:RED._("node-red:websocket.label.path")
+                })},
             tls: {type:"tls-config",required: false},
             wholemsg: {value:"false"},
-            hb: {value: "", validate: RED.validators.number(/*blank allowed*/true) },
+            hb: {
+                value: "",
+                validate: RED.validators.number(/*blank allowed*/true, {
+                    property:RED._("node-red:websocket.sendheartbeat")
+                }) },
             subprotocol: {value:"",required: false}
         },
         inputs:0,

--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.html
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.html
@@ -145,9 +145,8 @@
         category: 'config',
         defaults: {
             path: {value:"",required:true,
-                   validate:RED.validators.regex(/^((?!\/debug\/ws).)*$/, {
-                       property:RED._("node-red:websocket.label.path")
-                   })},
+                   label:RED._("node-red:websocket.label.path"),
+                   validate:RED.validators.regex(/^((?!\/debug\/ws).)*$/)},
             wholemsg: {value:"false"}
         },
         inputs:0,
@@ -185,16 +184,14 @@
         defaults: {
             path: {
                 value:"",required:true,
-                validate:RED.validators.regex(/^((?!\/debug\/ws).)*$/, {
-                    property:RED._("node-red:websocket.label.path")
-                })},
+                label:RED._("node-red:websocket.label.path"),
+                validate:RED.validators.regex(/^((?!\/debug\/ws).)*$/)},
             tls: {type:"tls-config",required: false},
             wholemsg: {value:"false"},
             hb: {
                 value: "",
-                validate: RED.validators.number(/*blank allowed*/true, {
-                    property:RED._("node-red:websocket.sendheartbeat")
-                }) },
+                label:RED._("node-red:websocket.sendheartbeat"),
+                validate: RED.validators.number(/*blank allowed*/true) },
             subprotocol: {value:"",required: false}
         },
         inputs:0,

--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
@@ -70,14 +70,28 @@
         defaults: {
             name: {value:""},
             server: {value:"server", required:true},
-            host: {value:"", validate:function(v) { return (this.server == "server")||v.length > 0;} },
-            port: {value:"", required:true, validate:RED.validators.number()},
+            host: {
+                value:"",
+                validate:function(v, opt) {
+                    if ((this.server == "server")||v.length > 0) {
+                        return true;
+                    }
+                    return RED._("node-red:tcpin.errors.invalid-host");
+                }
+            },
+            port: {
+                value:"", required:true,
+                label:RED._("node-red:tcpin.label.port"),
+                validate:RED.validators.number(false, {
+                    property: RED._("node-red:tcpin.label.port")
+                })},
             datamode:{value:"stream"},
             datatype:{value:"buffer"},
             newline:{value:""},
             topic: {value:""},
             base64: {/*deprecated*/ value:false, required:true},
-            tls: {type:"tls-config", value:'', required:false}
+            tls: {type:"tls-config", value:'', required:false,
+                  label:RED._("node-red:httpin.tls-config") }
         },
         inputs:0,
         outputs:1,
@@ -186,12 +200,29 @@
         color: "Silver",
         defaults: {
             name: {value:""},
-            host: {value:"",validate:function(v) { return (this.beserver != "client")||v.length > 0;} },
-            port: {value:"",validate:function(v) { return (this.beserver == "reply")||RED.validators.number()(v); } },
+            host: {
+                value:"",
+                validate:function(v, opt) {
+                    if ((this.beserver != "client")||v.length > 0) {
+                        return true;
+                    }
+                    return RED._("node-red:tcpin.errors.invalid-host");
+                }
+            },
+            port: {
+                value:"",
+                validate:function(v) {
+                    if ((this.beserver == "reply")||RED.validators.number()(v)) {
+                        return true;
+                    }
+                    return RED._("node-red:tcpin.errors.invalid-port");
+                }
+            },
             beserver: {value:"client", required:true},
             base64: {value:false, required:true},
             end: {value:false, required:true},
-            tls: {type:"tls-config", value:'', required:false}
+            tls: {type:"tls-config", value:'', required:false,
+                  label:RED._("node-red:httpin.tls-config") }
         },
         inputs:1,
         outputs:0,
@@ -301,12 +332,18 @@
         defaults: {
             name: {value:""},
             server: {value:""},
-            port: {value:"", validate:RED.validators.regex(/^(\d*|)$/)},
+            port: {
+                value:"",
+                validate:RED.validators.regex(/^(\d*|)$/, {
+                    property: RED._("node-red:tcpin.label.port")
+                })
+            },
             out: {value:"time", required:true},
             ret: {value:"buffer"},
             splitc: {value:"0", required:true},
             newline: {value:""},
-            tls: {type:"tls-config", value:'', required:false}
+            tls: {type:"tls-config", value:'', required:false,
+                  label:RED._("node-red:httpin.tls-config") }
         },
         inputs:1,
         outputs:1,

--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.html
@@ -82,9 +82,7 @@
             port: {
                 value:"", required:true,
                 label:RED._("node-red:tcpin.label.port"),
-                validate:RED.validators.number(false, {
-                    property: RED._("node-red:tcpin.label.port")
-                })},
+                validate:RED.validators.number(false)},
             datamode:{value:"stream"},
             datatype:{value:"buffer"},
             newline:{value:""},
@@ -334,9 +332,8 @@
             server: {value:""},
             port: {
                 value:"",
-                validate:RED.validators.regex(/^(\d*|)$/, {
-                    property: RED._("node-red:tcpin.label.port")
-                })
+                label: RED._("node-red:tcpin.label.port"),
+                validate:RED.validators.regex(/^(\d*|)$/)
             },
             out: {value:"time", required:true},
             ret: {value:"buffer"},

--- a/packages/node_modules/@node-red/nodes/core/network/32-udp.html
+++ b/packages/node_modules/@node-red/nodes/core/network/32-udp.html
@@ -62,10 +62,24 @@
         defaults: {
             name: {value:""},
             iface: {value:""},
-            port: {value:"",required:true,validate:RED.validators.number()},
+            port: {
+                value:"", required:true,
+                label:RED._("node-red:udp.label.port"),
+                validate:RED.validators.number(false, {
+                    property: RED._("node-red:udp.label.port")
+                })
+            },
             ipv: {value:"udp4"},
             multicast: {value:"false"},
-            group: {value:"",validate:function(v) { return (this.multicast !== "true")||v.length > 0;} },
+            group: {
+                value:"",
+                validate:function(v,opt) {
+                    if ((this.multicast !== "true")||v.length > 0) {
+                        return true;
+                    }
+                    return RED._("node-red:udp.errors.invalid-group");
+                }
+            },
             datatype: {value:"buffer",required:true}
         },
         inputs:0,

--- a/packages/node_modules/@node-red/nodes/core/network/32-udp.html
+++ b/packages/node_modules/@node-red/nodes/core/network/32-udp.html
@@ -65,9 +65,7 @@
             port: {
                 value:"", required:true,
                 label:RED._("node-red:udp.label.port"),
-                validate:RED.validators.number(false, {
-                    property: RED._("node-red:udp.label.port")
-                })
+                validate:RED.validators.number(false)
             },
             ipv: {value:"udp4"},
             multicast: {value:"false"},

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-CSV.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-CSV.html
@@ -78,9 +78,7 @@
             sep: {
                 value:',', required:true,
                 label:RED._("node-red:csv.label.separator"),
-                validate:RED.validators.regex(/^.{1,2}$/, {
-                    property: RED._("node-red:csv.label.separator")
-                })},
+                validate:RED.validators.regex(/^.{1,2}$/)},
             //quo: {value:'"',required:true},
             hdrin: {value:""},
             hdrout: {value:"none"},

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-CSV.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-CSV.html
@@ -75,7 +75,12 @@
         color:"#DEBD5C",
         defaults: {
             name: {value:""},
-            sep: {value:',',required:true,validate:RED.validators.regex(/^.{1,2}$/)},
+            sep: {
+                value:',', required:true,
+                label:RED._("node-red:csv.label.separator"),
+                validate:RED.validators.regex(/^.{1,2}$/, {
+                    property: RED._("node-red:csv.label.separator")
+                })},
             //quo: {value:'"',required:true},
             hdrin: {value:""},
             hdrout: {value:"none"},

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-JSON.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-JSON.html
@@ -31,7 +31,8 @@
         color:"#DEBD5C",
         defaults: {
             name: {value:""},
-            property: {value:"payload",required:true},
+            property: {value:"payload",required:true,
+                       label:RED._("node-red:json.label.property")},
             action: {value:""},
             pretty: {value:false}
         },

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-XML.html
@@ -26,7 +26,8 @@
         color:"#DEBD5C",
         defaults: {
             name: {value:""},
-            property: {value:"payload",required:true},
+            property: {value:"payload",required:true,
+                       label:RED._("node-red:common.label.property")},
             attr: {value:""},
             chr: {value:""}
         },

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-YAML.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-YAML.html
@@ -15,7 +15,8 @@
         category: 'parser',
         color:"#DEBD5C",
         defaults: {
-            property: {value:"payload",required:true},
+            property: {value:"payload",required:true,
+                       label:RED._("node-red:common.label.property")},
             name: {value:""}
         },
         inputs:1,

--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
@@ -204,9 +204,8 @@
             build: { value:"object"},
             property: {
                 value:"payload",
-                validate:RED.validators.typedInput("propertyType", false, {
-                    property: RED._("node-red:join.message-prop")
-                })
+                label: RED._("node-red:join.message-prop"),
+                validate:RED.validators.typedInput("propertyType", false)
             },
             propertyType: { value:"msg"},
             key: {value:"topic"},

--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
@@ -202,7 +202,12 @@
             name: {value:""},
             mode: {value:"auto"},
             build: { value:"object"},
-            property: { value:"payload", validate:RED.validators.typedInput("propertyType")},
+            property: {
+                value:"payload",
+                validate:RED.validators.typedInput("propertyType", false, {
+                    property: RED._("node-red:join.message-prop")
+                })
+            },
             propertyType: { value:"msg"},
             key: {value:"topic"},
             joiner: { value:"\\n"},

--- a/packages/node_modules/@node-red/nodes/core/sequence/19-batch.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/19-batch.html
@@ -73,9 +73,33 @@
         defaults: {
             name: {value:""},
             mode: {value:"count"},
-            count: {value:10,validate:function(v) { return RED.validators.number(v) && (v >= 1); }},
-            overlap: {value:0,validate:function(v) { return RED.validators.number(v) && (v >= 0); }},
-            interval: {value:10,validate:function(v) { return RED.validators.number(v) && (v >= 1); }},
+            count: {
+                value:10,
+                validate:function(v, opt) {
+                    if (RED.validators.number(v) && (v >= 1)) {
+                        return true;
+                    }
+                    return RED._("node-red:batch.error.invalid-count");
+                }
+            },
+            overlap: {
+                value:0,
+                validate:function(v, opt) {
+                    if (RED.validators.number(v) && (v >= 0)) {
+                        return true;
+                    }
+                    return RED._("node-red:batch.error.invalid-overlap");
+                }
+            },
+            interval: {
+                value:10,
+                validate:function(v, opt) {
+                    if (RED.validators.number(v) && (v >= 1)) {
+                        return true;
+                    }
+                    return RED._("node-red:batch.error.invalid-interval");
+                }
+            },
             allowEmptySequence: {value:false},
             topics: {value:[{topic:""}]}
         },

--- a/packages/node_modules/@node-red/nodes/core/storage/23-watch.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/23-watch.html
@@ -36,7 +36,8 @@
         category: 'storage',
         defaults: {
             name: {value:""},
-            files: {value:"",required:true},
+            files: {value:"",required:true,
+                    label:RED._("node-red:watch.label.files")},
             recursive: {value:""}
         },
         color:"BurlyWood",

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -85,7 +85,11 @@
         "errors": {
             "failed": "inject failed, see log for details",
             "toolong": "Interval too large",
-            "invalid-expr": "Invalid JSONata expression: __error__"
+            "invalid-expr": "Invalid JSONata expression: __error__",
+	    "invalid-jsonata": "__prop__: invalid property expression: __error__",
+	    "invalid-prop": "__prop__: invalid property expression: __error__",
+	    "invalid-json": "__prop__: invalid JSON data: __error__",
+	    "invalid-repeat": "Invalid repeat value"
         }
     },
     "catch": {
@@ -170,6 +174,7 @@
         "outMode": "Mode",
         "sendToAll": "Send to all connected link nodes",
         "returnToCaller": "Return to calling link node",
+	"timeout": "timeout",
         "error": {
             "missingReturn": "Missing return node information"
         }
@@ -196,7 +201,9 @@
             "alpnprotocol":"for use with ALPN"
         },
         "error": {
-            "missing-file": "No certificate/key file provided"
+            "missing-file": "No certificate/key file provided",
+	    "invalid-cert": "Certificate not specified",
+	    "invalid-key": "Private key not specified"
         }
     },
     "exec": {
@@ -251,7 +258,9 @@
             "moduleNameError": "Invalid module variable name: __name__",
             "moduleNameReserved": "Reserved variable name: __name__",
             "inputListener":"Cannot add listener to 'input' event within Function",
-            "non-message-returned":"Function tried to send a message of type __type__"
+            "non-message-returned":"Function tried to send a message of type __type__",
+	    "invalid-js": "Error in JavaScript code",
+	    "missing-module": "Module __module__ missing"
         }
     },
     "template": {
@@ -305,6 +314,9 @@
             "limit": "limit",
             "limitTopic": "limit topic",
             "random": "random",
+	    "rate": "rate",
+	    "random-first": "first random value",
+	    "random-last": "last random value",
             "units" : {
                 "second": {
                     "plural" : "Seconds",
@@ -325,7 +337,12 @@
             }
         },
         "errors": {
-            "too-many" : "too many pending messages in delay node"
+            "too-many" : "too many pending messages in delay node",
+	    "invalid-timeout": "Invalid delay value",
+	    "invalid-rate": "Invalid rate value",
+	    "invalid-rate-unit": "Invalid rate unit value",
+	    "invalid-random-first": "Invalid first random value",
+	    "invalid-random-last": "Invalid last random value"
         }
     },
     "trigger": {
@@ -362,7 +379,9 @@
             "reset": "Reset the trigger if:",
             "resetMessage":"msg.reset is set",
             "resetPayload":"msg.payload equals",
-            "resetprompt": "optional"
+            "resetprompt": "optional",
+	    "duration": "duration",
+	    "topic": "topic"
         }
     },
     "comment": {
@@ -465,7 +484,9 @@
             "invalid-json-parse": "Failed to parse JSON string",
             "invalid-action-action": "Invalid action specified",
             "invalid-action-alreadyconnected": "Disconnect from broker before connecting",
-            "invalid-action-badsubscription": "msg.topic is missing or invalid"
+            "invalid-action-badsubscription": "msg.topic is missing or invalid",
+	    "invalid-client-id": "Missing Client ID"
+
         }
     },
     "httpin": {
@@ -521,7 +542,8 @@
             "invalid-transport":"non-http transport requested",
             "timeout-isnan": "Timeout value is not a valid number, ignoring",
             "timeout-isnegative": "Timeout value is negative, ignoring",
-            "invalid-payload": "Invalid payload"
+            "invalid-payload": "Invalid payload",
+            "invalid-url": "Invalid url"
         },
         "status": {
             "requesting": "requesting"
@@ -554,7 +576,9 @@
             "connect-error": "An error occurred on the ws connection: ",
             "send-error": "An error occurred while sending: ",
             "missing-conf": "Missing server configuration",
-            "duplicate-path": "Cannot have two WebSocket listeners on the same path: __path__"
+            "duplicate-path": "Cannot have two WebSocket listeners on the same path: __path__",
+	    "missing-server": "Missing server configuration",
+	    "missing-client": "Missing client configuration"
         }
     },
     "watch": {
@@ -624,7 +648,9 @@
             "no-host": "Host and/or port not set",
             "connect-timeout": "connect timeout",
             "connect-fail": "connect failed",
-            "bad-string": "failed to convert to string"
+            "bad-string": "failed to convert to string",
+	    "invalid-host": "Invalid host",
+	    "invalid-port": "Invalid port"
         }
     },
     "udp": {
@@ -638,7 +664,8 @@
             "send": "Send a",
             "toport": "to port",
             "address": "Address",
-            "decode-base64": "Decode Base64 encoded payload?"
+            "decode-base64": "Decode Base64 encoded payload?",
+	    "port": "port"
         },
         "placeholder": {
             "interface": "(optional) local interface or address to bind to",
@@ -685,7 +712,8 @@
             "port-notset": "udp: port not set",
             "port-invalid": "udp: port number not valid",
             "alreadyused": "udp: port __port__ already in use",
-            "ifnotfound": "udp: interface __iface__ not found"
+            "ifnotfound": "udp: interface __iface__ not found",
+	    "invalid-group": "invalid multicast group"
         }
     },
     "switch": {
@@ -749,7 +777,9 @@
             "invalid-from": "Invalid 'from' property: __error__",
             "invalid-json": "Invalid 'to' JSON property",
             "invalid-expr": "Invalid JSONata expression: __error__",
-            "no-override": "Cannot set property of non-object type: __property__"
+            "no-override": "Cannot set property of non-object type: __property__",
+	    "invalid-prop": "Invalid property expression: __property__",
+	    "invalid-json-data": "Invalid JSON data: __error__"
         }
     },
     "range": {
@@ -760,7 +790,11 @@
             "resultrange": "to the target range",
             "from": "from",
             "to": "to",
-            "roundresult": "Round result to the nearest integer?"
+            "roundresult": "Round result to the nearest integer?",
+	    "minin": "input from",
+	    "maxin": "input to",
+	    "minout": "target from",
+	    "maxout": "target to"
         },
         "placeholder": {
             "min": "e.g. 0",
@@ -985,6 +1019,7 @@
         "complete": "After a message with the <code>msg.complete</code> property set",
         "tip": "This mode assumes this node is either paired with a <i>split</i> node or the received messages will have a properly configured <code>msg.parts</code> property.",
         "too-many": "too many pending messages in join node",
+	"message-prop": "message property",
         "merge": {
             "topics-label": "Merged Topics",
             "topics": "topics",
@@ -1042,7 +1077,12 @@
         },
         "too-many" : "too many pending messages in batch node",
         "unexpected" : "unexpected mode",
-        "no-parts" : "no parts property in message"
+        "no-parts" : "no parts property in message",
+	"error": {
+	    "invalid-count": "Invalid count",
+	    "invalid-overlap": "Invalid overlap",
+	    "invalid-interval": "Invalid interval"
+	}
     },
     "rbe": {
         "rbe": "filter",
@@ -1051,7 +1091,10 @@
             "init": "Send initial value",
             "start": "Start value",
             "name": "Name",
-            "septopics": "Apply mode separately for each "
+            "septopics": "Apply mode separately for each ",
+	    "gap": "value change",
+	    "property": "property",
+	    "topic": "topic"
         },
         "placeholder":{
             "bandgap": "e.g. 10 or 5%",

--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -85,7 +85,11 @@
         "errors": {
             "failed": "inject処理が失敗しました。詳細はログを確認してください。",
             "toolong": "時間間隔が大き過ぎます",
-            "invalid-expr": "JSONata式が不正: __error__"
+            "invalid-expr": "JSONata式が不正: __error__",
+	    "invalid-jsonata": "__prop__: プロパティ式が不正: __error__",
+	    "invalid-prop": "__prop__: プロパティ式が不正: __error__",
+	    "invalid-json": "__prop__: JSONデータが不正: __error__",
+	    "invalid-repeat": "繰り返し数が不正"
         }
     },
     "catch": {
@@ -170,6 +174,7 @@
         "outMode": "モード",
         "sendToAll": "接続された全てのlinkノードへ送信",
         "returnToCaller": "link callノードへ返却",
+	"timeout": "タイムアウト",
         "error": {
             "missingReturn": "返却するノードの情報が存在しません"
         }
@@ -196,7 +201,9 @@
             "alpnprotocol": "ALPNで使用"
         },
         "error": {
-            "missing-file": "証明書と秘密鍵のファイルが設定されていません"
+            "missing-file": "証明書と秘密鍵のファイルが設定されていません",
+	    "invalid-cert": "証明書が指定されていません",
+	    "invalid-key": "秘密鍵が指定されていません"
         }
     },
     "exec": {
@@ -251,7 +258,9 @@
             "moduleNameError": "モジュール変数名が不正です: __name__",
             "moduleNameReserved": "予約された変数名です: __name__",
             "inputListener": "コード内で'input'イベントのリスナを設定できません",
-            "non-message-returned": "Functionノードが __type__ 型のメッセージ送信を試みました"
+            "non-message-returned": "Functionノードが __type__ 型のメッセージ送信を試みました",
+	    "invalid-js": "JavaScriptコードのエラー",
+	    "missing-module": "モジュール __module__ が存在しません"
         }
     },
     "template": {
@@ -305,6 +314,9 @@
             "limit": "limit",
             "limitTopic": "limit topic",
             "random": "random",
+	    "rate": "流量",
+	    "random-first": "ランダム最小値",
+	    "random-last": "ランダム最大値",
             "units": {
                 "second": {
                     "plural": "秒",
@@ -325,7 +337,12 @@
             }
         },
         "errors": {
-            "too-many": "delayノード内で保持しているメッセージが多すぎます"
+            "too-many": "delayノード内で保持しているメッセージが多すぎます",
+	    "invalid-timeout": "遅延時間が不正",
+	    "invalid-rate": "流量値が不正",
+	    "invalid-rate-unit": "流量単位時間が不正",
+	    "invalid-random-first": "ランダム最小値が不正",
+	    "invalid-random-last": "ランダム最大値が不正"
         }
     },
     "trigger": {
@@ -362,7 +379,9 @@
             "reset": "初期化条件:",
             "resetMessage": "msg.resetを設定",
             "resetPayload": "msg.payloadが次の値",
-            "resetprompt": "任意"
+            "resetprompt": "任意",
+	    "duration": "時間間隔",
+	    "topic": "トピック"
         }
     },
     "comment": {
@@ -465,7 +484,8 @@
             "invalid-json-parse": "JSON文字列のパースに失敗しました",
             "invalid-action-action": "指定された動作が不正です",
             "invalid-action-alreadyconnected": "接続する前にブローカから切断してください",
-            "invalid-action-badsubscription": "msg.topicが存在しないか不正です"
+            "invalid-action-badsubscription": "msg.topicが存在しないか不正です",
+	    "invalid-client-id": "クライアントIDが未指定"
         }
     },
     "httpin": {
@@ -521,7 +541,8 @@
             "invalid-transport": "httpでないトランスポートが要求されました",
             "timeout-isnan": "タイムアウト値が数値ではないため無視します",
             "timeout-isnegative": "タイムアウト値が負数のため無視します",
-            "invalid-payload": "不正なペイロード"
+            "invalid-payload": "不正なペイロード",
+            "invalid-url": "URLが不正"
         },
         "status": {
             "requesting": "要求中"
@@ -554,7 +575,9 @@
             "connect-error": "ws接続でエラーが発生しました: ",
             "send-error": "送信中にエラーが発生しました: ",
             "missing-conf": "サーバ設定が不足しています",
-            "duplicate-path": "同じパスに対して2つのWebSocketリスナは指定できません: __path__"
+            "duplicate-path": "同じパスに対して2つのWebSocketリスナは指定できません: __path__",
+	    "missing-server": "サーバが設定されていません",
+	    "missing-client": "クライアントが設定されていません"
         }
     },
     "watch": {
@@ -623,7 +646,9 @@
             "no-host": "ホスト名またはポートが設定されていません",
             "connect-timeout": "接続がタイムアウトしました",
             "connect-fail": "接続に失敗しました",
-            "bad-string": "文字列への変換に失敗しました"
+            "bad-string": "文字列への変換に失敗しました",
+	    "invalid-host": "ホスト名が不正",
+	    "invalid-port": "ポートが不正"
         }
     },
     "udp": {
@@ -637,7 +662,8 @@
             "send": "送信",
             "toport": "ポート",
             "address": "アドレス",
-            "decode-base64": "Base64形式のペイロードを復号"
+            "decode-base64": "Base64形式のペイロードを復号",
+	    "port": "ポート"
         },
         "placeholder": {
             "interface": "(任意) 使用するローカルインターフェイスもしくはアドレス",
@@ -684,7 +710,8 @@
             "port-notset": "udp: ポートが設定されていません",
             "port-invalid": "udp: ポート番号が不正です",
             "alreadyused": "udp: 既に__port__番ポートが使用されています",
-            "ifnotfound": "udp: インターフェイス __iface__ がありません"
+            "ifnotfound": "udp: インターフェイス __iface__ がありません",
+	    "invalid-group": "マルチキャストグループが不正"
         }
     },
     "switch": {
@@ -748,7 +775,9 @@
             "invalid-from": "操作対象のプロパティが不正: __error__",
             "invalid-json": "対象の値のJSONプロパティが不正",
             "invalid-expr": "JSONata式が不正: __error__",
-            "no-override": "オブジェクト型でないプロパティを設定できません: __property__"
+            "no-override": "オブジェクト型でないプロパティを設定できません: __property__",
+	    "invalid-prop": "プロパティ式が不正: __property__",
+	    "invalid-json-data": "JSONデータが不正: __error__"
         }
     },
     "range": {
@@ -759,7 +788,11 @@
             "resultrange": "出力値の範囲",
             "from": "最小値",
             "to": "最大値",
-            "roundresult": "小数値を四捨五入し整数値へ変換"
+            "roundresult": "小数値を四捨五入し整数値へ変換",
+	    "minin": "入力最小値",
+	    "maxin": "入力最大値",
+	    "minout": "出力最小値",
+	    "maxout": "出力最大値"
         },
         "placeholder": {
             "min": "例) 0",
@@ -984,7 +1017,8 @@
         "complete": "<code>msg.complete</code> プロパティが設定されたメッセージ受信後",
         "tip": "このモードでは、本ノードが <i>split</i> ノードと組となるか、 <code>msg.parts</code> プロパティが設定されたメッセージを受け取ることが前提となります。",
         "too-many": "joinノード内部で保持しているメッセージが多すぎます",
-        "merge": {
+ 	"message-prop": "メッセージプロパティ",
+	"merge": {
             "topics-label": "対象トピック",
             "topics": "トピック",
             "topic": "トピック",
@@ -1041,7 +1075,12 @@
         },
         "too-many": "batchノード内で保持しているメッセージが多すぎます",
         "unexpected": "想定外のモード",
-        "no-parts": "メッセージにpartsプロパティがありません"
+        "no-parts": "メッセージにpartsプロパティがありません",
+	"error": {
+	    "invalid-count": "メッセージ数が不正",
+	    "invalid-overlap": "オーバラップが不正",
+	    "invalid-interval": "時間間隔が不正"
+	}
     },
     "rbe": {
         "rbe": "filter",
@@ -1050,7 +1089,10 @@
             "init": "初期値を送付",
             "start": "初期値",
             "name": "名前",
-            "septopics": "個別に動作を適用"
+            "septopics": "個別に動作を適用",
+	    "gap": "変化量",
+	    "property": "プロパティ",
+	    "topic": "トピック"
         },
         "placeholder": {
             "bandgap": "例:10、5%",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
As discussed in [this ](https://discourse.nodered.org/t/proposal-make-node-property-validation-tooltip-more-understandable/56661) forum thread, the purpose of this PR is to present to the user the cause of the failure of node property verification in an easy-to-understand manner.

- The property validation function of the property definition can return a string instead of a boolean value. This string is used as an explanation for the validation error.  

![スクリーンショット 2022-02-13 13 51 31](https://user-images.githubusercontent.com/30289092/153788785-93f42f66-4390-4990-b56c-6c5a72c79670.png)

For compatibility, this function takes optional second argument which is currently empty object.  So, newly developed node can check this argument and change its behavior.

```
// example:
defaults: {
    property_name: {
         value: ...,
         validate: function (v, opt) {
              if (check is ok) {
                  return true;
              }
              if (opt) {
                  return "error description";
              }
             return false;
         }
    }, ...
}
```

- Property definition may have `label` property.  The value s used as a display name in the validation of the required field and configuration node error.

```
// example:
defaults: {
    property_name: {
         value: ..., required: true, label: "meaningful name"
    }, ...
}
```

- Standard validation function generation functions provided as `RED.validators.*` is modified to accept additional  option object.  This object can have a `property` property. property The property is used as the display name when generating an error message.

```
// example:
defaults: {
    property_name: {
         value: ...,
         validate: RED.validators.number(false, { 
             property: "meaningful property name"
         })
    }, ...
}
```

- Show an error message using tooltip for a field that failed validation. 
    - For this, added `delete` function to ` RED.popover.tooltip`.
    - This feature does not work for some fields (e.g. `typedInput`), probably because of a conflict.

![スクリーンショット 2022-02-13 13 53 35](https://user-images.githubusercontent.com/30289092/153790808-9d31850a-e099-4634-9491-952d81f3cfcd.png)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
