### PR TITLE
Fix clicking on node in workspace to hide context menu

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
@@ -170,6 +170,7 @@ RED.contextMenu = (function() {
     }
 
     return {
-        show: show
+        show: show,
+        hide: disposeMenu
     }
 })()

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -988,6 +988,7 @@ RED.view = (function() {
         if (RED.view.DEBUG) {
             console.warn("canvasMouseDown", { mouse_mode, point: d3.mouse(this), event: d3.event });
         }
+        RED.contextMenu.hide();
         if (mouse_mode === RED.state.SELECTING_NODE) {
             d3.event.stopPropagation();
             return;
@@ -1779,6 +1780,9 @@ RED.view = (function() {
         }
         var i;
         var historyEvent;
+        if (d3.event.button === 2) {
+            return
+        }
         if (mouse_mode === RED.state.PANNING) {
             resetMouseVars();
             return
@@ -2903,6 +2907,7 @@ RED.view = (function() {
 
     function portMouseDown(d,portType,portIndex, evt) {
         if (RED.view.DEBUG) { console.warn("portMouseDown", mouse_mode,d,portType,portIndex); }
+        RED.contextMenu.hide();
         evt = evt || d3.event;
         if (evt === 1) {
             return;
@@ -3411,6 +3416,7 @@ RED.view = (function() {
     function nodeMouseDown(d) {
         if (RED.view.DEBUG) { console.warn("nodeMouseDown", mouse_mode,d); }
         focusView();
+        RED.contextMenu.hide();
         if (d3.event.button === 1) {
             return;
         }
@@ -3793,6 +3799,7 @@ RED.view = (function() {
         if (RED.view.DEBUG) {
             console.warn("linkMouseDown", { mouse_mode, point: d3.mouse(this), event: d3.event });
         }
+        RED.contextMenu.hide();
         if (mouse_mode === RED.state.SELECTING_NODE) {
             d3.event.stopPropagation();
             return;
@@ -3852,6 +3859,9 @@ RED.view = (function() {
     }
 
     function groupMouseUp(g) {
+        if (RED.view.DEBUG) {
+            console.warn("groupMouseUp", { mouse_mode, event: d3.event });
+        }
         if (dblClickPrimed && mousedown_group == g && clickElapsed > 0 && clickElapsed < dblClickInterval) {
             mouse_mode = RED.state.DEFAULT;
             RED.editor.editGroup(g);
@@ -3867,6 +3877,10 @@ RED.view = (function() {
         //     return
         // }
 
+        if (RED.view.DEBUG) {
+            console.warn("groupMouseDown", { mouse_mode, point: mouse, event: d3.event });
+        }
+        RED.contextMenu.hide();
         focusView();
         if (d3.event.button === 1) {
             return;


### PR DESCRIPTION
This ensures the context menu closes when clicking on anything in the workspace - previously clicking on a node, group or link would keep the context menu open.

Also stops clearing selection when using right-mouse button.