### PR TITLE
Do not generate new node-ids when pasting a cut flow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -630,7 +630,9 @@ RED.view = (function() {
 
         RED.actions.add("core:copy-selection-to-internal-clipboard",copySelection);
         RED.actions.add("core:cut-selection-to-internal-clipboard",function(){copySelection(true);deleteSelection();});
-        RED.actions.add("core:paste-from-internal-clipboard",function(){importNodes(clipboard,{generateIds: clipboardSource === 'copy', generateDefaultNames: clipboardSource === 'copy'});});
+        RED.actions.add("core:paste-from-internal-clipboard",function(){
+            importNodes(clipboard,{generateIds: clipboardSource === 'copy', generateDefaultNames: clipboardSource === 'copy'});
+        });
 
         RED.actions.add("core:detach-selected-nodes", function() { detachSelectedNodes() })
 
@@ -2150,6 +2152,9 @@ RED.view = (function() {
             }
         }
         if (mouse_mode == RED.state.IMPORT_DRAGGING) {
+            if (clipboardSource === 'cut') {
+                clipboardSource = 'copy'
+            }
             updateActiveNodes();
             RED.nodes.dirty(true);
         }
@@ -3479,6 +3484,9 @@ RED.view = (function() {
             updateSelection();
             RED.nodes.dirty(true);
             redraw();
+            if (clipboardSource === 'cut') {
+                clipboardSource = 'copy'
+            }
             resetMouseVars();
             d3.event.stopPropagation();
             return;

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -95,6 +95,7 @@ RED.view = (function() {
     let flashingNodeId;
 
     var clipboard = "";
+    let clipboardSource
 
     // Note: these are the permitted status colour aliases. The actual RGB values
     //       are set in the CSS - flow.scss/colors.scss
@@ -628,8 +629,8 @@ RED.view = (function() {
         });
 
         RED.actions.add("core:copy-selection-to-internal-clipboard",copySelection);
-        RED.actions.add("core:cut-selection-to-internal-clipboard",function(){copySelection();deleteSelection();});
-        RED.actions.add("core:paste-from-internal-clipboard",function(){importNodes(clipboard,{generateIds: true, generateDefaultNames: true});});
+        RED.actions.add("core:cut-selection-to-internal-clipboard",function(){copySelection(true);deleteSelection();});
+        RED.actions.add("core:paste-from-internal-clipboard",function(){importNodes(clipboard,{generateIds: clipboardSource === 'copy', generateDefaultNames: clipboardSource === 'copy'});});
 
         RED.actions.add("core:detach-selected-nodes", function() { detachSelectedNodes() })
 
@@ -2703,7 +2704,7 @@ RED.view = (function() {
         }
     }
 
-    function copySelection() {
+    function copySelection(isCut) {
         if (mouse_mode === RED.state.SELECTING_NODE) {
             return;
         }
@@ -2767,6 +2768,7 @@ RED.view = (function() {
                 }
             }
             clipboard = JSON.stringify(nns);
+            clipboardSource = isCut ? 'cut' : 'copy'
             RED.menu.setDisabled("menu-item-edit-paste", false);
             if (nodeCount > 0) {
                 RED.notify(RED._("clipboard.nodeCopied",{count:nodeCount}),{id:"clipboard"});
@@ -4086,7 +4088,7 @@ RED.view = (function() {
         var mdn = mousedown_node;
         var options = [];
         options.push({name:"delete",disabled:(movingSet.length()===0 && selectedLinks.length() === 0),onselect:function() {deleteSelection();}});
-        options.push({name:"cut",disabled:(movingSet.length()===0),onselect:function() {copySelection();deleteSelection();}});
+        options.push({name:"cut",disabled:(movingSet.length()===0),onselect:function() {copySelection(true);deleteSelection();}});
         options.push({name:"copy",disabled:(movingSet.length()===0),onselect:function() {copySelection();}});
         options.push({name:"paste",disabled:(clipboard.length===0),onselect:function() {importNodes(clipboard, {generateIds: true, touchImport: true});}});
         options.push({name:"edit",disabled:(movingSet.length() != 1),onselect:function() { RED.editor.edit(mdn);}});


### PR DESCRIPTION
Fixes #3629

After cutting a flow to the clipboard, we shouldn't generate new ids when it gets pasted. This ensures any nodes that were targeting the cut nodes (link-call, catch etc) still target the nodes after they are pasted.

When pasting a flow that was *copied* to the clipboard, we still generate ids as before.

This feels a more expected behaviour.