### PR TITLE
Prevent duplicate links being added between nodes

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -600,6 +600,14 @@ RED.nodes = (function() {
         RED.events.emit('nodes:add',n);
     }
     function addLink(l) {
+        if (nodeLinks[l.source.id]) {
+            const isUnique = nodeLinks[l.source.id].out.every(function(link) {
+                return link.sourcePort !== l.sourcePort || link.target.id !== l.target.id
+            })
+            if (!isUnique) {
+                return
+            }
+        }
         links.push(l);
         if (l.source) {
             // Possible the node hasn't been added yet


### PR DESCRIPTION
Whilst the fix in #3437 prevents the the bug in undo history adding duplicate wires, this PR ensures `RED.nodes.addLink` will filter out duplicate links wherever they come from.

This will also fixup any flows that were broken in 2.2.0 due to the original bug.