### PR TITLE
Fix JSONata evaluation of inject button

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.js
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.js
@@ -109,9 +109,10 @@ module.exports = function(RED) {
                 if (!property) return;
 
                 if (valueType === "jsonata") {
-                    if (p.exp) {
+                    if (p.v) {
                         try {
-                            var val = RED.util.evaluateJSONataExpression(p.exp, msg);
+                            var exp = RED.util.prepareJSONataExpression(p.v, node);
+                            var val = RED.util.evaluateJSONataExpression(exp, msg);
                             RED.util.setMessageProperty(msg, property, val, true);
                         }
                         catch  (err) {

--- a/test/nodes/core/common/20-inject_spec.js
+++ b/test/nodes/core/common/20-inject_spec.js
@@ -906,6 +906,7 @@ describe('inject node', function() {
                     msg.should.have.property("str1", "1"); //injected prop
                     msg.should.have.property("num1", 1); //injected prop
                     msg.should.have.property("bool1", true); //injected prop
+                    msg.should.have.property("jsonata1", "AB"); //injected prop
 
                     helper.clearFlows().then(function() {
                         done();
@@ -919,6 +920,7 @@ describe('inject node', function() {
                         {p:"str1", v:"1", vt:"str"}, //new prop
                         {p:"num1", v:"1", vt:"num"}, //new prop
                         {p:"bool1", v:"true", vt:"bool"}, //new prop
+                        {p:"jsonata1", v:'"A" & "B"', vt:"jsonata"}, //new prop
                     ]})
                     .expect(200).end(function(err) {
                         if (err) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Injecting a message using `Inject now` button of Inject node with a property defined by JSONata expression produces `undefined` value.
This PR try to fix this issue.

Example flow:
```
[
    {
        "id": "2ea53918bdf2be63",
        "type": "inject",
        "z": "1a963fe9a4d53595",
        "name": "",
        "props": [
            {
                "p": "payload"
            },
            {
                "p": "topic",
                "vt": "str"
            }
        ],
        "repeat": "",
        "crontab": "",
        "once": false,
        "onceDelay": 0.1,
        "topic": "",
        "payload": "\"Hello\" & \" \" & \"World\"",
        "payloadType": "jsonata",
        "x": 130,
        "y": 160,
        "wires": [
            [
                "daf0bf4581ce0e7f"
            ]
        ]
    },
    {
        "id": "daf0bf4581ce0e7f",
        "type": "debug",
        "z": "1a963fe9a4d53595",
        "name": "debug 1",
        "active": true,
        "tosidebar": true,
        "console": true,
        "tostatus": false,
        "complete": "payload",
        "targetType": "msg",
        "statusVal": "",
        "statusType": "auto",
        "x": 290,
        "y": 160,
        "wires": []
    }
]
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
