### PR TITLE
Fix close timeout of websocket node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
@@ -215,6 +215,7 @@ module.exports = function(RED) {
                 delete listenerNodes[node.fullPath];
                 node.server.close();
                 node._inputNodes = [];
+                done();
             }
             else {
                 node.closing = true;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Re-deploying a flow containing web socket node causes `Error stopping node: Close timed out`.
This PR try to fix the issue.

**Steps to reproduce**:
1. Import web socket node example and deploy it,
2. Delete the imported flow,
3. Re-Deploy,
4. (3) causes `Error: stopping node: Close timed out`,

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
