### PR TITLE
Add drop mode to range node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/16-range.html
+++ b/packages/node_modules/@node-red/nodes/core/function/16-range.html
@@ -10,6 +10,7 @@
             <option value="scale" data-i18n="range.scale.payload"></option>
             <option value="clamp" data-i18n="range.scale.limit"></option>
             <option value="roll" data-i18n="range.scale.wrap"></option>
+            <option value="drop" data-i18n="range.scale.drop"></option>
         </select>
     </div>
     <br/>

--- a/packages/node_modules/@node-red/nodes/core/function/16-range.js
+++ b/packages/node_modules/@node-red/nodes/core/function/16-range.js
@@ -32,11 +32,15 @@ module.exports = function(RED) {
             if (value !== undefined) {
                 var n = Number(value);
                 if (!isNaN(n)) {
-                    if (node.action == "clamp") {
+                    if (node.action === "drop") {
+                        if (n < node.minin) { done(); return; }
+                        if (n > node.maxin) { done(); return; }
+                    }
+                    if (node.action === "clamp") {
                         if (n < node.minin) { n = node.minin; }
                         if (n > node.maxin) { n = node.maxin; }
                     }
-                    if (node.action == "roll") {
+                    if (node.action === "roll") {
                         var divisor = node.maxin - node.minin;
                         n = ((n - node.minin) % divisor + divisor) % divisor + node.minin;
                     }

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/16-range.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/16-range.html
@@ -34,11 +34,14 @@
     the range specified within the target range.</p>
     <p><i>Scale and wrap within the target range</i> means that the result will
     be wrapped within the target range.</p>
+    <p><i>Scale, but drop if outside input range</i> means that the result will
+    be scaled, but any inputs outside of the inout range will be dropped.</p>
     <p>For example an input 0 - 10 mapped to 0 - 100.</p>
     <table style="outline-width:#888 solid thin">
         <tr><th width="80px">mode</th><th width="80px">input</th><th width="80px">output</th></tr>
         <tr><td><center>scale</center></td><td><center>12</center></td><td><center>120</center></td></tr>
         <tr><td><center>limit</center></td><td><center>12</center></td><td><center>100</center></td></tr>
         <tr><td><center>wrap</center></td><td><center>12</center></td><td><center>20</center></td></tr>
+        <tr><td><center>drop</center></td><td><center>12</center></td><td><center><i>(no output)</i></center></td></tr>
     </table>
 </script>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -813,7 +813,8 @@
         "scale": {
             "payload": "Scale the message property",
             "limit": "Scale and limit to the target range",
-            "wrap": "Scale and wrap within the target range"
+            "wrap": "Scale and wrap within the target range",
+            "drop": "Scale, but drop msg if outside input range"
         },
         "tip": "Tip: This node ONLY works with numbers.",
         "errors": {

--- a/test/nodes/core/function/16-range_spec.js
+++ b/test/nodes/core/function/16-range_spec.js
@@ -106,6 +106,27 @@ describe('range Node', function() {
         genericRangeTest("clamp", 0, 10, 0, 1000, false, -1, 0, done);
     });
 
+    it('drops msg if in drop mode and input outside range', function(done) {
+        var flow = [{"id":"rangeNode1","type":"range","minin":2,"maxin":8,"minout":20,"maxout":80,"action":"drop","round":true,"name":"rangeNode","wires":[["helperNode1"]]},
+                    {id:"helperNode1", type:"helper", wires:[]}];
+        helper.load(rangeNode, flow, function() {
+            var rangeNode1 = helper.getNode("rangeNode1");
+            var helperNode1 = helper.getNode("helperNode1");
+            helperNode1.on("input", function(msg) {
+                try {
+                    msg.should.have.property('payload');
+                    msg.payload.should.equal(50);
+                    done();
+                } catch(err) {
+                    done(err);
+                }
+            });
+            rangeNode1.receive({payload:1});
+            rangeNode1.receive({payload:9});
+            rangeNode1.receive({payload:5});
+        });
+    });
+
     it('just passes on msg if payload not present', function(done) {
         var flow = [{"id":"rangeNode1","type":"range","minin":0,"maxin":100,"minout":0,"maxout":100,"action":"scale","round":true,"name":"rangeNode","wires":[["helperNode1"]]},
                     {id:"helperNode1", type:"helper", wires:[]}];


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
As per a user request https://discourse.nodered.org/t/range-node-requested-action-scale-and-drop-message-outside-input-range/69772 - this PR adds a drop mode to the range node.

If the input msg property is outside of the input range the entire message is dropped... this acts a a simple input filter for out of range messages.

Includes a test.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
