### PR TITLE
Ensure workspace clean after undoing dropped node

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
@@ -979,13 +979,14 @@ RED.view.tools = (function() {
      *  - it uses `<paletteLabel> <N>` - where N is the next available integer that
      *    doesn't clash with any existing nodes of that type
      * @param {Object} node The node to set the name of - if not provided, uses current selection
+     * @param {{ renameBlank: boolean, renameClash: boolean, generateHistory: boolean }} options Possible options are `renameBlank`, `renameClash` and `generateHistory`
      */
     function generateNodeNames(node, options) {
-        options = options || {
+        options = Object.assign({
             renameBlank: true,
             renameClash: true,
             generateHistory: true
-        }
+        }, options)
         let nodes = node;
         if (node) {
             if (!Array.isArray(node)) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -5872,6 +5872,7 @@ RED.view = (function() {
      * @private
      */
      function createNode(type, x, y, z) {
+        const wasDirty = RED.nodes.dirty()
         var m = /^subflow:(.+)$/.exec(type);
         var activeSubflow = z ? RED.nodes.subflow(z) : null;
         if (activeSubflow && m) {
@@ -5930,7 +5931,7 @@ RED.view = (function() {
         var historyEvent = {
             t: "add",
             nodes: [nn.id],
-            dirty: RED.nodes.dirty()
+            dirty: wasDirty
         }
         if (activeSubflow) {
             var subflowRefresh = RED.subflow.refresh(true);

--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.html
@@ -558,7 +558,7 @@
         onadd: function() {
             if (this.name === '_DEFAULT_') {
                 this.name = ''
-                RED.actions.invoke("core:generate-node-names", this)
+                RED.actions.invoke("core:generate-node-names", this, {generateHistory: false})
             }
         }
     });

--- a/packages/node_modules/@node-red/nodes/core/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.html
@@ -221,7 +221,7 @@
     function onAdd() {
         if (this.name === '_DEFAULT_') {
             this.name = ''
-            RED.actions.invoke("core:generate-node-names", this)
+            RED.actions.invoke("core:generate-node-names", this, {generateHistory: false})
         }
         for (var i=0;i<this.links.length;i++) {
             var n = RED.nodes.node(this.links[i]);

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.html
@@ -639,7 +639,7 @@
         onadd: function() {
             if (this.name === '_DEFAULT_') {
                 this.name = ''
-                RED.actions.invoke("core:generate-node-names", this)
+                RED.actions.invoke("core:generate-node-names", this, {generateHistory: false})
             }
         }
     });


### PR DESCRIPTION
fixes #3701


## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Describe the nature of this change. What problem does it address? 
Ensures undo after dropping a debug/function/link onto workspace results in a clean (`!dirty`) workspace

## Proposed changes

* When creating a new node (`createNode()`), get workspace `dirty` state BEFORE generating the node
* ensure `generateHistory` is false for `onadd()` calls in debug, link and function nodes
* ensure `generateNodeNames` options are merged (not overwritten)
* correct JSDoc for `generateNodeNames`


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
