### PR TITLE
fix typo of will properties (properies)

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -465,7 +465,7 @@ module.exports = function(RED) {
                 };
                 if(hasProperty(opts, "willTopic")) {
                     //will v5 properties must be set in the "properties" sub object
-                    node.options.will = createLWT(opts.willTopic, opts.willPayload, opts.willQos, opts.willRetain, opts.willMsg, "properies");
+                    node.options.will = createLWT(opts.willTopic, opts.willPayload, opts.willQos, opts.willRetain, opts.willMsg, "properties");
                 };
             } else {
                 //update options


### PR DESCRIPTION
Fixes #3501

- [x] Bugfix (non-breaking change which fixes an issue)

## Proposed changes

Fix typo to permit `will` v5 properties being correctly set in broker.

NOTE: this was discovered due to new MQTT tests #3497 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
