### PR TITLE
Fix extra newline append for multipart file write

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         node-version: [14, 16]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.js
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.js
@@ -117,7 +117,9 @@ module.exports = function(RED) {
                 }
                 if (typeof data === "boolean") { data = data.toString(); }
                 if (typeof data === "number") { data = data.toString(); }
-                if ((node.appendNewline) && (!Buffer.isBuffer(data))) { data += os.EOL; }
+                var aflg = true;
+                if (msg.hasOwnProperty("parts") && msg.parts.type === "string" && (msg.parts.count === msg.parts.index + 1)) { aflg = false; }
+                if ((node.appendNewline) && (!Buffer.isBuffer(data)) && aflg) { data += os.EOL; }
                 var buf;
                 if (node.encoding === "setbymsg") {
                     buf = encode(data, msg.encoding || "none");
@@ -314,7 +316,6 @@ module.exports = function(RED) {
             });
             filename = filename || "";
             var fullFilename = filename;
-            var filePath = "";
             if (filename && RED.settings.fileWorkingDirectory && !path.isAbsolute(filename)) {
                 fullFilename = path.resolve(path.join(RED.settings.fileWorkingDirectory,filename));
             }


### PR DESCRIPTION
ref Issue #3913

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

If you write a file (previously read in - with msg.parts attached) - in per line mode - with append linefeed set - we currently add an extra line feed due to the blank / null line at the end that closes the file. This fix detects that and stops it happening so you can write out an identical file to that read in more correctly..

This is to address the Issue #3913

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
