### PR TITLE
Import default export if node is a transpiled es module

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/loader.js
+++ b/packages/node_modules/@node-red/registry/lib/loader.js
@@ -359,6 +359,7 @@ function loadNodeSet(node) {
     try {
         var loadPromise = null;
         var r = require(node.file);
+        r = r.__esModule ? r.default : r
         if (typeof r === "function") {
 
             var red = registryUtil.createNodeApi(node);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

Not sure here, one might argue it's a feature to now allow loading of transpiled esms, or one might argue it was a bug, that it was not possible to load them ...

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

If a node file is a transpiled esModule, I suggest to load the default export.
This allows the developer to export more than just the node init function from the node entry point file. This is especially relevant for TypeScript as I would like to export the class type from that file, so I can have type checks in other files referencing that node.

To make it a little less abstract, this is what already works right now:
```
let RED: any

export = function (pRED: any): void {
  class MyConfigNode {
    constructor(config: { myFancyOptionForMyConfigNode: string}) {
      RED.nodes.createNode(this, config);
    }
  }

  RED.nodes.registerType("config-server", MyConfigNode)
};
```
When the TypeScript compile is told to transpile to commonjs and target es5, this is the result:
```
"use strict";
var RED;
module.exports = function (pRED) {
    var MyConfigNode = /** @class */ (function () {
        function MyConfigNode(config) {
            RED.nodes.createNode(this, config);
        }
        return MyConfigNode;
    }());
    RED.nodes.registerType("config-server", MyConfigNode);
};
```

The problem is, that I cannot export the class like that (because the only export is the init function), so I cannot check the type in other files.
So what I would like to do is the following:

```
let RED: any

export class MyConfigNode {
  constructor(config: { myFancyOptionForMyConfigNode: string}) {
    RED.nodes.createNode(this, config);
  }
}

export default function (pRED: any): void {
  RED = pRED
  RED.nodes.registerType("config-server", MyConfigNode)
};
```
The module scope RED is not nice, but that's a different topic 😅 
Transpiling this results in this code:
```
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
exports.MyConfigNode = void 0;
var RED;
var MyConfigNode = /** @class */ (function () {
    function MyConfigNode(config) {
        RED.nodes.createNode(this, config);
    }
    return MyConfigNode;
}());
exports.MyConfigNode = MyConfigNode;
function default_1(pRED) {
    RED = pRED;
    RED.nodes.registerType("config-server", MyConfigNode);
}
exports.default = default_1;
;
```

which can be succesfully loaded after applying my patch.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
