### PR TITLE
Fix error hanndling of JSONata expression editor for extended functions

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -936,6 +936,9 @@
             "invalid-expr": "Invalid JSONata expression:\n  __message__",
             "invalid-msg": "Invalid example JSON message:\n  __message__",
             "context-unsupported": "Cannot test context functions\n $flowContext or $globalContext",
+            "env-unsupported": "Cannot test $env function",
+            "moment-unsupported": "Cannot test $moment function",
+            "clone-unsupported": "Cannot test $clone function",
             "eval": "Error evaluating expression:\n  __message__"
         }
     },

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -936,6 +936,9 @@
             "invalid-expr": "不正なJSONata式:\n  __message__",
             "invalid-msg": "不正なJSONメッセージ例:\n  __message__",
             "context-unsupported": "$flowContext や $globalContextの\nコンテキスト機能をテストできません",
+            "env-unsupported": "$env関数はテストできません",
+            "moment-unsupported": "$moment関数はテストできません",
+            "clone-unsupported": "$clone関数はテストできません",
             "eval": "表現評価エラー:\n  __message__"
         }
     },

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/expression.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/expression.js
@@ -255,6 +255,9 @@
                         var currentExpression = expressionEditor.getValue();
                         var expr;
                         var usesContext = false;
+                        var usesEnv = false;
+                        var usesMoment = false;
+                        var usesClone = false;
                         var legacyMode = /(^|[^a-zA-Z0-9_'".])msg([^a-zA-Z0-9_'"]|$)/.test(currentExpression);
                         $(".red-ui-editor-type-expression-legacy").toggle(legacyMode);
                         try {
@@ -265,6 +268,18 @@
                             });
                             expr.assign('globalContext',function(val) {
                                 usesContext = true;
+                                return null;
+                            });
+                            expr.assign("env", function(name) {
+                                usesEnv = true;
+                                return null;
+                            });
+                            expr.assign("moment", function(name) {
+                                usesMoment = true;
+                                return null;
+                            });
+                            expr.assign("clone", function(name) {
+                                usesClone = true;
                                 return null;
                             });
                         } catch(err) {
@@ -282,6 +297,18 @@
                             var result = expr.evaluate(legacyMode?{msg:parsedData}:parsedData);
                             if (usesContext) {
                                 testResultEditor.setValue(RED._("expressionEditor.errors.context-unsupported"),-1);
+                                return;
+                            }
+                            if (usesEnv) {
+                                testResultEditor.setValue(RED._("expressionEditor.errors.env-unsupported"),-1);
+                                return;
+                            }
+                            if (usesMoment) {
+                                testResultEditor.setValue(RED._("expressionEditor.errors.moment-unsupported"),-1);
+                                return;
+                            }
+                            if (usesClone) {
+                                testResultEditor.setValue(RED._("expressionEditor.errors.clone-unsupported"),-1);
                                 return;
                             }
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Current JSONata editor reports extended functions `$flowContext` and `$globalContext` as not testable but not reports for `$env`, `$moment`, and `$clone`.
This PR makes all these functions reported as not testable.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
