### PR TITLE
Fix clear pinned paths of debug sidebar menu

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/lib/debug/debug-utils.js
+++ b/packages/node_modules/@node-red/nodes/core/common/lib/debug/debug-utils.js
@@ -459,30 +459,38 @@ RED.debug = (function() {
     function showMessageMenu(button,dbgMessage,sourceId) {
         activeMenuMessage = dbgMessage;
         if (!menuOptionMenu) {
-            menuOptionMenu = RED.menu.init({id:"red-ui-debug-msg-option-menu",
-                options: [
-                    {id:"red-ui-debug-msg-menu-item-collapse",label:RED._("node-red:debug.messageMenu.collapseAll"),onselect:function(){
-                        activeMenuMessage.collapse();
-                    }},
+            var opts = [
+                {id:"red-ui-debug-msg-menu-item-collapse",label:RED._("node-red:debug.messageMenu.collapseAll"),onselect:function(){
+                    activeMenuMessage.collapse();
+                }},
+            ];
+            if (activeMenuMessage.clearPinned) {
+                opts.push(
                     {id:"red-ui-debug-msg-menu-item-clear-pins",label:RED._("node-red:debug.messageMenu.clearPinned"),onselect:function(){
                         activeMenuMessage.clearPinned();
                     }},
-                    null,
-                    {id:"red-ui-debug-msg-menu-item-filter", label:RED._("node-red:debug.messageMenu.filterNode"),onselect:function(){
-                        var candidateNodes = RED.nodes.filterNodes({type:'debug'});
-                        candidateNodes.forEach(function(n) {
-                            filteredNodes[n.id] = true;
-                        });
-                        delete filteredNodes[sourceId];
-                        $("#red-ui-sidebar-debug-filterSelected").trigger("click");
-                        RED.settings.set('debug.filteredNodes',Object.keys(filteredNodes))
-                        refreshMessageList();
-                    }},
-                    {id:"red-ui-debug-msg-menu-item-clear-filter",label:RED._("node-red:debug.messageMenu.clearFilter"),onselect:function(){
-                        $("#red-ui-sidebar-debug-filterAll").trigger("click");
-                        refreshMessageList();
-                    }}
-                ]
+                );
+            }
+            opts.push(
+                null,
+                {id:"red-ui-debug-msg-menu-item-filter", label:RED._("node-red:debug.messageMenu.filterNode"),onselect:function(){
+                    var candidateNodes = RED.nodes.filterNodes({type:'debug'});
+                    candidateNodes.forEach(function(n) {
+                        filteredNodes[n.id] = true;
+                    });
+                    delete filteredNodes[sourceId];
+                    $("#red-ui-sidebar-debug-filterSelected").trigger("click");
+                    RED.settings.set('debug.filteredNodes',Object.keys(filteredNodes))
+                    refreshMessageList();
+                }},
+                {id:"red-ui-debug-msg-menu-item-clear-filter",label:RED._("node-red:debug.messageMenu.clearFilter"),onselect:function(){
+                    $("#red-ui-sidebar-debug-filterAll").trigger("click");
+                    refreshMessageList();
+                }}
+            );
+
+            menuOptionMenu = RED.menu.init({id:"red-ui-debug-msg-option-menu",
+                options: opts
             });
             menuOptionMenu.css({
                 position: "absolute"


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->
## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Selecting `Clear pinned paths` of debug sidebar item menu for global message causes editor runtime error.
```
debug-utils.js:468 Uncaught TypeError: activeMenuMessage.clearPinned is not a function
    at Object.onselect (debug-utils.js:468:43)
    at f (red.min.js?v=3.0.0-beta.4:18:47386)
    at HTMLAnchorElement.<anonymous> (red.min.js?v=3.0.0-beta.4:18:46029)
    at HTMLAnchorElement.dispatch (vendor.js?v=3.0.0-beta.4:2:43090)
    at v.handle (vendor.js?v=3.0.0-beta.4:2:41074)
```
This PR try to fix the issue. 

![スクリーンショット 2022-07-08 13 13 43](https://user-images.githubusercontent.com/30289092/177915662-87f1c3b9-256b-4e53-9e4f-3070c6c10b00.png)



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
