### PR TITLE
Increase quick-add height to reveal 2 most recent entries

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/search.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/search.scss
@@ -54,7 +54,7 @@
     }
     .red-ui-search-results-container {
         display: none;
-        height: 150px;
+        height: 195px;
         .red-ui-editableList-container {
             border: 1px dashed $primary-border-color;
             border-top: 1px solid $secondary-border-color;


### PR DESCRIPTION
fixes #3568

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Increase quick-add height from 150px to 195px to reveal 2 most recent entries

### Before
![image](https://user-images.githubusercontent.com/44235289/175811544-bdd7568f-97b5-432a-8180-98408246f878.png)


### After
![image](https://user-images.githubusercontent.com/44235289/175811537-b061f343-9bf5-4490-9d12-ff3329ff257c.png)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
