### PR TITLE
Use solid colour as config node icon background to hide text overflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
@@ -37,7 +37,7 @@ ul.red-ui-sidebar-node-config-list {
     }
     .red-ui-palette-node {
         overflow: hidden;
-
+        cursor: default;
         &.selected {
             border-color: transparent;
             box-shadow: 0 0 0 2px $node-selected-color;
@@ -58,7 +58,7 @@ ul.red-ui-sidebar-node-config-list {
     .red-ui-palette-icon-container {
         font-size: 12px;
         line-height: 30px;
-        background-color: $node-icon-background-color;
+        background-color: $node-port-background;
         border-top-right-radius: 4px;
         border-bottom-right-radius: 4px;
         a {
@@ -68,6 +68,7 @@ ul.red-ui-sidebar-node-config-list {
             left: 0;
             right: 0;
             color: $node-port-label-color;
+            cursor: pointer;
             &:hover {
                 text-decoration: none;
                 background: $node-port-background-hover;


### PR DESCRIPTION
fixes #3572

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

* Use `$node-port-background` for config node background (this seems to make sense since it should contrast the `$node-port-label-color` used already for icon text)
* Only show pointer if node icon has count

### Before
![chrome_LYMTitoBvX](https://user-images.githubusercontent.com/44235289/175810799-b05697ad-a3c7-400f-8af7-6d7e29e92d3b.gif)

### After
![chrome_MWBY5wsA7s](https://user-images.githubusercontent.com/44235289/175810820-94ce2645-bbc2-4e14-87df-abbf8631565e.gif)


## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
