### PR TITLE
Feature: Change basic Filename field to a typedInput 

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.html
@@ -198,8 +198,8 @@
         category: 'storage',
         defaults: {
             name: {value:""},
-            filename: {value:""},
-            filenameType: {value:""},
+            filename: {value:"filename"},
+            filenameType: {value:"msg"},
             appendNewline: {value:true},
             createDir: {value:false},
             overwriteFile: {value:"false"},
@@ -236,7 +236,7 @@
                 label: node._("file.encoding.setbymsg")
             }).text(label).appendTo(encSel);
             $("#node-input-filename").typedInput({
-                default: "str",
+                default: "msg",
                 types:[{ value: "str", label:"", icon:"red/images/typedInput/az.svg"}, "msg", "jsonata", "env"],
                 typeField: $("#node-input-filenameType")
             });
@@ -297,8 +297,8 @@
         category: 'storage',
         defaults: {
             name: {value:""},
-            filename: {value:""},
-            filenameType: {value:""},
+            filename: {value:"filename"},
+            filenameType: {value:"msg"},
             format: {value:"utf8"},
             chunk: {value:false},
             sendError: {value: false},
@@ -341,7 +341,7 @@
                 label: label
             }).text(label).appendTo(encSel);
             $("#node-input-filename").typedInput({
-                default: "str",
+                default: "msg",
                 types:[{ value: "str", label:"", icon:"red/images/typedInput/az.svg"}, "msg", "jsonata", "env"],
                 typeField: $("#node-input-filenameType")
             });

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.html
@@ -30,7 +30,7 @@
     </div>
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
+        <input type="text" id="node-input-name">
     </div>
     <div class="form-tips"><span data-i18n="file.tip"></span></div>
 </script>
@@ -38,7 +38,7 @@
 <script type="text/html" data-template-name="file in">
     <div class="form-row">
          <label for="node-input-filename"><i class="fa fa-file"></i> <span data-i18n="file.label.filename"></span></label>
-         <input id="node-input-filename" type="text" data-i18n="[placeholder]file.label.filename">
+         <input id="node-input-filename" type="text">
          <input type="hidden" id="node-input-filenameType">
     </div>
     <div class="form-row">
@@ -62,7 +62,7 @@
     </div>
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
+        <input type="text" id="node-input-name">
     </div>
     <div class="form-tips"><span data-i18n="file.tip"></span></div>
 </script>

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.html
@@ -3,6 +3,7 @@
     <div class="form-row node-input-filename">
          <label for="node-input-filename"><i class="fa fa-file"></i> <span data-i18n="file.label.filename"></span></label>
          <input id="node-input-filename" type="text">
+         <input type="hidden" id="node-input-filenameType">
     </div>
     <div class="form-row">
         <label for="node-input-overwriteFile"><i class="fa fa-random"></i> <span data-i18n="file.label.action"></span></label>
@@ -38,6 +39,7 @@
     <div class="form-row">
          <label for="node-input-filename"><i class="fa fa-file"></i> <span data-i18n="file.label.filename"></span></label>
          <input id="node-input-filename" type="text" data-i18n="[placeholder]file.label.filename">
+         <input type="hidden" id="node-input-filenameType">
     </div>
     <div class="form-row">
         <label for="node-input-format"><i class="fa fa-sign-out"></i> <span data-i18n="file.label.outputas"></span></label>
@@ -197,6 +199,7 @@
         defaults: {
             name: {value:""},
             filename: {value:""},
+            filenameType: {value:""},
             appendNewline: {value:true},
             createDir: {value:false},
             overwriteFile: {value:"false"},
@@ -207,10 +210,12 @@
         outputs:1,
         icon: "file-out.svg",
         label: function() {
+            var fn = this.filename;
+            if(this.filenameType != "str") { fn = ""; } 
             if (this.overwriteFile === "delete") {
-                return this.name||this._("file.label.deletelabel",{file:this.filename});
+                return this.name||this._("file.label.deletelabel",{file:fn});
             } else {
-                return this.name||this.filename||this._("file.label.write");
+                return this.name||fn||this._("file.label.write");
             }
         },
         paletteLabel: RED._("node-red:file.label.write"),
@@ -229,6 +234,17 @@
                 value: "setbymsg",
                 label: node._("file.encoding.setbymsg")
             }).text(label).appendTo(encSel);
+            $("#node-input-filename").typedInput({
+                default: "str",
+                types:[{ value: "str", label:"", icon:"red/images/typedInput/az.svg"}, "msg", "jsonata", "env"],
+                typeField: $("#node-input-filenameType")
+            });
+            if(!node.filename && !node.filenameType) {
+                node.filename = "filename" 
+                node.filenameType = "msg"
+                $("#node-input-filename").typedInput("type", node.filenameType);
+                $("#node-input-filename").typedInput("value", node.filename);
+            }
             encodings.forEach(function(item) {
                 if(Array.isArray(item)) {
                     var group = $("<optgroup/>", {
@@ -267,6 +283,7 @@
         defaults: {
             name: {value:""},
             filename: {value:""},
+            filenameType: {value:""},
             format: {value:"utf8"},
             chunk: {value:false},
             sendError: {value: false},
@@ -291,7 +308,9 @@
         },
         icon: "file-in.svg",
         label: function() {
-            return this.name||this.filename||this._("file.label.read");
+            var fn = this.filename;
+            if(this.filenameType != "str") { fn = ""; } 
+            return this.name||fn||this._("file.label.read");
         },
         paletteLabel: RED._("node-red:file.label.read"),
         labelStyle: function() {
@@ -305,6 +324,17 @@
                 value: "none",
                 label: label
             }).text(label).appendTo(encSel);
+            $("#node-input-filename").typedInput({
+                default: "str",
+                types:[{ value: "str", label:"", icon:"red/images/typedInput/az.svg"}, "msg", "jsonata", "env"],
+                typeField: $("#node-input-filenameType")
+            });
+            if(!node.filename && !node.filenameType) {
+                node.filename = "filename" 
+                node.filenameType = "msg"
+                $("#node-input-filename").typedInput("type", node.filenameType);
+                $("#node-input-filename").typedInput("value", node.filename);
+            }
             encodings.forEach(function(item) {
                 if(Array.isArray(item)) {
                     var group = $("<optgroup/>", {

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.html
@@ -211,7 +211,8 @@
         icon: "file-out.svg",
         label: function() {
             var fn = this.filename;
-            if(this.filenameType != "str") { fn = ""; } 
+            if(this.filenameType != "str" && this.filenameType != "env" ) { fn = ""; }
+            if(this.filenameType === "env") { fn = "env."+fn; }
             if (this.overwriteFile === "delete") {
                 return this.name||this._("file.label.deletelabel",{file:fn});
             } else {
@@ -239,11 +240,25 @@
                 types:[{ value: "str", label:"", icon:"red/images/typedInput/az.svg"}, "msg", "jsonata", "env"],
                 typeField: $("#node-input-filenameType")
             });
-            if(!node.filename && !node.filenameType) {
-                node.filename = "filename" 
-                node.filenameType = "msg"
-                $("#node-input-filename").typedInput("type", node.filenameType);
-                $("#node-input-filename").typedInput("value", node.filename);
+            if(typeof node.filenameType == 'undefined') {
+                //existing node AND filenameType is not set - inplace (compatible) upgrade to new typedInput
+                if(node.filename == "") { //was using empty value to denote msg.filename - set typedInput to match
+                    node.filename = "filename";
+                    node.filenameType = "msg";
+                    $("#node-input-filename").typedInput("type", node.filenameType);
+                    $("#node-input-filename").typedInput("value", node.filename);
+                } else if(/^\${[^}]+}$/.test(node.filename)) { //was using an ${ENV_VAR}
+                    node.filenameType = "env";
+                    node.filename = node.filename.replace(/\${([^}]+)}/g, function(match, name) {
+                        return (name === undefined)?"":name;
+                    });
+                    $("#node-input-filename").typedInput("type", node.filenameType);
+                    $("#node-input-filename").typedInput("value", node.filename);
+                } else { //was using a static filename - set typedInput type to str
+                    node.filenameType = "str";
+                    $("#node-input-filename").typedInput("type", node.filenameType);
+                    $("#node-input-filename").typedInput("value", node.filename);
+                }
             }
             encodings.forEach(function(item) {
                 if(Array.isArray(item)) {
@@ -309,7 +324,8 @@
         icon: "file-in.svg",
         label: function() {
             var fn = this.filename;
-            if(this.filenameType != "str") { fn = ""; } 
+            if(this.filenameType != "str" && this.filenameType != "env" ) { fn = ""; }
+            if(this.filenameType === "env") { fn = "env."+fn; }
             return this.name||fn||this._("file.label.read");
         },
         paletteLabel: RED._("node-red:file.label.read"),
@@ -329,11 +345,25 @@
                 types:[{ value: "str", label:"", icon:"red/images/typedInput/az.svg"}, "msg", "jsonata", "env"],
                 typeField: $("#node-input-filenameType")
             });
-            if(!node.filename && !node.filenameType) {
-                node.filename = "filename" 
-                node.filenameType = "msg"
-                $("#node-input-filename").typedInput("type", node.filenameType);
-                $("#node-input-filename").typedInput("value", node.filename);
+            if(typeof node.filenameType == 'undefined') {
+                //existing node AND filenameType is not set - inplace (compatible) upgrade to new typedInput
+                if(node.filename == "") { //was using empty value to denote msg.filename - set typedInput to match
+                    node.filename = "filename";
+                    node.filenameType = "msg";
+                    $("#node-input-filename").typedInput("type", node.filenameType);
+                    $("#node-input-filename").typedInput("value", node.filename);
+                } else if(/^\${[^}]+}$/.test(node.filename)) { //was using an ${ENV_VAR}
+                    node.filenameType = "env";
+                    node.filename = node.filename.replace(/\${([^}]+)}/g, function(match, name) {
+                        return (name === undefined)?"":name;
+                    });
+                    $("#node-input-filename").typedInput("type", node.filenameType);
+                    $("#node-input-filename").typedInput("value", node.filename);
+                } else { //was using a static filename - set typedInput type to str
+                    node.filenameType = "str";
+                    $("#node-input-filename").typedInput("type", node.filenameType);
+                    $("#node-input-filename").typedInput("value", node.filename);
+                }
             }
             encodings.forEach(function(item) {
                 if(Array.isArray(item)) {

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.js
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.js
@@ -58,11 +58,6 @@ module.exports = function(RED) {
                 if(filename == "") { //was using empty value to denote msg.filename
                     node.filename = "filename";
                     node.filenameType = "msg";
-                } else if(/^\${[^}]+}$/.test(filename)) { //was using an ${ENV_VAR}
-                    node.filenameType = "env";
-                    node.filename = filename.replace(/\${([^}]+)}/g, function(match, name) {
-                        return (name === undefined)?"":name;
-                    });
                 } else { //was using a static filename - set typedInput type to str
                     node.filenameType = "str";
                 }
@@ -305,11 +300,6 @@ module.exports = function(RED) {
                 if(filename == "") { //was using empty value to denote msg.filename
                     node.filename = "filename";
                     node.filenameType = "msg";
-                } else if(/^\${[^}]+}$/.test(filename)) { //was using an ${ENV_VAR}
-                    node.filenameType = "env";
-                    node.filename = filename.replace(/\${([^}]+)}/g, function(match, name) {
-                        return (name === undefined)?"":name;
-                    });
                 } else { //was using a static filename - set typedInput type to str
                     node.filenameType = "str";
                 }

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.js
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.js
@@ -39,7 +39,7 @@ module.exports = function(RED) {
         // Write/delete a file
         RED.nodes.createNode(this,n);
         this.filename = n.filename;
-        this.filenameType = n.filenameTpye;
+        this.filenameType = n.filenameType;
         this.appendNewline = n.appendNewline;
         this.overwriteFile = n.overwriteFile.toString();
         this.createDir = n.createDir || false;
@@ -77,6 +77,7 @@ module.exports = function(RED) {
                 }
             });
             filename = filename || "";
+            msg.filename = filename;
             var fullFilename = filename;
             if (filename && RED.settings.fileWorkingDirectory && !path.isAbsolute(filename)) {
                 fullFilename = path.resolve(path.join(RED.settings.fileWorkingDirectory,filename));

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.js
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.js
@@ -39,6 +39,7 @@ module.exports = function(RED) {
         // Write/delete a file
         RED.nodes.createNode(this,n);
         this.filename = n.filename;
+        this.filenameType = n.filenameTpye;
         this.appendNewline = n.appendNewline;
         this.overwriteFile = n.overwriteFile.toString();
         this.createDir = n.createDir || false;
@@ -50,7 +51,22 @@ module.exports = function(RED) {
         node.closeCallback = null;
 
         function processMsg(msg,nodeSend, done) {
-            var filename = node.filename || msg.filename || "";
+            var filename = node.filename || "";
+            //Pre V3 compatibility - if filename and filenameType are empty, check msg.filename
+            if(!node.filenameType && !node.filename) {
+                msg.filename = "filename";
+                node.filenameType = "msg";
+            }
+
+            RED.util.evaluateNodeProperty(node.filename,node.filenameType,node,msg,(err,value) => {
+                if (err) {
+                    node.error(err,msg);
+                    return done();
+                } else {
+                    filename = value;
+                }
+            });
+
             var fullFilename = filename;
             if (filename && RED.settings.fileWorkingDirectory && !path.isAbsolute(filename)) {
                 fullFilename = path.resolve(path.join(RED.settings.fileWorkingDirectory,filename));
@@ -158,7 +174,7 @@ module.exports = function(RED) {
                             done();
                         });
                     }
-                    if (node.filename) {
+                    if (node.filenameType === "str") {
                         // Static filename - write and reuse the stream next time
                         node.wstream.write(buf, function() {
                             nodeSend(msg);
@@ -256,6 +272,7 @@ module.exports = function(RED) {
         // Read a file
         RED.nodes.createNode(this,n);
         this.filename = n.filename;
+        this.filenameType = n.filenameType;
         this.format = n.format;
         this.chunk = false;
         this.encoding = n.encoding || "none";
@@ -270,8 +287,24 @@ module.exports = function(RED) {
         var node = this;
 
         this.on("input",function(msg, nodeSend, nodeDone) {
-            var filename = (node.filename || msg.filename || "").replace(/\t|\r|\n/g,'');
+            var filename = node.filename || "";
+            //Pre V3 compatibility - if filename and filenameType are empty, check msg.filename
+            if(!node.filenameType && !node.filename) {
+                msg.filename = "filename";
+                node.filenameType = "msg";
+            }
+
+            RED.util.evaluateNodeProperty(node.filename,node.filenameType,node,msg,(err,value) => {
+                if (err) {
+                    node.error(err,msg);
+                    return done();
+                } else {
+                    filename = (value || "").replace(/\t|\r|\n/g,'');
+                }
+            });
+
             var fullFilename = filename;
+            var filePath = "";
             if (filename && RED.settings.fileWorkingDirectory && !path.isAbsolute(filename)) {
                 fullFilename = path.resolve(path.join(RED.settings.fileWorkingDirectory,filename));
             }

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.js
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.js
@@ -76,7 +76,7 @@ module.exports = function(RED) {
                     filename = value;
                 }
             });
-
+            filename = filename || "";
             var fullFilename = filename;
             if (filename && RED.settings.fileWorkingDirectory && !path.isAbsolute(filename)) {
                 fullFilename = path.resolve(path.join(RED.settings.fileWorkingDirectory,filename));
@@ -321,7 +321,7 @@ module.exports = function(RED) {
                     filename = (value || "").replace(/\t|\r|\n/g,'');
                 }
             });
-
+            filename = filename || "";
             var fullFilename = filename;
             var filePath = "";
             if (filename && RED.settings.fileWorkingDirectory && !path.isAbsolute(filename)) {

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.js
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.js
@@ -52,10 +52,20 @@ module.exports = function(RED) {
 
         function processMsg(msg,nodeSend, done) {
             var filename = node.filename || "";
-            //Pre V3 compatibility - if filename and filenameType are empty, check msg.filename
-            if(!node.filenameType && !node.filename) {
-                msg.filename = "filename";
-                node.filenameType = "msg";
+            //Pre V3 compatibility - if filenameType is empty, do in place upgrade
+            if(typeof node.filenameType == 'undefined' || node.filenameType == "") {
+                //existing node AND filenameType is not set - inplace (compatible) upgrade
+                if(filename == "") { //was using empty value to denote msg.filename
+                    node.filename = "filename";
+                    node.filenameType = "msg";
+                } else if(/^\${[^}]+}$/.test(filename)) { //was using an ${ENV_VAR}
+                    node.filenameType = "env";
+                    node.filename = filename.replace(/\${([^}]+)}/g, function(match, name) {
+                        return (name === undefined)?"":name;
+                    });
+                } else { //was using a static filename - set typedInput type to str
+                    node.filenameType = "str";
+                }
             }
 
             RED.util.evaluateNodeProperty(node.filename,node.filenameType,node,msg,(err,value) => {
@@ -174,7 +184,7 @@ module.exports = function(RED) {
                             done();
                         });
                     }
-                    if (node.filenameType === "str") {
+                    if (node.filenameType === "str" || node.filenameType === "env") {
                         // Static filename - write and reuse the stream next time
                         node.wstream.write(buf, function() {
                             nodeSend(msg);
@@ -288,12 +298,21 @@ module.exports = function(RED) {
 
         this.on("input",function(msg, nodeSend, nodeDone) {
             var filename = node.filename || "";
-            //Pre V3 compatibility - if filename and filenameType are empty, check msg.filename
-            if(!node.filenameType && !node.filename) {
-                msg.filename = "filename";
-                node.filenameType = "msg";
+            //Pre V3 compatibility - if filenameType is empty, do in place upgrade
+            if(typeof node.filenameType == 'undefined' || node.filenameType == "") {
+                //existing node AND filenameType is not set - inplace (compatible) upgrade
+                if(filename == "") { //was using empty value to denote msg.filename
+                    node.filename = "filename";
+                    node.filenameType = "msg";
+                } else if(/^\${[^}]+}$/.test(filename)) { //was using an ${ENV_VAR}
+                    node.filenameType = "env";
+                    node.filename = filename.replace(/\${([^}]+)}/g, function(match, name) {
+                        return (name === undefined)?"":name;
+                    });
+                } else { //was using a static filename - set typedInput type to str
+                    node.filenameType = "str";
+                }
             }
-
             RED.util.evaluateNodeProperty(node.filename,node.filenameType,node,msg,(err,value) => {
                 if (err) {
                     node.error(err,msg);

--- a/packages/node_modules/@node-red/nodes/locales/en-US/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/storage/10-file.html
@@ -19,6 +19,10 @@
        Alternatively, it can delete the file.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">
+        <dt class="optional">filename <span class="property-type">string</span></dt>
+        <dd>The name of the file to be updated can be provided in the node configuration, or as a message property. 
+            By default it will use <code>msg.filename</code> but this can be customised in the node.
+        </dd>
         <dt class="optional">encoding <span class="property-type">string</span></dt>
         <dd>If encoding is configured to be set by msg, then this optional property can set the encoding.</dt>
     </dl>
@@ -38,6 +42,13 @@
 
 <script type="text/html" data-help-name="file in">
     <p>Reads the contents of a file as either a string or binary buffer.</p>
+    <h3>Inputs</h3>
+    <dl class="message-properties">
+        <dt class="optional">filename <span class="property-type">string</span></dt>
+        <dd>The name of the file to be read can be provided in the node configuration, or as a message property. 
+            By default it will use <code>msg.filename</code> but this can be customised in the node.
+        </dd>
+    </dl>
     <h3>Outputs</h3>
     <dl class="message-properties">
         <dt>payload <span class="property-type">string | buffer</span></dt>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/storage/10-file.html
@@ -19,8 +19,6 @@
        Alternatively, it can delete the file.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">
-        <dt class="optional">filename <span class="property-type">string</span></dt>
-        <dd>If not configured in the node, this optional property sets the name of the file to be updated.</dd>
         <dt class="optional">encoding <span class="property-type">string</span></dt>
         <dd>If encoding is configured to be set by msg, then this optional property can set the encoding.</dt>
     </dl>
@@ -40,11 +38,6 @@
 
 <script type="text/html" data-help-name="file in">
     <p>Reads the contents of a file as either a string or binary buffer.</p>
-    <h3>Inputs</h3>
-    <dl class="message-properties">
-        <dt class="optional">filename <span class="property-type">string</span></dt>
-        <dd>if not set in the node configuration, this property sets the filename to read.</dd>
-    </dl>
     <h3>Outputs</h3>
     <dl class="message-properties">
         <dt>payload <span class="property-type">string | buffer</span></dt>


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

As discussed on forum: https://discourse.nodered.org/t/dynamically-passing-msg-filename-from-watch-node-into-file-in-node/61011/15

### Outline...
* use typedInput for file nodes to reduce the confusion around whether the field should be blank or contain filename to use `msg.filename`

NOTE: I have deliberately excluded `flow.` and `global.` from the typed input as I suspect it would lead to confusion.

## Proposed changes

* continue to operate as per v2 - see demo below
* To auto upgrade file nodes to use the typedInput when opened -  see demo below


### demo...
![chrome_7v23hMRklY](https://user-images.githubusercontent.com/44235289/163676738-b2aeec8f-0b7a-4e60-9b5b-2233245d9d30.gif)

### TODO...
* update tests to cover new properties 
  * The existing tests are all passing:  `√ 195 tests are passing (22s)`

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
