### PR TITLE
Ensure errors in preDeliver callback are handled

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -823,7 +823,6 @@ function deliverMessageToDestination(sendEvent) {
         try {
             sendEvent.destination.node.receive(sendEvent.msg);
         } catch(err) {
-            const info = `${sendEvent.destination.node?.id}`
             Log.error(`Error delivering message to node:${sendEvent.destination.node._path} [${sendEvent.destination.node.type}]`)
             Log.error(err.stack)
         }


### PR DESCRIPTION
Fixes #3848

If, for any reason, there is an error whilst delivering a message to a node, rather than cause a fatal error, it will now get logged as follows. You get the full node path, its type and the stack of the error.

```
    4 Oct 15:18:12 - [error] Error handling message: node:d5771324312036f6/dd93c1103d5aee6e [function]
    4 Oct 15:18:12 - [error] TypeError: sendEvent.destination.node.receive is not a function
        at Immediate._onImmediate (/Users/nol/code/node-red/node-red/packages/node_modules/@node-red/runtime/lib/flows/Flow.js:832:56)
        at processImmediate (node:internal/timers:464:21)
```
