### PR TITLE
Improve module location parsing (of stack info) when adding hook

### DIFF
--- a/packages/node_modules/@node-red/util/lib/hooks.js
+++ b/packages/node_modules/@node-red/util/lib/hooks.js
@@ -67,8 +67,25 @@ function add(hookId, callback) {
         throw new Error("Hook "+hookId+" already registered")
     }
     // Get location of calling code
+    let callModule;
     const stack = new Error().stack;
-    const callModule = stack.split("\n")[2].split("(")[1].slice(0,-1);
+    const stackEntries = stack.split("\n").slice(1);//drop 1st line (error message)
+    const stackEntry2 = stackEntries[1];//get 2nd stack entry
+    if (stackEntry2) {
+        try {
+            if (stackEntry2.indexOf(" (") >= 0) {
+                callModule = stackEntry2.split("(")[1].slice(0, -1);
+            } else {
+                callModule = stackEntry2.split(" ").slice(-1)[0];
+            }
+        } catch (error) {
+            Log.debug(`Unable to determined module when adding hook '${hookId}'. Stack:\n${stackEntries.join("\n")}`);
+            callModule = "unknown:0:0";
+        }
+    } else {
+        Log.debug(`Unable to determined module when adding hook '${hookId}'. Stack:\n${stackEntries.join("\n")}`);
+        callModule = "unknown:0:0";
+    }
     Log.debug(`Adding hook '${hookId}' from ${callModule}`);
 
     const hookItem = {cb:callback, location: callModule, previousHook: null, nextHook: null }


### PR DESCRIPTION
fixes #3401

- [x] Bugfix (non-breaking change which fixes an issue)  



## Proposed changes

### basic...
- handles brackets and no brackets in stack line
- handles short stack

### details...
* Ensure "TypeError: Cannot read property 'slice' of undefined" if called from within callback does not occur
* if short stack, location is assigned `"unknown:0:0"` and node-red debug log will contain the hook name and stack
* if an error occurs parsing a stack, location is assigned `"unknown:0:0"` and node-red debug log will contain the hook name and stack

### Local Tests...
I wrapped the new code in a temporary function and tested locally in a Node JS 16 env REPL...
![image](https://user-images.githubusercontent.com/44235289/154065053-33663be2-c13f-4ad8-ab61-6f6faf52a7e3.png)


### Future: 
refactor code to permit testing?

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
