### PR TITLE
Handle mixed-cased filter terms in keyboard shortcut dialog

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/keyboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/keyboard.js
@@ -625,7 +625,7 @@ RED.keyboard = (function() {
         pane.find("#red-ui-settings-tab-keyboard-filter").searchBox({
             delay: 100,
             change: function() {
-                var filterValue = $(this).val().trim();
+                var filterValue = $(this).val().trim().toLowerCase();
                 if (filterValue === "") {
                     shortcutList.editableList('filter', null);
                 } else {


### PR DESCRIPTION
Fixes #3400

Uses `.toLowerCase()` on the filter term so it works.