### PR TITLE
fix: ensure mqtt v5 props can be set false

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -103,7 +103,7 @@ module.exports = function(RED) {
             if(src[propName] === "true" || src[propName] === true) {
                 dst[propName] = true;
             } else if(src[propName] === "false" || src[propName] === false) {
-                dst[propName] = true;
+                dst[propName] = false;
             }
         } else {
             if(def != undefined) dst[propName] = def;


### PR DESCRIPTION
fixes #3471

## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Ensure a false v5 property is set false in v5 packet options object

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
