### PR TITLE
Remove dot from variable name for external module in function node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.html
@@ -294,7 +294,7 @@
                     if (val === "_custom_") {
                         val = $(this).val();
                     }
-                    var varName = val.trim().replace(/^@/,"").replace(/@.*$/,"").replace(/[-_/].?/g, function(v) { return v[1]?v[1].toUpperCase():"" });
+                    var varName = val.trim().replace(/^@/,"").replace(/@.*$/,"").replace(/[-_/\.].?/g, function(v) { return v[1]?v[1].toUpperCase():"" });
                     fvar.val(varName);
                     fvar.trigger("change");
 


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
In the external modules UI of the function node, the variable name is automatically converted to fit JavaScript code. In this UI, I found that it cannot handle module names including a dot. For example, `fft.js` is not converted but it should be `fftJs` to use in JavaScript code.

<img width="1280" alt="Screen Shot 2022-09-10 at 12 27 45" src="https://user-images.githubusercontent.com/20310935/189467211-0bf5ea4c-e2de-4cc5-9a7e-e1c7c0ea7f39.png">

In this pull request, I added the change to support converting dot.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality