### PR TITLE
Ensure link-call cache is updated when link-in is modified

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
         "marked": "4.0.17",
         "minami": "1.2.3",
         "mocha": "9.2.2",
-        "node-red-node-test-helper": "^0.2.7",
+        "node-red-node-test-helper": "^0.3.0",
         "nodemon": "2.0.16",
         "proxy": "^1.0.2",
         "sass": "1.52.3",

--- a/packages/node_modules/@node-red/nodes/core/common/60-link.js
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.js
@@ -109,16 +109,13 @@ module.exports = function(RED) {
             },
             remove(node) {
                 const target = generateTarget(node);
-                const tn = this.getTarget(target.name, target.flowId);
-                if (tn) {
-                    const targs = this.getTargets(tn.name);
-                    const idx = getIndex(targs, tn.id);
-                    if (idx > -1) {
-                        targs.splice(idx, 1);
-                    }
-                    if (targs.length === 0) {
-                        delete registry.name[tn.name];
-                    }
+                const targs = this.getTargets(target.name);
+                const idx = getIndex(targs, target.id);
+                if (idx > -1) {
+                    targs.splice(idx, 1);
+                }
+                if (targs.length === 0) {
+                    delete registry.name[tn.name];
                 }
                 delete registry.id[target.id];
             },


### PR DESCRIPTION
fixes #3694
depends on node-red-node-test-helper@0.3.0

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

Discussed here: https://node-red.slack.com/archives/C9RSU6S56/p1655726225125419 

## Proposed changes

* Ensures registered nodes are removed from the cache to avoid the "Multiple nodes with name" error
* Adds a suitable test that loads a flow with 2 link nodes named the same then deploys a name change

NOTE: Depends on [node-red-node-test-helper@0.3.0 #54](https://github.com/node-red/node-red-node-test-helper/pull/54) being merged and published

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
