### PR TITLE
Add option flag `reimport` to `importNodes`

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1654,21 +1654,19 @@ RED.nodes = (function() {
      * Options:
      *  - generateIds - whether to replace all node ids
      *  - addFlow - whether to import nodes to a new tab
-     *  - importToCurrent
+     *  - reimport - if node has a .z property, dont overwrite it
+     *               Only applicible when `generateIds` is false
      *  - importMap - how to resolve any conflicts.
      *       - id:import - import as-is
      *       - id:copy - import with new id
      *       - id:replace - import over the top of existing
      */
     function importNodes(newNodesObj,options) { // createNewIds,createMissingWorkspace) {
-        options = options || {
-            generateIds: false,
-            addFlow: false,
-        }
-        options.importMap = options.importMap || {};
-
-        var createNewIds = options.generateIds;
-        var createMissingWorkspace = options.addFlow;
+        const defOpts = { generateIds: false, addFlow: false, reimport: false, importMap: {} }
+        options = Object.assign({}, defOpts, options)
+        const createNewIds = options.generateIds;
+        const reimport = (!createNewIds && !!options.reimport)
+        const createMissingWorkspace = options.addFlow;
         var i;
         var n;
         var newNodes;
@@ -1969,7 +1967,8 @@ RED.nodes = (function() {
                         }
                     }
                 } else {
-                    if (n.z && !workspace_map[n.z] && !subflow_map[n.z]) {
+                    const keepNodesCurrentZ = reimport && n.z && RED.workspaces.contains(n.z)
+                    if (!keepNodesCurrentZ && n.z && !workspace_map[n.z] && !subflow_map[n.z]) {
                         n.z = activeWorkspace;
                     }
                 }
@@ -2070,7 +2069,8 @@ RED.nodes = (function() {
                         node.id = getID();
                     } else {
                         node.id = n.id;
-                        if (node.z == null || (!workspace_map[node.z] && !subflow_map[node.z])) {
+                        const keepNodesCurrentZ = reimport && node.z && RED.workspaces.contains(node.z)
+                        if (!keepNodesCurrentZ && (node.z == null || (!workspace_map[node.z] && !subflow_map[node.z]))) {
                             if (createMissingWorkspace) {
                                 if (missingWorkspace === null) {
                                     missingWorkspace = RED.workspaces.add(null,true);
@@ -2769,7 +2769,7 @@ RED.nodes = (function() {
                     // Force the redraw to be synchronous so the view updates
                     // *now* and removes the unknown node
                     RED.view.redraw(true, true);
-                    var result = importNodes(reimportList,{generateIds:false});
+                    var result = importNodes(reimportList,{generateIds:false, reimport: true});
                     var newNodeMap = {};
                     result.nodes.forEach(function(n) {
                         newNodeMap[n.id] = n;


### PR DESCRIPTION
fixes #3699

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

Add option flag `reimport` to `importNodes()` to instruct the function to skip the relocation of `z` if it is already present and a matching workspace (flow/subflow) is present.

The `reimport` flag is only ever set in `RED.events.on("registry:node-type-added",function(type) {` so is only operational when a registration event occurs


I have tested this by delaying the call to `RED.nodes.registerType('debug',{` in `packages\node_modules\@node-red\nodes\core\common\21-debug.html` for both regular flows and subflows.


## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
