### PR TITLE
Fix storing subflow credential type when input has multiple types

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -931,6 +931,7 @@ RED.subflow = (function() {
 
 
     function buildEnvUIRow(row, tenv, ui, node) {
+        console.log(tenv, ui)
         ui.label = ui.label||{};
         if ((tenv.type === "cred" || (tenv.parent && tenv.parent.type === "cred")) && !ui.type) {
             ui.type = "cred";
@@ -991,6 +992,17 @@ RED.subflow = (function() {
                         default: inputType
                     })
                     input.typedInput('value',val.value)
+                    if (inputType === 'cred') {
+                        if (node.credentials) {
+                            if (node.credentials[tenv.name]) {
+                                input.typedInput('value', node.credentials[tenv.name]);
+                            } else if (node.credentials['has_'+tenv.name]) {
+                                input.typedInput('value', "__PWRD__")
+                            } else {
+                                input.typedInput('value', "");
+                            }
+                        }
+                    }
                 } else {
                     input.val(val.value)
                 }


### PR DESCRIPTION
Fixes #3749

If a subflow property has a UI defined with multiple types, including credential - the value is lost if the type is set to credential. This fix ensure the value does not get lost.