### PR TITLE
Palette: Remember category open/close state across reloads.

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -89,19 +89,23 @@ RED.palette = (function() {
     }
     function rememberCategoryState(cat, open) {
         const stateStr = localStorage.getItem('closedCategories');
-        if (!stateStr && open) return;
+        if (!stateStr && open) {
+            return;
+        }
         const state = stateStr ? JSON.parse(stateStr) : [];
         const idx = state.indexOf(cat);
-        if (open && idx >= 0)
+        if (open && idx >= 0) {
             state.splice(idx, 1);
-        else if (!open && idx < 0)
+        } else if (!open && idx < 0) {
             state.push(cat);
-        else
+        } else {
             return;
-        if (state.length <= 0)
+        }
+        if (state.length <= 0) {
             localStorage.removeItem('closedCategories');
-        else
+        } else {
             localStorage.setItem('closedCategories', JSON.stringify(state));
+        }
     }
 
     function setLabel(type, el,label, info) {
@@ -427,10 +431,11 @@ RED.palette = (function() {
             if (categoryNode.find(".red-ui-palette-node").length === 1) {
                 const closedCategoriesStr = localStorage.getItem('closedCategories');
                 const closedCategories = closedCategoriesStr ? JSON.parse(closedCategoriesStr) : [];
-                if (closedCategories.indexOf(rootCategory) < 0)
+                if (closedCategories.indexOf(rootCategory) < 0) {
                     categoryContainers[rootCategory].open();
-                else
+                } else {
                     categoryContainers[rootCategory].close();
+                }
             }
 
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -65,12 +65,14 @@ RED.palette = (function() {
                 catDiv.addClass("red-ui-palette-closed");
                 $("#red-ui-palette-base-category-"+category).slideUp();
                 $("#red-ui-palette-header-"+category+" i").removeClass("expanded");
+                rememberCategoryState(category, false)
             },
             open: function() {
                 catDiv.addClass("red-ui-palette-open");
                 catDiv.removeClass("red-ui-palette-closed");
                 $("#red-ui-palette-base-category-"+category).slideDown();
                 $("#red-ui-palette-header-"+category+" i").addClass("expanded");
+                rememberCategoryState(category, true)
             },
             toggle: function() {
                 if (catDiv.hasClass("red-ui-palette-open")) {
@@ -84,6 +86,22 @@ RED.palette = (function() {
         $("#red-ui-palette-header-"+category).on('click', function(e) {
             categoryContainers[category].toggle();
         });
+    }
+    function rememberCategoryState(cat, open) {
+        const stateStr = localStorage.getItem('closedCategories');
+        if (!stateStr && open) return;
+        const state = stateStr ? JSON.parse(stateStr) : [];
+        const idx = state.indexOf(cat);
+        if (open && idx >= 0)
+            state.splice(idx, 1);
+        else if (!open && idx < 0)
+            state.push(cat);
+        else
+            return;
+        if (state.length <= 0)
+            localStorage.removeItem('closedCategories');
+        else
+            localStorage.setItem('closedCategories', JSON.stringify(state));
     }
 
     function setLabel(type, el,label, info) {
@@ -407,7 +425,12 @@ RED.palette = (function() {
 
             var categoryNode = $("#red-ui-palette-container-"+rootCategory);
             if (categoryNode.find(".red-ui-palette-node").length === 1) {
-                categoryContainers[rootCategory].open();
+                const closedCategoriesStr = localStorage.getItem('closedCategories');
+                const closedCategories = closedCategoriesStr ? JSON.parse(closedCategoriesStr) : [];
+                if (closedCategories.indexOf(rootCategory) < 0)
+                    categoryContainers[rootCategory].open();
+                else
+                    categoryContainers[rootCategory].close();
             }
 
         }
@@ -652,7 +675,7 @@ RED.palette = (function() {
         });
         RED.popover.tooltip(paletteExpandAll,RED._('palette.actions.expand-all'));
 
-        RED.actions.add("core:toggle-palette", function(state) {
+				RED.actions.add("core:toggle-palette", function(state) {
             if (state === undefined) {
                 RED.menu.toggleSelected("menu-item-palette");
             } else {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

If you are working on some custom nodes and have them in a new category at the bottom of the list, it's nice to have the others closed even after a page reload.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
They seem to fail, but not because of this change.
- [ ] I have added suitable unit tests to cover the new/changed functionality
