### PR TITLE
Improve scroll into view

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -5621,7 +5621,7 @@ RED.view = (function() {
                         node.dirty = true;
                         RED.workspaces.show(node.z);
 
-                        var screenSize = [chart.width()/scaleFactor,chart.height()/scaleFactor];
+                        var screenSize = [chart[0].clientWidth/scaleFactor,chart[0].clientHeight/scaleFactor];
                         var scrollPos = [chart.scrollLeft()/scaleFactor,chart.scrollTop()/scaleFactor];
                         var cx = node.x;
                         var cy = node.y;


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

### Issue
- if a node is behind the d3 chart scrollbar, it is not scrolled into view when it is revealed (flashed) by a search

### Reason
- jQuery `.width()` & `.width()` actually includes the scroll bar.

### The fix 
- using native `clientWidth` and `clientHeight` fixes this ([extra info](https://stackoverflow.com/a/39330216/4018881))

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
