### PR TITLE
Don't let themes change node config colors

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
@@ -212,6 +212,7 @@ $node-icon-background-color-opacity: 0.05;
 $node-icon-border-color: #000;
 $node-icon-border-color-opacity: 0.1;
 
+$node-config-background: #f3f3f3;
 
 $node-link-port-background: #eee;
 

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
@@ -54,7 +54,7 @@ ul.red-ui-sidebar-node-config-list {
     .red-ui-palette-icon-container {
         font-size: 12px;
         line-height: 30px;
-        background-color: $secondary-background-selected;
+        background-color: $node-icon-background-color;
         border-top-right-radius: 4px;
         border-bottom-right-radius: 4px;
         a {
@@ -63,10 +63,10 @@ ul.red-ui-sidebar-node-config-list {
             bottom: 0;
             left: 0;
             right: 0;
-            color: $secondary-text-color;
+            color: $node-port-label-color;
             &:hover {
                 text-decoration: none;
-                background: $secondary-background-hover;
+                background: $node-port-background-hover;
             }
         }
     }
@@ -74,7 +74,7 @@ ul.red-ui-sidebar-node-config-list {
 .red-ui-palette-node-config {
     width: 160px;
     height: 30px;
-    background: $primary-background;
+    background: $node-config-background;
     color: $primary-text-color;
     cursor: pointer;
 }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Based on #3270 and the discussion in #3555, it seems to be a better option to prevent themes from changing the colors of configuration nodes. This PR does that.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
