### PR TITLE
Fix: Sidebar "Configuration" filter button tooltip

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
@@ -346,7 +346,7 @@ RED.sidebar.config = (function() {
                 refreshConfigNodeList();
             }
         });
-        RED.popover.tooltip($('#red-ui-sidebar-config-filter-all'), RED._("sidebar.config.showAllUnusedConfigNodes"));
+        RED.popover.tooltip($('#red-ui-sidebar-config-filter-all'), RED._("sidebar.config.showAllConfigNodes"));
         RED.popover.tooltip($('#red-ui-sidebar-config-filter-unused'), RED._("sidebar.config.showAllUnusedConfigNodes"));
 
     }


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
"Configuration" sidebar shows wrong tooltip for filter button "All". Fixed.

<img width="369" alt="image" src="https://user-images.githubusercontent.com/16342003/159189803-eca7c1ab-ca09-41ec-bb27-4372af327977.png">

Is: `Show all unused config nodes`
Should be: `Show all config nodes`

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
