### PR TITLE
Dont delete TCP socket twice

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
@@ -432,7 +432,7 @@ module.exports = function(RED) {
             });
         }
         else {
-            var connectedSockets = [];
+            const connectedSockets = new Set();
             node.status({text:RED._("tcpin.status.connections",{count:0})});
             let srv = net;
             let connOpts;
@@ -453,16 +453,16 @@ module.exports = function(RED) {
                 });
                 socket.on('close',function() {
                     node.log(RED._("tcpin.status.connection-closed",{host:socket.remoteAddress, port:socket.remotePort}));
-                    connectedSockets.splice(connectedSockets.indexOf(socket),1);
-                    node.status({text:RED._("tcpin.status.connections",{count:connectedSockets.length})});
+                    connectedSockets.delete(socket);
+                    node.status({text:RED._("tcpin.status.connections",{count:connectedSockets.size})});
                 });
                 socket.on('error',function() {
                     node.log(RED._("tcpin.errors.socket-error",{host:socket.remoteAddress, port:socket.remotePort}));
-                    connectedSockets.splice(connectedSockets.indexOf(socket),1);
-                    node.status({text:RED._("tcpin.status.connections",{count:connectedSockets.length})});
+                    connectedSockets.delete(socket);
+                    node.status({text:RED._("tcpin.status.connections",{count:connectedSockets.size})});
                 });
-                connectedSockets.push(socket);
-                node.status({text:RED._("tcpin.status.connections",{count:connectedSockets.length})});
+                connectedSockets.add(socket);
+                node.status({text:RED._("tcpin.status.connections",{count:connectedSockets.size})});
             });
 
             node.on("input", function(msg, nodeSend, nodeDone) {
@@ -475,10 +475,10 @@ module.exports = function(RED) {
                     } else {
                         buffer = Buffer.from(""+msg.payload);
                     }
-                    for (var i = 0; i < connectedSockets.length; i += 1) {
-                        if (node.doend === true) { connectedSockets[i].end(buffer); }
-                        else { connectedSockets[i].write(buffer); }
-                    }
+                    connectedSockets.forEach(soc => {
+                        if (node.doend === true) { soc.end(buffer); }
+                        else { soc.write(buffer); }
+                    })
                 }
                 nodeDone();
             });
@@ -495,12 +495,10 @@ module.exports = function(RED) {
                 } else {
                     node.log(RED._("tcpin.status.listening-port",{port:node.port}));
                     node.on('close', function() {
-                        for (var c in connectedSockets) {
-                            if (connectedSockets.hasOwnProperty(c)) {
-                                connectedSockets[c].end();
-                                connectedSockets[c].unref();
-                            }
-                        }
+                        connectedSockets.forEach(soc => {
+                            soc.end();
+                            soc.unref();
+                        })
                         server.close();
                         node.log(RED._("tcpin.status.stopped-listening",{port:node.port}));
                     });


### PR DESCRIPTION
fixes #3619 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Problem

It looks like on some systems and certain conditions, both the `error` and `close` event handers are operating causing the code to (try to) remove the socket twice.  Since it is an array and uses the `splice` method, it can end up removing more that the problem socket


## Proposed changes

Change `connectedSockets` from an `array` to a `Set` to better manage the connections



## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
