### PR TITLE
Remove use of Object.hasOwn

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4906,7 +4906,7 @@ RED.view = (function() {
                         if (d._def.button) {
                             var buttonEnabled = isButtonEnabled(d);
                             this.__buttonGroup__.classList.toggle("red-ui-flow-node-button-disabled", !buttonEnabled);
-                            if (RED.runtime && Object.hasOwn(RED.runtime,'started')) {
+                            if (RED.runtime && RED.runtime.started !== undefined) {
                                 this.__buttonGroup__.classList.toggle("red-ui-flow-node-button-stopped", !RED.runtime.started);
                             }
 


### PR DESCRIPTION
Fixes #3778

Whilst all major browsers support Object.hasOwn, it is realistically a bit too new. We are getting too many issues with users on slightly out of date browsers - such as those included in LTS OS releases.

Given we only use it in one place, and is easily replaced, it is better to remove it than require browser upgrades.