### PR TITLE
Prevent invalid mqtt birth topic crashing node-red

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -991,14 +991,21 @@ module.exports = function(RED) {
                 }
 
                 if (topicOK) {
-                    node.client.publish(msg.topic, msg.payload, options, function(err) {
-                        done && done(err);
-                        return
-                    });
+                    node.client.publish(msg.topic, msg.payload, options, function (err) {
+                        if (done) {
+                            done(err)
+                        } else {
+                            node.error(err, msg)
+                        }
+                    })
                 } else {
-                    const error = new Error(RED._("mqtt.errors.invalid-topic"));
-                    error.warn = true;
-                    done(error);
+                    const error = new Error(RED._("mqtt.errors.invalid-topic"))
+                    error.warn = true
+                    if (done) {
+                        done(error)
+                    } else {
+                        node.warn(error, msg)
+                    }
                 }
             }
         };


### PR DESCRIPTION
fixes #3865

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

ensure `done` is present otherwise call `node.error`
NOTE: upon connect, when a birth message is sent, the context in which execution arrives at the `done` call is from within the callback of the MQTT client connect (not within the context the node-red node) meaning there is no `done` callback to call.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
