### PR TITLE
Add check that node sends object rather than primitive type

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
@@ -373,6 +373,11 @@ Node.prototype.send = function(msg) {
     if (msg === null || typeof msg === "undefined") {
         return;
     } else if (!util.isArray(msg)) {
+        // A single message has been passed in
+        if (typeof msg !== 'object') {
+            this.error(Log._("nodes.flow.non-message-returned", { type: typeof msg }));
+            return
+        }
         if (this._wire) {
             // A single message and a single wire on output 0
             // TODO: pre-load flows.get calls - cannot do in constructor
@@ -425,27 +430,31 @@ Node.prototype.send = function(msg) {
                     for (k = 0; k < msgs.length; k++) {
                         var m = msgs[k];
                         if (m !== null && m !== undefined) {
-                            if (!m._msgid) {
-                                hasMissingIds = true;
+                            if (typeof m !== 'object') {
+                                this.error(Log._("nodes.flow.non-message-returned", { type: typeof m }));
+                            } else {
+                                if (!m._msgid) {
+                                    hasMissingIds = true;
+                                }
+                                /* istanbul ignore else */
+                                if (!sentMessageId) {
+                                    sentMessageId = m._msgid;
+                                }
+                                sendEvents.push({
+                                    msg: m,
+                                    source: {
+                                        id: this.id,
+                                        node: this,
+                                        port: i
+                                    },
+                                    destination: {
+                                        id: wires[j],
+                                        node: undefined
+                                    },
+                                    cloneMessage: msgSent
+                                });
+                                msgSent = true;
                             }
-                            /* istanbul ignore else */
-                            if (!sentMessageId) {
-                                sentMessageId = m._msgid;
-                            }
-                            sendEvents.push({
-                                msg: m,
-                                source: {
-                                    id: this.id,
-                                    node: this,
-                                    port: i
-                                },
-                                destination: {
-                                    id: wires[j],
-                                    node: undefined
-                                },
-                                cloneMessage: msgSent
-                            });
-                            msgSent = true;
                         }
                     }
                 }

--- a/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
@@ -134,7 +134,8 @@
         "flow": {
             "unknown-type": "Unknown type: __type__",
             "missing-types": "missing types",
-            "error-loop": "Message exceeded maximum number of catches"
+            "error-loop": "Message exceeded maximum number of catches",
+            "non-message-returned": "Node tried to send a message of type __type__"
         },
         "index": {
             "unrecognised-id": "Unrecognised id: __id__",


### PR DESCRIPTION
Fixes #3876

We already had a similar check in the Function node - where end users could accidentally try to return the wrong type of thing.

We didn't do this on the core messaging path on the assumption that a Node implementation would always do the right thing. But if they didn't there was no feedback to help them identify the issue. This adds an explicit check and logging if a node doesn't do the right thing.