### PR TITLE
Use theme page and header values if settings.js values are not present

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -266,6 +266,63 @@ module.exports = {
                     theme.page = theme.page || {_:{}}
                     theme.page._.scripts = scriptFiles.concat(theme.page._.scripts || [])
                 }
+                // check and load page settings from theme
+                if (themePlugin.page) {
+                    if (themePlugin.page.favicon  && !theme.page.favicon) {
+                        const result = serveFilesFromTheme(
+                            [themePlugin.page.favicon],
+                            themeApp,
+                            "/",
+                            themePlugin.path
+                        )
+                        if(result && result.length > 0) {
+                            // update themeContext page favicon
+                            themeContext.page.favicon = result[0]
+                            theme.page = theme.page || {_:{}}
+                            theme.page._.favicon = result[0]
+                        }
+                    }
+                    if (themePlugin.page.tabicon && themePlugin.page.tabicon.icon && !theme.page.tabicon) {
+                        const result = serveFilesFromTheme(
+                            [themePlugin.page.tabicon.icon],
+                            themeApp,
+                            "/page/",
+                            themePlugin.path
+                        )
+                        if(result && result.length > 0) {
+                            // update themeContext page tabicon
+                            themeContext.page.tabicon.icon = result[0]
+                            themeContext.page.tabicon.colour = themeContext.page.tabicon.colour || themeContext.page.tabicon.colour
+                            theme.page = theme.page || {_:{}}
+                            theme.page._.tabicon = theme.page._.tabicon || {}
+                            theme.page._.tabicon.icon = themeContext.page.tabicon.icon 
+                            theme.page._.tabicon.colour = themeContext.page.tabicon.colour
+                        }
+                    }
+                    // if the plugin has a title AND the users settings.js does NOT have a title
+                    if (themePlugin.page.title && !theme.page.title) {
+                        themeContext.page.title = themePlugin.page.title || themeContext.page.title
+                    }
+                }
+                // check and load header settings from theme
+                if (themePlugin.header) {
+                    if (themePlugin.header.image && !theme.header.image) {
+                        const result = serveFilesFromTheme(
+                            [themePlugin.header.image],
+                            themeApp,
+                            "/header/",
+                            themePlugin.path
+                        )
+                        if(result && result.length > 0) {
+                            // update themeContext header image
+                            themeContext.header.image = result[0]
+                        }
+                    }
+                    // if the plugin has a title AND the users settings.js does NOT have a title
+                    if (themePlugin.header.title && !theme.header.title) {
+                        themeContext.header.title = themePlugin.header.title || themeContext.header.title
+                    }
+                }
                 if(theme.codeEditor) {
                     theme.codeEditor.options = Object.assign({}, themePlugin.monacoOptions, theme.codeEditor.options);
                 }

--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -299,7 +299,7 @@ module.exports = {
                             theme.page._.tabicon.colour = themeContext.page.tabicon.colour
                         }
                     }
-                    // if the plugin has a title AND the users settings.js does NOT have a title
+                    // if the plugin has a title AND the users settings.js does NOT
                     if (themePlugin.page.title && !theme.page.title) {
                         themeContext.page.title = themePlugin.page.title || themeContext.page.title
                     }
@@ -321,6 +321,10 @@ module.exports = {
                     // if the plugin has a title AND the users settings.js does NOT have a title
                     if (themePlugin.header.title && !theme.header.title) {
                         themeContext.header.title = themePlugin.header.title || themeContext.header.title
+                    }
+                    // if the plugin has a header url AND the users settings.js does NOT
+                    if (themePlugin.header.url && !theme.header.url) {
+                        themeContext.header.url = themePlugin.header.url || themeContext.header.url
                     }
                 }
                 if(theme.codeEditor) {


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

* Permit a theme plugin to specify `header` and `page` values
* Only use theme `page` and `header` values if `settings.js` values are not present
* If neither are present, then NR defaults are used (as per v2.x)
* If settings.js values are present, use them (as per v2.x)


### Tested...
| settings.js | theme | Results in... |
| - | - | - |
| `page.favicon = null` | `page.favicon = null` | uses default NR favicon | 
| `page.favicon = null` | `page.favicon = 'common/favicon.ico'` | uses theme favicon | 
| `page.favicon = 'custom-icon.ico'` | `page.favicon = 'common/favicon.ico'` | uses settings.js custom favicon | 
| . | . | . |
| `page.title = null` | `page.title = null` | uses default NR title | 
| `page.title = null` | `page.title = 'theme title'` | uses theme title | 
| `page.title = 'settings.js title'` | `page.title = 'theme title'` | uses settings.js title | 
| . | . | . |
| `header.image = null` | `header.image = null` | uses default NR image | 
| `header.image = null` | `header.image = 'common/image.ico'` | uses theme image | 
| `header.image = 'custom-icon.ico'` | `header.image = 'common/image.ico'` | uses settings.js custom image | 
| . | . | . |
| `header.title = null` | `header.title = null` | uses default NR title | 
| `header.title = null` | `header.title = 'theme title'` | uses theme title | 
| `header.title = 'settings.js title'` | `header.title = 'theme title'` | uses settings.js title | 
| . | . | . |
| `header.url = null` | `header.url = null` | uses default NR url | 
| `header.url = null` | `header.url = 'theme url'` | uses theme url | 
| `header.url = 'settings.js url'` | `header.url = 'theme url'` | uses settings.js url | 


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
