### PR TITLE
Fix defaulting to monaco if settings does not contain codeEditor

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -101,7 +101,10 @@ module.exports = {
         }
         themeSettings = null;
         theme = settings.editorTheme || {};
-        themeContext.asset.vendorMonaco = ((theme.codeEditor || {}).lib === "monaco") ? "vendor/monaco/monaco-bootstrap.js" : "";
+        themeContext.asset.vendorMonaco = "vendor/monaco/monaco-bootstrap.js"
+        if (theme.codeEditor && theme.codeEditor.lib === 'ace') {
+            themeContext.asset.vendorMonaco = ''
+        }
         activeTheme = theme.theme;
     },
 

--- a/test/unit/@node-red/editor-api/lib/editor/theme_spec.js
+++ b/test/unit/@node-red/editor-api/lib/editor/theme_spec.js
@@ -51,7 +51,7 @@ describe("api/editor/theme", function () {
         context.should.have.a.property("asset");
         context.asset.should.have.a.property("red", "red/red.min.js");
         context.asset.should.have.a.property("main", "red/main.min.js");
-        context.asset.should.have.a.property("vendorMonaco", "");
+        context.asset.should.have.a.property("vendorMonaco", "vendor/monaco/monaco-bootstrap.js");
 
         should.not.exist(theme.settings());
     });
@@ -69,16 +69,16 @@ describe("api/editor/theme", function () {
         }
     });
 
-    it("Adds monaco bootstrap when enabled", async function () {
+    it("Does not add monaco bootstrap when ace selected", async function () {
         theme.init({
             editorTheme: {
                 codeEditor: {
-                    lib: 'monaco'
+                    lib: 'ace'
                 }
             }
         });
         var context = await theme.context();
-        context.asset.should.have.a.property("vendorMonaco", "vendor/monaco/monaco-bootstrap.js");
+        context.asset.should.have.a.property("vendorMonaco", "");
     });
 
     it("picks up custom theme", async function () {


### PR DESCRIPTION
We didn't do a complete enough job of defaulting to monaco. If the settings.js file doesn't contain a `codeEditor` entry, the editor will default to monaco, but the runtime will not have ensured the monaco library was loaded by the editor.