### PR TITLE
Don't let themes change disabled config node background color

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
@@ -217,6 +217,7 @@ $node-icon-border-color: #000;
 $node-icon-border-color-opacity: 0.1;
 
 $node-config-background: #f3f3f3;
+$node-config-icon-container-disabled: #aaa;
 
 $node-link-port-background: #eee;
 

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
@@ -103,13 +103,13 @@ ul.red-ui-sidebar-node-config-list li.red-ui-palette-node-config-type {
     border-color: var(--red-ui-primary-border-color);
     background: var(--red-ui-node-config-background);
     border-style: dashed;
-    color: var(--red-ui-tertiary-text-color);
+    color: var(--red-ui-node-config-icon-container-disabled);
 }
 .red-ui-palette-node-config-disabled {
     opacity: 0.6;
     font-style: italic;
     i {
-        color: var(--red-ui-secondary-text-color);
+        color: var(--red-ui-node-port-label-color);
         margin-right: 5px;
     }
 }

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
@@ -101,7 +101,7 @@ ul.red-ui-sidebar-node-config-list li.red-ui-palette-node-config-type {
 }
 .red-ui-palette-node-config-unused,.red-ui-palette-node-config-disabled {
     border-color: var(--red-ui-primary-border-color);
-    background: var(--red-ui-secondary-background-inactive);
+    background: var(--red-ui-node-config-background);
     border-style: dashed;
     color: var(--red-ui-tertiary-text-color);
 }

--- a/packages/node_modules/@node-red/editor-client/src/sass/variables.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/variables.scss
@@ -203,6 +203,7 @@
     --red-ui-node-icon-border-color-opacity: #{$node-icon-border-color-opacity};
 
     --red-ui-node-config-background: #{$node-config-background};
+    --red-ui-node-config-icon-container-disabled: #{$node-config-icon-container-disabled};
 
     --red-ui-node-link-port-background: #{$node-link-port-background};
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
While testing the changes from #3730, I noticed that I left disabled config nodes out of #3564.

<img width="1280" alt="Screen Shot 2022-07-04 at 4 59 41 PM" src="https://user-images.githubusercontent.com/29807944/177217598-fd35ce2c-d528-47f8-b22c-c776290a79c9.png">

This PR fixes that by using the same background color as in the default theme.

<img width="1280" alt="Screen Shot 2022-07-04 at 5 03 00 PM" src="https://user-images.githubusercontent.com/29807944/177217654-6824c2d0-2ee9-4fd3-bbef-9dc31aef2af7.png">
<img width="1280" alt="Screen Shot 2022-07-04 at 5 04 03 PM" src="https://user-images.githubusercontent.com/29807944/177217657-24c88a36-5780-4815-b02c-dde083ec4b60.png">

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
