### PR TITLE
Fix change node, not handling from field properly when using context

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/15-change.js
+++ b/packages/node_modules/@node-red/nodes/core/function/15-change.js
@@ -168,9 +168,9 @@ module.exports = function(RED) {
                         return getFromValueType(RED.util.getMessageProperty(msg,rule.from),done);
                     } else if (rule.fromt === 'flow' || rule.fromt === 'global') {
                         var contextKey = RED.util.parseContextStore(rule.from);
-                        if (/\[msg\./.test(context.key)) {
+                        if (/\[msg\./.test(contextKey.key)) {
                             // The key has a nest msg. reference to evaluate first
-                            context.key = RED.util.normalisePropertyExpression(contextKey.key,msg,true);
+                            contextKey.key = RED.util.normalisePropertyExpression(contextKey.key,msg,true);
                         }
                         node.context()[rule.fromt].get(contextKey.key, contextKey.store, (err,fromValue) => {
                             if (err) {


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fix a typo introduced in https://github.com/node-red/node-red/pull/2822 that breaks using context to replace a value.

The bug can be replicated with the following minimalist flow :

```JSON
[{"id":"906bd15b.bf1a5","type":"change","z":"40930c8d.9ea28c","name":"","rules":[{"t":"set","p":"prefix","pt":"flow","to":"myFilePrefix/","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":560,"y":1160,"wires":[["98a5ca24.feff1"]]},{"id":"98a5ca24.feff1","type":"change","z":"40930c8d.9ea28c","name":"","rules":[{"t":"change","p":"filename","pt":"msg","from":"prefix","fromt":"flow","to":"","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":760,"y":1160,"wires":[["3341cce4.c0dc14"]]},{"id":"9ef6ce5a.decc","type":"inject","z":"40930c8d.9ea28c","name":"specific file","props":[{"p":"payload"},{"p":"filename","v":"myFilePrefix/TAM_HIST_20210521_110828.csv","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"","payloadType":"date","x":400,"y":1160,"wires":[["906bd15b.bf1a5"]]},{"id":"3341cce4.c0dc14","type":"debug","z":"40930c8d.9ea28c","name":"","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"true","targetType":"full","statusVal":"","statusType":"auto","x":930,"y":1160,"wires":[]}]
```

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
