### PR TITLE
Add support for multiple static paths with optional static root

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/index.js
@@ -207,8 +207,12 @@ function start() {
                 if (settings.readOnly){
                     log.info(log._("settings.readonly-mode"))
                 }
-                if (settings.httpStatic) {
-                    log.info(log._("runtime.paths.httpStatic",{path:path.resolve(settings.httpStatic)}));
+                if (settings.httpStatic && settings.httpStatic.length) {
+                    for (let si = 0; si < settings.httpStatic.length; si++) {
+                        let p = path.resolve(settings.httpStatic[si].path);
+                        let r = settings.httpStatic[si].root || "/";
+                        log.info(log._("runtime.paths.httpStatic",{path:`${p} > ${r}`}));
+                    }
                 }
                 return redNodes.loadContextsPlugin().then(function () {
                     redNodes.loadFlows().then(redNodes.startFlows).catch(function(err) {});

--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -298,6 +298,26 @@ httpsPromise.then(function(startupHttps) {
         settings.httpNodeAuth = settings.httpNodeAuth || settings.httpAuth;
     }
 
+    if(settings.httpStatic) {
+        settings.httpStaticRoot = formatRoot(settings.httpStaticRoot || "/");
+        const statics = Array.isArray(settings.httpStatic) ? settings.httpStatic : [settings.httpStatic];
+        const sanitised = [];
+        for (let si = 0; si < statics.length; si++) {
+            let sp = statics[si];
+            if(typeof sp === "string") {
+                sp = { path: sp, root: "" }
+                sanitised.push(sp);
+            } else if (typeof sp === "object" && sp.path ) {
+                sanitised.push(sp);
+            } else {
+                continue;
+            }
+            sp.subRoot = formatRoot(sp.root);
+            sp.root = formatRoot(path.posix.join(settings.httpStaticRoot,sp.subRoot));
+        }
+        settings.httpStatic = sanitised.length ? sanitised : false;    
+    }
+
     // if we got a port from command line, use it (even if 0)
     // replicate (settings.uiPort = parsedArgs.port||settings.uiPort||1880;) but allow zero
     if (parsedArgs.port !== undefined){
@@ -390,12 +410,28 @@ httpsPromise.then(function(startupHttps) {
     if (settings.httpNodeRoot !== false) {
         app.use(settings.httpNodeRoot,RED.httpNode);
     }
+    // if (settings.httpStatic) {
+    //     settings.httpStaticAuth = settings.httpStaticAuth || settings.httpAuth;
+    //     if (settings.httpStaticAuth) {
+    //         app.use("/",basicAuthMiddleware(settings.httpStaticAuth.user,settings.httpStaticAuth.pass));
+    //     }
+    //     app.use("/",express.static(settings.httpStatic));
+    // }
     if (settings.httpStatic) {
-        settings.httpStaticAuth = settings.httpStaticAuth || settings.httpAuth;
-        if (settings.httpStaticAuth) {
-            app.use("/",basicAuthMiddleware(settings.httpStaticAuth.user,settings.httpStaticAuth.pass));
+        let appUseMem = {};
+        for (let si = 0; si < settings.httpStatic.length; si++) {
+            const sp = settings.httpStatic[si];
+            const filePath = sp.path;
+            const thisRoot = sp.root || "/";
+            if(appUseMem[filePath + "::" + thisRoot]) {
+                continue;// this path and root already registered!
+            }
+            appUseMem[filePath + "::" + thisRoot] = true;
+            if (settings.httpStaticAuth) {
+                app.use(thisRoot, basicAuthMiddleware(settings.httpStaticAuth.user, settings.httpStaticAuth.pass));
+            }
+            app.use(thisRoot, express.static(filePath));
         }
-        app.use("/",express.static(settings.httpStatic));
     }
 
     function getListenPath() {

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -137,6 +137,8 @@ module.exports = {
  *  - httpNodeCors
  *  - httpNodeMiddleware
  *  - httpStatic
+ *  - httpStaticRoot
+ *  - httpStaticCors
  ******************************************************************************/
 
     /** the tcp port that the Node-RED web server is listening on */
@@ -218,8 +220,25 @@ module.exports = {
     /** When httpAdminRoot is used to move the UI to a different root path, the
      * following property can be used to identify a directory of static content
      * that should be served at http://localhost:1880/.
+     * When httpStaticRoot is set differently to httpAdminRoot, there is no need 
+     * to move httpAdminRoot
      */
-    //httpStatic: '/home/nol/node-red-static/',
+    //httpStatic: '/home/nol/node-red-static/', //single static source
+    /* OR multiple static sources can be created using an array of objects... */
+    //httpStatic: [
+    //    {path: '/home/nol/pics/',    root: "/img/"}, 
+    //    {path: '/home/nol/reports/', root: "/doc/"}, 
+    //],
+
+    /**  
+     * All static routes will be appended to httpStaticRoot
+     * e.g. if httpStatic = "/home/nol/docs" and  httpStaticRoot = "/static/"
+     *      then "/home/nol/docs" will be served at "/static/"
+     * e.g. if httpStatic = [{path: '/home/nol/pics/', root: "/img/"}]
+     *      and httpStaticRoot = "/static/"
+     *      then "/home/nol/pics/" will be served at "/static/img/"
+     */
+    //httpStaticRoot: '/static/',
 
 /*******************************************************************************
  * Runtime Settings

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -138,7 +138,6 @@ module.exports = {
  *  - httpNodeMiddleware
  *  - httpStatic
  *  - httpStaticRoot
- *  - httpStaticCors
  ******************************************************************************/
 
     /** the tcp port that the Node-RED web server is listening on */


### PR DESCRIPTION
closes #3510


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Permits single or multiple static source paths and allows each of those to be served from a different root

By adding the `httpStaticRoot` we can avoid the need for changing `httpAdminRoot` when `httpStatic` is enabled.


### Examples...
==========

####  Single path, default root
##### Settings File
```js
    httpStatic: 'c:\\temp',
    //httpStaticRoot: '/',
```

##### Log Output
```log
22 Apr 17:05:34 - [info] HTTP Static    : c:\temp > /
```

<br>

#### Multiple paths, alternative base root
##### Settings File
```js
    httpStatic: [{path:'c:\\temp'}, {path:'c:\\tmp'}],
    httpStaticRoot: '/static_stuff/',
```

##### Log Output
```log
22 Apr 17:05:34 - [info] HTTP Static    : c:\temp > /static_stuff/
22 Apr 17:05:34 - [info] HTTP Static    : c:\tmp > /static_stuff/
```

<br>

#### Multiple paths with default root and individual root
##### Settings File
```js
    httpStatic: [{path:'c:\\temp', root: "/stuff/"}, {path:'c:\\tmp', root: "/other/"}],
    //httpStaticRoot: '/',
```

##### Log Output
```log
22 Apr 17:05:34 - [info] HTTP Static    : c:\temp > /stuff/
22 Apr 17:05:34 - [info] HTTP Static    : c:\tmp > /other/
```

<br>


#### Multiple paths with base root and individual root
##### Settings File
```js
    httpStatic: [{path:'c:\\temp', root: "/stuff/"}, {path:'c:\\tmp', root: "/other/"}],
    httpStaticRoot: '/static/',
```

##### Log Output
```log
22 Apr 17:05:34 - [info] HTTP Static    : c:\temp > /static/stuff/
22 Apr 17:05:34 - [info] HTTP Static    : c:\tmp > /static/other/
```

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
