### PR TITLE
Phase out d3

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/keyboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/keyboard.js
@@ -267,7 +267,7 @@ RED.keyboard = (function() {
                     return resolveKeyEvent(evt);
                 }
                 if (Object.keys(handler).length > 0) {
-                    // check if there's a potential combined handler initiated by this keyCode 
+                    // check if there's a potential combined handler initiated by this keyCode
                     for (let h in handler) {
                         if (matchHandlerToEvent(evt,handler[h]) > -1) {
                             partialState = handler;
@@ -298,21 +298,21 @@ RED.keyboard = (function() {
             return resolveKeyEvent(evt);
         }
     }
-    d3.select(window).on("keydown",function() {
+    document.addEventListener("keydown", function(event) {
         if (!handlersActive) {
             return;
         }
-        if (metaKeyCodes[d3.event.keyCode]) {
+        if (metaKeyCodes[event.keyCode]) {
             return;
         }
-        var handler = resolveKeyEvent(d3.event);
+        var handler = resolveKeyEvent(event);
         if (handler && handler.ondown) {
             if (typeof handler.ondown === "string") {
                 RED.actions.invoke(handler.ondown);
             } else {
                 handler.ondown();
             }
-            d3.event.preventDefault();
+            event.preventDefault();
         }
     });
 


### PR DESCRIPTION
Node-RED has used D3 since day one of its existence. The original structure of the view code was based on a D3 example (can't track down the actual one, but was similar to https://observablehq.com/@d3/force-directed-graph).

Whilst it has remained quite fundamental to how `view.js` works, there is something to be said for phasing out its use. There are optimisations we can make in the code if we aren't having to work in the d3 way.

We're also on an ancient version of d3. Faced with the choice of phasing out its use, or upgrading across multiple major version changes, I want to explore the former.

This PR is a work-in-progress towards that goal.

There are a handful of places where we use d3 for no reason other than it was convenient at the time - and vanilla javascript is more than good enough. That's where I'll start.