### PR TITLE
Fix display direction of context sub-menu

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
@@ -152,8 +152,16 @@ RED.contextMenu = (function() {
             }
 
         }
+
+        var direction = "right";
+        var MENU_WIDTH = 600; // can not use menu width here
+        if ((options.x -$(document).scrollLeft()) >
+            ($(window).height() -MENU_WIDTH)) {
+            direction = "left";
+        }
+        
         menu = RED.menu.init({
-            direction: 'right',
+            direction: direction,
             onpreselect: function() {
                 disposeMenu()
             },


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
When context menu is displayed on the right end of the workspace, its sub-menu is difficult to see the contents because the sub-menu is always displayed on the right side of parent menu.
This PR try to fix the issue.

![スクリーンショット 2022-07-07 16 55 46](https://user-images.githubusercontent.com/30289092/177724150-5d2af135-7578-4ee8-9051-2b53d832d4a0.png)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
