### PR TITLE
Fix importing external module from node-red module

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/util.js
+++ b/packages/node_modules/@node-red/registry/lib/util.js
@@ -16,6 +16,7 @@
 
 const path = require("path");
 const semver = require("semver");
+const url = require("url");
 const {events,i18n,log} = require("@node-red/util");
 
 var runtime;
@@ -53,8 +54,8 @@ function requireModule(name) {
 function importModule(name) {
     var moduleInfo = require("./index").getModuleInfo(name);
     if (moduleInfo && moduleInfo.path) {
-        var relPath = path.relative(__dirname, moduleInfo.path);
-        return import(relPath);
+        const moduleFile = url.pathToFileURL(require.resolve(moduleInfo.path));
+        return import(moduleFile);
     } else {
         // Require it here to avoid the circular dependency
         return require("./externalModules").import(name);


### PR DESCRIPTION
This allows a Node-RED node module (one that provides nodes) to *also* be loaded as an external module in the Function node.

For example, a module may provide a set of nodes and a library for the Function node to help work with the data those nodes produce or consume.

The fix ensures we generate the proper url for the module to take into account the `main` entry in its package.json file.