### PR TITLE
Allow codeEditor theme to be set even if `codeEditor` is not set in settings.js

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -327,9 +327,8 @@ module.exports = {
                         themeContext.header.url = themePlugin.header.url || themeContext.header.url
                     }
                 }
-                if(theme.codeEditor) {
-                    theme.codeEditor.options = Object.assign({}, themePlugin.monacoOptions, theme.codeEditor.options);
-                }
+                theme.codeEditor = theme.codeEditor || {}
+                theme.codeEditor.options = Object.assign({}, themePlugin.monacoOptions, theme.codeEditor.options);
             }
             activeThemeInitialised = true;
         }


### PR DESCRIPTION
fixes #3779

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

[Allow codeEditor theme to be set even if `codeEditor` is not set in settings.js](https://github.com/node-red/node-red/commit/bc7852c1cc0889ec9f4686d0efca00592a99a0d0)

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
