### PR TITLE
Fix credential type input item of subflow template

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/envVarList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/envVarList.js
@@ -94,6 +94,11 @@ RED.editor.envVarList = (function() {
                         }
                         opt.ui.label = opt.ui.label || {};
                         opt.ui.type = opt.ui.type || "input";
+                        if ((opt.ui.type === "cred") &&
+                            opt.ui.opts &&
+                            opt.ui.opts.types) {
+                            opt.ui.type = "input";
+                        }
 
                         var uiRow = $('<div/>').appendTo(container).hide();
                         // save current info for reverting on cancel

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/envVarList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/envVarList.js
@@ -44,9 +44,7 @@ RED.editor.envVarList = (function() {
                     }).attr("autocomplete","disable").appendTo(envRow);
                     var types = (opt.ui && opt.ui.opts && opt.ui.opts.types);
                     if (!types) {
-                        types = isTemplateNode
-                            ? DEFAULT_ENV_TYPE_LIST
-                            : DEFAULT_ENV_TYPE_LIST_INC_CRED;
+                        types = isTemplateNode ? DEFAULT_ENV_TYPE_LIST : DEFAULT_ENV_TYPE_LIST_INC_CRED;
                     }
                     valueField.typedInput({default:'str',types:types});
                     valueField.typedInput('type', opt.type);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/envVarList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/envVarList.js
@@ -41,8 +41,14 @@ RED.editor.envVarList = (function() {
                         style: "width:100%",
                         class: "node-input-env-value",
                         type: "text",
-                    }).attr("autocomplete","disable").appendTo(envRow)
-                    valueField.typedInput({default:'str',types:isTemplateNode?DEFAULT_ENV_TYPE_LIST:DEFAULT_ENV_TYPE_LIST_INC_CRED});
+                    }).attr("autocomplete","disable").appendTo(envRow);
+                    var types = (opt.ui && opt.ui.opts && opt.ui.opts.types);
+                    if (!types) {
+                        types = isTemplateNode
+                            ? DEFAULT_ENV_TYPE_LIST
+                            : DEFAULT_ENV_TYPE_LIST_INC_CRED;
+                    }
+                    valueField.typedInput({default:'str',types:types});
                     valueField.typedInput('type', opt.type);
                     if (opt.type === "cred") {
                         if (opt.value) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
If a typedInput-style environment variable input item of subflow template is defined with credential as default type, it changes to credential-style input item.
This PR try to fix the issue.

**Steps to reproduce:**

1. Create a subflow
2. Open subflow template properties edit panel.
3. Add an environment variable.
    a. Set  "input type" of the variable to "input" with "credential" selected,
    b. Change default value type to "credential".
4. Re-open subflow template properties edit panel.
5. "input type" of the variable changes to "credential".

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
