### PR TITLE
Dont show 1st tab if hidden when loading

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -252,8 +252,21 @@ var RED = (function() {
                         if (/^#flow\/.+$/.test(currentHash)) {
                             RED.workspaces.show(currentHash.substring(6),true);
                         }
-                        if (RED.workspaces.active() === 0 && RED.workspaces.count() > 0) {
-                            RED.workspaces.show(RED.nodes.getWorkspaceOrder()[0])
+                        if (RED.workspaces.count() > 0) {
+                            const hiddenTabs = JSON.parse(RED.settings.getLocal("hiddenTabs")||"{}");
+                            const workspaces = RED.nodes.getWorkspaceOrder();
+                            if (RED.workspaces.active() === 0) {
+                                for (let index = 0; index < workspaces.length; index++) {
+                                    const ws = workspaces[index];
+                                    if (!hiddenTabs[ws]) {
+                                        RED.workspaces.show(ws);
+                                        break;
+                                    }
+                                }
+                            }
+                            if (RED.workspaces.active() === 0) {
+                                RED.workspaces.show(workspaces[0]);
+                            }
                         }
                     } catch(err) {
                         console.warn(err);


### PR DESCRIPTION
fixes #3455 

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

At start up, test workspace ID against the `hiddenTabs` in localstorage - dont call `RED.workspaces.show` if present

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
