### PR TITLE
Further simplify file node filename entry UX (v3)

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.html
@@ -198,8 +198,8 @@
         category: 'storage',
         defaults: {
             name: {value:""},
-            filename: {value:"filename"},
-            filenameType: {value:"msg"},
+            filename: {value:""},
+            filenameType: {value:"str"},
             appendNewline: {value:true},
             createDir: {value:false},
             overwriteFile: {value:"false"},
@@ -236,8 +236,8 @@
                 label: node._("file.encoding.setbymsg")
             }).text(label).appendTo(encSel);
             $("#node-input-filename").typedInput({
-                default: "msg",
-                types: ["str", "msg", "jsonata", "env"],
+                default: "str",
+                types: [{label:RED._("node-red:file.label.path"), value:"str", icon:""}, "msg", "jsonata", "env"],
                 typeField: $("#node-input-filenameType")
             });
             if(typeof node.filenameType == 'undefined') {
@@ -297,8 +297,8 @@
         category: 'storage',
         defaults: {
             name: {value:""},
-            filename: {value:"filename"},
-            filenameType: {value:"msg"},
+            filename: {value:""},
+            filenameType: {value:"str"},
             format: {value:"utf8"},
             chunk: {value:false},
             sendError: {value: false},
@@ -341,8 +341,8 @@
                 label: label
             }).text(label).appendTo(encSel);
             $("#node-input-filename").typedInput({
-                default: "msg",
-                types: ["str", "msg", "jsonata", "env"],
+                default: "str",
+                types: [{label:RED._("node-red:file.label.path"), value:"str", icon:""}, "msg", "jsonata", "env"],
                 typeField: $("#node-input-filenameType")
             });
             if(typeof node.filenameType == 'undefined') {

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -928,6 +928,7 @@
             "write": "write file",
             "read": "read file",
             "filename": "Filename",
+            "path": "path",
             "action": "Action",
             "addnewline": "Add newline (\\n) to each payload?",
             "createdir": "Create directory if it doesn't exist?",


### PR DESCRIPTION
fixes #3668

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Proposed changes

Default to string entry to imprive novice user experience
Maintain backwards compatibility by in-place upgrade where required


## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
