### PR TITLE
Allow adminAuth to auto-login users when using passport strategy

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/auth/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/index.js
@@ -106,9 +106,15 @@ async function login(req,res) {
                 urlPrefix += "/";
             }
             response = {
-                "type":"strategy",
-                "prompts":[{type:"button",label:mergedAdminAuth.strategy.label, url: urlPrefix + "auth/strategy"}]
+                "type":"strategy"
             }
+            if (mergedAdminAuth.strategy.autoLogin) {
+                response.autoLogin = true
+                response.loginRedirect = urlPrefix + "auth/strategy"
+            }
+            response.prompts = [
+                {type:"button",label:mergedAdminAuth.strategy.label, url: urlPrefix + "auth/strategy"}
+            ]
             if (mergedAdminAuth.strategy.icon) {
                 response.prompts[0].icon = mergedAdminAuth.strategy.icon;
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/user.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/user.js
@@ -118,20 +118,26 @@ RED.user = (function() {
                     });
 
                 } else if (data.type == "strategy") {
+                    var sessionMessage = /[?&]session_message=(.*?)(?:$|&)/.exec(window.location.search);
+                    RED.sessionMessages = RED.sessionMessages || [];
+                    if (sessionMessage) {
+                        RED.sessionMessages.push(decodeURIComponent(sessionMessage[1]));
+                        if (history.pushState) {
+                            var newurl = window.location.protocol+"//"+window.location.host+window.location.pathname
+                            window.history.replaceState({ path: newurl }, "", newurl);
+                        } else {
+                            window.location.search = "";
+                        }
+                    }
+
+                    if (RED.sessionMessages.length === 0 && data.autoLogin) {
+                        document.location = data.loginRedirect
+                        return
+                    }
+
                     i = 0;
                     for (;i<data.prompts.length;i++) {
                         var field = data.prompts[i];
-                        var sessionMessage = /[?&]session_message=(.*?)(?:$|&)/.exec(window.location.search);
-                        if (sessionMessage) {
-                            RED.sessionMessages = RED.sessionMessages || [];
-                            RED.sessionMessages.push(sessionMessage[1]);
-                            if (history.pushState) {
-                                var newurl = window.location.protocol+"//"+window.location.host+window.location.pathname
-                                window.history.replaceState({ path: newurl }, "", newurl);
-                            } else {
-                                window.location.search = "";
-                            }
-                        }
                         if (RED.sessionMessages) {
                             var sessionMessages = $("<div/>",{class:"form-row",style:"text-align: center"}).appendTo("#node-dialog-login-fields");
                             RED.sessionMessages.forEach(function (msg) {


### PR DESCRIPTION
Adds an option to `adminAuth` when using a `strategy` type scheme to automatically redirect the user to the required auth system rather than prompt with a dialog to click a button first.

The dialog will still get shown if there are any errors whilst handling the login.

```
adminAuth: {
    type: 'strategy',
    strategy: {
        ...
        autoLogin: true,
        ...
    }
}
```