### PR TITLE
Ensure key_path is quoted in GIT_SSH_COMMAND in case of spaces in pathname

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/git/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/git/index.js
@@ -106,7 +106,7 @@ function runGitCommandWithSSHCommand(args,cwd,auth,emit) {
         commandEnv.GIT_SSH = path.join(__dirname,"node-red-ssh.sh");
         commandEnv.NODE_RED_KEY_FILE=auth.key_path;
         // GIT_SSH_COMMAND - added in git 2.3.0
-        commandEnv.GIT_SSH_COMMAND = "ssh -i " + auth.key_path + " -F /dev/null";
+        commandEnv.GIT_SSH_COMMAND = "ssh -i \"" + auth.key_path + "\" -F /dev/null";
         // console.log('commandEnv:', commandEnv);
         return runGitCommand(args,cwd,commandEnv,emit).then( result => {
             rs.close();


### PR DESCRIPTION
See https://discourse.nodered.org/t/cant-clone-remote-repository/9957/2?u=knolleary for reference

If the username has a space in it, then the generated path needs to be properly quoted to work.