### PR TITLE
Ensure i18n of scoped package name

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -474,7 +474,7 @@ var RED = (function() {
             var parts = topic.split("/");
             var node = RED.nodes.node(parts[1]);
             if (node) {
-                if (msg.hasOwnProperty("text") && msg.text !== null && /^[a-zA-Z]/.test(msg.text)) {
+                if (msg.hasOwnProperty("text") && msg.text !== null && /^[@a-zA-Z]/.test(msg.text)) {
                     msg.text = node._(msg.text.toString(),{defaultValue:msg.text.toString()});
                 }
                 node.status = msg;


### PR DESCRIPTION
fixes #3453 


- [x] Bugfix (non-breaking change which fixes an issue)


## Proposed changes

Modify regex from `/^[a-zA-Z]/` to `/^[@a-zA-Z]/` so that scoped package names are translated.

before...
![image](https://user-images.githubusercontent.com/44235289/161576822-a798a442-3db1-46b1-8bce-adf8eff1cc2d.png)

after...
![image](https://user-images.githubusercontent.com/44235289/161577233-0c7e6c98-dd7d-4eb6-86d8-5cf6588a819e.png)



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
