### PR TITLE
Fix project switching when junctions are present

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2462,6 +2462,8 @@ RED.nodes = (function() {
         workspacesOrder = [];
         groups = {};
         groupsByZ = {};
+        junctions = {};
+        junctionsByZ = {};
 
         var subflowIds = Object.keys(subflows);
         subflowIds.forEach(function(id) {


### PR DESCRIPTION
fixes #3588

## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Ensure lookup objects `junctions` and `junctionsByZ` inside the closure `RED.nodes` are cleared to prevent the "Duplicate Nodes" warning (as seen in #3588) and permit the flows to be loaded in the editor.  This fixes a compound issue when loading projects that due to there being no flow loaded client side, the incoming debug messages cannot lookup the "flow tab" name & thus cause a secondary error in `23-debug.html` where inside `this.handleDebugMessage()` an exception occurs.

We might want to add try/catch handlers on the new code inside `handleDebugMessage()` - something like...

```js
                if (o.path && RED.workspaces.count()) { //<<< check workspaces are present
                    // Path is a `/`-separated list of ids that identifies the
                    // complete parentage of the node that generated this message.
                    //    flow-id/subflow-A-instance/subflow-B-instance

                    // If it has one id, that is a top level flow
                    // each subsequent id is the instance id of a subflow node
                    pathParts = o.path.split("/");
                    if (pathParts.length === 1) {
                        // The source node is on a flow - so can use its id to find
                        sourceNode = RED.nodes.node(o.id);
                    } else if (pathParts.length > 1) {
                        // Highlight the subflow instance node.
                        sourceNode = RED.nodes.node(pathParts[1]);
                    }
                    try { //<<< surround problematic parts with try/catch
                        pathHierarchy = pathParts.map((id,index) => {
                            if (index === 0) {
                                return {
                                    id: id,
                                    label: RED.nodes.workspace(id).label
                                }
                            } else {
                                const instanceNode = RED.nodes.node(id)
                                return {
                                    id: id,
                                    label: (instanceNode.name || RED.nodes.subflow(instanceNode.type.substring(8)).name)
                                }
                            }
                        })
                        if (pathParts.length === 1) {
                            pathHierarchy.push({
                                id: o.id,
                                label: sourceNode.name || sourceNode.type+":"+sourceNode.id
                            })
                        }
                        if (o._alias) {
                            let aliasNode = RED.nodes.node(o._alias)
                            if (aliasNode) {
                                pathHierarchy.push({
                                    id: o._alias,
                                    label: aliasNode.name || aliasNode.type+":"+aliasNode.id
                                })
                            }
                        } 
                    } catch(err) {
                        //ignore errors
                    }
                } else {
                    // This is probably redundant...
                    sourceNode = RED.nodes.node(o.id) || RED.nodes.node(o.z);
                }

```

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
