### PR TITLE
Do not flag hasUsers=false nodes as unused in search

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
@@ -187,7 +187,7 @@ RED.search = (function() {
                         }
                         if (flags.hasOwnProperty("unused")) {
                             var isUnused = (node.node.type === 'subflow' && node.node.instances.length === 0) ||
-                                           (isConfigNode && node.node.users.length === 0)
+                                           (isConfigNode && node.node.users.length === 0 && node.node._def.hasUsers !== false)
                             if (flags.unused !== isUnused) {
                                 continue;
                             }
@@ -538,7 +538,7 @@ RED.search = (function() {
                 $(previousActiveElement).trigger("focus");
             }
             previousActiveElement = null;
-        } 
+        }
         if(!keepSearchToolbar) {
             clearActiveSearch();
         }
@@ -630,7 +630,7 @@ RED.search = (function() {
         $("#red-ui-sidebar-shade").on('mousedown',hide);
 
         $("#red-ui-view-searchtools-close").on("click", function close() {
-            clearActiveSearch();            
+            clearActiveSearch();
             updateSearchToolbar();
         });
         $("#red-ui-view-searchtools-close").trigger("click");


### PR DESCRIPTION
Fixes #3777

Sometimes it is valid to have a config node that is "unused" - such as the `ui_base` node from Dashboard.

Such nodes can set a property called `hasUsers` to `false` in their definition. This stops the Configuration Nodes sidebar from showing them as unused, and for the unused-nodes check to flag them after a deploy.

This fix updates the search filter `is:unused` to take the flag in to account.