### PR TITLE
fix error on system-info action

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/api/diagnostics.js
+++ b/packages/node_modules/@node-red/runtime/lib/api/diagnostics.js
@@ -165,7 +165,7 @@ function buildDiagnosticReport(scope, callback) {
 
     /** gets a sanitised list containing only the module name */
     function listContextModules() {
-        const keys = Object.keys(runtime.settings.contextStorage);
+        const keys = Object.keys(runtime.settings.contextStorage || {});
         const result = {};
         keys.forEach(e => {
             result[e] = {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Calling `show-system-info` action causes ` TypeError: Cannot convert undefined or null to object` if `contextStorage` is not defined in settings.  This PR tries to fix the issue.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
