### PR TITLE
Fix layer of palette node

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/palette.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/palette.scss
@@ -131,6 +131,7 @@
     width: 120px;
     background-size: contain;
     position: relative;
+    z-index: 4;
     &:not(.red-ui-palette-node-config):not(.red-ui-palette-node-small):first-child {
         margin-top: 15px;
     }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->


## Checklist
<!-- Put an `x` in the boxes that apply -->
When dragging a node from the palette into the workspace, the node is displayed below the tab label as shown below.
This PR try to fix the issue.

![スクリーンショット 2022-06-08 15 12 52](https://user-images.githubusercontent.com/30289092/172544926-52f8ae58-68bd-4326-b964-b267a21f5d81.png)


- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
