### PR TITLE
Multi-path support added to httpStatic.

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/index.js
@@ -208,7 +208,10 @@ function start() {
                     log.info(log._("settings.readonly-mode"))
                 }
                 if (settings.httpStatic) {
-                    log.info(log._("runtime.paths.httpStatic",{path:path.resolve(settings.httpStatic)}));
+                    let httpStatic = Array.isArray(settings.httpStatic) ? settings.httpStatic : [settings.httpStatic]
+                    httpStatic.forEach(s => {
+                        log.info(log._("runtime.paths.httpStatic",{path:path.resolve(s)}));
+                    })
                 }
                 return redNodes.loadContextsPlugin().then(function () {
                     redNodes.loadFlows().then(redNodes.startFlows).catch(function(err) {});

--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -395,7 +395,10 @@ httpsPromise.then(function(startupHttps) {
         if (settings.httpStaticAuth) {
             app.use("/",basicAuthMiddleware(settings.httpStaticAuth.user,settings.httpStaticAuth.pass));
         }
-        app.use("/",express.static(settings.httpStatic));
+        let httpStatic = Array.isArray(settings.httpStatic) ? settings.httpStatic : [settings.httpStatic]
+        httpStatic.forEach(s => {
+            app.use("/",express.static(s));
+        })
     }
 
     function getListenPath() {

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -219,7 +219,7 @@ module.exports = {
      * following property can be used to identify a directory of static content
      * that should be served at http://localhost:1880/.
      */
-    //httpStatic: '/home/nol/node-red-static/',
+    //httpStatic: ['/home/nol/node-red-static/'],
 
 /*******************************************************************************
  * Runtime Settings


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Multible httpStatic folders were not supported in Node-Red. But multible static folders are supported in expressjs library. I added multible folders support to httpStatic property in setting.js.

This topic it has been discussed on the [forum](https://discourse.nodered.org/t/multiple-httpstatic-folders-in-nodered/60458)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
