### PR TITLE
ensure sessionExpiry(Interval) is applied

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -474,7 +474,6 @@ module.exports = function(RED) {
             setIfHasProperty(opts, node, "protocolVersion", init);
             setIfHasProperty(opts, node, "keepalive", init);
             setIfHasProperty(opts, node, "cleansession", init);
-            setIfHasProperty(opts, node, "sessionExpiry", init);
             setIfHasProperty(opts, node, "topicAliasMaximum", init);
             setIfHasProperty(opts, node, "maximumPacketSize", init);
             setIfHasProperty(opts, node, "receiveMaximum", init);
@@ -483,6 +482,11 @@ module.exports = function(RED) {
                 node.userProperties = opts.userProperties;
             } else if (hasProperty(opts, "userProps")) {
                 node.userProperties = opts.userProps;
+            }
+            if (hasProperty(opts, "sessionExpiry")) {
+                node.sessionExpiryInterval = opts.sessionExpiry;
+            } else if (hasProperty(opts, "sessionExpiryInterval")) {
+                node.sessionExpiryInterval = opts.sessionExpiryInterval
             }
 
             function createLWT(topic, payload, qos, retain, v5opts, v5SubPropName) {

--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -786,7 +786,9 @@ module.exports = function(RED) {
 
                         // Send any birth message
                         if (node.birthMessage) {
-                            node.publish(node.birthMessage);
+                            setTimeout(() => {
+                                node.publish(node.birthMessage);
+                            }, 1);
                         }
                     });
                     node._clientOn("reconnect", function() {

--- a/test/nodes/core/network/21-mqtt_spec.js
+++ b/test/nodes/core/network/21-mqtt_spec.js
@@ -27,7 +27,7 @@ describe('MQTT Nodes', function () {
         } catch (error) { }
     });
 
-    it('should be loaded and have default values', function (done) {
+    it('should be loaded and have default values (MQTT V4)', function (done) {
         this.timeout = 2000;
         const { flow, nodes } = buildBasicMQTTSendRecvFlow({ id: "mqtt.broker", name: "mqtt_broker", autoConnect: false }, { id: "mqtt.in", topic: "in_topic" }, { id: "mqtt.out", topic: "out_topic" });
         helper.load(mqttNodes, flow, function () {
@@ -61,6 +61,52 @@ describe('MQTT Nodes', function () {
                 mqttBroker.options.clientId.should.containEql('nodered_');
                 mqttBroker.options.should.have.property('keepalive').type("number");
                 mqttBroker.options.should.have.property('reconnectPeriod').type("number");
+                //as this is not a v5 connection, ensure v5 properties are not present
+                mqttBroker.options.should.not.have.property('protocolVersion', 5);
+                mqttBroker.options.should.not.have.property('properties');
+                done();
+            } catch (error) {
+                done(error)
+            }
+        });
+    });
+    it('should be loaded and have default values (MQTT V5)', function (done) {
+        this.timeout = 2000;
+        const { flow, nodes } = buildBasicMQTTSendRecvFlow({ id: "mqtt.broker", name: "mqtt_broker", autoConnect: false, cleansession: false, clientid: 'clientid', keepalive: 35, sessionExpiry: '6000', protocolVersion: '5', userProps: {"prop": "val"}}, { id: "mqtt.in", topic: "in_topic" }, { id: "mqtt.out", topic: "out_topic" });
+        helper.load(mqttNodes, flow, function () {
+            try {
+                const mqttIn = helper.getNode("mqtt.in");
+                const mqttOut = helper.getNode("mqtt.out");
+                const mqttBroker = helper.getNode("mqtt.broker");
+
+                should(mqttIn).be.type("object", "mqtt in node should be an object")
+                mqttIn.should.have.property('broker', nodes.mqtt_broker.id); //should be the id of the broker node
+                mqttIn.should.have.property('datatype', 'utf8'); //default: 'utf8'
+                mqttIn.should.have.property('isDynamic', false);  //default: false
+                mqttIn.should.have.property('inputs', 0); //default: 0 
+                mqttIn.should.have.property('qos', 2); //default: 2
+                mqttIn.should.have.property('topic', "in_topic");
+                mqttIn.should.have.property('wires', [["helper.node"]]);
+
+                should(mqttOut).be.type("object", "mqtt out node should be an object")
+                mqttOut.should.have.property('broker', nodes.mqtt_broker.id); //should be the id of the broker node
+                mqttOut.should.have.property('topic', "out_topic");
+
+                should(mqttBroker).be.type("object", "mqtt broker node should be an object")
+                mqttBroker.should.have.property('broker', BROKER_HOST);
+                mqttBroker.should.have.property('port', BROKER_PORT);
+                mqttBroker.should.have.property('brokerurl');
+                // mqttBroker.should.have.property('autoUnsubscribe', true);//default: true 
+                mqttBroker.should.have.property('autoConnect', false);//Set "autoConnect:false" in brokerOptions 
+                mqttBroker.should.have.property('options');
+                mqttBroker.options.should.have.property('clean', false);
+                mqttBroker.options.should.have.property('clientId', 'clientid');
+                mqttBroker.options.should.have.property('keepalive').type("number", 35);
+                mqttBroker.options.should.have.property('reconnectPeriod').type("number");
+                //as this IS a v5 connection, ensure v5 properties are not present
+                mqttBroker.options.should.have.property('protocolVersion', 5);
+                mqttBroker.options.should.have.property('properties');
+                mqttBroker.options.properties.should.have.property('sessionExpiryInterval');
                 done();
             } catch (error) {
                 done(error)
@@ -666,6 +712,7 @@ function buildMQTTBrokerNode(id, name, brokerHost, brokerPort, options) {
     node.cleansession = String(options.cleansession) == "false" ? false : true;
     node.autoUnsubscribe = String(options.autoUnsubscribe) == "false" ? false : true;
     node.autoConnect = String(options.autoConnect) == "false" ? false : true;
+    node.sessionExpiry = options.sessionExpiry ? options.sessionExpiry : undefined;
 
     if (options.birthTopic) {
         node.birthTopic = options.birthTopic;


### PR DESCRIPTION
fixes #3838 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Ensure MQTT v5 `options.property.sessionExpiryInterval` is set if configured in UI or passed in as an option with the "connect" action

NOTE: This PR also addresses some existing issues with the local MQTT tests namely...
* `done` being called more than once
* MQTT `birth` being published BEFORE `connect` is complete, making it impossible to test birth msg correctly


## Local MQTT Test results (MQTT Tests are skipped in GitHub)...
```
  MQTT Nodes
    √ should be loaded and have default values (MQTT V4) (108ms)  << modified to check MQTT v5 properties are not present
    √ should be loaded and have default values (MQTT V5)  << new test to check MQTT v5 properties are present
    √ basic send and receive tests (64ms)
    √ should send JSON and receive string (auto mode)
    √ should send JSON and receive object (auto-detect mode) (43ms)
    √ should send invalid JSON and receive string (auto mode)
    √ should send invalid JSON and receive string (auto-detect mode)
    √ should send JSON and receive string (utf8 mode)
    √ should send JSON and receive Object (json mode)
    √ should send invalid JSON and raise error (json mode)
    √ should send String and receive Buffer (buffer mode)
    √ should send utf8 Buffer and receive String (auto mode) (42ms)
    √ should send non utf8 Buffer and receive Buffer (auto mode)
    √ should send/receive all v5 flags and settings
    √ should send regular string with v5 media type "text/plain" and receive a string (auto mode) (40ms)
    √ should send JSON with v5 media type "text/plain" and receive a string (auto mode)
    √ should send JSON with v5 media type "text/plain" and receive a string (auto-detect mode)
    √ should send JSON with v5 media type "application/json" and receive an object (auto-detect mode)
    √ should send invalid JSON with v5 media type "application/json" and raise an error (auto mode)
    √ should send buffer with v5 media type "application/json" and receive an object (auto-detect mode)
    √ should send buffer with v5 media type "text/plain" and receive a string (auto mode)
    √ should send buffer with v5 media type "application/zip" and receive a buffer (auto mode)
    √ should subscribe dynamically via action
    √ should connect via "connect" action
    √ should disconnect via "disconnect" action
    √ should publish birth message
  29 passing (1s)
```

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
