### PR TITLE
Fix httprequest tests to be more lenient on error message

### DIFF
--- a/test/nodes/core/network/21-httprequest_spec.js
+++ b/test/nodes/core/network/21-httprequest_spec.js
@@ -1529,7 +1529,7 @@ describe('HTTP Request Node', function() {
                         msg.payload.headers.should.have.property('Content-Type').which.startWith('application/json');
                         //msg.dynamicHeaderName should be present in headers with the value of msg.dynamicHeaderValue
                         msg.payload.headers.should.have.property('dyn-header-name').which.startWith('dyn-header-value');
-                        //static (custom) header set in Flow UI should be present 
+                        //static (custom) header set in Flow UI should be present
                         msg.payload.headers.should.have.property('static-header-name').which.startWith('static-header-value');
                         //msg.headers['location'] should be deleted because Flow UI "Location" header has a blank value
                         //ensures headers with matching characters but different case are eliminated
@@ -2281,7 +2281,7 @@ describe('HTTP Request Node', function() {
             let port = testPort++
 
             let server;
-        
+
             before(function() {
                 server = net.createServer(function (socket) {
                     socket.write("HTTP/1.0 200\nContent-Type: text/plain\n\nHelloWorld")
@@ -2291,7 +2291,7 @@ describe('HTTP Request Node', function() {
                 server.listen(port,'127.0.0.1', function(err) {
                 })
             });
-            
+
             after(function() {
                 server.close()
             });
@@ -2322,14 +2322,14 @@ describe('HTTP Request Node', function() {
                     var n2 = helper.getNode("n2");
                     n2.on('input', function(msg) {
                         try{
-                            msg.payload.should.equal(`RequestError: Parse Error: Missing expected CR after header value : http://localhost:${port}/`)
+                            msg.payload.should.match(/RequestError: Parse Error/)
                             done()
                         } catch (err) {
                             done(err)
                         }
                     })
                     n1.receive({payload: 'foo'})
-                    
+
                 });
             });
         }


### PR DESCRIPTION
The unit tests for the httprequest node have been broken for a little while but gone unnoticed.

This is due to some new tests that were recently added in #3776. Took me a moment to track down the issue as the tests check the version of node and only run if on the versions of node that introduced the strict parser... and I was slightly down-level so couldn't recreate.

The tests was looking for a very specific error message - however it appears the text of the error changes in different node versions. So I've relaxed the test just to check for an error, rather than the full text.