### PR TITLE
fix reference error of msg.status in debug node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.js
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.js
@@ -108,7 +108,9 @@ module.exports = function(RED) {
             }
         })
         this.on("input", function(msg, send, done) {
-            if (hasOwnProperty.call(msg, "status") && hasOwnProperty.call(msg.status, "source") && hasOwnProperty.call(msg.status.source, "id") && (msg.status.source.id === node.id)) {
+            if (hasOwnProperty.call(msg, "status") && msg.status &&
+                hasOwnProperty.call(msg.status, "source") && msg.status.source &&
+                hasOwnProperty.call(msg.status.source, "id") && (msg.status.source.id === node.id)) {
                 done();
                 return;
             }
@@ -129,7 +131,8 @@ module.exports = function(RED) {
                             fill = "red";
                             st = msg.error.message;
                         }
-                        if (hasOwnProperty.call(msg, "status")) {
+                        if (hasOwnProperty.call(msg, "status") &&
+                           msg.status) {
                             fill = msg.status.fill || "grey";
                             shape = msg.status.shape || "ring";
                             st = msg.status.text || "";


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
If a debug node receives a message with `msg.status = null` it causes following error:
```
TypeError: Cannot read property 'hasOwnProperty' of null
```

This PR try to fix this isseue.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
