### PR TITLE
Fix "split with" on virtual links

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
@@ -97,6 +97,7 @@ RED.contextMenu = (function () {
                             RED.nodes.addJunction(nn);
                             RED.history.push(historyEvent);
                             RED.nodes.dirty(true);
+                            RED.view.select({nodes: [nn] });
                             RED.view.redraw(true)
                         }
                     },

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
@@ -69,13 +69,12 @@ RED.contextMenu = (function () {
                             })
                         }
                     },
-                    (hasSelection || hasLinks) ? { // has nodes or at least 1 wire selected
+                    (hasLinks) ? { // has least 1 wire selected
                         label: RED._("contextMenu.junction"),
                         onselect: 'core:split-wires-with-junctions',
                         disabled: !hasLinks
                     } : {
                         label: RED._("contextMenu.junction"),
-                        disabled: !noSelection, // has 0 nodes, 0 links selected (i.e. workspace right click)
                         onselect: function () {
                             const nn = {
                                 _def: { defaults: {} },

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
@@ -30,11 +30,14 @@ RED.contextMenu = (function () {
         }
 
         const selection = RED.view.selection()
+        const noSelection = !selection || Object.keys(selection).length === 0
         const hasSelection = (selection.nodes && selection.nodes.length > 0);
         const hasMultipleSelection = hasSelection && selection.nodes.length > 1;
-        const hasLinks = selection.links && selection.links.length > 0;
-        const isSingleLink = !hasSelection && hasLinks && selection.links.length === 1
-        const isMultipleLinks = !hasSelection && hasLinks && selection.links.length > 1
+        const virtulLinks = (selection.links && selection.links.filter(e => !!e.link)) || [];
+        const wireLinks = (selection.links && selection.links.filter(e => !e.link)) || [];
+        const hasLinks = wireLinks.length > 0;
+        const isSingleLink = !hasSelection && hasLinks && wireLinks.length === 1
+        const isMultipleLinks = !hasSelection && hasLinks && wireLinks.length > 1
         const canDelete = hasSelection || hasLinks
         const isGroup = hasSelection && selection.nodes.length === 1 && selection.nodes[0].type === 'group'
 
@@ -66,12 +69,13 @@ RED.contextMenu = (function () {
                             })
                         }
                     },
-                    (hasSelection || hasLinks) ? {
+                    (hasSelection || hasLinks) ? { // has nodes or at least 1 wire selected
                         label: RED._("contextMenu.junction"),
                         onselect: 'core:split-wires-with-junctions',
                         disabled: !hasLinks
                     } : {
                         label: RED._("contextMenu.junction"),
+                        disabled: !noSelection, // has 0 nodes, 0 links selected (i.e. workspace right click)
                         onselect: function () {
                             const nn = {
                                 _def: { defaults: {} },

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
@@ -823,7 +823,7 @@ RED.view.tools = (function() {
      * @param {Object || Object[]} wires The wire(s) to split and replace with link-out, link-in nodes.
      */
     function splitWiresWithLinkNodes(wires) {
-        let wiresToSplit = wires || RED.view.selection().links;
+        let wiresToSplit = wires || (RED.view.selection().links && RED.view.selection().links.filter(e => !e.link));
         if (!wiresToSplit) {
             return
         }
@@ -1061,7 +1061,7 @@ RED.view.tools = (function() {
     }
 
     function addJunctionsToWires(wires) {
-        let wiresToSplit = wires || RED.view.selection().links;
+        let wiresToSplit = wires || (RED.view.selection().links && RED.view.selection().links.filter(e => !e.link));
         if (!wiresToSplit) {
             return
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
@@ -1187,6 +1187,7 @@ RED.view.tools = (function() {
                 removedLinks: Array.from(removedLinks)
             })
             RED.nodes.dirty(true)
+            RED.view.select({nodes: addedJunctions });
         }
         RED.view.redraw(true);
     }


### PR DESCRIPTION
fixes #3765

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

* [Ensure only wire links are split with junctions/links](https://github.com/node-red/node-red/commit/e2f42fddb5afa66e57dacb043fd8b581eb09075f)
 * [fix context menu insert junc/links enabled state](https://github.com/node-red/node-red/commit/c648e1e8d621fd79e1494c921fe57c379e6ffc5a)
* [Ensure added junc(s) are selected](https://github.com/node-red/node-red/commit/75d3444391306155aaa3655e39f92a184bf77c53)
  * Feature parity with "Add Node" "Split wires with links" etc


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality

