### PR TITLE
Display link targets of nodes in a regular flow, for Link Call nodes inside a subflow

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.html
@@ -48,7 +48,7 @@
 <script type="text/javascript">
 (function() {
 
-    var treeList;
+    let treeList;
 
     function onEditPrepare(node,targetType) {
         if (!node.links) {
@@ -56,7 +56,7 @@
         }
         node.oldLinks = [];
 
-        var activeSubflow = RED.nodes.subflow(node.z);
+        const activeSubflow = RED.nodes.subflow(node.z);
 
         treeList = $("<div>")
             .css({width: "100%", height: "100%"})
@@ -76,10 +76,10 @@
                     RED.view.redraw();
                 }
             });
-        var candidateNodes = RED.nodes.filterNodes({type:targetType});
-        var candidateNodesCount = 0;
+        const candidateNodes = RED.nodes.filterNodes({type:targetType});
+        let candidateNodesCount = 0;
 
-        var search = $("#node-input-link-target-filter").searchBox({
+        const search = $("#node-input-link-target-filter").searchBox({
             style: "compact",
             delay: 300,
             change: function() {
@@ -88,7 +88,7 @@
                     treeList.treeList("filter", null);
                     search.searchBox("count","");
                 } else {
-                    var count = treeList.treeList("filter", function(item) {
+                    const count = treeList.treeList("filter", function(item) {
                         return item.label.toLowerCase().indexOf(val) > -1 || (item.node && item.node.type.toLowerCase().indexOf(val) > -1)
                     });
                     search.searchBox("count",count+" / "+candidateNodesCount);
@@ -96,25 +96,27 @@
             }
         });
 
-
-        var flows = [];
-        var flowMap = {};
+        const flows = [];
+        const flowMap = {};
 
         if (activeSubflow) {
             flowMap[activeSubflow.id] = {
                 id: activeSubflow.id,
                 class: 'red-ui-palette-header',
-                label:  "Subflow : "+(activeSubflow.name || activeSubflow.id),
+                label: "Subflow : " + (activeSubflow.name || activeSubflow.id),
                 expanded: true,
                 children: []
             };
             flows.push(flowMap[activeSubflow.id])
-        } else {
-            RED.nodes.eachWorkspace(function(ws) {
+        }
+        if (!activeSubflow || node.type === "link call") {
+            // Only "Link Call" can look outside of its own subflow
+            // Link In and Link Out nodes outside of a subflow should be ignored
+            RED.nodes.eachWorkspace(function (ws) {
                 flowMap[ws.id] = {
                     id: ws.id,
                     class: 'red-ui-palette-header',
-                    label: (ws.label || ws.id)+(node.z===ws.id ? " *":""),
+                    label: (ws.label || ws.id) + (node.z === ws.id ? " *" : ""),
                     expanded: true,
                     children: []
                 }
@@ -122,22 +124,21 @@
             })
         }
 
-        candidateNodes.forEach(function(n) {
+        candidateNodes.forEach(function (n) {
             if (flowMap[n.z]) {
                 if (targetType === "link out" && n.mode === 'return') {
                     // Link In nodes looking for Link Out nodes should not
                     // include return-mode nodes.
-                    return
+                    return;
                 }
-                var isChecked = false;
-                isChecked = (node.links.indexOf(n.id) !== -1) || (n.links||[]).indexOf(node.id) !== -1;
+                const isChecked = (node.links.indexOf(n.id) !== -1) || (n.links || []).indexOf(node.id) !== -1;
                 if (isChecked) {
                     node.oldLinks.push(n.id);
                 }
                 flowMap[n.z].children.push({
                     id: n.id,
                     node: n,
-                    label: n.name||n.id,
+                    label: n.name || n.id,
                     selected: isChecked,
                     checkbox: node.type !== "link call",
                     radio: node.type === "link call"
@@ -145,8 +146,8 @@
                 candidateNodesCount++;
             }
         });
-        flows = flows.filter(function(f) { return f.children.length > 0 })
-        treeList.treeList('data',flows);
+        const flowsFiltered = flows.filter(function(f) { return f.children.length > 0 })
+        treeList.treeList('data',flowsFiltered);
         setTimeout(function() {
             treeList.treeList('show',node.z);
         },100);
@@ -218,8 +219,6 @@
     }
 
     function onAdd() {
-        RED.actions.invoke("core:generate-node-names",this)
-
         for (var i=0;i<this.links.length;i++) {
             var n = RED.nodes.node(this.links[i]);
             if (n && n.links.indexOf(this.id) === -1) {
@@ -316,10 +315,7 @@
         oneditsave: function() {
             onEditSave(this);
         },
-        oneditresize: resizeNodeList,
-        onadd: function() {
-            RED.actions.invoke("core:generate-node-names",this)
-        }
+        oneditresize: resizeNodeList
     });
 
     RED.nodes.registerType('link out',{


### PR DESCRIPTION
fixes #3248

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

* Make link call display targets both inside its own subflow and on regular flows
* Ensure link in & link out nodes on a subflow ONLY show targets inside the same subflow
* Ensure link targets inside a subflow are not displayed for link nodes on regular flows

![image](https://user-images.githubusercontent.com/44235289/163047384-e6482b3f-cccf-443f-bfa1-961175203d75.png)

![image](https://user-images.githubusercontent.com/44235289/163047546-1cb0ee6c-309d-4f9b-a27e-5200e76fb7f6.png)

![image](https://user-images.githubusercontent.com/44235289/163047950-33b1c601-826c-4ebb-8bef-d3d8d0d2b767.png)


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality

