### PR TITLE
use text width instead of number of characters for deciding select fi…

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.html
@@ -247,6 +247,8 @@
                     var row2 = $('<div/>',{style:"display: flex; padding-top: 5px; padding-left: 175px;"}).appendTo(inputRows);
                     var row3 = $('<div/>',{style:"display: flex; padding-top: 5px; align-items: center"}).appendTo(inputRows);
 
+                    var row4 = $('<div/>',{style:"visibility: hidden; height: 0px;"}).appendTo(inputRows);
+                    var textSpan = $("<span/>").appendTo(row4);
                     var selectField = $('<select/>',{style:"width:120px; text-align: center;"}).appendTo(row);
                     var group0 = $('<optgroup/>', { label: "value rules" }).appendTo(selectField);
                     for (var d in operators) {
@@ -340,9 +342,12 @@
                             row3.hide();
                         }
                         var selectedLabel = selectField.find("option:selected").text();
-                        if (selectedLabel.length <= 5) {
+
+                        textSpan.text(selectedLabel);
+                        var width = textSpan.width();
+                        if (width <= 30) {
                             selectField.outerWidth(60);
-                        } else if (selectedLabel.length < 12) {
+                        } else if (width <= 85) {
                             selectField.outerWidth(120);
                         } else {
                             selectField.width("auto")


### PR DESCRIPTION
…eld width of switch node rule

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Currently, number of characters is used to calculate width of a rule selection menu of switch node. 
In some cases, this is not accurate estimate of text width, especially in multibyte character locales.
This PR tries to solve this issue by using the actual drawing width.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
