### PR TITLE
Handle replacing unknown node inside group or subflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1768,6 +1768,7 @@ RED.nodes = (function() {
                     unknownTypes.push(n.type);
             }
             if (n.z) {
+if (n.id === '42051f44c151e5d7') console.log('importing',n.z)
                 nodeZmap[n.z] = nodeZmap[n.z] || [];
                 nodeZmap[n.z].push(n);
             } else if (isInitialLoad && n.hasOwnProperty('x') && n.hasOwnProperty('y') && !n.z) {
@@ -1965,7 +1966,7 @@ RED.nodes = (function() {
                         }
                     }
                 } else {
-                    const keepNodesCurrentZ = reimport && n.z && RED.workspaces.contains(n.z)
+                    const keepNodesCurrentZ = reimport && n.z && (RED.workspaces.contains(n.z) || RED.nodes.subflow(n.z))
                     if (!keepNodesCurrentZ && n.z && !workspace_map[n.z] && !subflow_map[n.z]) {
                         n.z = activeWorkspace;
                     }
@@ -2067,7 +2068,7 @@ RED.nodes = (function() {
                         node.id = getID();
                     } else {
                         node.id = n.id;
-                        const keepNodesCurrentZ = reimport && node.z && RED.workspaces.contains(node.z)
+                        const keepNodesCurrentZ = reimport && node.z && (RED.workspaces.contains(node.z) || RED.nodes.subflow(node.z))
                         if (!keepNodesCurrentZ && (node.z == null || (!workspace_map[node.z] && !subflow_map[node.z]))) {
                             if (createMissingWorkspace) {
                                 if (missingWorkspace === null) {
@@ -2740,6 +2741,7 @@ RED.nodes = (function() {
                     }
                 });
 
+                var nodeGroupMap = {}
                 var replaceNodeIds = Object.keys(replaceNodes);
                 if (replaceNodeIds.length > 0) {
                     var reimportList = [];
@@ -2749,6 +2751,12 @@ RED.nodes = (function() {
                             delete configNodes[n.id];
                         } else {
                             allNodes.removeNode(n);
+                        }
+                        if (n.g) {
+                            // reimporting a node *without* including its group object
+                            // will cause the g property to be cleared. Cache it
+                            // here so we can restore it
+                            nodeGroupMap[n.id] = n.g
                         }
                         reimportList.push(convertNode(n));
                         RED.events.emit('nodes:remove',n);
@@ -2771,6 +2779,18 @@ RED.nodes = (function() {
                     var newNodeMap = {};
                     result.nodes.forEach(function(n) {
                         newNodeMap[n.id] = n;
+                        if (nodeGroupMap[n.id]) {
+                            // This node is in a group - need to substitute the
+                            // node reference inside the group
+                            n.g = nodeGroupMap[n.id]
+                            const group = RED.nodes.group(n.g)
+                            if (group) {
+                                var index = group.nodes.findIndex(gn => gn.id === n.id)
+                                if (index > -1) {
+                                    group.nodes[index] = n
+                                }
+                            }
+                        }
                     });
                     RED.nodes.eachLink(function(l) {
                         if (newNodeMap.hasOwnProperty(l.source.id)) {

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1768,7 +1768,6 @@ RED.nodes = (function() {
                     unknownTypes.push(n.type);
             }
             if (n.z) {
-if (n.id === '42051f44c151e5d7') console.log('importing',n.z)
                 nodeZmap[n.z] = nodeZmap[n.z] || [];
                 nodeZmap[n.z].push(n);
             } else if (isInitialLoad && n.hasOwnProperty('x') && n.hasOwnProperty('y') && !n.z) {

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2740,7 +2740,7 @@ RED.nodes = (function() {
                     }
                 });
 
-                var nodeGroupMap = {}
+                const nodeGroupMap = {}
                 var replaceNodeIds = Object.keys(replaceNodes);
                 if (replaceNodeIds.length > 0) {
                     var reimportList = [];


### PR DESCRIPTION
This fixes two issues related to replacing unknown nodes in the editor.

One reported https://discourse.nodered.org/t/group-does-not-show-styling-until-browser-refresh-made/69078 - the other discovered whilst fixing the first one.

Background: when importing a flow, any unrecognised types are replaced by a special `unknown` node. If that unrecognised type gets registered later on (either some very async work was done before the type registered, or the user had to install it via the Palette Managed), the editor would swap out the unknown nodes for the 'real' node.

This PR fixes two scenarios that were not being handled properly:

1. if the node was in a group, the group was left with the `unknown` node still referenced in its internal list of nodes

   This fix ensures the `unknown` node is swapped out for the proper node

2. if the node was in a subflow, it would get 'moved' to the current flow

    The `importNodes` code has been updated to handle reimporting a node back into a subflow
