### PR TITLE
Fix image paths where `red/image/typedInput/XXXX.png` should be `red/image/typedInput/XXXX.svg`

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/json.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/json.js
@@ -311,8 +311,8 @@
                 types:[
                     'str','num','bool',
                     {value:"null",label:RED._("common.type.null"),hasValue:false},
-                    {value:"array",label:RED._("common.type.array"),hasValue:false,icon:"red/images/typedInput/json.png"},
-                    {value:"object",label:RED._("common.type.object"),hasValue:false,icon:"red/images/typedInput/json.png"}
+                    {value:"array",label:RED._("common.type.array"),hasValue:false,icon:"red/images/typedInput/json.svg"},
+                    {value:"object",label:RED._("common.type.object"),hasValue:false,icon:"red/images/typedInput/json.svg"}
                 ],
                 default: valType
             });

--- a/packages/node_modules/@node-red/nodes/99-sample.html.demo
+++ b/packages/node_modules/@node-red/nodes/99-sample.html.demo
@@ -69,7 +69,7 @@
         outputs:1,              // set the number of outputs - 0 to n
         color: "#ddd",          // set icon color
         // set the icon (held in icons dir below where you save the node)
-        icon: "myicon.png",     // saved in  icons/myicon.png
+        icon: "myicon.svg",     // saved in  icons/myicon.svg
         label: function() {     // sets the default label contents
             return this.name||this.topic||"sample";
         },

--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.html
@@ -146,13 +146,13 @@
 
     function createTypeValueField(row, defaultType){
         return $('<input/>',{class:"node-input-rule-type-value",type:"text",style:"width: 100%;"}).appendTo(row).typedInput({default:defaultType || 'string',types:[
-            {value:"string",label:RED._("common.type.string"),hasValue:false,icon:"red/images/typedInput/az.png"},
-            {value:"number",label:RED._("common.type.number"),hasValue:false,icon:"red/images/typedInput/09.png"},
-            {value:"boolean",label:RED._("common.type.boolean"),hasValue:false,icon:"red/images/typedInput/bool.png"},
-            {value:"array",label:RED._("common.type.array"),hasValue:false,icon:"red/images/typedInput/json.png"},
-            {value:"buffer",label:RED._("common.type.buffer"),hasValue:false,icon:"red/images/typedInput/bin.png"},
-            {value:"object",label:RED._("common.type.object"),hasValue:false,icon:"red/images/typedInput/json.png"},
-            {value:"json",label:RED._("common.type.jsonString"),hasValue:false,icon:"red/images/typedInput/json.png"},
+            {value:"string",label:RED._("common.type.string"),hasValue:false,icon:"red/images/typedInput/az.svg"},
+            {value:"number",label:RED._("common.type.number"),hasValue:false,icon:"red/images/typedInput/09.svg"},
+            {value:"boolean",label:RED._("common.type.boolean"),hasValue:false,icon:"red/images/typedInput/bool.svg"},
+            {value:"array",label:RED._("common.type.array"),hasValue:false,icon:"red/images/typedInput/json.svg"},
+            {value:"buffer",label:RED._("common.type.buffer"),hasValue:false,icon:"red/images/typedInput/bin.svg"},
+            {value:"object",label:RED._("common.type.object"),hasValue:false,icon:"red/images/typedInput/json.svg"},
+            {value:"json",label:RED._("common.type.jsonString"),hasValue:false,icon:"red/images/typedInput/json.svg"},
             {value:"undefined",label:RED._("common.type.undefined"),hasValue:false},
             {value:"null",label:RED._("common.type.null"),hasValue:false}
         ]});

--- a/packages/node_modules/@node-red/nodes/core/network/21-httpin.html
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httpin.html
@@ -129,7 +129,7 @@
     var headerTypes = [
         {value:"content-type",label:"Content-Type",hasValue: false},
         {value:"location",label:"Location",hasValue: false},
-        {value:"other",label:RED._("node-red:httpin.label.other"),icon:"red/images/typedInput/az.png"}
+        {value:"other",label:RED._("node-red:httpin.label.other"),icon:"red/images/typedInput/az.svg"}
        ]
     var contentTypes = [
         {value:"application/json",label:"application/json",hasValue: false},
@@ -139,7 +139,7 @@
         {value:"text/plain",label:"text/plain",hasValue: false},
         {value:"image/gif",label:"image/gif",hasValue: false},
         {value:"image/png",label:"image/png",hasValue: false},
-        {value:"other",label:RED._("node-red:httpin.label.other"),icon:"red/images/typedInput/az.png"}
+        {value:"other",label:RED._("node-red:httpin.label.other"),icon:"red/images/typedInput/az.svg"}
     ];
 
     RED.nodes.registerType('http response',{
@@ -180,7 +180,7 @@
                     var propertyValue = $('<input/>',{class:"node-input-header-value",type:"text",style:"width: 100%"})
                         .appendTo(propertyValueCell)
                         .typedInput({types:
-                            header.h === 'content-type'?contentTypes:[{value:"other",label:"other",icon:"red/images/typedInput/az.png"}]
+                            header.h === 'content-type'?contentTypes:[{value:"other",label:"other",icon:"red/images/typedInput/az.svg"}]
                         });
 
                     var matchedType = headerTypes.filter(function(ht) {
@@ -223,7 +223,7 @@
                         if (type === 'content-type') {
                             propertyValue.typedInput('types',contentTypes);
                         } else {
-                            propertyValue.typedInput('types',[{value:"other",label:"other",icon:"red/images/typedInput/az.png"}]);
+                            propertyValue.typedInput('types',[{value:"other",label:"other",icon:"red/images/typedInput/az.svg"}]);
                         }
                     });
                 },

--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
@@ -247,7 +247,7 @@
                     var jsonata_or_empty = {
                         value: "jsonata",
                         label: "expression",
-                        icon: "red/images/typedInput/expr.png",
+                        icon: "red/images/typedInput/expr.svg",
                         validate: function(v) {
                             try{
                                 if(v !== "") {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
While I was translating the message catalog, I found that some icon paths are png.
To avoid path confusion in reusing code, I changed the file path from png to svg.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
