### PR TITLE
Reset mouse state when switching tabs

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -385,6 +385,9 @@ RED.view = (function() {
         drag_lines = [];
 
         RED.events.on("workspace:change",function(event) {
+            // Just in case the mouse left the workspace whilst doing an action,
+            // put us back into default mode so the refresh works
+            mouse_mode = 0
             if (event.old !== 0) {
                 workspaceScrollPositions[event.old] = {
                     left:chart.scrollLeft(),
@@ -955,7 +958,7 @@ RED.view = (function() {
     }
 
     function canvasMouseDown() {
-        if (RED.view.DEBUG) { 
+        if (RED.view.DEBUG) {
             console.warn("canvasMouseDown", { mouse_mode, point: d3.mouse(this), event: d3.event });
         }
         if (mouse_mode === RED.state.SELECTING_NODE) {
@@ -1719,7 +1722,7 @@ RED.view = (function() {
 
     function canvasMouseUp() {
         lastClickPosition = [d3.event.offsetX/scaleFactor,d3.event.offsetY/scaleFactor];
-        if (RED.view.DEBUG) { 
+        if (RED.view.DEBUG) {
             console.warn("canvasMouseUp", { mouse_mode, point: d3.mouse(this), event: d3.event });
         }
         var i;
@@ -3719,7 +3722,7 @@ RED.view = (function() {
     function junctionMouseOutProxy(e) { junctionMouseOut(d3.select(this), this.__data__) }
 
     function linkMouseDown(d) {
-        if (RED.view.DEBUG) { 
+        if (RED.view.DEBUG) {
             console.warn("linkMouseDown", { mouse_mode, point: d3.mouse(this), event: d3.event });
         }
         if (mouse_mode === RED.state.SELECTING_NODE) {


### PR DESCRIPTION
Fixes #3639

If the mouse is in the middle of an action (MOVING_ACTIVE, LASSO etc) and it leaves the workspace and the mouse button released, the view doesn't know because the event isn't captured.

If they then switch tabs, the code to rebuild the view thinks we're still in one of those other states and a bunch of things don't happen. Specifically, in the context of #3639, if the view thinks we're in MOVING_ACTIVE state, it doesn't bother setting the node widths/heights (because they can't change whilst moving). That causes the nodes to have no width/height at all.

The fix is to reset the mouse state to the default when we detect a tab switch - as there are no mouse actions that span tab changes.

