### PR TITLE
Editor: With an input/output port on a node, give the icon more space.

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4134,20 +4134,22 @@ RED.view = (function() {
                 iconUrl = RED.settings.apiRootUrl+"icons/"+iconPath.module+"/"+iconPath.file;
             }
         }
+        const rightAlign = "right" === d._def.align
+        const offsetX = d.inputs && !rightAlign ? 2 : d.outputs && rightAlign ? -2 : 0
         if (fontAwesomeUnicode) {
             // Since Node-RED workspace uses SVG, i tag cannot be used for font-awesome icon.
             // On SVG, use text tag as an alternative.
             icon_group.append("text")
                 .attr("xlink:href",iconUrl)
                 .attr("class","fa-lg")
-                .attr("x",15)
+                .attr("x",15+offsetX)
                 .text(fontAwesomeUnicode);
         } else {
             var icon = icon_group.append("image")
                 .style("display","none")
                 .attr("xlink:href",iconUrl)
                 .attr("class","red-ui-flow-node-icon")
-                .attr("x",0)
+                .attr("x",0+offsetX)
                 .attr("width","30")
                 .attr("height","30");
 
@@ -4164,7 +4166,7 @@ RED.view = (function() {
                     var height = img.height * scaleFactor;
                     icon.attr("width",width);
                     icon.attr("height",height);
-                    icon.attr("x",15-width/2);
+                    icon.attr("x",15-width/2+offsetX);
                 }
                 icon.attr("xlink:href",iconUrl);
                 icon.style("display",null);
@@ -4741,7 +4743,7 @@ RED.view = (function() {
                         if ((!d._def.align && d.inputs !== 0 && d.outputs === 0) || "right" === d._def.align) {
                             if (this.__iconGroup__) {
                                 this.__iconGroup__.classList.add("red-ui-flow-node-icon-group-right");
-                                this.__iconGroup__.setAttribute("transform", "translate("+(d.w-30)+",0)");
+                                this.__iconGroup__.setAttribute("transform", "translate("+(d.w-(d.outputs ? 32 : 30))+",0)");
                             }
                             this.__textGroup__.classList.add("red-ui-flow-node-label-right");
                             this.__textGroup__.setAttribute("transform", "translate("+(d.w-38)+","+yp+")");
@@ -4877,9 +4879,8 @@ RED.view = (function() {
 
                             icon.attr("y",function(){return (d.h-d3.select(this).attr("height"))/2;});
 
-
                             const iconShadeHeight = d.h
-                            const iconShadeWidth = 30
+                            const iconShadeWidth = d.inputs && d.outputs ? 32 : 30
                             this.__iconShade__.setAttribute("d", hideLabel ?
                                 `M5 0 h${iconShadeWidth-10} a 5 5 0 0 1 5 5 v${iconShadeHeight-10} a 5 5 0 0 1 -5 5 h-${iconShadeWidth-10} a 5 5 0 0 1 -5 -5  v-${iconShadeHeight-10} a 5 5 0 0 1 5 -5` : (
                                     "right" === d._def.align ?
@@ -4889,7 +4890,7 @@ RED.view = (function() {
                             )
                             this.__iconShadeBorder__.style.display = hideLabel?'none':''
                             this.__iconShadeBorder__.setAttribute("d",
-                                                                  "M " + (((!d._def.align && d.inputs !== 0 && d.outputs === 0) || "right" === d._def.align) ? 0.5 : 29.5) + " "+(d.selected?1:0.5)+" l 0 " + (d.h - (d.selected?2:1))
+                                                                  "M " + (((!d._def.align && d.inputs !== 0 && d.outputs === 0) || "right" === d._def.align) ? 0.5 : iconShadeWidth-0.5) + " "+(d.selected?1:0.5)+" l 0 " + (d.h - (d.selected?2:1))
                                                                  );
                             faIcon.attr("y",(d.h+13)/2);
                         }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

With a port-connector in place icons don't really look centered anymore. Some even touch the port symbol. I have just moved it 2px to the left. Even though the port-connector has a 3px radius, 2px seem enough.
For right-aligned I couldn't find a node with an icon and an output port, so it might not work...
The text is now a little closer to the shade-border, but it looks good enough this way to present to my customer ;)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
They seem to fail, but not because of this change.
- [ ] I have added suitable unit tests to cover the new/changed functionality
