### PR TITLE
Fix label overflow @ config-node palette

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
@@ -54,6 +54,9 @@ ul.red-ui-sidebar-node-config-list {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        &:not(:last-child) {
+            width: calc(100% - 38px);
+        }
     }
     .red-ui-palette-icon-container {
         font-size: 12px;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
This is another attempt to fix the issue raised in #3572.

As-Is (3.0.0-beta.4):
<img width="181" alt="image" src="https://user-images.githubusercontent.com/16342003/176992094-f1360774-7f41-467c-9fd0-fbe9a959b992.png">

To-Be:
<img width="181" alt="image" src="https://user-images.githubusercontent.com/16342003/176992135-e49a8bd5-7d26-4524-8428-e469d0994b72.png">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
