### PR TITLE
Hide scrollbars until they're needed

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
@@ -160,7 +160,7 @@
                 this.element.css("maxHeight",null);
             }
             if (this.options.height !== 'auto') {
-                this.uiContainer.css("overflow-y","scroll");
+                this.uiContainer.css("overflow-y","auto");
                 if (!isNaN(this.options.height)) {
                     this.uiHeight = this.options.height;
                 }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-help.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-help.js
@@ -50,7 +50,7 @@ RED.sidebar.help = (function() {
 
         tocPanel = $("<div>", {class: "red-ui-sidebar-help-toc"}).appendTo(stackContainer);
         var helpPanel = $("<div>").css({
-            "overflow-y": "scroll"
+            "overflow-y": "auto"
         }).appendTo(stackContainer);
 
         panels = RED.panels.create({

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info.js
@@ -98,7 +98,7 @@ RED.sidebar.info = (function() {
 
         propertiesPanelContent = $("<div>").css({
             "flex":"1 1 auto",
-            "overflow-y":"scroll",
+            "overflow-y":"auto",
         }).appendTo(propertiesPanel);
 
 

--- a/packages/node_modules/@node-red/editor-client/src/sass/debug.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/debug.scss
@@ -30,7 +30,7 @@
     bottom: 0px;
     left:0px;
     right: 0px;
-    overflow-y: scroll;
+    overflow-y: auto;
 }
 .red-ui-debug-filter-box {
     position:absolute;

--- a/packages/node_modules/@node-red/editor-client/src/sass/editor.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/editor.scss
@@ -368,7 +368,7 @@ button.red-ui-button-small
     border:1px solid var(--red-ui-secondary-border-color);
     border-radius:5px;
     height: calc(100% - 21px);
-    overflow-y: scroll;
+    overflow-y: auto;
     background: var(--red-ui-secondary-background);
 }
 
@@ -562,7 +562,7 @@ div.red-ui-button-small.red-ui-color-picker-opacity-slider-handle {
 .red-ui-icon-list {
     width: 308px;
     height: 200px;
-    overflow-y: scroll;
+    overflow-y: auto;
     line-height: 0px;
     position: relative;
     &.red-ui-icon-list-dark {

--- a/packages/node_modules/@node-red/editor-client/src/sass/projects.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/projects.scss
@@ -26,7 +26,7 @@
     }
 }
 #red-ui-project-settings-tab-settings {
-    overflow-y: scroll;
+    overflow-y: auto;
 }
 .red-ui-sidebar-vc-shade {
     background: var(--red-ui-primary-background);
@@ -183,7 +183,7 @@
 }
 .red-ui-projects-dialog-project-list-inner-container {
     flex-grow: 1 ;
-    overflow-y: scroll;
+    overflow-y: auto;
     position:relative;
     .red-ui-editableList-border {
         border: none;

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-context.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-context.scss
@@ -20,7 +20,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    overflow-y: scroll;
+    overflow-y: auto;
 
     .red-ui-palette-category {
         &:not(.expanded) button {

--- a/packages/node_modules/@node-red/editor-client/src/sass/userSettings.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/userSettings.scss
@@ -67,7 +67,7 @@
     left: 0;
     bottom: 0;
     padding: 8px 20px 20px;
-    overflow-y: scroll;
+    overflow-y: auto;
 }
 .red-ui-settings-row {
     padding: 5px 10px 2px;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
As I mentioned on Slack, most sidebar panels show scrollbars even when they're not needed. This PR changes that by hiding the scrollbars until the content overflows.

Tested on a Mac in Chrome, Safari, and Firefox.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
