### PR TITLE
Feature add: Store external token when authenticate if provided

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/auth/strategies.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/strategies.js
@@ -92,10 +92,16 @@ var passwordTokenExchange = function(client, username, password, scope, done) {
                 loginAttempts = loginAttempts.filter(function(logEntry) {
                     return logEntry.user !== username;
                 });
-                Tokens.create(username,client.id,scope).then(function(tokens) {
-                    log.audit({event: "auth.login",user,username:username,client:client.id,scope:scope});
-                    done(null,tokens.accessToken,null,{expires_in:tokens.expires_in});
-                });
+                // Check if the user contains a user defined token and use it
+                // instead of generating a new token
+                if(user.token){
+                    done(null,user.token,null,null);
+                } else {
+                    Tokens.create(username,client.id,scope).then(function(tokens) {
+                        log.audit({event: "auth.login",user,username:username,client:client.id,scope:scope});
+                        done(null,tokens.accessToken,null,{expires_in:tokens.expires_in});
+                    });
+                }
             } else {
                 log.audit({event: "auth.login.fail.permissions",username:username,client:client.id,scope:scope});
                 done(null,false);

--- a/test/unit/@node-red/editor-api/lib/auth/strategies_spec.js
+++ b/test/unit/@node-red/editor-api/lib/auth/strategies_spec.js
@@ -92,7 +92,23 @@ describe("api/auth/strategies", function() {
                     tokenCreate.restore();
                 }
             });
+        });
 
+        it('Uses provided token on authentication success and token provided',function(done) {
+            userAuthentication = sinon.stub(Users,"authenticate").callsFake(function(username,password) {
+                return Promise.resolve({username:"user",permissions:"*",token:"123456"});
+            });
+
+            strategies.passwordTokenExchange({id:"myclient"},"user","password","read",function(err,token) {
+                try {
+                    should.not.exist(err);
+                    token.should.equal("123456");
+                    done();
+                } catch(e) {
+                    done(e);
+                }
+            });
+        
         });
     });
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

As discussed [here](https://discourse.nodered.org/t/custom-authentication-storing-own-token/59006/4), this proposed change aims to close the loop for authentication with external APIs.

Currently:

1. You can authenticate via external API with username and password.
2. You can validate a _token_ via external API.
3. But you **can't** save your _token_ when you authenticate via external API, so you can then validate the _token_ via the same external API.

This feature adds the possibility for number 3, where you can return a _token_ with your user and it gets stored instead of the Node-RED generated _token_.

Here is an example of how to use it (this would be placed on settings.js):
```
adminAuth: {
   ...
   authenticate: function(username,password) {
       return new Promise(function(resolve) {
           // Do whatever work is needed to validate the username/password
           // combination, and receive/generate a token.
           if (valid) {
               // Resolve with the user object. Equivalent to having
               // called users(username);
               var user = { username: "admin", permissions: "*", token: token };
               resolve(user);
           } else {
               // Resolve with null to indicate the username/password pair
               // were not valid.
               resolve(null);
           }
       });
   },
   ...
}
```

Then you can use the `adminAuth.tokens()`to validate your _token_ as usual.

Furthermore, this addition is future proof, and it just replaces the token generation before it happens. This means if it's decided to change where the _token_ is stored, it will not impact this solution.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
