### PR TITLE
Allow nbRateUnits to be undefined when validating

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.html
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.html
@@ -115,7 +115,7 @@
             timeoutUnits: {value:"seconds"},
             rate: {value:"1", required:true, validate:function(v) { return RED.validators.number(v) && (v >= 0); }},
             nbRateUnits: {value:"1", required:false,
-                          validate:function(v) { return RED.validators.number(v) && (v >= 0); }},
+                          validate:function(v) { return v === undefined || (RED.validators.number(v) && (v >= 0)); }},
             rateUnits: {value: "second"},
             randomFirst: {value:"1", required:true, validate:function(v) { return RED.validators.number(v) && (v >= 0); }},
             randomLast: {value:"5", required:true, validate:function(v) { return RED.validators.number(v) && (v >= 0); }},


### PR DESCRIPTION
Fixes #3407

This partially reverts #3351 in that it allows the `nbRateUnits` property of the Delay node to be undefined. This means very old nodes don't get incorrectly flagged as invalid