### PR TITLE
Fix nodesDir scan when node package has js/html in sub dir to package.json

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/loader.js
+++ b/packages/node_modules/@node-red/registry/lib/loader.js
@@ -43,37 +43,40 @@ function load(disableNodePathScan) {
     return loadModuleFiles(modules);
 }
 
+function splitPath(p) {
+    return path.posix.normalize((p || '').replace(/\\/g, path.sep)).split(path.sep)
+}
 
 function loadModuleTypeFiles(module, type) {
     const things = module[type];
-    var first = true;
-    var promises = [];
-    for (var thingName in things) {
+    let first = true;
+    const promises = [];
+    for (let thingName in things) {
         /* istanbul ignore else */
         if (things.hasOwnProperty(thingName)) {
             if (module.name != "node-red" && first) {
                 // Check the module directory exists
                 first = false;
-                var fn = things[thingName].file;
-                var parts = fn.split("/");
-                var i = parts.length-1;
-                for (;i>=0;i--) {
-                    if (parts[i] == "node_modules") {
-                        break;
-                    }
+                let moduleFn = module.path
+                const fn = things[thingName].file
+                const parts = splitPath(fn)
+                const nmi = parts.indexOf('node_modules')
+                if(nmi > -1) {
+                    moduleFn = parts.slice(0,nmi+2).join(path.sep);
                 }
-                var moduleFn = parts.slice(0,i+2).join("/");
-
+                if (!moduleFn) {
+                    // shortcut - skip calling statSync on empty string 
+                    break; // Module not found, don't attempt to load its nodes
+                }
                 try {
-                    var stat = fs.statSync(moduleFn);
+                    const stat = fs.statSync(moduleFn);
                 } catch(err) {
-                    // Module not found, don't attempt to load its nodes
-                    break;
+                    break; // Module not found, don't attempt to load its nodes
                 }
             }
 
             try {
-                var promise;
+                let promise;
                 if (type === "nodes") {
                     promise = loadNodeConfig(things[thingName]);
                 } else if (type === "plugins") {
@@ -82,8 +85,7 @@ function loadModuleTypeFiles(module, type) {
                 promises.push(
                     promise.then(
                         (function() {
-                            var m = module.name;
-                            var n = thingName;
+                            const n = thingName;
                             return function(nodeSet) {
                                 things[n] = nodeSet;
                                 return nodeSet;
@@ -93,7 +95,6 @@ function loadModuleTypeFiles(module, type) {
                 );
             } catch(err) {
                 console.log(err)
-                //
             }
         }
     }

--- a/packages/node_modules/@node-red/registry/lib/localfilesystem.js
+++ b/packages/node_modules/@node-red/registry/lib/localfilesystem.js
@@ -156,6 +156,16 @@ function scanDirForNodesModules(dir,moduleName,package) {
                 }
             }
         }
+
+        // if we have found a package.json, this IS a node_module, lets see if it is a node-red node
+        if (!isNodeRedModule && files.indexOf('package.json') > -1) {
+            package = getPackageDetails(dir) // get package details
+            if(package && package.isNodeRedModule) {
+                isNodeRedModule = true
+                files = ['package.json'] // shortcut the file scan
+            }
+        }
+
         for (let i=0;i<files.length;i++) {
             let fn = files[i];
             if (!isNodeRedModule && /^@/.test(fn)) {

--- a/packages/node_modules/@node-red/registry/lib/registry.js
+++ b/packages/node_modules/@node-red/registry/lib/registry.js
@@ -185,17 +185,18 @@ function loadNodeConfigs() {
 function addModule(module) {
     moduleNodes[module.name] = [];
     moduleConfigs[module.name] = module;
-    for (var setName in module.nodes) {
+    for (const setName in module.nodes) {
         if (module.nodes.hasOwnProperty(setName)) {
-            var set = module.nodes[setName];
+            const set = module.nodes[setName];
+            if(setName === 'lower-case') {
+                delete set.types
+            }
             if (!set.types) {
-                const err = new Error("Node has no types")
-                err.code = "has_no_types"
+                const err = new Error("Set has no types")
+                err.code = "set_has_no_types"
                 err.details = {
-                    setName: set.name,
-                    set: { ...set }
+                    ...set
                 }
-                console.warn(err)
                 set.err = err
             }
             moduleNodes[module.name].push(set.name);

--- a/packages/node_modules/@node-red/registry/lib/registry.js
+++ b/packages/node_modules/@node-red/registry/lib/registry.js
@@ -185,10 +185,19 @@ function loadNodeConfigs() {
 function addModule(module) {
     moduleNodes[module.name] = [];
     moduleConfigs[module.name] = module;
-    // console.log("registry.js.addModule",module.name,"user?",module.user,"usedBy",module.usedBy,"dependencies",module.dependencies)
     for (var setName in module.nodes) {
         if (module.nodes.hasOwnProperty(setName)) {
             var set = module.nodes[setName];
+            if (!set.types) {
+                const err = new Error("Node has no types")
+                err.code = "has_no_types"
+                err.details = {
+                    setName: set.name,
+                    set: { ...set }
+                }
+                console.warn(err)
+                set.err = err
+            }
             moduleNodes[module.name].push(set.name);
             nodeList.push(set.id);
             if (!set.err) {

--- a/packages/node_modules/@node-red/registry/lib/registry.js
+++ b/packages/node_modules/@node-red/registry/lib/registry.js
@@ -188,9 +188,6 @@ function addModule(module) {
     for (const setName in module.nodes) {
         if (module.nodes.hasOwnProperty(setName)) {
             const set = module.nodes[setName];
-            if(setName === 'lower-case') {
-                delete set.types
-            }
             if (!set.types) {
                 const err = new Error("Set has no types")
                 err.code = "set_has_no_types"

--- a/packages/node_modules/@node-red/runtime/lib/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/index.js
@@ -161,6 +161,8 @@ function start() {
                     for (i=0;i<nodeErrors.length;i+=1) {
                         if (nodeErrors[i].err.code === "type_already_registered") {
                             log.warn("["+nodeErrors[i].id+"] "+log._("server.type-already-registered",{type:nodeErrors[i].err.details.type,module: nodeErrors[i].err.details.moduleA}));
+                        } else if (nodeErrors[i].err.code === "set_has_no_types") {
+                            log.warn("["+nodeErrors[i].id+"] "+log._("server.set-has-no-types", nodeErrors[i].err.details));
                         } else {
                             log.warn("["+nodeErrors[i].id+"] "+nodeErrors[i].err);
                         }

--- a/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
@@ -20,6 +20,7 @@
         "errors-help": "Run with -v for details",
         "missing-modules": "Missing node modules:",
         "node-version-mismatch": "Node module cannot be loaded on this version. Requires: __version__ ",
+        "set-has-no-types": "Set does not have any types. name: '__name__', module: '__module__', file: '__file__'",
         "type-already-registered": "'__type__' already registered by module __module__",
         "removing-modules": "Removing modules from config",
         "added-types": "Added node types:",

--- a/test/unit/@node-red/registry/lib/localfilesystem_spec.js
+++ b/test/unit/@node-red/registry/lib/localfilesystem_spec.js
@@ -329,16 +329,35 @@ describe("red/nodes/registry/localfilesystem",function() {
             localfilesystem.init({nodesDir:[nodesDir2]});
             const nodeModule = localfilesystem.getModuleFiles();
             const loaded = Object.keys(nodeModule)
-            loaded.should.have.a.property("length", 3)
             loaded.indexOf('@test/testnode').should.greaterThan(-1, "Should load @test/testnode")
+            loaded.indexOf('lower-case').should.greaterThan(-1, "Should load lower-case")
+            loaded.indexOf('@lowercase/lower-case2').should.greaterThan(-1, "Should load @lowercase/lower-case2")
             loaded.indexOf('testnode2').should.greaterThan(-1, "Should load testnode2")
             loaded.indexOf('test-theme2').should.greaterThan(-1, "Should load test-theme2")
+            loaded.should.have.a.property("length", 5)
 
+            // scoped module with nodes in same dir as package.json
             nodeModule['@test/testnode'].should.have.a.property('name','@test/testnode');
             nodeModule['@test/testnode'].should.have.a.property('version','1.0.0');
             nodeModule['@test/testnode'].should.have.a.property('nodes');
             nodeModule['@test/testnode'].should.have.a.property('path');
             nodeModule['@test/testnode'].should.have.a.property('user', false);
+
+            // node-red module with nodes in sub dir
+            nodeModule['@lowercase/lower-case2'].should.have.a.property('name','@lowercase/lower-case2');
+            nodeModule['@lowercase/lower-case2'].should.have.a.property('version','2.0.0');
+            nodeModule['@lowercase/lower-case2'].should.have.a.property('nodes');
+            nodeModule['@lowercase/lower-case2'].nodes.should.have.a.property('lower-case');
+            nodeModule['@lowercase/lower-case2'].should.have.a.property('path');
+            nodeModule['@lowercase/lower-case2'].should.have.a.property('user', false);
+
+            // scoped module with nodes in sub dir
+            nodeModule['lower-case'].should.have.a.property('name', 'lower-case');
+            nodeModule['lower-case'].should.have.a.property('version','1.0.0');
+            nodeModule['lower-case'].should.have.a.property('nodes');
+            nodeModule['lower-case'].nodes.should.have.a.property('lower-case');
+            nodeModule['lower-case'].should.have.a.property('path');
+            nodeModule['lower-case'].should.have.a.property('user', false);
 
             nodeModule['testnode2'].should.have.a.property('name','testnode2');
             nodeModule['testnode2'].should.have.a.property('version','1.0.0');

--- a/test/unit/@node-red/registry/lib/resources/nodesDir2/@lower-case2/lower-case2/lower-case.html
+++ b/test/unit/@node-red/registry/lib/resources/nodesDir2/@lower-case2/lower-case2/lower-case.html
@@ -1,0 +1,26 @@
+<script type="text/javascript">
+    RED.nodes.registerType('lower-case2',{
+        category: 'function',
+        color: '#a6bbcf',
+        defaults: {
+            name: {value:""}
+        },
+        inputs:1,
+        outputs:1,
+        icon: "file.png",
+        label: function() {
+            return this.name||"lower-case2";
+        }
+    });
+</script>
+
+<script type="text/html" data-template-name="lower-case2">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+
+<script type="text/html" data-help-name="lower-case2">
+    <p>A simple node that converts the message payloads into all lower-case2 characters</p>
+</script>

--- a/test/unit/@node-red/registry/lib/resources/nodesDir2/@lower-case2/lower-case2/lower-case.js
+++ b/test/unit/@node-red/registry/lib/resources/nodesDir2/@lower-case2/lower-case2/lower-case.js
@@ -1,0 +1,11 @@
+module.exports = function(RED) {
+function LowerCaseNode(config) {
+        RED.nodes.createNode(this,config);
+        var node = this;
+        node.on('input', function(msg) {
+            msg.payload = msg.payload.toLowerCase();
+            node.send(msg);
+        });
+    }
+    RED.nodes.registerType("lower-case2",LowerCaseNode);
+}

--- a/test/unit/@node-red/registry/lib/resources/nodesDir2/@lower-case2/package.json
+++ b/test/unit/@node-red/registry/lib/resources/nodesDir2/@lower-case2/package.json
@@ -1,0 +1,9 @@
+{
+    "name" : "@lowercase/lower-case2",
+    "node-red" : {
+        "nodes": {
+            "lower-case": "lower-case2/lower-case.js"
+        }
+    },
+    "version": "2.0.0"
+}

--- a/test/unit/@node-red/registry/lib/resources/nodesDir2/lower-case/lower-case/lower-case.html
+++ b/test/unit/@node-red/registry/lib/resources/nodesDir2/lower-case/lower-case/lower-case.html
@@ -1,0 +1,26 @@
+<script type="text/javascript">
+    RED.nodes.registerType('lower-case',{
+        category: 'function',
+        color: '#a6bbcf',
+        defaults: {
+            name: {value:""}
+        },
+        inputs:1,
+        outputs:1,
+        icon: "file.png",
+        label: function() {
+            return this.name||"lower-case";
+        }
+    });
+</script>
+
+<script type="text/html" data-template-name="lower-case">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+
+<script type="text/html" data-help-name="lower-case">
+    <p>A simple node that converts the message payloads into all lower-case characters</p>
+</script>

--- a/test/unit/@node-red/registry/lib/resources/nodesDir2/lower-case/lower-case/lower-case.js
+++ b/test/unit/@node-red/registry/lib/resources/nodesDir2/lower-case/lower-case/lower-case.js
@@ -1,0 +1,11 @@
+module.exports = function(RED) {
+    function LowerCaseNode(config) {
+        RED.nodes.createNode(this,config);
+        var node = this;
+        node.on('input', function(msg) {
+            msg.payload = msg.payload.toLowerCase();
+            node.send(msg);
+        });
+    }
+    RED.nodes.registerType("lower-case",LowerCaseNode);
+}

--- a/test/unit/@node-red/registry/lib/resources/nodesDir2/lower-case/package.json
+++ b/test/unit/@node-red/registry/lib/resources/nodesDir2/lower-case/package.json
@@ -1,0 +1,9 @@
+{
+    "name" : "lower-case",
+    "node-red" : {
+        "nodes": {
+            "lower-case": "lower-case/lower-case.js"
+        }
+    },
+    "version": "1.0.0"
+}


### PR DESCRIPTION
fixes #3861 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

First, please read through the issue detailed in [this comment](https://github.com/node-red/node-red/issues/3861#issuecomment-1236124417)

## Proposed changes

* Normalise path before splitting (`loader.js`)
* Skip calling statSync on empty string  (`loader.js`)
* Shortcut scanning of a directories files/folders if the directory contains a package.json (`localfilesystem.js`)
* Prevent crashing node-red when `set.types` is not set  (`registry.js`)
* Print out which node caused the error 
    * BEFORE: 
    ```
    TypeError: Cannot read properties of undefined (reading 'forEach')
    at Object.addModule (/usr/lib/node_modules/node-red/node_modules/@node-red/registry/lib/registry.js:195:27)
    at /usr/lib/node_modules/node-red/node_modules/@node-red/registry/lib/loader.js:153:34
    ```
    * AFTER:    (Updated 2022/09/29, after commit e6b3793)
    ```
    29 Sep 21:25:17 - [warn] [node-red/lower-case] Set does not have any types. name: 'lower-case', module: 'node-red', file: 'C:\Users\user\repos\_node-red-issue-3861\lower-case.js'
    packages/node_modules/@node-red/util/lib/log.js:94
    29 Sep 21:25:31 - [warn] [node-red-node-google/google-api-config] 'google-api-config' already registered by module node-red-contrib-google-calendar
    packages/node_modules/@node-red/util/lib/log.js:94
    29 Sep 21:25:31 - [warn] [node-red-node-rbe/rbe] 'rbe' already registered by module node-red
    packages/node_modules/@node-red/util/lib/log.js:94
    29 Sep 21:25:31 - [warn] [@flowforge/nr-project-nodes/project-link] Error: Project Link nodes cannot be loaded outside of flowforge EE environment
    packages/node_modules/@node-red/util/lib/log.js:94
    29 Sep 21:25:57 - [warn] [lower-case/lower-case] Set does not have any types. name: 'lower-case', module: 'lower-case', file: 'C:\Users\user\repos\_node-red-issue-3861\lower-case\lower-case\lower-case.js'
    packages/node_modules/@node-red/util/lib/log.js:94
    29 Sep 21:26:06 - [warn] [@lowercase/lower-case2/lower-case] Set does not have any types. name: 'lower-case', module: '@lowercase/lower-case2', file: 'C:\Users\user\repos\_node-red-issue-3861\@lower-case\lower-case2\lower-case.js'
    ```

* Add more tests that load nodes with js/html files in a sub directory (`registry.js`)

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
