### PR TITLE
Fix down arrow triggering menu in search box

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/searchBox.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/searchBox.js
@@ -105,8 +105,8 @@
                     }
                 });
                 this.element.on("keydown",function(e) {
-                    if (!menuShown && e.keyCode === 40) {
-                        //DOWN
+                    if (!menuShown && e.keyCode === 40 && $(this).val() === '') {
+                        //DOWN (only show menu if search field is emty)
                         showMenu();
                     }
                 });


### PR DESCRIPTION
fixes #3491


- [x] Bugfix (non-breaking change which fixes an issue)

## Proposed changes

Only show the drop down in the search menu if the search term is blank 
Fixes the issue where after you have typed something in the action bar search field & you press down to select a found item, the dropdown menu is shown! 

NOTE: this is targeted to `dev` because the addition of the dropdown menu in the action bar search field is currently in `dev` branch.


## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
