### PR TITLE
Ensure importMap is not null when using import UI

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1664,6 +1664,7 @@ RED.nodes = (function() {
     function importNodes(newNodesObj,options) { // createNewIds,createMissingWorkspace) {
         const defOpts = { generateIds: false, addFlow: false, reimport: false, importMap: {} }
         options = Object.assign({}, defOpts, options)
+        options.importMap = options.importMap || {}
         const createNewIds = options.generateIds;
         const reimport = (!createNewIds && !!options.reimport)
         const createMissingWorkspace = options.addFlow;


### PR DESCRIPTION
fixes #3722


## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

double check `options.importMap` is "something" to prevent exception

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
