### PR TITLE
Ensure msg.req.headers is enumerable

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/21-httpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httpin.js
@@ -46,7 +46,7 @@ module.exports = function(RED) {
                     isText = true;
                 } else if (parsedType.type !== "application") {
                     isText = false;
-                } else if ((parsedType.subtype !== "octet-stream") 
+                } else if ((parsedType.subtype !== "octet-stream")
                     && (parsedType.subtype !== "cbor")
                     && (parsedType.subtype !== "x-protobuf")) {
                     checkUTF = true;
@@ -200,6 +200,15 @@ module.exports = function(RED) {
             this.callback = function(req,res) {
                 var msgid = RED.util.generateId();
                 res._msgid = msgid;
+                // Since Node 15, req.headers are lazily computed and the property
+                // marked as non-enumerable.
+                // That means it doesn't show up in the Debug sidebar.
+                // This redefines the property causing it to be evaluated *and*
+                // marked as enumerable again.
+                Object.defineProperty(req, 'headers', {
+                    value: req.headers,
+                    enumerable: true
+                })
                 if (node.method.match(/^(post|delete|put|options|patch)$/)) {
                     node.send({_msgid:msgid,req:req,res:createResponseWrapper(node,res),payload:req.body});
                 } else if (node.method == "get") {


### PR DESCRIPTION
Fixes #3878

This is done to ensure `msg.req.headers` shows up in the Debug sidebar.

However it isn't ideal. We have to balance the UX of the editor, versus the overall performance of flows. This change ensures the headers show up in the Debug sidebar, but comes at the cost of a small bit of additional work in the HTTP In node - work that is *only* required to solve the Debug sidebar issue.