### PR TITLE
Add "search for" buttons to notifications

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/de/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/de/editor.json
@@ -186,7 +186,7 @@
             "no-thanks": "Nein, Danke",
             "create-default-project": "Standardprojektdateien erstellen",
             "show-merge-conflicts": "Merge-Konflikte anzeigen",
-            "unknownNodesButton": "Search for unknown nodes"
+            "unknownNodesButton": "Finden Sie unbekannte nodes"
         }
     },
     "clipboard": {

--- a/packages/node_modules/@node-red/editor-client/locales/de/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/de/editor.json
@@ -185,7 +185,8 @@
             "create-default-package": "Standardpaketdatei erstellen",
             "no-thanks": "Nein, Danke",
             "create-default-project": "Standardprojektdateien erstellen",
-            "show-merge-conflicts": "Merge-Konflikte anzeigen"
+            "show-merge-conflicts": "Merge-Konflikte anzeigen",
+            "unknownNodesButton": "Search for unknown nodes"
         }
     },
     "clipboard": {
@@ -269,7 +270,9 @@
         "successfulRestart": "Flows erfolgreich neugestartet",
         "deployFailed": "Übernahme (deploy) fehlgeschlagen: __message__",
         "unusedConfigNodes": "Einige Konfigurations-Nodes werden nicht verwendet.",
-        "unusedConfigNodesLink": "Hier klicken, um sie anzuschauen.",
+        "unusedConfigNodesButton":"Finden Sie ungenutzte konfig nodes",
+        "unknownNodesButton":"Finden Sie unbekannte nodes",
+        "invalidNodesButton":"Finden Sie ungültige nodes",
         "errors": {
             "noResponse": "Keine Antwort vom Server"
         },

--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -217,7 +217,8 @@
             "create-default-package": "Create default package file",
             "no-thanks": "No thanks",
             "create-default-project": "Create default project files",
-            "show-merge-conflicts": "Show merge conflicts"
+            "show-merge-conflicts": "Show merge conflicts",
+            "unknownNodesButton": "Search for unknown nodes"
         }
     },
     "clipboard": {
@@ -301,7 +302,9 @@
         "successfulRestart": "Successfully restarted flows",
         "deployFailed": "Deploy failed: __message__",
         "unusedConfigNodes":"You have some unused configuration nodes.",
-        "unusedConfigNodesLink":"Click here to see them",
+        "unusedConfigNodesButton":"Search unused config nodes",
+        "unknownNodesButton":"Search for unknown nodes",
+        "invalidNodesButton":"Search for invalid nodes",
         "errors": {
             "noResponse": "no response from server"
         },

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -217,7 +217,8 @@
             "create-default-package": "デフォルトパッケージファイルの作成",
             "no-thanks": "不要",
             "create-default-project": "デフォルトプロジェクトファイルの作成",
-            "show-merge-conflicts": "マージ競合を表示"
+            "show-merge-conflicts": "マージ競合を表示",
+            "unknownNodesButton": "不明なノードを検索する"
         }
     },
     "clipboard": {
@@ -301,7 +302,9 @@
         "successfulRestart": "フローの再起動が成功しました",
         "deployFailed": "デプロイが失敗しました: __message__",
         "unusedConfigNodes": "使われていない設定ノードがあります。",
-        "unusedConfigNodesLink": "設定を参照する",
+        "unusedConfigNodesButton":"未使用の構成ノードを検索",
+        "unknownNodesButton":"不明なノードを検索する",
+        "invalidNodesButton":"無効なノードを検索する",
         "errors": {
             "noResponse": "サーバの応答がありません"
         },

--- a/packages/node_modules/@node-red/editor-client/locales/ko/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ko/editor.json
@@ -141,7 +141,8 @@
       "create-default-package": "기본 패키지 파일 생성",
       "no-thanks": "괜찮습니다",
       "create-default-project": "기본 프로젝트 파일 생성",
-      "show-merge-conflicts": "병합 충돌 보여주기"
+      "show-merge-conflicts": "병합 충돌 보여주기",
+      "unknownNodesButton": "알 수 없는 노드 검색"
     }
   },
   "clipboard": {
@@ -203,7 +204,9 @@
     "successfulRestart": "플로우 재시작을 성공했습니다",
     "deployFailed": "배포 실패 : __message__",
     "unusedConfigNodes": "사용되지 않는 설정노드가 있습니다",
-    "unusedConfigNodesLink": "여기를 클릭하면 볼 수 있습니다",
+    "unusedConfigNodesButton":"사용하지 않는 구성 노드 검색",
+    "unknownNodesButton":"알 수 없는 노드 검색",
+    "invalidNodesButton":"잘못된 노드 검색",
     "errors": {
       "noResponse": "서버의 응답이 없습니다"
     },

--- a/packages/node_modules/@node-red/editor-client/locales/ru/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ru/editor.json
@@ -183,7 +183,8 @@
             "create-default-package": "Создать файл пакета по умолчанию",
             "no-thanks": "Нет, спасибо",
             "create-default-project": "Создать файлы проекта по умолчанию",
-            "show-merge-conflicts": "Показать конфликты слияния"
+            "show-merge-conflicts": "Показать конфликты слияния",
+            "unknownNodesButton": "Поиск неизвестных узлов"
         }
     },
     "clipboard": {
@@ -277,7 +278,9 @@
         "successfulRestart": "Потоки успешно перезапущены",
         "deployFailed": "Развертывание не удалось: __message__",
         "unusedConfigNodes":"У вас есть неиспользуемых узлы конфигурации.",
-        "unusedConfigNodesLink":"Нажмите здесь, чтобы их увидеть",
+        "unusedConfigNodesButton":"Поиск неиспользуемых узлов конфигурации",
+        "unknownNodesButton":"Поиск неизвестных узлов",
+        "invalidNodesButton":"Поиск недопустимых узлов",
         "errors": {
             "noResponse": "нет ответа от сервера"
         },

--- a/packages/node_modules/@node-red/editor-client/locales/zh-CN/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/zh-CN/editor.json
@@ -182,7 +182,8 @@
             "create-default-package": "创建默认的包文件",
             "no-thanks": "不了，谢谢",
             "create-default-project": "创建默认项目文件",
-            "show-merge-conflicts": "显示合并冲突"
+            "show-merge-conflicts": "显示合并冲突",
+            "unknownNodesButton": "搜索未知节点"
         }
     },
     "clipboard": {
@@ -264,7 +265,9 @@
         "successfulRestart": "成功重启流程",
         "deployFailed": "部署失败: __message__",
         "unusedConfigNodes": "您有一些未使用的配置节点",
-        "unusedConfigNodesLink": "点击此处查看它们",
+        "unusedConfigNodesButton":"搜索未使用的配置节点",
+        "unknownNodesButton":"搜索未知节点",
+        "invalidNodesButton":"搜索无效节点",
         "errors": {
             "noResponse": "服务器没有响应"
         },

--- a/packages/node_modules/@node-red/editor-client/locales/zh-TW/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/zh-TW/editor.json
@@ -182,7 +182,8 @@
             "create-default-package": "創建默認的包文件",
             "no-thanks": "不了，謝謝",
             "create-default-project": "創建默認項目文件",
-            "show-merge-conflicts": "顯示合併衝突"
+            "show-merge-conflicts": "顯示合併衝突",
+            "unknownNodesButton": "搜索未知節點"
         }
     },
     "clipboard": {
@@ -264,7 +265,9 @@
         "successfulRestart": "成功重啟流程",
         "deployFailed": "部署失敗: __message__",
         "unusedConfigNodes": "您有一些未使用的配置節點",
-        "unusedConfigNodesLink": "點擊此處查看它們",
+        "unusedConfigNodesButton":"搜索未使用的配置節點",
+        "unknownNodesButton":"搜索未知節點",
+        "invalidNodesButton":"搜索無效節點",
         "errors": {
             "noResponse": "伺服器沒有回應"
         },

--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -361,7 +361,7 @@ var RED = (function() {
                                     text: RED._("notification.label.unknownNodesButton"),
                                     class: "pull-left",
                                     click: function() {
-                                        RED.actions.invoke("core:search", "type:unknown");
+                                        RED.actions.invoke("core:search", "type:unknown ");
                                     }
                                 },
                                 {

--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -358,6 +358,14 @@ var RED = (function() {
                         } else {
                             options.buttons = [
                                 {
+                                    text: RED._("notification.label.unknownNodesButton"),
+                                    class: "pull-left",
+                                    click: function() {
+                                        RED.actions.invoke("core:search", "type:unknown");
+                                    }
+                                },
+                                {
+                                    class: "primary",
                                     text: RED._("common.label.close"),
                                     click: function() {
                                         persistentNotifications[notificationId].hideNotification();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -387,6 +387,7 @@ RED.deploy = (function() {
                         text: RED._("deploy.unknownNodesButton"),
                         class: "pull-left",
                         click: function() {
+                            notification.close();
                             RED.actions.invoke("core:search","type:unknown ");
                         }
                     },
@@ -487,6 +488,7 @@ RED.deploy = (function() {
                             text: RED._("deploy.unusedConfigNodesButton"),
                             class: "pull-left",
                             click: function() {
+                                notification.close();
                                 RED.actions.invoke("core:search","is:config is:unused ");
                             }
                         },

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -387,7 +387,7 @@ RED.deploy = (function() {
                         text: RED._("deploy.unknownNodesButton"),
                         class: "pull-left",
                         click: function() {
-                            RED.actions.invoke("core:search","type:unknown");
+                            RED.actions.invoke("core:search","type:unknown ");
                         }
                     },
                     {
@@ -414,7 +414,7 @@ RED.deploy = (function() {
                         class: "pull-left",
                         click: function() {
                             notification.close();
-                            RED.actions.invoke("core:search","is:invalid");
+                            RED.actions.invoke("core:search","is:invalid ");
                         }
                     },
                     {
@@ -486,7 +486,7 @@ RED.deploy = (function() {
                             text: RED._("deploy.unusedConfigNodesButton"),
                             class: "pull-left",
                             click: function() {
-                                RED.actions.invoke("core:search","is:config is:unused");
+                                RED.actions.invoke("core:search","is:config is:unused ");
                             }
                         },
                         {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -384,6 +384,13 @@ RED.deploy = (function() {
 
                 notificationButtons = [
                     {
+                        text: RED._("deploy.unknownNodesButton"),
+                        class: "pull-left",
+                        click: function() {
+                            RED.actions.invoke("core:search","type:unknown");
+                        }
+                    },
+                    {
                         id: "red-ui-deploy-dialog-confirm-deploy-deploy",
                         text: RED._("deploy.confirm.button.confirm"),
                         class: "primary",
@@ -402,6 +409,14 @@ RED.deploy = (function() {
                     RED._('deploy.confirm.confirm') +
                     "</p>";
                 notificationButtons = [
+                    {
+                        text: RED._("deploy.invalidNodesButton"),
+                        class: "pull-left",
+                        click: function() {
+                            notification.close();
+                            RED.actions.invoke("core:search","is:invalid");
+                        }
+                    },
                     {
                         id: "red-ui-deploy-dialog-confirm-deploy-deploy",
                         text: RED._("deploy.confirm.button.confirm"),
@@ -462,9 +477,31 @@ RED.deploy = (function() {
             RED.nodes.version(data.rev);
             RED.nodes.originalFlow(nns);
             if (hasUnusedConfig) {
+                const opts = {
+                    type: "success",
+                    fixed: false,
+                    timeout: 6000,
+                    buttons: [
+                        {
+                            text: RED._("deploy.unusedConfigNodesButton"),
+                            class: "pull-left",
+                            click: function() {
+                                RED.actions.invoke("core:search","is:config is:unused");
+                            }
+                        },
+                        {
+                            text: RED._("common.label.close"),
+                            class: "primary",
+                            click: function () {
+                                save(true);
+                                notification.close();
+                            }
+                        }
+                    ]
+                }
                 RED.notify(
                     '<p>' + RED._("deploy.successfulDeploy") + '</p>' +
-                    '<p>' + RED._("deploy.unusedConfigNodes") + ' <a href="#" onclick="RED.sidebar.config.show(true); return false;">' + RED._("deploy.unusedConfigNodesLink") + '</a></p>', "success", false, 6000);
+                    '<p>' + RED._("deploy.unusedConfigNodes") + '</p>', opts);
             } else {
                 RED.notify('<p>' + RED._("deploy.successfulDeploy") + '</p>', "success");
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -477,6 +477,7 @@ RED.deploy = (function() {
             RED.nodes.version(data.rev);
             RED.nodes.originalFlow(nns);
             if (hasUnusedConfig) {
+                let notification;
                 const opts = {
                     type: "success",
                     fixed: false,
@@ -499,7 +500,7 @@ RED.deploy = (function() {
                         }
                     ]
                 }
-                RED.notify(
+                notification = RED.notify(
                     '<p>' + RED._("deploy.successfulDeploy") + '</p>' +
                     '<p>' + RED._("deploy.unusedConfigNodes") + '</p>', opts);
             } else {


### PR DESCRIPTION

## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Proposed changes

As discussed here: https://discourse.nodered.org/t/flows-stopped-due-to-missing-node-types-a-feature-suggestion-to-help/61995

Adds buttons...
        * "Search unused config nodes",
        * "Search for unknown nodes",
        * "Search for invalid nodes",


### Before deploy notifications...

#### 1. deploying bad import
![image](https://user-images.githubusercontent.com/44235289/166153735-3922d5a0-893b-4a4e-b528-ffea42cf8a4a.png)


#### 2. deploying misconfigured nodes
![image](https://user-images.githubusercontent.com/44235289/166153744-dbe6a875-8d57-4b45-a150-d73a388ad12b.png)


### After deploy notifications...

#### 3. stopped due to missing/unknown node types
![image](https://user-images.githubusercontent.com/44235289/166153748-aa2a32b0-e20d-4564-a68f-e4ffbf2f4aad.png)

#### 4. successful deploy but unused config nodes remain
![image](https://user-images.githubusercontent.com/44235289/166153753-be132fd3-b610-4271-af7b-4d2fd0512655.png)



### Other stuff
* Look at last two screenshots. 
  * 3. has no primary accent (white) on the <kbd>close</kbd> button (this is original condition)
  * 4. has primary accent (red) on the <kbd>close</kbd> button (this is new - this notification never had a close button)
  * **Which is preferable?**
* When clicking the "Search for xxxxx" should the notification close or remain open?



## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
