### PR TITLE
Add the ability to customize diff colors even more

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
@@ -151,6 +151,8 @@ $popover-button-border-color-hover: #666;
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: #ffd;
 $diff-text-header-background-hover: #ffc;
+$diff-state-color: $primary-text-color;
+$diff-state-prefix-color: $secondary-text-color;
 $diff-state-added: #009900;
 $diff-state-deleted: #f80000;
 $diff-state-changed: #f89406;

--- a/packages/node_modules/@node-red/editor-client/src/sass/diff.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/diff.scss
@@ -562,7 +562,7 @@ ul.red-ui-deploy-dialog-confirm-list {
                 width: 30px;
                 display: inline-block;
                 text-align: center;
-                color: $secondary-text-color;
+                color: $diff-state-prefix-color;
             }
 
             &.added {
@@ -577,9 +577,11 @@ ul.red-ui-deploy-dialog-confirm-list {
         }
         td.added {
             background: $diff-state-added-background;
+            color: $diff-state-color;
         }
         td.removed {
             background: $diff-state-deleted-background;
+            color: $diff-state-color;
         }
         tr.mergeHeader td {
             color: $diff-merge-header-color;
@@ -652,7 +654,7 @@ ul.red-ui-deploy-dialog-confirm-list {
             font-family: $monospace-font;
             padding: 5px 10px;
             text-align: left;
-            color: $secondary-text-color;
+            color: $diff-text-header-color;
             background: $diff-text-header-background;
             height: 30px;
             vertical-align: middle;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
While reviewing the themes, I noticed that there is currently no way to customize the colors on certain parts of the diff. This PR fixes that by adding two new SASS variables.

Before
<img width="1280" alt="Screen Shot 2022-03-15 at 11 55 03 AM" src="https://user-images.githubusercontent.com/29807944/159186122-7e21d123-0396-4538-a20e-775d18639276.png">

After
<img width="1280" alt="Screen Shot 2022-03-15 at 11 55 41 AM" src="https://user-images.githubusercontent.com/29807944/159186127-a6b715c0-e18e-4a0f-8426-0337a67a17bb.png">


<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
