### PR TITLE
Support color reset to the default in subflow and group

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/colorPicker.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/colorPicker.js
@@ -76,6 +76,9 @@ RED.editor.colorPicker = RED.colorPicker = (function() {
             var focusTarget = colorInput;
             colorInput.on("change", function (e) {
                 var color = colorInput.val();
+                if (options.defaultValue && !color.match(/^([a-z]+|#[0-9a-fA-F]{6}|#[0-9a-fA-F]{3})$/)) {
+                    color = options.defaultValue;
+                }
                 colorHiddenInput.val(color).trigger('change');
                 refreshDisplay(color);
             });

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/appearance.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/appearance.js
@@ -235,6 +235,7 @@
             RED.editor.colorPicker.create({
                 id: "red-ui-editor-node-color",
                 value: color,
+                defaultValue: "#DDAA99",
                 palette: recommendedColors,
                 sortPalette: function (a, b) {return a.l - b.l;}
             }).appendTo(colorRow);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
@@ -101,6 +101,7 @@ RED.group = (function() {
             RED.editor.colorPicker.create({
                 id:"node-input-style-stroke",
                 value: style.stroke || defaultGroupStyle.stroke || "#a4a4a4",
+                defaultValue: "#a4a4a4",
                 palette: colorPalette,
                 cellPerRow: colorCount,
                 cellWidth: 16,
@@ -112,6 +113,7 @@ RED.group = (function() {
             RED.editor.colorPicker.create({
                 id:"node-input-style-fill",
                 value: style.fill || defaultGroupStyle.fill ||"none",
+                defaultValue: "none",
                 palette: colorPalette,
                 cellPerRow: colorCount,
                 cellWidth: 16,
@@ -129,6 +131,7 @@ RED.group = (function() {
             RED.editor.colorPicker.create({
                 id:"node-input-style-color",
                 value: style.color || defaultGroupStyle.color ||"#a4a4a4",
+                defaultValue: "#a4a4a4",
                 palette: colorPalette,
                 cellPerRow: colorCount,
                 cellWidth: 16,


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
To solve the situation in #3800, I submitted this pull request.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
