### PR TITLE
Fix junction: when wiring from a regular nodes INPUT, backwards to a junction

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -2918,7 +2918,7 @@ RED.view = (function() {
                     } else if (drag_line.portType === PORT_TYPE_INPUT) {
                         src = mouseup_node;
                         dst = drag_line.node;
-                        src_port = portIndex;
+                        src_port = portIndex || 0;
                     }
                     var link = {source: src, sourcePort:src_port, target: dst};
                     if (drag_line.virtualLink) {


### PR DESCRIPTION
fixes #3587


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Ensure `sourcePort` is not undefined when linking from a regular nodes INPUT, backwards to a junction. 

Where it was falling down was in `addLink` [here](https://github.com/node-red/node-red/blob/b918b75414fb9a393a19c3f8b6a539b19fd0a62d/packages/node_modules/@node-red/editor-client/src/js/nodes.js#L610-L620) because `sourcePort`  of the junction node was undefined, this `isUnique` test considered it unique & returned without linking.

```js
        if (nodeLinks[l.source.id]) {
            const isUnique = nodeLinks[l.source.id].out.every(function(link) {
                return link.sourcePort !== l.sourcePort || link.target.id !== l.target.id
            })
            if (!isUnique) {
                return  //<< HERE
            }
        }
```

The fix chosen was to ensure `sourcePort` is set to `0` [here](https://github.com/node-red/node-red/blob/b918b75414fb9a393a19c3f8b6a539b19fd0a62d/packages/node_modules/%40node-red/editor-client/src/js/ui/view.js#L2921) if undefined (i.e. `src_port = portIndex || 0;`) but TBH, this probably could be handled in the `isUnique` test or further up in `view.js` where `portIndex` is defined.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
