### PR TITLE
Register subflow module instance node with parent flow

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -134,10 +134,12 @@ function createNode(flow,config) {
                 subflowInstanceConfig,
                 instanceConfig
             );
+            // Register this subflow as an instance node of the parent flow.
+            // This allows nodes inside the subflow to get ahold of each other
+            // such as a node accessing its config node
+            flow.subflowInstanceNodes[config.id] = subflow
             subflow.start();
             return subflow.node;
-
-            Log.error(Log._("nodes.flow.unknown-type", {type:type}));
         }
     } catch(err) {
         Log.error(err);


### PR DESCRIPTION
Fixes #3798

When creating a subflow module instance, we would create the Subflow object then start it before returning back to the parent Flow. However, starting the subflow requires all of its nodes being started - which could involve node lookups (eg `mqtt in` node calling `RED.nodes.getNode()` to get ahold of its broker node. For that type of node lookup to work, the flow needs to know the subflow module instance exists - but as that is being done as part of the start code which happens *before* the parent flow knows about it, the lookups will fail.

This PR fixes it by getting the subflow instance registered with the parent Flow before the instance gets started. It isn't the most beautiful fix as the Flow's view of subflow instances should not be externally modifiable like this... but then again, it works.