### PR TITLE
Add SASS variables for config nodes label color

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
@@ -204,7 +204,6 @@ $node-border-placeholder: #aaa;
 $node-background-placeholder: #eee;
 
 $node-config-label-color: $node-label-color;
-$node-config-border: $node-border;
 
 $node-port-background: #d9d9d9;
 $node-port-background-hover: #eee;

--- a/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
@@ -203,6 +203,9 @@ $node-border-unknown: #f33;
 $node-border-placeholder: #aaa;
 $node-background-placeholder: #eee;
 
+$node-config-label-color: $node-label-color;
+$node-config-border: $node-border;
+
 $node-port-background: #d9d9d9;
 $node-port-background-hover: #eee;
 $node-icon-color: #fff;

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
@@ -37,7 +37,6 @@ ul.red-ui-sidebar-node-config-list {
     }
     .red-ui-palette-node {
         overflow: hidden;
-        border-color: $node-config-border;
 
         &.selected {
             border-color: transparent;

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
@@ -37,6 +37,7 @@ ul.red-ui-sidebar-node-config-list {
     }
     .red-ui-palette-node {
         overflow: hidden;
+        border-color: $node-config-border;
 
         &.selected {
             border-color: transparent;
@@ -50,6 +51,7 @@ ul.red-ui-sidebar-node-config-list {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        color: $node-config-label-color;
     }
     .red-ui-palette-icon-container {
         font-size: 12px;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

As mentioned on Slack, the nodes in the config nodes tab don’t have SASS variables to change their label and border colors. This PR fixes that.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
