### PR TITLE
Support sortable list on property UI of http request and http response nodes

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/06-httpproxy.html
+++ b/packages/node_modules/@node-red/nodes/core/network/06-httpproxy.html
@@ -101,6 +101,7 @@
                             hostField.val(data.host);
                         }
                     },
+                    sortable: true,
                     removable: true
                 });
             if (this.noproxy) {

--- a/packages/node_modules/@node-red/nodes/core/network/21-httpin.html
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httpin.html
@@ -227,6 +227,7 @@
                         }
                     });
                 },
+                sortable: true,
                 removable: true
             });
 

--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.html
@@ -417,6 +417,7 @@
                     });
 
                 },
+                sortable: true,
                 removable: true
             });
             if (node.headers) {


### PR DESCRIPTION
## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes
I added the options to make the list sortable on the property UI of the http request and http response nodes.
We discussed this new functionality on the following Node-RED forum.
https://discourse.nodered.org/t/sortable-list-in-the-header-area-of-the-http-request-node/67076

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality