### PR TITLE
Fix "close timed out" error when performing full deploy or modifying broker node.

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -637,24 +637,8 @@ module.exports = function(RED) {
 
         node.deregister = function(mqttNode,done) {
             delete node.users[mqttNode.id];
-            if (node.closing) {
-                return done();
-            }
-            if (Object.keys(node.users).length === 0) {
-                if (node.client && node.client.connected) {
-                    // Send close message
-                    if (node.closeMessage) {
-                        node.publish(node.closeMessage,function(err) {
-                            node.client.end(done);
-                        });
-                    } else {
-                        node.client.end(done);
-                    }
-                    return;
-                } else {
-                    if (node.client) { node.client.end(); }
-                    return done();
-                }
+            if (!node.closing && node.connected && Object.keys(node.users).length === 0) {
+                node.disconnect();
             }
             done();
         };
@@ -663,6 +647,7 @@ module.exports = function(RED) {
         }
         node.connect = function (callback) {
             if (node.canConnect()) {
+                node.closing = false;
                 node.connecting = true;
                 setStatusConnecting(node, true);
                 try {
@@ -672,6 +657,7 @@ module.exports = function(RED) {
                     let callbackDone = false; //prevent re-connects causing node.client.on('connect' firing callback multiple times
                     // Register successful connect or reconnect handler
                     node.client.on('connect', function (connack) {
+                        node.closing = false;
                         node.connecting = false;
                         node.connected = true;
                         if(!callbackDone && typeof callback == "function") {
@@ -740,6 +726,7 @@ module.exports = function(RED) {
                             reasonCode: rc,
                             reasonString: rs
                         }
+                        node.connected = false;
                         node.log(RED._("mqtt.state.broker-disconnected", details));
                         setStatusDisconnected(node, true);
                     });
@@ -764,25 +751,31 @@ module.exports = function(RED) {
             }
         };
         node.disconnect = function (callback) {
-            const _callback = function () {
+            const _callback = function (resetNodeConnectedState) {
                 setStatusDisconnected(node, true);
-                node.connecting = false;
-                node.connected = false;
+                if(resetNodeConnectedState) {
+                    node.closing = true;
+                    node.connecting = false;
+                    node.connected = false;
+                }
                 callback && typeof callback == "function" && callback();
             };
 
-            if(node.client) {
-                if(node.client.connected && node.closeMessage) {
-                    node.publish(node.closeMessage, function (err) {
-                        node.client.end(_callback);
-                    });
-                } else if(node.client.connected || node.client.reconnecting) {
-                    node.client.end(_callback);
-                } else if(node.client.disconnecting || node.client.connected === false) {
-                    _callback();
-                }
+            if(node.closing) {
+                return _callback(false);
+            }
+            var endCallBack = function endCallBack() {
+            }
+            if(node.connected && node.closeMessage) {
+                node.publish(node.closeMessage, function (err) {
+                    node.client.end(endCallBack);
+                    _callback(true);
+                });
+            } else if(node.connected) {
+                node.client.end(endCallBack);
+                _callback(true);
             } else {
-                _callback();
+                _callback(false);
             }
         }
         node.subscriptionIds = {};
@@ -1074,6 +1067,8 @@ module.exports = function(RED) {
                         node.brokerConn.unsubscribe(node.topic,node.id, removed);
                     }
                     node.brokerConn.deregister(node, done);
+                } else {
+                    done();
                 }
             });
         } else {
@@ -1134,7 +1129,11 @@ module.exports = function(RED) {
             }
             node.brokerConn.register(node);
             node.on('close', function(done) {
-                node.brokerConn.deregister(node,done);
+                if (node.brokerConn) {
+                    node.brokerConn.deregister(node,done);
+                } else {
+                    done();
+                }
             });
         } else {
             node.error(RED._("mqtt.errors.missing-config"));


### PR DESCRIPTION
fixes #2934

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Prevent the `close timed out` issue (see references below)

* Move all calls to `node.client.end()` to one location in code base (broker node function `.disconnect()` ) to reduce code paths and early calls.
* Ensure `done` is always called for the "close" event in MQTT In/Out/Broker nodes (`node.on('close'`) by removing the `done` callback from the `node.client.end()` signature - since it is (at best) unreliable due to the myriad of combination of user options and order of events (i.e. which nodes close first, flow file ordering, whether node has a `close` packet to sent etc)


### References...
https://github.com/node-red/node-red/issues/2934
https://github.com/martin-doyle/node-red-contrib-aedes/issues/46
https://github.com/martin-doyle/node-red-contrib-aedes/issues/54
https://discourse.nodered.org/t/error-stopping-node-close-timed-out-mqtt-nodes/52830/5
https://discourse.nodered.org/t/mqtt-close-timeout-issue-using-aedes/57583
https://discourse.nodered.org/t/mqtt-in-node-not-working-properly-in-node-red-2-2-1/58428 
https://discourse.nodered.org/t/mqtt-connects-then-disconnects/39609/6



## Checklist


- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
