### PR TITLE
Do not slice-junction link node wires

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4959,10 +4959,11 @@ RED.view = (function() {
                     .on("touchstart",linkTouchStart)
                     .on("mousemove", function(d) {
                         if (mouse_mode === RED.state.SLICING) {
+
                             selectedLinks.add(d)
                             l.classed("red-ui-flow-link-splice",true)
                             redraw()
-                        } else if (mouse_mode === RED.state.SLICING_JUNCTION) {
+                        } else if (mouse_mode === RED.state.SLICING_JUNCTION && !d.link) {
                             if (!l.classed("red-ui-flow-link-splice")) {
                                 // Find intersection point
                                 var lineLength = pathLine.getTotalLength();


### PR DESCRIPTION
The slice-junction action should not apply to link node virtual wires.

The slice action does apply as it is a valid way to delete virtual wires.

