### PR TITLE
Include junctions/groups when exporting subflows plus related fixes

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -868,14 +868,7 @@ RED.nodes = (function() {
             var node;
 
             if (allNodes.hasTab(id)) {
-                removedNodes = allNodes.getNodes(id).filter(n => {
-                    if (n.type === 'junction') {
-                        removedJunctions.push(n)
-                        return false
-                    } else {
-                        return true
-                    }
-                })
+                removedNodes = allNodes.getNodes(id).slice()
             }
             for (i in configNodes) {
                 if (configNodes.hasOwnProperty(i)) {
@@ -885,6 +878,7 @@ RED.nodes = (function() {
                     }
                 }
             }
+            removedJunctions = RED.nodes.junctions(id)
 
             for (i=0;i<removedNodes.length;i++) {
                 var result = removeNode(removedNodes[i].id);
@@ -1331,7 +1325,6 @@ RED.nodes = (function() {
         } else {
             nodeSet = [sf];
         }
-        console.log(nodeSet);
         return createExportableNodeSet(nodeSet);
     }
     /**
@@ -1367,6 +1360,10 @@ RED.nodes = (function() {
                             exportedConfigNodes[n.id] = true;
                         }
                     });
+
+                    subflowSet = subflowSet.concat(RED.nodes.junctions(subflowId))
+                    subflowSet = subflowSet.concat(RED.nodes.groups(subflowId))
+
                     var exportableSubflow = createExportableNodeSet(subflowSet, exportedIds, exportedSubflows, exportedConfigNodes);
                     nns = exportableSubflow.concat(nns);
                 }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -506,6 +506,13 @@ RED.subflow = (function() {
         RED.nodes.groups(id).forEach(function(n) {
             removedGroups.push(n);
         })
+
+        var removedJunctions = RED.nodes.junctions(id)
+        for (var i=0;i<removedJunctions.length;i++) {
+            var removedEntities = RED.nodes.removeJunction(removedJunctions[i])
+            removedLinks = removedLinks.concat(removedEntities.links)
+        }
+
         var removedConfigNodes = [];
         for (var i=0;i<removedNodes.length;i++) {
             var removedEntities = RED.nodes.remove(removedNodes[i].id);
@@ -536,6 +543,7 @@ RED.subflow = (function() {
             nodes:removedNodes,
             links:removedLinks,
             groups: removedGroups,
+            junctions: removedJunctions,
             subflows: [activeSubflow]
         }
     }


### PR DESCRIPTION
Fixes #3805

Exporting subflows did not properly include junctions or groups - which would break things when reimporting.

This also tidies up logic around removing junctions when a subflow definition or flow is deleted.