### PR TITLE
Fix handling of spacebar inside JSON visual editor

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
@@ -21,6 +21,7 @@
  *   - multi : boolean - if true, .selected will return an array of results
  *                       otherwise, returns the first selected item
  *   - sortable: boolean/string - TODO: see editableList
+ *   - selectable: boolean - default true - whether individual items can be selected
  *   - rootSortable: boolean - if 'sortable' is set, then setting this to
  *                             false, prevents items being sorted to the
  *                             top level of the tree
@@ -118,6 +119,7 @@
                 switch(evt.keyCode) {
                     case 32: // SPACE
                     case 13: // ENTER
+                        if (!that.options.selectable) { return }
                         if (evt.altKey || evt.ctrlKey || evt.metaKey || evt.shiftKey) {
                             return
                         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/json.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/json.js
@@ -534,6 +534,7 @@
                     var container = $("#red-ui-editor-type-json-tab-ui-container").css({"height":"100%"});
                     var filterDepth = Infinity;
                     var list = $('<div class="red-ui-debug-msg-payload red-ui-editor-type-json-editor">').appendTo(container).treeList({
+                        selectable: false,
                         rootSortable: false,
                         sortable: ".red-ui-editor-type-json-editor-item-handle",
                     }).on("treelistchangeparent", function(event, evt) {


### PR DESCRIPTION
Fixes #3682

The treeList keyboard handling was consuming the event - used
to select the item in the list.

The fix here adds a 'selectable' flag on the treeList that can
be used to disabled (=false) the keyboard selection of items.
