### PR TITLE
fix PR 'split wire with link nodes' #3416

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -493,9 +493,9 @@ RED.view = (function() {
                 nn.y = mousePos[1];
 
                 if (snapGrid) {
-                    var gridOffset = calculateGridSnapOffsets(nn);
-                    nn.x -= gridOffset[0];
-                    nn.y -= gridOffset[1];
+                    var gridOffset = RED.view.tools.calculateGridSnapOffsets(nn);
+                    nn.x -= gridOffset.x;
+                    nn.y -= gridOffset.y;
                 }
 
                 var spliceLink = $(ui.helper).data("splice");


### PR DESCRIPTION
## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

* fully qualify call to `calculateGridSnapOffsets`
* use .x and .y properties of calculated offsets (not array indexes)

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
