### PR TITLE
Editor: quick-add when connect to empty.

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1798,22 +1798,15 @@ RED.view = (function() {
             return;
         }
         if (mousedown_node && mouse_mode == RED.state.JOINING) {
-            var removedLinks = [];
-            for (i=0;i<drag_lines.length;i++) {
-                if (drag_lines[i].link) {
-                    removedLinks.push(drag_lines[i].link)
-                }
+            // Trigger quick add dialog
+            d3.event.stopPropagation();
+            clearSelection();
+            const point = d3.mouse(this);
+            var clickedGroup = getGroupAt(point[0], point[1]);
+            if (drag_lines.length > 0) {
+                clickedGroup = clickedGroup || RED.nodes.group(drag_lines[0].node.g)
             }
-            if (removedLinks.length > 0) {
-                historyEvent = {
-                    t:"delete",
-                    links: removedLinks,
-                    dirty:RED.nodes.dirty()
-                };
-                RED.history.push(historyEvent);
-                RED.nodes.dirty(true);
-            }
-            hideDragLines();
+            showQuickAddDialog({ position: point, group: clickedGroup });
         }
         if (lasso) {
             var x = parseInt(lasso.attr("x"));


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

The Ctrl-Quick-Add feature extended without the "Ctrl". Creating a new wire to empty space does not serve any purpose other than wanting to add a new node to connect to.
The user setting to turn off this feature (included in the last combined PR) is not included here.

### How to use
Click on a port, start to draw a wire, release on empty space, the quick-add selection is offered instead of the wire being cleaned up.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
They seem to fail, but not because of this change.
- [ ] I have added suitable unit tests to cover the new/changed functionality
