### PR TITLE
Allow node name to be auto-generated when added

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -224,14 +224,7 @@ RED.palette = (function() {
 
             var d = $('<div>',{class:"red-ui-palette-node"}).attr("data-palette-type",nt).data('category',rootCategory);
 
-            var label = nt;///^(.*?)([ -]in|[ -]out)?$/.exec(nt)[1];
-            if (typeof def.paletteLabel !== "undefined") {
-                try {
-                    label = (typeof def.paletteLabel === "function" ? def.paletteLabel.call(def) : def.paletteLabel)||"";
-                } catch(err) {
-                    console.log("Definition error: "+nt+".paletteLabel",err);
-                }
-            }
+            var label = RED.utils.getPaletteLabel(nt, def);///^(.*?)([ -]in|[ -]out)?$/.exec(nt)[1];
 
             $('<div/>', {
                 class: "red-ui-palette-label"+(((!def.align && def.inputs !== 0 && def.outputs === 0) || "right" === def.align) ? " red-ui-palette-label-right" : "")

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -1105,6 +1105,18 @@ RED.utils = (function() {
         return RED.text.bidi.enforceTextDirectionWithUCC(l);
     }
 
+    function getPaletteLabel(nodeType, def) {
+        var label = nodeType;
+        if (typeof def.paletteLabel !== "undefined") {
+            try {
+                label = (typeof def.paletteLabel === "function" ? def.paletteLabel.call(def) : def.paletteLabel)||"";
+            } catch(err) {
+                console.log("Definition error: "+nodeType+".paletteLabel",err);
+            }
+        }
+        return label
+    }
+
     var nodeColorCache = {};
     function clearNodeColorCache() {
         nodeColorCache = {};
@@ -1388,6 +1400,7 @@ RED.utils = (function() {
         getNodeIcon: getNodeIcon,
         getNodeLabel: getNodeLabel,
         getNodeColor: getNodeColor,
+        getPaletteLabel: getPaletteLabel,
         clearNodeColorCache: clearNodeColorCache,
         addSpinnerOverlay: addSpinnerOverlay,
         decodeObject: decodeObject,

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -5419,7 +5419,7 @@ RED.view = (function() {
     }
 
     /**
-     * Create a node from a type string.  
+     * Create a node from a type string.
      * **NOTE:** Can throw on error - use `try` `catch` block when calling
      * @param {string} type The node type to create
      * @param {number} [x] (optional) The horizontal position on the workspace
@@ -5456,6 +5456,34 @@ RED.view = (function() {
                         nn[d] = JSON.parse(JSON.stringify(nn._def.defaults[d].value));
                     }
                 }
+            }
+
+            if (nn._def.defaults.name && nn._def.defaults.name.autoGenerate) {
+                let filter = { type }
+                if (nn._def.defaults.name.autoGenerate.scope === "flow") {
+                    filter.z = RED.workspaces.active()
+                }
+                const existingNodes = RED.nodes.filterNodes(filter)
+                let maxNameNumber = 0;
+                //
+                let defaultNodeName;
+                if (nn._def.defaults.name.autoGenerate.label) {
+                    defaultNodeName = RED._(nn._def.defaults.name.autoGenerate.label)
+                } else {
+                    defaultNodeName = RED.utils.getPaletteLabel(type, nn._def)+' __number__'
+                }
+                const defaultNodeNameRE = new RegExp('^'+defaultNodeName.replace('__number__','(\\d+)')+'$')
+                existingNodes.forEach(n => {
+                    let match = defaultNodeNameRE.exec(n.name)
+                    if (match) {
+                        let nodeNumber = parseInt(match[1])
+                        if (nodeNumber > maxNameNumber) {
+                            maxNameNumber = nodeNumber
+                        }
+                    }
+                })
+                maxNameNumber++
+                nn.name = defaultNodeName.replace('__number__', maxNameNumber)
             }
 
             if (nn._def.onadd) {

--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.html
@@ -74,7 +74,7 @@
     RED.nodes.registerType('debug',{
         category: 'common',
         defaults: {
-            name: {value:""},
+            name: {value:"", autoGenerate: { label: "node-red:debug.defaultName", scope:'flow' } },
             active: {value:true},
             tosidebar: {value:true},
             console: {value:false},

--- a/packages/node_modules/@node-red/nodes/core/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.html
@@ -221,7 +221,7 @@
         category: 'common',
         color:"#ddd",//"#87D8CF",
         defaults: {
-            name: {value:""},
+            name: {value:"", autoGenerate: { label: RED._("node-red:link.linkIn")+" __number__ " } },
             links: { value: [], type:"link out[]" }
         },
         inputs:0,
@@ -293,7 +293,7 @@
         category: 'common',
         color:"#ddd",//"#87D8CF",
         defaults: {
-            name: {value:""},
+            name: {value:"", autoGenerate: { label: RED._("node-red:link.linkOut")+" __number__ " } },
             mode: { value: "link" },// link || return
             links: { value: [], type:"link in[]"}
         },

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -118,6 +118,7 @@
         "completeNodes": "complete: __number__"
     },
     "debug": {
+        "defaultName": "debug __number__",
         "output": "Output",
         "status": "status",
         "none": "None",


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

Closes #3418 

## Proposed changes

This allows a node to tell the editor to auto-generate its name property when it gets added to the editor.

The name will be of the form `debug 1`, `debug 2`, `debug 3` etc.

This PR applies it to the Debug, Link In and Link Out nodes - as they benefit the most from having more human readable, distinct, default names.

To enable this feature, a node should set the new `autoGenerate` property as part of the definition of the `name` default:

```
defaults: {
    name: {value:"", autoGenerate: true }
}
```

If it is set to `true`, then the name will be set to `<PaletteLabel> <N>` (where `N` is the highest existing value plus one).

Some additional customisation is available by setting it to an object:

```
defaults: {
    name: {value:"", autoGenerate: { label: "node-red:debug.defaultName", scope: "flow" } }
}
```

 - `autoGenerate.label` is the message catalogue identifier to use for the default label. It must have a `__number__` placeholder in it that will get substituted when added.
 - `autoGenerate.scope` can be set to `"flow"` to cause the numbering to be unique per-flow rather than globally

