### PR TITLE
Allow HTTP Headers not in spec

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.html
@@ -91,6 +91,11 @@
         <label for="node-input-senderr" style="width: auto" data-i18n="httpin.senderr"></label>
     </div>
 
+    <div class="form-row">
+        <input type="checkbox" id="node-input-insecureHTTPParser" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-insecureHTTPParser", style="width: auto;" data-i18n="httpin.insecureHTTPParser"></label>
+    </div>
+
 
     <div class="form-row">
         <label for="node-input-ret"><i class="fa fa-arrow-left"></i> <span data-i18n="httpin.label.return"></span></label>
@@ -227,6 +232,7 @@
             persist: {value:false},
             proxy: {type:"http proxy",required: false,
                     label:RED._("node-red:httpin.proxy-config") },
+            insecureHTTPParser: {value: false},
             authType: {value: ""},
             senderr: {value: false},
             headers: { value: [] }
@@ -337,6 +343,12 @@
                 $("#node-input-useProxy").prop("checked", true);
             } else {
                 $("#node-input-useProxy").prop("checked", false);
+            }
+
+            if (node.insecureHTTPParser) {
+                $("node-intput-insecureHTTPParser").prop("checked", true)
+            } else {
+                $("node-intput-insecureHTTPParser").prop("checked", false)
             }
             updateProxyOptions();
             $("#node-input-useProxy").on("click", function() {

--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
@@ -244,6 +244,10 @@ in your Node-RED user directory (${RED.settings.userDir}).
                                 delete options.headers[h];
                             }
                         })
+
+                        if (node.insecureHTTPParser) {
+                            options.insecureHTTPParser = true
+                        }
                     }
                 ],
                 beforeRedirect: [

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -554,7 +554,8 @@
         },
         "status": {
             "requesting": "requesting"
-        }
+        },
+        "insecureHTTPParser": "Lenient HTTP Header Parsing"
     },
     "websocket": {
         "label": {

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -555,7 +555,7 @@
         "status": {
             "requesting": "requesting"
         },
-        "insecureHTTPParser": "Lenient HTTP Header Parsing"
+        "insecureHTTPParser": "Disable strict HTTP parsing"
     },
     "websocket": {
         "label": {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Allow the relaxing of HTTP Header parsing

potential fix for #3772

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality

Need to think about how to add tests for "broken" headers when using express as the test http server
