### PR TITLE
Fix to place a node dragged from palette within the workspace

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -526,6 +526,23 @@ RED.view = (function() {
                 nn.x = mousePos[0];
                 nn.y = mousePos[1];
 
+                var minX = nn.w/2 -5;
+                if (nn.x < minX) {
+                    nn.x = minX;
+                }
+                var minY = nn.h/2 -5;
+                if (nn.y < minY) {
+                    nn.y = minY;
+                }
+                var maxX = space_width -nn.w/2 +5;
+                if (nn.x > maxX) {
+                    nn.x = maxX;
+                }
+                var maxY = space_height -nn.h +5;
+                if (nn.y > maxY) {
+                    nn.y = maxY;
+                }
+
                 if (snapGrid) {
                     var gridOffset = RED.view.tools.calculateGridSnapOffsets(nn);
                     nn.x -= gridOffset.x;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
A node dragged from the palette can be placed halfway out of the workspace.
Since the movement of nodes within the workspace is designed to fit within the workspace, this PR change the dragged node placed within the workspace.

![スクリーンショット 2022-06-08 9 29 12](https://user-images.githubusercontent.com/30289092/172507038-a601ef0e-309b-4912-9533-2841aca1cfe9.png)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
