### PR TITLE
Update add-junction menu to work in more cases

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
@@ -43,7 +43,16 @@ RED.contextMenu = (function() {
         const isGroup = hasSelection && selection.nodes.length === 1 && selection.nodes[0].type === 'group'
 
         const canRemoveFromGroup = hasSelection && !!selection.nodes[0].g
+        const offset = $("#red-ui-workspace-chart").offset()
 
+        let addX = options.x - offset.left + $("#red-ui-workspace-chart").scrollLeft()
+        let addY = options.y - offset.top + $("#red-ui-workspace-chart").scrollTop()
+
+        if (RED.view.snapGrid) {
+            const gridSize = RED.view.gridSize()
+            addX = gridSize*Math.floor(addX/gridSize)
+            addY = gridSize*Math.floor(addY/gridSize)
+        }
 
         const menuItems = [
             { onselect: 'core:show-action-list', onpostselect: function() {} },
@@ -54,17 +63,42 @@ RED.contextMenu = (function() {
                         label: RED._("contextMenu.node"),
                         onselect: function() {
                             RED.view.showQuickAddDialog({
-                                position: [ options.x - offset.left, options.y - offset.top ],
+                                position: [ addX, addY ],
                                 touchTrigger: true,
                                 splice: isSingleLink?selection.links[0]:undefined,
                                 // spliceMultiple: isMultipleLinks
                             })
                         }
                     },
-                    {
+                    ( hasSelection || hasLinks ) ? {
                         label: RED._("contextMenu.junction"),
                         onselect: 'core:split-wires-with-junctions',
-                        disabled: hasSelection || !hasLinks
+                        disabled: !hasLinks
+                    } : {
+                        label: RED._("contextMenu.junction"),
+                        onselect: function() {
+                            const nn = {
+                                _def: {defaults:{}},
+                                type: 'junction',
+                                z: RED.workspaces.active(),
+                                id: RED.nodes.id(),
+                                x: addX,
+                                y: addY,
+                                w: 0, h: 0,
+                                outputs: 1,
+                                inputs: 1,
+                                dirty: true
+                            }
+                            const historyEvent = {
+                                dirty: RED.nodes.dirty(),
+                                t:'add',
+                                junctions:[nn]
+                            }
+                            RED.nodes.addJunction(nn);
+                            RED.history.push(historyEvent);
+                            RED.nodes.dirty(true);
+                            RED.view.redraw(true)
+                        }
                     },
                     {
                         label: RED._("contextMenu.linkNodes"),
@@ -118,7 +152,6 @@ RED.contextMenu = (function() {
             }
 
         }
-        const offset = $("#red-ui-workspace-chart").offset()
         menu = RED.menu.init({
             direction: 'right',
             onpreselect: function() {


### PR DESCRIPTION
This PR updates the context menu handling of 'add junction' to address some feedback from the beta:

 - 'Insert -> Junction' is now available in more cases. When nothing is selected, it inserts a bare junction in the workspace. When only nodes are selected, the junction option is disabled. If wires are selected (ignoring any nodes) the junctions are inserted

 - The positioning of the Inject -> Node quick add dialog is now accounts for snapToGrid and whether the workspace is scrolled.