### PR TITLE
fix buffer parse error message of evaluateNodeProperty

### DIFF
--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -641,7 +641,12 @@ function evaluateNodeProperty(value, type, node, msg, callback) {
         result = Date.now();
     } else if (type === 'bin') {
         var data = JSON.parse(value);
-        result = Buffer.from(data);
+        if (Array.isArray(data) || (typeof(data) === "string")) {
+            result = Buffer.from(data);
+        }
+        else {
+            throw createError("INVALID_BUFFER_DATA", "Not string or array");
+        }
     } else if (type === 'msg' && msg) {
         try {
             result = getMessageProperty(msg,value);

--- a/test/unit/@node-red/util/lib/util_spec.js
+++ b/test/unit/@node-red/util/lib/util_spec.js
@@ -388,6 +388,19 @@ describe("@node-red/util/util", function() {
             result[0].should.eql(1);
             result[1].should.eql(2);
         });
+        it('throws an error if buffer data is not array or string', function (done) {
+            try {
+                var result = util.evaluateNodeProperty('12','bin');
+                done("should throw an error");
+            } catch (err) {
+                if (err.code === "INVALID_BUFFER_DATA") {
+                    done();
+                }
+                else {
+                    done("should throw an error");
+                }
+            }
+        });
         it('returns msg property',function() {
             var result = util.evaluateNodeProperty('foo.bar','msg',{},{foo:{bar:"123"}});
             result.should.eql("123");


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
If inject node is configured to inject buffer with value `12`, it causes following error:
```
TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received type number (12)
```

This message is difficult to understand for users. 
This PR try to make it more understandable.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
