### PR TITLE
Remove console.log when ignoring disabled module

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/loader.js
+++ b/packages/node_modules/@node-red/registry/lib/loader.js
@@ -353,7 +353,6 @@ async function loadPluginConfig(fileInfo) {
  */
 function loadNodeSet(node) {
     if (!node.enabled) {
-        console.log("BAIL ON",node.id)
         return Promise.resolve(node);
     } else {
     }


### PR DESCRIPTION
Removes a rogue console.log that shouldn't be there.