### PR TITLE
Fix z-index value for shade to cover nodes in palette

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/base.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/base.scss
@@ -44,7 +44,7 @@ body {
 
 #red-ui-palette-shade, #red-ui-editor-shade, #red-ui-header-shade, #red-ui-sidebar-shade  {
     @include shade;
-    z-index: 2;
+    z-index: 5;
 }
 #red-ui-sidebar-shade  {
     left: -8px;


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Fixed https://github.com/node-red/node-red/issues/3648. The `z-index` of the nodes in the palette is currently `4`. Therefore, the `z-index` of the shade should have `5` or more (The maximum value seems to be `9`).

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
