### PR TITLE
Set default editor to monaco in absence of user preference

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editor.js
@@ -21,7 +21,7 @@
 
     const MONACO = "monaco";
     const ACE = "ace";
-    const defaultEditor = ACE;
+    const defaultEditor = MONACO;
     const DEFAULT_SETTINGS = { lib: defaultEditor, options: {} };
     var selectedCodeEditor = null;
     var initialised = false;
@@ -48,12 +48,12 @@
     }
 
     function create(options) {
-        //TODO: (quandry - for consideration) 
+        //TODO: (quandry - for consideration)
         // Below, I had to create a hidden element if options.id || options.element is not in the DOM
-        // I have seen 1 node calling  `this.editor = RED.editor.createEditor()` with an 
+        // I have seen 1 node calling  `this.editor = RED.editor.createEditor()` with an
         // invalid (non existing html element selector) (e.g. node-red-contrib-components does this)
-        // This causes monaco to throw an error when attempting to hook up its events to the dom  & the rest of the 'oneditperapre' 
-        // code is thus skipped. 
+        // This causes monaco to throw an error when attempting to hook up its events to the dom  & the rest of the 'oneditperapre'
+        // code is thus skipped.
         // In ACE mode, creating an ACE editor (with an invalid ID) allows the editor to be created (but obviously there is no UI)
         // Because one (or more) contrib nodes have left this bad code in place, how would we handle this?
         // For compatibility, I have decided to create a hidden element so that at least an editor is created & errors do not occur.
@@ -79,7 +79,7 @@
             return this.editor.create(options);//fallback to ACE
         }
     }
- 
+
     return {
         init: init,
         /**
@@ -91,7 +91,7 @@
         },
         /**
          * Get user selected code editor
-         * @return {string} Returns 
+         * @return {string} Returns
          * @memberof RED.editor.codeEditor
          */
         get editor() {

--- a/packages/node_modules/@node-red/runtime/lib/api/settings.js
+++ b/packages/node_modules/@node-red/runtime/lib/api/settings.js
@@ -91,7 +91,7 @@ var api = module.exports = {
             safeSettings.context = runtime.nodes.listContextStores();
             if (runtime.settings.editorTheme && runtime.settings.editorTheme.codeEditor) {
                 safeSettings.codeEditor = runtime.settings.editorTheme.codeEditor || {};
-                safeSettings.codeEditor.lib = safeSettings.codeEditor.lib || "ace";
+                safeSettings.codeEditor.lib = safeSettings.codeEditor.lib || "monaco";
                 safeSettings.codeEditor.options = safeSettings.codeEditor.options || {};
             }
             safeSettings.libraries = runtime.library.getLibraries();


### PR DESCRIPTION
In an earlier PR we changed the default settings.js to specify monaco. With this PR, we now default to monaco if the settings file doesn't specify anything.