### PR TITLE
Fix undoing junction to subflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/history.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/history.js
@@ -22,6 +22,14 @@ RED.history = (function() {
     var undoHistory = [];
     var redoHistory = [];
 
+    function nodeOrJunction(id) {
+        var node = RED.nodes.node(id);
+        if (node) {
+            return node;
+        }
+        return RED.nodes.junction(id);
+    }
+
     function undoEvent(ev) {
         var i;
         var len;
@@ -514,6 +522,7 @@ RED.history = (function() {
                     var z = ev.activeWorkspace;
                     var fullNodeList = RED.nodes.filterNodes({z:ev.subflow.subflow.id});
                     fullNodeList = fullNodeList.concat(RED.nodes.groups(ev.subflow.subflow.id))
+                    fullNodeList = fullNodeList.concat(RED.nodes.junctions(ev.subflow.subflow.id))
                     fullNodeList.forEach(function(n) {
                         n.x += ev.subflow.offsetX;
                         n.y += ev.subflow.offsetY;
@@ -523,7 +532,7 @@ RED.history = (function() {
                     });
                     inverseEv.subflows = [];
                     for (i=0;i<ev.nodes.length;i++) {
-                        inverseEv.subflows.push(RED.nodes.node(ev.nodes[i]));
+                        inverseEv.subflows.push(nodeOrJunction(ev.nodes[i]));
                         RED.nodes.remove(ev.nodes[i]);
                     }
                 }

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -738,6 +738,10 @@ RED.nodes = (function() {
             moveGroupToTab(node,z);
             return;
         }
+        if (node.type === "junction") {
+            moveJunctionToTab(node,z);
+            return;
+        }
         var oldZ = node.z;
         allNodes.moveNode(node,z);
         var nl = nodeLinks[node.id];
@@ -770,6 +774,38 @@ RED.nodes = (function() {
         groupsByZ[z].push(group);
         group.z = z;
         RED.events.emit("groups:change",group);
+    }
+
+    function moveJunctionToTab(junction, z) {
+        var index = junctionsByZ[junction.z].indexOf(junction);
+        junctionsByZ[junction.z].splice(junction,1);
+        junctionsByZ[z] = junctionsByZ[z] || [];
+        junctionsByZ[z].push(junction);
+        junction.z = z;
+
+        var oldZ = junction.z;
+        var nl = nodeLinks[junction.id];
+        if (nl) {
+            nl.in.forEach(function(l) {
+                var idx = linkTabMap[oldZ].indexOf(l);
+                if (idx != -1) {
+                    linkTabMap[oldZ].splice(idx, 1);
+                }
+                if ((l.source.z === z) && linkTabMap[z]) {
+                    linkTabMap[z].push(l);
+                }
+            });
+            nl.out.forEach(function(l) {
+                var idx = linkTabMap[oldZ].indexOf(l);
+                if (idx != -1) {
+                    linkTabMap[oldZ].splice(idx, 1);
+                }
+                if ((l.target.z === z) && linkTabMap[z]) {
+                    linkTabMap[z].push(l);
+                }
+            });
+        }
+        RED.events.emit("junctions:change",junction);
     }
 
     function removeLink(l) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -604,6 +604,14 @@ RED.subflow = (function() {
         return x;
     }
 
+    function nodeOrJunction(id) {
+        var node = RED.nodes.node(id);
+        if (node) {
+            return node;
+        }
+        return RED.nodes.junction(id);
+    }
+
     function convertToSubflow() {
         var selection = RED.view.selection();
         if (!selection.nodes) {
@@ -792,14 +800,15 @@ RED.subflow = (function() {
 
         subflow.in.forEach(function(input) {
             input.wires.forEach(function(wire) {
-                var link = {source: input, sourcePort: 0, target: RED.nodes.node(wire.id) }
+                var link = {source: input, sourcePort: 0, target: nodeOrJunction(wire.id) }
                 new_links.push(link);
                 RED.nodes.addLink(link);
             });
         });
+
         subflow.out.forEach(function(output,i) {
             output.wires.forEach(function(wire) {
-                var link = {source: RED.nodes.node(wire.id), sourcePort: wire.port , target: output }
+                var link = {source: nodeOrJunction(wire.id), sourcePort: wire.port , target: output }
                 new_links.push(link);
                 RED.nodes.addLink(link);
             });
@@ -815,7 +824,7 @@ RED.subflow = (function() {
                 n.links = n.links.filter(function(id) {
                     var isLocalLink = nodes.hasOwnProperty(id);
                     if (!isLocalLink) {
-                        var otherNode = RED.nodes.node(id);
+                        var otherNode = nodeOrJunction(id);
                         if (otherNode && otherNode.links) {
                             var i = otherNode.links.indexOf(n.id);
                             if (i > -1) {
@@ -830,7 +839,6 @@ RED.subflow = (function() {
             n.y -= offsetY;
             RED.nodes.moveNodeToTab(n, subflow.id);
         }
-
 
         var historyEvent = {
             t:'createSubflow',


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
[This PR](https://github.com/node-red/node-red/pull/3652) solves the problem of converting Junction node to SUBFLOW.  
However, this conversion cannot be undone. 
This PR attempts to solve the issue.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
