### PR TITLE
call done after ws disconnects

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
@@ -236,8 +236,6 @@ module.exports = function(RED) {
                         return done();
                     }
                     closeMonitorCount--;
-                    if(closeMonitorCount <= 0) {
-                    }
                 }, closeMonitorInterval);
             }
         });

--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
@@ -35,8 +35,6 @@ module.exports = function(RED) {
         }
     }
     var listenerNodes = {};
-    var activeListenerNodes = 0;
-
 
     // A node red node that sets up a local websocket server
     function WebSocketListenerNode(n) {
@@ -166,7 +164,6 @@ module.exports = function(RED) {
         }
 
         if (node.isServer) {
-            activeListenerNodes++;
             if (!serverUpgradeAdded) {
                 RED.server.on('upgrade', handleServerUpgrade);
                 serverUpgradeAdded = true

--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
@@ -210,7 +210,7 @@ module.exports = function(RED) {
             startconn(); // start outbound connection
         }
 
-        node.on("close", function() {
+        node.on("close", function(done) {
             if (node.heartbeatInterval) {
                 clearInterval(node.heartbeatInterval);
             }
@@ -218,19 +218,27 @@ module.exports = function(RED) {
                 delete listenerNodes[node.fullPath];
                 node.server.close();
                 node._inputNodes = [];
-                activeListenerNodes--;
-                // if (activeListenerNodes === 0 && serverUpgradeAdded) {
-                //     RED.server.removeListener('upgrade', handleServerUpgrade);
-                //     serverUpgradeAdded = false;
-                // }
             }
             else {
                 node.closing = true;
                 node.server.close();
-                if (node.tout) {
-                    clearTimeout(node.tout);
-                    node.tout = null;
-                }
+                //wait 20*50 (1000ms max) for ws to close. 
+                //call done when readyState === ws.CLOSED (or 1000ms, whichever comes fist)
+                const closeMonitorInterval = 20;
+                let closeMonitorCount = 50;
+                let si = setInterval(() => {
+                    if(node.server.readyState === ws.CLOSED || closeMonitorCount <= 0) {
+                        if (node.tout) {
+                            clearTimeout(node.tout);
+                            node.tout = null;
+                        }
+                        clearInterval(si);
+                        return done();
+                    }
+                    closeMonitorCount--;
+                    if(closeMonitorCount <= 0) {
+                    }
+                }, closeMonitorInterval);
             }
         });
     }


### PR DESCRIPTION
fixes #3527


## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

As discussed in #3527 ...

> this issue is *mostly a visual problem. (some internal state is modified by the old sockets disconnect event)
>
> I can see why this happens ...
> 
> restarting flows re-creates the node
> the newly created websocket is opened - causing the CONNECTED status
> then the previous websocket reports it has closed - causing the DISCONNECTED status
> 
>
>  ![chrome_i2GPcRyAeo](https://user-images.githubusercontent.com/44235289/163364213-d5911de8-043c-444c-9087-1e0050e5f37d.gif)

## Proposed changes

Monitor the ws `readyState` using a 20ms interval & call done() once `readyState == closed` OR a MAX of 1000ms (whichever comes first)?

e.g...
```js
        node.on("close", function(done) {
            node.closing = true;
            node.server.close();
            //wait 20*50 (1000ms max) for ws to close
            const closeMonitorInterval = 20;
            let closeMonitorCount = 50;
            let si = setInterval(() => {
                if(node.server.readyState === ws.CLOSED || closeMonitorCount <= 0) {
                    clearInterval(si);
                    return done();
                }
                closeMonitorCount--;
            }, closeMonitorInterval);
        }
```

#### Result - now the flows stop waits for ws disconnection...
![chrome_x5usA8iH13](https://user-images.githubusercontent.com/44235289/163476236-c6890e87-b121-4d7a-9f8f-26bbbcb271fa.gif)



## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
