### PR TITLE
prevent exception generating tooltip for deleted nodes

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -3293,11 +3293,17 @@ RED.view = (function() {
 
         if (active && ((portType === PORT_TYPE_INPUT && ((d._def && d._def.inputLabels)||d.inputLabels)) || (portType === PORT_TYPE_OUTPUT && ((d._def && d._def.outputLabels)||d.outputLabels)))) {
             portLabelHoverTimeout = setTimeout(function() {
+                const n = port && port.node()
+                const nId = n && n.__data__ && n.__data__.id
+                //check see if node has been deleted since timeout started
+                if(!n || !n.parentNode || !RED.nodes.node(n.__data__.id)) {
+                    return; //node is gone!
+                }
                 var tooltip = getPortLabel(d,portType,portIndex);
                 if (!tooltip) {
                     return;
                 }
-                var pos = getElementPosition(port.node());
+                var pos = getElementPosition(n);
                 portLabelHoverTimeout = null;
                 portLabelHover = showTooltip(
                     (pos[0]+(portType===PORT_TYPE_INPUT?-2:12)),
@@ -3734,6 +3740,10 @@ RED.view = (function() {
             if (d.hasOwnProperty('l')?!d.l : (d.type === "link in" || d.type === "link out")) {
                 var parentNode = this.parentNode;
                 portLabelHoverTimeout = setTimeout(function() {
+                    //check see if node has been deleted since timeout started
+                    if(!parentNode || !parentNode.parentNode || !RED.nodes.node(parentNode.id)) {
+                        return; //node is gone!
+                    }
                     var tooltip;
                     if (d._def.label) {
                         tooltip = d._def.label;


### PR DESCRIPTION
fixes #3740 (Uncaught TypeError error in browser console when deleting nodes from canvas)

## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

Check that node exists inside the timer callback - before attempting to generate a tooltip and calculate offsets etc.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
