### PR TITLE
Join node in reduce mode doesn't keep existing msg properties

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -314,11 +314,13 @@ module.exports = function(RED) {
                         if (err) {
                             return done(err);
                         }
-                        msgInfo.send({payload: result});
+                        msgInfo.msg.payload = result;
+                        msgInfo.send(msgInfo.msg);
                         done();
                     });
                 } else {
-                    msgInfo.send({payload: result});
+                    msgInfo.msg.payload = result;
+                    msgInfo.send(msgInfo.msg);
                     done();
                 }
             } else {


### PR DESCRIPTION


<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
see https://discourse.nodered.org/t/no-response-object-after-split-join/63919

When in reduce mode the join node currently creates a new msg rather than re-using the existing one - which then drops things like any msg.res from a http request. This patch tries to fix that.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
