### PR TITLE
remove left column from horizontal panel

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/panels.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/panels.scss
@@ -88,20 +88,4 @@
         cursor: ew-resize;
         background-color: $primary-background;
     }
-
-        &:before {
-            content: '';
-            display: block;
-            width: 100%;
-            height: 100%;
-            -webkit-mask-image: url(images/grip.svg);
-            mask-image: url(images/grip.svg);
-            -webkit-mask-size: contain;
-            mask-size: contain;
-            -webkit-mask-position: 50% 50%;
-            mask-position: 50% 50%;
-            -webkit-mask-repeat: no-repeat;
-            mask-repeat: no-repeat;
-            background-color: $grip-color;
-        }
 }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
`function library` dialog of `Open Library...` of Function node has unexpected column on the left as shown in the following figure.  This makes the preview area narrower.

![スクリーンショット 2022-05-27 9 13 07](https://user-images.githubusercontent.com/30289092/170604707-1cce765d-ac09-4857-9fd0-f793a833a2bc.png)

This [PR](https://github.com/node-red/node-red/pull/3515) introduced `&:before` selector to `red-ui-panels-horizontal`.   My understanding may be wrong, but I don't think this is necessary.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
