### PR TITLE
Ensure global-config and flow-config have info in the hierarchy popover

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.html
@@ -245,47 +245,37 @@
                     // complete parentage of the node that generated this message.
                     //    flow-id/subflow-A-instance/subflow-B-instance
 
-                    // If it has one id, that is a top level flow
+                    // If it has one id, that is a top level flow or config node/global
                     // each subsequent id is the instance id of a subflow node
                     //
                     pathParts = o.path.split("/");
                     if (pathParts.length === 1) {
-                        // The source node is on a flow - so can use its id to find
+                        // The source node is on a flow or is a global/config - so can use its id to find
                         sourceNode = RED.nodes.node(o.id);
-                        if (pathParts[0] === "global") {
-                            pathParts = [];
-                        }
                     } else if (pathParts.length > 1) {
                         // Highlight the subflow instance node.
                         sourceNode = RED.nodes.node(pathParts[1]);
                     }
+                    const getNodeLabel = (n) => n.name || (typeof n.label === "function" && n.label())  || (typeof n.label === "string" && n.label) || (n.type + ":" + n.id);
                     pathHierarchy = pathParts.map((id,index) => {
                         if (index === 0) {
-                            return {
-                                id: id,
-                                label: RED.nodes.workspace(id).label
-                            }
+                            if (id === "global") {
+                                return { id: sourceNode.id, label: getNodeLabel(sourceNode) }
+                            } 
+                            return { id: id, label: RED.nodes.workspace(id).label } //flow id + name
                         } else {
-                            var instanceNode = RED.nodes.node(id)
-                            return {
-                                id: id,
-                                label: (instanceNode.name || RED.nodes.subflow(instanceNode.type.substring(8)).name)
-                            }
+                            const instanceNode = RED.nodes.node(id)
+                            const pathLabel = (instanceNode.name || RED.nodes.subflow(instanceNode.type.substring(8)).name)
+                            return { id: id, label: pathLabel }
                         }
                     })
-                    if (pathParts.length === 1) {
-                        pathHierarchy.push({
-                            id: o.id,
-                            label: sourceNode.name || sourceNode.type+":"+sourceNode.id
-                        })
+                    if (pathParts.length === 1 && pathParts[0] !== "global") {
+                        pathHierarchy.push({ id: o.id, label: getNodeLabel(sourceNode) })
                     }
                     if (o._alias) {
                         let aliasNode = RED.nodes.node(o._alias)
                         if (aliasNode) {
-                            pathHierarchy.push({
-                                id: o._alias,
-                                label: aliasNode.name || aliasNode.type+":"+aliasNode.id
-                            })
+                            pathHierarchy.push({ id: o._alias, label: getNodeLabel(aliasNode) })
                         }
                     }
                 } else {


### PR DESCRIPTION
fixes #3750

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Ensure global configs are listed and clickable

Tested with named, unnamed, global/flow config nodes


### global config now looks like...
![chrome_00lugEGWvy](https://user-images.githubusercontent.com/44235289/178261770-c8363399-63c0-4442-b035-e091483aa048.gif)

### flow config now looks like...
![chrome_2qrqL0dKEN](https://user-images.githubusercontent.com/44235289/178261829-35f91fa9-072e-4566-8af2-713ede213d3d.gif)



## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
