### PR TITLE
Add support for evalulating {{env.<var>}} within a template node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/80-template.js
+++ b/packages/node_modules/@node-red/nodes/core/function/80-template.js
@@ -44,6 +44,14 @@ module.exports = function(RED) {
         return undefined;
     }
 
+    function parseEnv(key) {
+        var match = /^env\.(.+)/.exec(key);
+        if (match) {
+            return match[1];
+        }
+        return undefined;
+    }
+
     /**
      * Custom Mustache Context capable to collect message property and node
      * flow and global context
@@ -72,6 +80,11 @@ module.exports = function(RED) {
                     value = value.replace(/[\b]/g, "\\b");
                 }
                 return value;
+            }
+
+            // try env
+            if (parseEnv(name)) {
+                return this.cachedContextTokens[name];
             }
 
             // try flow/global context:
@@ -156,6 +169,17 @@ module.exports = function(RED) {
                     var tokens = extractTokens(mustache.parse(template));
                     var resolvedTokens = {};
                     tokens.forEach(function(name) {
+                        var env_name = parseEnv(name);
+                        if (env_name) {
+                            var promise = new Promise((resolve, reject) => {
+                                var val = RED.util.evaluateNodeProperty(env_name, 'env', node)
+                                resolvedTokens[name] = val;
+                                resolve();
+                            });
+                            promises.push(promise);
+                            return;
+                        }
+
                         var context = parseContext(name);
                         if (context) {
                             var type = context.type;

--- a/test/nodes/core/function/80-template_spec.js
+++ b/test/nodes/core/function/80-template_spec.js
@@ -144,6 +144,28 @@ describe('template node', function() {
         });
     });
 
+    describe('env var', function() {
+        before(function() {
+            process.env.TEST = 'xyzzy';
+        })
+        after(function() {
+            delete process.env.TEST;
+        })
+
+        it('should modify payload from env variable', function(done) {
+            var flow = [{id:"n1",z:"t1", type:"template", field:"payload", template:"payload={{env.TEST}}",wires:[["n2"]]},{id:"n2",z:"t1",type:"helper"}];
+            helper.load(templateNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var n2 = helper.getNode("n2");
+                n2.on("input", function(msg) {
+                    msg.should.have.property('payload', 'payload=xyzzy');
+                    done();
+                });
+                n1.receive({payload:"foo",topic: "bar"});
+            });
+        });
+    });
+
     it('should modify payload from flow context', function(done) {
         var flow = [{id:"n1",z:"t1", type:"template", field:"payload", template:"payload={{flow.value}}",wires:[["n2"]]},{id:"n2",z:"t1",type:"helper"}];
         helper.load(templateNode, flow, function() {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

This feature adds template node be able evaluate env variables within the mustache template.
It solves adding intermediate change node which is the goto solution.

Very useful in subflow to evaluate the subflow properties.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `grunt` to verify the unit tests pass
- [X] I have added suitable unit tests to cover the new/changed functionality
