### PR TITLE
Fix CSV node to handle \n when outputting text fields

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/parsers/70-CSV.js
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-CSV.js
@@ -89,6 +89,9 @@ module.exports = function(RED) {
                                     else if (msg.payload[s][t].toString().indexOf(node.sep) !== -1) { // add quotes if any "commas"
                                         msg.payload[s][t] = node.quo + msg.payload[s][t].toString() + node.quo;
                                     }
+                                    else if (msg.payload[s][t].toString().indexOf("\n") !== -1) { // add quotes if any "\n"
+                                        msg.payload[s][t] = node.quo + msg.payload[s][t].toString() + node.quo;
+                                    }
                                 }
                                 ou += msg.payload[s].join(node.sep) + node.ret;
                             }
@@ -112,7 +115,7 @@ module.exports = function(RED) {
                                                     q = q.replace(/"/g, '""');
                                                     ou += node.quo + q + node.quo + node.sep;
                                                 }
-                                                else if (q.indexOf(node.sep) !== -1) { // add quotes if any "commas"
+                                                else if (q.indexOf(node.sep) !== -1 || p.indexOf("\n") !== -1) { // add quotes if any "commas" or "\n"
                                                     ou += node.quo + q + node.quo + node.sep;
                                                 }
                                                 else { ou += q + node.sep; } // otherwise just add
@@ -134,7 +137,7 @@ module.exports = function(RED) {
                                                 p = p.replace(/"/g, '""');
                                                 ou += node.quo + p + node.quo + node.sep;
                                             }
-                                            else if (p.indexOf(node.sep) !== -1) { // add quotes if any "commas"
+                                            else if (p.indexOf(node.sep) !== -1 || p.indexOf("\n") !== -1) { // add quotes if any "commas" or "\n"
                                                 ou += node.quo + p + node.quo + node.sep;
                                             }
                                             else { ou += p + node.sep; } // otherwise just add

--- a/test/nodes/core/parsers/70-CSV_spec.js
+++ b/test/nodes/core/parsers/70-CSV_spec.js
@@ -693,19 +693,19 @@ describe('CSV node', function() {
     describe('json object to csv', function() {
 
         it('should convert a simple object back to a csv', function(done) {
-            var flow = [ { id:"n1", type:"csv", temp:"a,b,c,,e", wires:[["n2"]] },
+            var flow = [ { id:"n1", type:"csv", temp:"a,b,c,,e,f", wires:[["n2"]] },
                 {id:"n2", type:"helper"} ];
             helper.load(csvNode, flow, function() {
                 var n1 = helper.getNode("n1");
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
                     try {
-                        msg.should.have.property('payload', '4,foo,true,,0\n');
+                        msg.should.have.property('payload', '4,foo,true,,0,"Hello\nWorld"\n');
                         done();
                     }
                     catch(e) { done(e); }
                 });
-                var testJson = { e:0, d:1, b:"foo", c:true, a:4 };
+                var testJson = { e:0, d:1, b:"foo", c:true, a:4, f:"Hello\nWorld" };
                 n1.emit("input", {payload:testJson});
             });
         });
@@ -777,7 +777,7 @@ describe('CSV node', function() {
                     }
                     catch(e) { done(e); }
                 });
-                var testJson = [{ d: 1, b: 3, c: 2, a: 4 },{d:4,a:1,c:3,b:2}];
+                var testJson = [{ d:1, b:3, c:2, a:4 },{d:4, a:1, c:3, b:2}];
                 n1.emit("input", {payload:testJson});
             });
         });
@@ -790,12 +790,12 @@ describe('CSV node', function() {
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
                     try {
-                        msg.should.have.property('payload', 'a,b,c,d\n4,3,2,1\n1,2,3,4\n');
+                        msg.should.have.property('payload', 'a,b,c,d\n4,3,2,1\n1,2,3,"a\nb"\n');
                         done();
                     }
                     catch(e) { done(e); }
                 });
-                var testJson = [{ d: 1, b: 3, c: 2, a: 4 },{d:4,a:1,c:3,b:2}];
+                var testJson = [{ d:1, b:3, c:2, a:4 },{d:"a\nb", a:1, c:3, b:2}];
                 n1.emit("input", {payload:testJson});
             });
         });
@@ -826,12 +826,12 @@ describe('CSV node', function() {
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
                     try {
-                        msg.should.have.property('payload', 'd,b,c,a\n1,3,2,4\n4,2,3,1\n');
+                        msg.should.have.property('payload', 'd,b,c,a\n1,3,2,4\n4,"f\ng",3,1\n');
                         done();
                     }
                     catch(e) { done(e); }
                 });
-                var testJson = [{ d: 1, b: 3, c: 2, a: 4 },{d:4,a:1,c:3,b:2}];
+                var testJson = [{ d: 1, b: 3, c: 2, a: 4 },{d:4,a:1,c:3,b:"f\ng"}];
                 n1.emit("input", {payload:testJson});
             });
         });
@@ -844,12 +844,12 @@ describe('CSV node', function() {
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
                     try {
-                        msg.should.have.property('payload', ',0,1,foo,"ba""r","di,ng"\n');
+                        msg.should.have.property('payload', ',0,1,foo,"ba""r","di,ng","fa\nba"\n');
                         done();
                     }
                     catch(e) { done(e); }
                 });
-                var testJson = ["",0,1,"foo",'ba"r','di,ng'];
+                var testJson = ["",0,1,"foo",'ba"r','di,ng',"fa\nba"];
                 n1.emit("input", {payload:testJson});
             });
         });
@@ -898,12 +898,12 @@ describe('CSV node', function() {
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
                     try {
-                        msg.should.have.property('payload', 'col1,col2,col3,col4\r\nH1,H2,H3,H4\r\nA,B,,\r\nA,,C,\r\nA,,,D\r\n');
+                        msg.should.have.property('payload', 'col1,col2,col3,col4\r\nH1,H2,H3,H4\r\nA,B,,\r\nA,,C,\r\nA,,,"D\nE"\r\n');
                         done();
                     }
                     catch(e) { done(e); }
                 });
-                var testJson = [{"col1":"H1","col2":"H2","col3":"H3","col4":"H4"},{"col1":"A","col2":"B"},{"col1":"A","col3":"C"},{"col1":"A","col4":"D"}];
+                var testJson = [{"col1":"H1","col2":"H2","col3":"H3","col4":"H4"},{"col1":"A","col2":"B"},{"col1":"A","col3":"C"},{"col1":"A","col4":"D\nE"}];
                 n1.emit("input", {payload:testJson});
             });
         });


### PR DESCRIPTION
and add tests

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

As pointed out here - https://discourse.nodered.org/t/csv-string-values-containing-new-lines/64437
the CSV node does not escape any strings that contain \n within hem when outputting to csv file. 
This fix wraps the field in " so that they can then be imported into excel etc.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
