### PR TITLE
Fix to sanitize tab name

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
@@ -828,7 +828,7 @@ RED.tabs = (function() {
                 }
 
                 // link.attr("title",tab.label);
-                RED.popover.tooltip(link,function() { return tab.label})
+                RED.popover.tooltip(link,function() { return RED.utils.sanitize(tab.label); });
 
                 if (options.onadd) {
                     options.onadd(tab);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->
## Proposed changes
Tooltip for tab name is displayed without sanitization as shown below.
This PR try to fix this issue.

![画面収録 2022-06-10 20 27 44](https://user-images.githubusercontent.com/30289092/173056184-722c1623-ab50-4530-abe9-1642dd8a4e75.gif)

<!-- Describe the nature of this change. What problem does it address? -->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
