### PR TITLE
add function node monaco types util and promisify

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
@@ -100,7 +100,7 @@ RED.editor.codeEditor.monaco = (function() {
         "node-red-util": {package: "node-red", module: "util", path: "node-red/util.d.ts" },
         "node-red-func": {package: "node-red", module: "func", path: "node-red/func.d.ts" },
     }
-    const defaultServerSideTypes = [ knownModules["node-red-util"], knownModules["node-red-func"], knownModules["globals"], knownModules["console"], knownModules["buffer"] ];
+    const defaultServerSideTypes = [ knownModules["node-red-util"], knownModules["node-red-func"], knownModules["globals"], knownModules["console"], knownModules["buffer"] , knownModules["util"] ];
 
     const modulesCache = {};
 

--- a/packages/node_modules/@node-red/editor-client/src/types/node-red/func.d.ts
+++ b/packages/node_modules/@node-red/editor-client/src/types/node-red/func.d.ts
@@ -14,6 +14,9 @@ declare var msg: NodeMessage;
 /** @type {string} the id of the incoming `msg` (alias of msg._msgid) */
 declare const __msgid__:string;
 
+declare const util:typeof import('util')
+declare const promisify:typeof import('util').promisify
+
 /**
  * @typedef NodeStatus
  * @type {object}


### PR DESCRIPTION
fixes #3851

## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

`util` and `promisify` are added into the server side function node `vm` but the monaco environment did not recognise these variables and did not offer type hints etc.

This PR adds them to the type d.ts file & pre-loads the `util` module

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
