### PR TITLE
Fix to prevent node from moving out of workspace

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
@@ -105,6 +105,8 @@ RED.view.tools = (function() {
                 $(document).one('keyup',endKeyboardMove);
                 endMoveSet = true;
             }
+            var space_width = 5000;
+            var space_height = 5000;
             var minX = 0;
             var minY = 0;
             var node;
@@ -120,6 +122,12 @@ RED.view.tools = (function() {
                 node.n.dirty = true;
                 node.n.x += dx;
                 node.n.y += dy;
+                if ((node.n.x +node.n.w/2) >= space_width) {
+                    node.n.x = space_width -node.n.w/2;
+                }
+                if ((node.n.y +node.n.h/2) >= space_height) {
+                    node.n.y = space_height -node.n.h/2;
+                }
                 node.n.dirty = true;
                 if (node.n.type === "group") {
                     RED.group.markDirty(node.n);
@@ -130,6 +138,7 @@ RED.view.tools = (function() {
                     minY = Math.min(node.n.y-node.n.h/2-5,minY);
                 }
             }
+            console.log("; mS:", dx, dy, minX, minY);
             if (minX !== 0 || minY !== 0) {
                 for (var n = 0; n<moving_set.length; n++) {
                     node = moving_set[n];


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
A node can be moved out of the right or bottom edge of workspace using *Move Selection to Right/Down* action.
This PR try to fix the issue.

![スクリーンショット 2022-07-03 21 08 34](https://user-images.githubusercontent.com/30289092/177038996-df2e6baf-04e4-4d3b-b9c7-c7b80ed7c97e.png)

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x]  I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
