### PR TITLE
Ensure quick-add dialog does not obscure ghost node when shifted

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js
@@ -269,8 +269,8 @@ RED.typeSearch = (function() {
         moveCallback = opts.move;
         RED.events.emit("type-search:open");
         //shade.show();
-        if ($("#red-ui-main-container").height() - opts.y - 150 < 0) {
-            opts.y = opts.y - 235;
+        if ($("#red-ui-main-container").height() - opts.y - 195 < 0) {
+            opts.y = opts.y - 275;
         }
         dialog.css({left:opts.x+"px",top:opts.y+"px"}).show();
         searchResultsDiv.slideDown(300);


### PR DESCRIPTION
The change in 3.0 to make the Quick Add dialog taller didn't get carried through to the code that repositions the menu if it goes off the bottom of the screen. As a result, it was covering the ghost node.

This PR adds the additional height into the calculations

