### PR TITLE
Add client and Runtime MQTT topic validation and fix subsequent connection lockup (that arises due to bad birth/will topic)

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
@@ -452,7 +452,17 @@
         }
         return defaultContentType || 'none'
     }
-
+    /**
+     * Test a topic string is valid for publishing
+     * @param {string} topic
+     * @returns `true` if it is a valid topic
+     */
+    function validateMQTTPublishTopic(topic) {
+        if(!topic || topic == "") {
+            return true;
+        }
+        return !/[\+#\b\f\n\r\t\v\0]/.test(topic);
+    }
     RED.nodes.registerType('mqtt-broker',{
         category: 'config',
         defaults: {
@@ -487,17 +497,17 @@
                 label: RED._("node-red:mqtt.label.keepalive"),
                 validate:RED.validators.number(false)},
             cleansession: {value: true},
-            birthTopic: {value:""},
+            birthTopic: {value:"", validate:validateMQTTPublishTopic},
             birthQos: {value:"0"},
             birthRetain: {value:false},
             birthPayload: {value:""},
             birthMsg: { value: {}},
-            closeTopic: {value:""},
+            closeTopic: {value:"", validate:validateMQTTPublishTopic},
             closeQos: {value:"0"},
             closeRetain: {value:false},
             closePayload: {value:""},
             closeMsg: { value: {}},
-            willTopic: {value:""},
+            willTopic: {value:"", validate:validateMQTTPublishTopic},
             willQos: {value:"0"},
             willRetain: {value:false},
             willPayload: {value:""},
@@ -856,7 +866,7 @@
         category: 'network',
         defaults: {
             name: {value:""},
-            topic: {value:""},
+            topic: {value:"", validate:validateMQTTPublishTopic},
             qos: {value:""},
             retain: {value:""},
             respTopic: {value:""},

--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
@@ -457,11 +457,11 @@
      * @param {string} topic
      * @returns `true` if it is a valid topic
      */
-    function validateMQTTPublishTopic(topic) {
-        if(!topic || topic == "") {
+    function validateMQTTPublishTopic(topic, opts) {
+        if(!topic || topic == "" || !/[\+#\b\f\n\r\t\v\0]/.test(topic)) {
             return true;
         }
-        return !/[\+#\b\f\n\r\t\v\0]/.test(topic);
+        return RED._("node-red:mqtt.errors.invalid-topic");
     }
     RED.nodes.registerType('mqtt-broker',{
         category: 'config',

--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -91,12 +91,21 @@ module.exports = function(RED) {
     }
 
     /**
-     * Test a topic string is valid
+     * Test a topic string is valid for subscription
      * @param {string} topic
      * @returns `true` if it is a valid topic
      */
     function isValidSubscriptionTopic(topic) {
-        return /^(#$|(\+|[^+#]*)(\/(\+|[^+#]*))*(\/(\+|#|[^+#]*))?$)/.test(topic)
+        return /^(#$|(\+|[^+#]*)(\/(\+|[^+#]*))*(\/(\+|#|[^+#]*))?$)/.test(topic);
+    }
+
+    /**
+     * Test a topic string is valid for publishing
+     * @param {string} topic
+     * @returns `true` if it is a valid topic
+     */
+    function isValidPublishTopic(topic) {
+        return !/[\+#\b\f\n\r\t\v\0]/.test(topic);
     }
 
     /**
@@ -340,38 +349,15 @@ module.exports = function(RED) {
                     msg.messageExpiryInterval = node.messageExpiryInterval;
                 }
             }
-            if (msg.userProperties && typeof msg.userProperties !== "object") {
-                delete msg.userProperties;
-            }
-            if (hasProperty(msg, "topicAlias") && !isNaN(msg.topicAlias) && (msg.topicAlias === 0 || bsp.topicAliasMaximum === 0 || msg.topicAlias > bsp.topicAliasMaximum)) {
-                delete msg.topicAlias;
-            }
-
             if (hasProperty(msg, "payload")) {
-
-                //check & sanitise topic
-                let topicOK = hasProperty(msg, "topic") && (typeof msg.topic === "string") && (msg.topic !== "");
-
-                if (!topicOK && v5) {
-                    //NOTE: A value of 0 (in server props topicAliasMaximum) indicates that the Server does not accept any Topic Aliases on this connection
-                    if (hasProperty(msg, "topicAlias") && !isNaN(msg.topicAlias) && msg.topicAlias >= 0 && bsp.topicAliasMaximum && bsp.topicAliasMaximum >= msg.topicAlias) {
-                        topicOK = true;
-                        msg.topic = ""; //must be empty string
-                    } else if (hasProperty(msg, "responseTopic") && (typeof msg.responseTopic === "string") && (msg.responseTopic !== "")) {
-                        //TODO: if topic is empty but responseTopic has a string value, use that instead. Is this desirable?
-                        topicOK = true;
-                        msg.topic = msg.responseTopic;
-                        //TODO: delete msg.responseTopic - to prevent it being resent?
+                // send the message
+                node.brokerConn.publish(msg, function(err) {
+                    if(err && err.warn) {
+                        node.warn(err);
+                        return;
                     }
-                }
-                topicOK = topicOK && !/[\+#\b\f\n\r\t\v\0]/.test(msg.topic);
-
-                if (topicOK) {
-                    node.brokerConn.publish(msg, done); // send the message
-                } else {
-                    node.warn(RED._("mqtt.errors.invalid-topic"));
-                    done();
-                }
+                    done(err);
+                }); 
             } else {
                 done();
             }
@@ -827,31 +813,46 @@ module.exports = function(RED) {
             }
         };
         node.disconnect = function (callback) {
-            const _callback = function (resetNodeConnectedState) {
-                setStatusDisconnected(node, true);
-                if(resetNodeConnectedState) {
-                    node.closing = true;
-                    node.connecting = false;
-                    node.connected = false;
+            const _callback = function () {
+                if(node.connected || node.connecting) {
+                    setStatusDisconnected(node, true);
                 }
+                if(node.client) { node.client.removeAllListeners(); }
+                node.connecting = false;
+                node.connected = false;
                 callback && typeof callback == "function" && callback();
             };
+            if(!node.client) { return _callback(); }
+            if(node.closing) { return _callback(); }
 
-            if(node.closing) {
-                return _callback(false);
-            }
-            var endCallBack = function endCallBack() {
-            }
+            let waitEnd = (client, ms) => {
+                return new Promise( (resolve, reject) => {
+                    node.closing = true;
+                    if(!client) { 
+                        resolve();
+                     } else {
+                         const t = setTimeout(reject, ms);
+                         client.end(() => {
+                             clearTimeout(t);
+                             resolve()
+                         });
+                     }
+                });
+            };
             if(node.connected && node.closeMessage) {
                 node.publish(node.closeMessage, function (err) {
-                    node.client.end(endCallBack);
-                    _callback(true);
+                    waitEnd(node.client, 2000).then(() => {
+                        _callback();
+                    }).catch((e) => {
+                        _callback();
+                    })
                 });
-            } else if(node.connected) {
-                node.client.end(endCallBack);
-                _callback(true);
             } else {
-                _callback(false);
+                waitEnd(node.client, 2000).then(() => {
+                    _callback();
+                }).catch((e) => {
+                    _callback();
+                })
             }
         }
         node.subscriptionIds = {};
@@ -933,8 +934,18 @@ module.exports = function(RED) {
                     qos: msg.qos || 0,
                     retain: msg.retain || false
                 };
+                let topicOK = hasProperty(msg, "topic") && (typeof msg.topic === "string") && (isValidPublishTopic(msg.topic));
                 //https://github.com/mqttjs/MQTT.js/blob/master/README.md#mqttclientpublishtopic-message-options-callback
                 if(node.options.protocolVersion == 5) {
+                    const bsp = node.serverProperties || {};
+                    if (msg.userProperties && typeof msg.userProperties !== "object") {
+                        delete msg.userProperties;
+                    }
+                    if (hasProperty(msg, "topicAlias") && !isNaN(Number(msg.topicAlias))) {
+                        msg.topicAlias = parseInt(msg.topicAlias);
+                    } else {
+                        delete msg.topicAlias;
+                    }
                     options.properties = options.properties || {};
                     setStrProp(msg, options.properties, "responseTopic");
                     setBufferProp(msg, options.properties, "correlationData");
@@ -944,29 +955,46 @@ module.exports = function(RED) {
                     setIntProp(msg, options.properties, "topicAlias", 1, node.serverProperties.topicAliasMaximum || 0);
                     setBoolProp(msg, options.properties, "payloadFormatIndicator");
                     //FUTURE setIntProp(msg, options.properties, "subscriptionIdentifier", 1, 268435455);
-                    if (options.properties.topicAlias) {
-                        if (!node.topicAliases.hasOwnProperty(options.properties.topicAlias) && msg.topic == "") {
+
+                    //check & sanitise topic
+                    if (topicOK && options.properties.topicAlias) {
+                        let aliasValid = (bsp.topicAliasMaximum && bsp.topicAliasMaximum >= options.properties.topicAlias);
+                        if (!aliasValid) {
                             done("Invalid topicAlias");
                             return
                         }
                         if (node.topicAliases[options.properties.topicAlias] === msg.topic) {
-                            msg.topic = ""
+                            msg.topic = "";
                         } else {
-                            node.topicAliases[options.properties.topicAlias] = msg.topic
+                            node.topicAliases[options.properties.topicAlias] = msg.topic;
                         }
+                    } else if (!msg.topic && options.properties.responseTopic) {
+                        msg.topic = msg.responseTopic;
+                        topicOK = isValidPublishTopic(msg.topic);
+                        delete msg.responseTopic; //prevent responseTopic being resent?
                     }
                 }
 
-                node.client.publish(msg.topic, msg.payload, options, function(err) {
-                    done && done(err);
-                    return
-                });
+                if (topicOK) {
+                    node.client.publish(msg.topic, msg.payload, options, function(err) {
+                        done && done(err);
+                        return
+                    });
+                } else {
+                    const error = new Error(RED._("mqtt.errors.invalid-topic"));
+                    error.warn = true;
+                    done(error);
+                }
             }
         };
 
         node.on('close', function(done) {
-            node.closing = true;
-            node.disconnect(done);
+            node.disconnect(function() {
+                if(node.client) {
+                    node.client.removeAllListeners();
+                }
+                done();
+            }, true);
         });
 
     }
@@ -1143,6 +1171,7 @@ module.exports = function(RED) {
                         node.brokerConn.unsubscribe(node.topic,node.id, removed);
                     }
                     node.brokerConn.deregister(node, done);
+                    node.brokerConn = null;
                 } else {
                     done();
                 }
@@ -1207,6 +1236,7 @@ module.exports = function(RED) {
             node.on('close', function(done) {
                 if (node.brokerConn) {
                     node.brokerConn.deregister(node,done);
+                    node.brokerConn = null;
                 } else {
                     done();
                 }


### PR DESCRIPTION
closes #3557

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

1. Validate topics in client side
1. Validate topics in runtime
   1. Required some de-duplication & re-arranging of code in `doPublish` and `node.publish`
   2. This was necessary as the existing code for checking a topic at runtime was in `doPublish` but was required for both `doPublish` and `node.publish`.  
      **NOTE:** All code in  `doPublish()` was originally inside the MQTT OUT `on("input", ...` event but was refactored to `doPublish()` when the Dynamic MQTT was under design. If you recall, there was a design note for the MQTT IN node (when in dynamic mode) to ALSO perform a publish. So the code was refactored to be called by both the MQTT IN (via the `action` property) and of-course the MQTT OUT.  When we dropped the `publish` `action`, it made little sense to revert the refactoring.
4. Better disconnection detection (using promise instead of callback)
   1. The callback from `client.end` depending on internal state of the MQTT broker (e.g. connecting to unknown broker) is unreliable. The change from callback to promise includes a timeout to ensure `done()` is called otherwise the nodes internal state and client status become out of sync
5. Update tests
    1. none of the actual tests have changed, only the way the connection test is performed. I was experiencing issues while waiting for the broker connect during tests. Tests are functionally the same. 
    3. All original 28 tests are still passing. 

## Checklist


- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
