### PR TITLE
do JSON comparison of old value/new value

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
@@ -107,7 +107,7 @@
                                         newValue = "";
                                     }
                                 }
-                                if (!JSON.stringify(node[d]) ===  JSON.stringify(newValue)) {
+                                if (!isEqual(node[d], newValue)) {
                                     if (node._def.defaults[d].type) {
                                         // Change to a related config node
                                         var configNode = RED.nodes.node(node[d]);
@@ -138,6 +138,22 @@
             }
         }
     });
+    /**
+     * Compares `v1` with `v2` for equality
+     * @param {*} v1 variable 1
+     * @param {*} v2 variable 2
+     * @returns {boolean} true if variable 1 equals variable 2, otherwise false
+     */
+    function isEqual(v1, v2) {
+        try {
+            if(v1 === v2) {
+                return true;
+            }
+            return JSON.stringify(v1) === JSON.stringify(v2);
+        } catch (err) {
+            return false;
+        }
+    }
 
     /**
      * Update the node credentials from the edit form

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
@@ -138,22 +138,17 @@
             }
         }
     });
+
     /**
      * Compares `newValue` with `originalValue` for equality.  
-     * NOTES: 
-     * * If `newValue` is a string or number, comparison is not strict
-     * * If `newValue` is anything else, comparison is strict
      * @param {*} originalValue Original value
      * @param {*} newValue New value
      * @returns {boolean} true if originalValue equals newValue, otherwise false
      */
-    function isEqual(originalValue, newValue) {
+     function isEqual(originalValue, newValue) {
         try {
-            if (typeof newValue === "string" || typeof newValue === "number") {
-                return originalValue == newValue;
-            }
-            if (typeof newValue === "boolean") {
-                return originalValue === newValue;
+            if(originalValue == newValue) {
+                return true; 
             }
             return JSON.stringify(originalValue) === JSON.stringify(newValue);
         } catch (err) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
@@ -139,17 +139,23 @@
         }
     });
     /**
-     * Compares `v1` with `v2` for equality
-     * @param {*} v1 variable 1
-     * @param {*} v2 variable 2
-     * @returns {boolean} true if variable 1 equals variable 2, otherwise false
+     * Compares `newValue` with `originalValue` for equality.  
+     * NOTES: 
+     * * If `newValue` is a string or number, comparison is not strict
+     * * If `newValue` is anything else, comparison is strict
+     * @param {*} originalValue Original value
+     * @param {*} newValue New value
+     * @returns {boolean} true if originalValue equals newValue, otherwise false
      */
-    function isEqual(v1, v2) {
+    function isEqual(originalValue, newValue) {
         try {
-            if(v1 === v2) {
-                return true;
+            if (typeof newValue === "string" || typeof newValue === "number") {
+                return originalValue == newValue;
             }
-            return JSON.stringify(v1) === JSON.stringify(v2);
+            if (typeof newValue === "boolean") {
+                return originalValue === newValue;
+            }
+            return JSON.stringify(originalValue) === JSON.stringify(newValue);
         } catch (err) {
             return false;
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
@@ -107,7 +107,7 @@
                                         newValue = "";
                                     }
                                 }
-                                if (node[d] != newValue) {
+                                if (!JSON.stringify(node[d]) ===  JSON.stringify(newValue)) {
                                     if (node._def.defaults[d].type) {
                                         // Change to a related config node
                                         var configNode = RED.nodes.node(node[d]);


### PR DESCRIPTION
fixes #3475

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Use `JSON.stringify` to compare old value to new value. This takes care of array and object values & prevents the node signalling a change (thus preventing the deploy button becoming enabled)

More details in issue #3475 


## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
