### PR TITLE
Fix delay rate limit last timing when empty

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.js
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.js
@@ -275,17 +275,21 @@ module.exports = function(RED) {
                     if (msg.hasOwnProperty("flush")) {
                         var len = node.buffer.length;
                         if (typeof(msg.flush) == 'number') { len = Math.min(Math.floor(msg.flush),len); }
-                        while (len > 0) {
-                            const msgInfo = node.buffer.shift();
-                            if (Object.keys(msgInfo.msg).length > 1) {
-                                node.send(msgInfo.msg);
-                                msgInfo.done();
-                            }
-                            len = len - 1;
-                        }
-                        if (node.buffer.length === 0) {
+                        if (len === 0) {
                             clearInterval(node.intervalID);
                             node.intervalID = -1;
+                        }
+                        else {
+                            while (len > 0) {
+                                const msgInfo = node.buffer.shift();
+                                if (Object.keys(msgInfo.msg).length > 1) {
+                                    node.send(msgInfo.msg);
+                                    msgInfo.done();
+                                }
+                                len = len - 1;
+                            }
+                            clearInterval(node.intervalID);
+                            node.intervalID = setInterval(sendMsgFromBuffer, node.rate);
                         }
                         node.status({fill:"blue",shape:"dot",text:node.buffer.length});
                         done();


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This thread https://discourse.nodered.org/t/wait-for-payload-to-finish-flow-before-passing-another-payload/64171 - has identified a subtle edge case where when in rate limit mode and using msg.flush to release messages - that when the lst one is released then if another message arrives then it will get passed through immediately. 
This fix allows any feedback to clear the default timeout rather than auto clear it - so the timing is still honoured by default - (but can still be over-ridden once the last message has been handled.)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
