### PR TITLE
Fix to extend escaped subflow category characters (backport #3647 to v2.x)

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -208,7 +208,7 @@ RED.palette = (function() {
     }
 
     function escapeCategory(category) {
-        return category.replace(/[ /.]/g,"_");
+        return category.replace(/[\x00-\x2c\x2e-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]/g,"_");
     }
     function addNodeType(nt,def) {
         if (getPaletteNode(nt).length) {


### PR DESCRIPTION
Manually implements @HiroyasuNishiyama commit 30d88bbe7efcbf72519e18bbbca246de6a5e0484 (cherry-pick not possible)
