### PR TITLE
Allow generateNodeNames to handle names containing regex control chars

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
@@ -1015,7 +1015,7 @@ RED.view.tools = (function() {
                 const nodeDef = n._def || RED.nodes.getType(n.type)
                 if (nodeDef && nodeDef.defaults && nodeDef.defaults.name) {
                     const paletteLabel = RED.utils.getPaletteLabel(n.type, nodeDef)
-                    const defaultNodeNameRE = new RegExp('^'+paletteLabel+' (\\d+)$')
+                    const defaultNodeNameRE = new RegExp('^'+paletteLabel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')+' (\\d+)$')
                     if (!typeIndex.hasOwnProperty(n.type)) {
                         const existingNodes = RED.nodes.filterNodes({type: n.type})
                         let maxNameNumber = 0;


### PR DESCRIPTION
Fixes #3813

Handles names that contain things like `+` by escaping them.