### PR TITLE
Quick-add to empty. Remember palette categories state. Minor icon styling.

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/de/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/de/editor.json
@@ -124,6 +124,7 @@
             "projects-open": "Öffnen",
             "projects-settings": "Einstellungen",
             "showNodeLabelDefault": "Zeige Namen von neu hinzugefügten Nodes",
+            "nodeQuickAddLabel": "Zeige Schnellauswahl beim Verbinden ins Leere",
             "codeEditor": "Code-Editor",
             "groups": "Gruppen",
             "groupSelection": "Auswahl gruppieren",

--- a/packages/node_modules/@node-red/editor-client/locales/de/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/de/editor.json
@@ -86,6 +86,7 @@
                 "rtl": "Von rechts nach links",
                 "auto": "Kontextabhängig",
                 "language": "Sprache",
+                "nodeQuickAdd": "Zeige Schnellauswahl beim Verbinden ins Leere",
                 "browserDefault": "Browservorgabe"
             },
             "sidebar": {
@@ -124,7 +125,6 @@
             "projects-open": "Öffnen",
             "projects-settings": "Einstellungen",
             "showNodeLabelDefault": "Zeige Namen von neu hinzugefügten Nodes",
-            "nodeQuickAddLabel": "Zeige Schnellauswahl beim Verbinden ins Leere",
             "codeEditor": "Code-Editor",
             "groups": "Gruppen",
             "groupSelection": "Auswahl gruppieren",

--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -86,6 +86,7 @@
                 "rtl": "Right-to-left",
                 "auto": "Contextual",
                 "language": "Language",
+								"nodeQuickAdd": "Quick-add node when joining to empty space",
                 "browserDefault": "Browser default"
             },
             "sidebar": {

--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -86,7 +86,7 @@
                 "rtl": "Right-to-left",
                 "auto": "Contextual",
                 "language": "Language",
-								"nodeQuickAdd": "Quick-add node when joining to empty space",
+                "nodeQuickAdd": "Quick-add node when joining to empty space",
                 "browserDefault": "Browser default"
             },
             "sidebar": {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -65,12 +65,14 @@ RED.palette = (function() {
                 catDiv.addClass("red-ui-palette-closed");
                 $("#red-ui-palette-base-category-"+category).slideUp();
                 $("#red-ui-palette-header-"+category+" i").removeClass("expanded");
+								rememberCategoryState(category, false)
             },
             open: function() {
                 catDiv.addClass("red-ui-palette-open");
                 catDiv.removeClass("red-ui-palette-closed");
                 $("#red-ui-palette-base-category-"+category).slideDown();
                 $("#red-ui-palette-header-"+category+" i").addClass("expanded");
+								rememberCategoryState(category, true)
             },
             toggle: function() {
                 if (catDiv.hasClass("red-ui-palette-open")) {
@@ -85,6 +87,22 @@ RED.palette = (function() {
             categoryContainers[category].toggle();
         });
     }
+		function rememberCategoryState(cat, open) {
+			const stateStr = localStorage.getItem('closedCategories');
+			if (!stateStr && open) return;
+			const state = stateStr ? JSON.parse(stateStr) : [];
+			const idx = state.indexOf(cat);
+			if (open && idx >= 0)
+				state.splice(idx, 1);
+			else if (!open && idx < 0)
+				state.push(cat);
+			else
+				return;
+			if (state.length <= 0)
+				localStorage.removeItem('closedCategories');
+			else
+				localStorage.setItem('closedCategories', JSON.stringify(state));
+		}
 
     function setLabel(type, el,label, info) {
         var nodeWidth = 82;
@@ -405,10 +423,15 @@ RED.palette = (function() {
             }
             setLabel(nt,d,label,nodeInfo);
 
-            var categoryNode = $("#red-ui-palette-container-"+rootCategory);
-            if (categoryNode.find(".red-ui-palette-node").length === 1) {
-                categoryContainers[rootCategory].open();
-            }
+						var categoryNode = $("#red-ui-palette-container-"+rootCategory);
+						if (categoryNode.find(".red-ui-palette-node").length === 1) {
+							const closedCategoriesStr = localStorage.getItem('closedCategories');
+							const closedCategories = closedCategoriesStr ? JSON.parse(closedCategoriesStr) : [];
+							if (closedCategories.indexOf(rootCategory) < 0)
+								categoryContainers[rootCategory].open();
+							else
+								categoryContainers[rootCategory].close();
+						}
 
         }
     }
@@ -640,8 +663,6 @@ RED.palette = (function() {
             }
         });
         RED.popover.tooltip(paletteCollapseAll,RED._('palette.actions.collapse-all'));
-        // collapse at startup
-        setTimeout(() => { paletteCollapseAll.trigger('click') }, 0);
 
         var paletteExpandAll = $('<button type="button" class="red-ui-footer-button"><i class="fa fa-angle-double-down"></i></button>').appendTo(paletteFooterButtons);
         paletteExpandAll.on("click", function(e) {
@@ -654,7 +675,7 @@ RED.palette = (function() {
         });
         RED.popover.tooltip(paletteExpandAll,RED._('palette.actions.expand-all'));
 
-        RED.actions.add("core:toggle-palette", function(state) {
+				RED.actions.add("core:toggle-palette", function(state) {
             if (state === undefined) {
                 RED.menu.toggleSelected("menu-item-palette");
             } else {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -640,6 +640,8 @@ RED.palette = (function() {
             }
         });
         RED.popover.tooltip(paletteCollapseAll,RED._('palette.actions.collapse-all'));
+        // collapse at startup
+        setTimeout(() => { paletteCollapseAll.trigger('click') }, 0);
 
         var paletteExpandAll = $('<button type="button" class="red-ui-footer-button"><i class="fa fa-angle-double-down"></i></button>').appendTo(paletteFooterButtons);
         paletteExpandAll.on("click", function(e) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -65,14 +65,14 @@ RED.palette = (function() {
                 catDiv.addClass("red-ui-palette-closed");
                 $("#red-ui-palette-base-category-"+category).slideUp();
                 $("#red-ui-palette-header-"+category+" i").removeClass("expanded");
-								rememberCategoryState(category, false)
+                rememberCategoryState(category, false);
             },
             open: function() {
                 catDiv.addClass("red-ui-palette-open");
                 catDiv.removeClass("red-ui-palette-closed");
                 $("#red-ui-palette-base-category-"+category).slideDown();
                 $("#red-ui-palette-header-"+category+" i").addClass("expanded");
-								rememberCategoryState(category, true)
+                rememberCategoryState(category, true);
             },
             toggle: function() {
                 if (catDiv.hasClass("red-ui-palette-open")) {
@@ -87,22 +87,26 @@ RED.palette = (function() {
             categoryContainers[category].toggle();
         });
     }
-		function rememberCategoryState(cat, open) {
-			const stateStr = localStorage.getItem('closedCategories');
-			if (!stateStr && open) return;
-			const state = stateStr ? JSON.parse(stateStr) : [];
-			const idx = state.indexOf(cat);
-			if (open && idx >= 0)
-				state.splice(idx, 1);
-			else if (!open && idx < 0)
-				state.push(cat);
-			else
-				return;
-			if (state.length <= 0)
-				localStorage.removeItem('closedCategories');
-			else
-				localStorage.setItem('closedCategories', JSON.stringify(state));
-		}
+    function rememberCategoryState(cat, open) {
+        const stateStr = localStorage.getItem('closedCategories');
+        if (!stateStr && open) {
+            return;
+        }
+        const state = stateStr ? JSON.parse(stateStr) : [];
+        const idx = state.indexOf(cat);
+        if (open && idx >= 0) {
+            state.splice(idx, 1);
+        } else if (!open && idx < 0) {
+            state.push(cat);
+        } else {
+            return;
+        }
+        if (state.length <= 0) {
+            localStorage.removeItem('closedCategories');
+        } else {
+            localStorage.setItem('closedCategories', JSON.stringify(state));
+        }
+    }
 
     function setLabel(type, el,label, info) {
         var nodeWidth = 82;
@@ -423,15 +427,16 @@ RED.palette = (function() {
             }
             setLabel(nt,d,label,nodeInfo);
 
-						var categoryNode = $("#red-ui-palette-container-"+rootCategory);
-						if (categoryNode.find(".red-ui-palette-node").length === 1) {
-							const closedCategoriesStr = localStorage.getItem('closedCategories');
-							const closedCategories = closedCategoriesStr ? JSON.parse(closedCategoriesStr) : [];
-							if (closedCategories.indexOf(rootCategory) < 0)
-								categoryContainers[rootCategory].open();
-							else
-								categoryContainers[rootCategory].close();
-						}
+            var categoryNode = $("#red-ui-palette-container-"+rootCategory);
+            if (categoryNode.find(".red-ui-palette-node").length === 1) {
+              const closedCategoriesStr = localStorage.getItem('closedCategories');
+              const closedCategories = closedCategoriesStr ? JSON.parse(closedCategoriesStr) : [];
+              if (closedCategories.indexOf(rootCategory) < 0) {
+                categoryContainers[rootCategory].open();
+              } else {
+                categoryContainers[rootCategory].close();
+              }
+            }
 
         }
     }
@@ -675,7 +680,7 @@ RED.palette = (function() {
         });
         RED.popover.tooltip(paletteExpandAll,RED._('palette.actions.expand-all'));
 
-				RED.actions.add("core:toggle-palette", function(state) {
+        RED.actions.add("core:toggle-palette", function(state) {
             if (state === undefined) {
                 RED.menu.toggleSelected("menu-item-palette");
             } else {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
@@ -140,7 +140,8 @@ RED.userSettings = (function() {
             title: "menu.label.nodes",
             options: [
                 {setting:"view-node-status",oldSetting:"menu-menu-item-status",label:"menu.label.displayStatus",default: true, toggle:true,onchange:"core:toggle-status"},
-                {setting:"view-node-show-label",label:"menu.label.showNodeLabelDefault",default: true, toggle:true}
+                {setting:"view-node-show-label",label:"menu.label.showNodeLabelDefault",default: true, toggle:true},
+                {setting:"node-quick-add",label:"menu.label.view.nodeQuickAdd",default: true, toggle:true}
             ]
         },
         {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4149,20 +4149,22 @@ RED.view = (function() {
                 iconUrl = RED.settings.apiRootUrl+"icons/"+iconPath.module+"/"+iconPath.file;
             }
         }
+        const rightAlign = "right" === d._def.align
+        const offsetX = d.inputs && !rightAlign ? 2 : d.outputs && rightAlign ? -2 : 0
         if (fontAwesomeUnicode) {
             // Since Node-RED workspace uses SVG, i tag cannot be used for font-awesome icon.
             // On SVG, use text tag as an alternative.
             icon_group.append("text")
                 .attr("xlink:href",iconUrl)
                 .attr("class","fa-lg")
-                .attr("x",15)
+                .attr("x",15+offsetX)
                 .text(fontAwesomeUnicode);
         } else {
             var icon = icon_group.append("image")
                 .style("display","none")
                 .attr("xlink:href",iconUrl)
                 .attr("class","red-ui-flow-node-icon")
-                .attr("x",0)
+                .attr("x",0+offsetX)
                 .attr("width","30")
                 .attr("height","30");
 
@@ -4179,7 +4181,7 @@ RED.view = (function() {
                     var height = img.height * scaleFactor;
                     icon.attr("width",width);
                     icon.attr("height",height);
-                    icon.attr("x",15-width/2);
+                    icon.attr("x",15-width/2+offsetX);
                 }
                 icon.attr("xlink:href",iconUrl);
                 icon.style("display",null);
@@ -4892,12 +4894,8 @@ RED.view = (function() {
 
                             icon.attr("y",function(){return (d.h-d3.select(this).attr("height"))/2;});
 
-                            const rightAlign = "right" === d._def.align
-                            if (d.inputs && !rightAlign) icon.attr("x",3);
-                            if (d.outputs && rightAlign) icon.attr("x",-3);
-
                             const iconShadeHeight = d.h
-                            const iconShadeWidth = d.inputs && d.outputs ? 33 : 30
+                            const iconShadeWidth = d.inputs && d.outputs ? 32 : 30
                             this.__iconShade__.setAttribute("d", hideLabel ?
                                 `M5 0 h${iconShadeWidth-10} a 5 5 0 0 1 5 5 v${iconShadeHeight-10} a 5 5 0 0 1 -5 5 h-${iconShadeWidth-10} a 5 5 0 0 1 -5 -5  v-${iconShadeHeight-10} a 5 5 0 0 1 5 -5` : (
                                     "right" === d._def.align ?

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1801,34 +1801,34 @@ RED.view = (function() {
             return;
         }
         if (mousedown_node && mouse_mode == RED.state.JOINING) {
-						if (RED.settings.get("editor.view.node-quick-add")) {
-								// Trigger quick add dialog
-								d3.event.stopPropagation();
-								clearSelection();
-								const point = d3.mouse(this);
-								var clickedGroup = getGroupAt(point[0], point[1]);
-								if (drag_lines.length > 0) {
-										clickedGroup = clickedGroup || RED.nodes.group(drag_lines[0].node.g)
-								}
-								showQuickAddDialog({ position: point, group: clickedGroup });
-						} else {
-								var removedLinks = [];
-								for (i=0;i<drag_lines.length;i++) {
-										if (drag_lines[i].link) {
-												removedLinks.push(drag_lines[i].link)
-										}
-								}
-								if (removedLinks.length > 0) {
-										historyEvent = {
-												t:"delete",
-												links: removedLinks,
-												dirty:RED.nodes.dirty()
-										};
-										RED.history.push(historyEvent);
-										RED.nodes.dirty(true);
-								}
-								hideDragLines();
-						}
+            if (RED.settings.get("editor.view.node-quick-add")) {
+                // Trigger quick add dialog
+                d3.event.stopPropagation();
+                clearSelection();
+                const point = d3.mouse(this);
+                var clickedGroup = getGroupAt(point[0], point[1]);
+                if (drag_lines.length > 0) {
+                    clickedGroup = clickedGroup || RED.nodes.group(drag_lines[0].node.g)
+                }
+                showQuickAddDialog({ position: point, group: clickedGroup });
+            } else {
+                var removedLinks = [];
+                for (i=0;i<drag_lines.length;i++) {
+                    if (drag_lines[i].link) {
+                        removedLinks.push(drag_lines[i].link)
+                    }
+                }
+                if (removedLinks.length > 0) {
+                    historyEvent = {
+                        t:"delete",
+                        links: removedLinks,
+                        dirty:RED.nodes.dirty()
+                    };
+                    RED.history.push(historyEvent);
+                    RED.nodes.dirty(true);
+                }
+                hideDragLines();
+            }
         }
         if (lasso) {
             var x = parseInt(lasso.attr("x"));
@@ -4892,9 +4892,9 @@ RED.view = (function() {
 
                             icon.attr("y",function(){return (d.h-d3.select(this).attr("height"))/2;});
 
-														const rightAlign = "right" === d._def.align
-														if (d.inputs && !rightAlign) icon.attr("x",3);
-														if (d.outputs && rightAlign) icon.attr("x",-3);
+                            const rightAlign = "right" === d._def.align
+                            if (d.inputs && !rightAlign) icon.attr("x",3);
+                            if (d.outputs && rightAlign) icon.attr("x",-3);
 
                             const iconShadeHeight = d.h
                             const iconShadeWidth = d.inputs && d.outputs ? 33 : 30

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1801,22 +1801,34 @@ RED.view = (function() {
             return;
         }
         if (mousedown_node && mouse_mode == RED.state.JOINING) {
-            var removedLinks = [];
-            for (i=0;i<drag_lines.length;i++) {
-                if (drag_lines[i].link) {
-                    removedLinks.push(drag_lines[i].link)
-                }
-            }
-            if (removedLinks.length > 0) {
-                historyEvent = {
-                    t:"delete",
-                    links: removedLinks,
-                    dirty:RED.nodes.dirty()
-                };
-                RED.history.push(historyEvent);
-                RED.nodes.dirty(true);
-            }
-            hideDragLines();
+						if (RED.settings.get("editor.view.node-quick-add")) {
+								// Trigger quick add dialog
+								d3.event.stopPropagation();
+								clearSelection();
+								const point = d3.mouse(this);
+								var clickedGroup = getGroupAt(point[0], point[1]);
+								if (drag_lines.length > 0) {
+										clickedGroup = clickedGroup || RED.nodes.group(drag_lines[0].node.g)
+								}
+								showQuickAddDialog({ position: point, group: clickedGroup });
+						} else {
+								var removedLinks = [];
+								for (i=0;i<drag_lines.length;i++) {
+										if (drag_lines[i].link) {
+												removedLinks.push(drag_lines[i].link)
+										}
+								}
+								if (removedLinks.length > 0) {
+										historyEvent = {
+												t:"delete",
+												links: removedLinks,
+												dirty:RED.nodes.dirty()
+										};
+										RED.history.push(historyEvent);
+										RED.nodes.dirty(true);
+								}
+								hideDragLines();
+						}
         }
         if (lasso) {
             var x = parseInt(lasso.attr("x"));

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4756,7 +4756,7 @@ RED.view = (function() {
                         if ((!d._def.align && d.inputs !== 0 && d.outputs === 0) || "right" === d._def.align) {
                             if (this.__iconGroup__) {
                                 this.__iconGroup__.classList.add("red-ui-flow-node-icon-group-right");
-                                this.__iconGroup__.setAttribute("transform", "translate("+(d.w-30)+",0)");
+                                this.__iconGroup__.setAttribute("transform", "translate("+(d.w-(d.outputs ? 33 : 30))+",0)");
                             }
                             this.__textGroup__.classList.add("red-ui-flow-node-label-right");
                             this.__textGroup__.setAttribute("transform", "translate("+(d.w-38)+","+yp+")");
@@ -4892,9 +4892,12 @@ RED.view = (function() {
 
                             icon.attr("y",function(){return (d.h-d3.select(this).attr("height"))/2;});
 
+														const rightAlign = "right" === d._def.align
+														if (d.inputs && !rightAlign) icon.attr("x",3);
+														if (d.outputs && rightAlign) icon.attr("x",-3);
 
                             const iconShadeHeight = d.h
-                            const iconShadeWidth = 30
+                            const iconShadeWidth = d.inputs && d.outputs ? 33 : 30
                             this.__iconShade__.setAttribute("d", hideLabel ?
                                 `M5 0 h${iconShadeWidth-10} a 5 5 0 0 1 5 5 v${iconShadeHeight-10} a 5 5 0 0 1 -5 5 h-${iconShadeWidth-10} a 5 5 0 0 1 -5 -5  v-${iconShadeHeight-10} a 5 5 0 0 1 5 -5` : (
                                     "right" === d._def.align ?
@@ -4904,7 +4907,7 @@ RED.view = (function() {
                             )
                             this.__iconShadeBorder__.style.display = hideLabel?'none':''
                             this.__iconShadeBorder__.setAttribute("d",
-                                                                  "M " + (((!d._def.align && d.inputs !== 0 && d.outputs === 0) || "right" === d._def.align) ? 0.5 : 29.5) + " "+(d.selected?1:0.5)+" l 0 " + (d.h - (d.selected?2:1))
+                                                                  "M " + (((!d._def.align && d.inputs !== 0 && d.outputs === 0) || "right" === d._def.align) ? 0.5 : iconShadeWidth-0.5) + " "+(d.selected?1:0.5)+" l 0 " + (d.h - (d.selected?2:1))
                                                                  );
                             faIcon.attr("y",(d.h+13)/2);
                         }

--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
@@ -371,9 +371,10 @@ module.exports = function(RED) {
                 });
             });
             this.serverConfig.on('erro', function(event) {
+                node.error(event.err);
                 node.status({
                     fill:"red",shape:"ring",text:"common.status.error",
-                    event:"error",
+                    event:"error", error: event.err,
                     _session: {type:"websocket",id:event.id}
                 })
             });


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.
-->

## Proposed changes

1) The Ctrl-Quick-Add feature extended. Creating a new wire to empty space does not serve any purpose other than wanting to add a new node to connect to. After using it for about a week, I think the added user setting to switch it off is not even necessary.
2) If you are working on some custom nodes and have them in a new category at the bottom of the list, it's nice to have the others closed even after a page reload.
3) With a port-connector in place icons don't really look centered anymore. Some even touch the port symbol. I have just moved it 2px to the left. Even though the port-connector has a 3px radius, 2px seem enough.
For right-aligned I couldn't find a node with an output port, so it might not work...
The text is now closer to the shade-border, but it looks good enough this way to present to my customer ;)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
Sorry, I started on master before I have read these guidelines.
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
These are just minor changes I have made when starting to use Node Red. Why not discuss them here in the PR so we know what we are talking about...
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
Sorry, don't know where to begin...