### PR TITLE
Allow `mode` and `title` to be omitted in `options` argument for `createEditor`

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
@@ -764,7 +764,7 @@ RED.editor.codeEditor.monaco = (function() {
 
         
         if(!options.stateId && options.stateId !== false) {
-            options.stateId = RED.editor.generateViewStateId("monaco", options, (options.mode || options.title).split("/").pop());
+            options.stateId = RED.editor.generateViewStateId("monaco", options, (options.mode || options.title || "").split("/").pop());
         }
         var el = options.element || $("#"+options.id)[0];
         var toolbarRow = $("<div>").appendTo(el);


### PR DESCRIPTION
fixes #3774

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

If `options.mode` and `options.title` are missing, ensure the suffix argument of `RED.editor.generateViewStateId` is something.

This permits creating an editor with minimal options.

NOTE: the user should ALWAYS provide an `options` object with the target `element`. In not doing so, the `monaco` editor has no idea where to display the editor.  As a level of compatibility to earlier node-red versions (and to prevent an exception), a hidden element will be auto generated in the event of `options` or `options.element` being missing (and a warning will be generated in the browser indicating this) but the UI will not see the editor.



## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
