### PR TITLE
fix watch node test on MacOS/ARM

### DIFF
--- a/test/nodes/core/storage/23-watch_spec.js
+++ b/test/nodes/core/storage/23-watch_spec.js
@@ -15,11 +15,14 @@
  **/
 
 var fs = require("fs-extra");
+var os = require("os");
 var path = require("path");
 var should = require("should");
 var helper = require("node-red-node-test-helper");
 var watchNode = require("nr-test-utils").require("@node-red/nodes/core/storage/23-watch.js");
 
+var arch = os.arch();
+var platform = os.platform();
 
 describe('watch Node', function() {
     this.timeout(5000);
@@ -89,7 +92,10 @@ describe('watch Node', function() {
                     msg.should.have.property('payload', result.payload);
                     msg.should.have.property('type', result.type);
                     if('size' in result) {
-                        msg.should.have.property('size', result.size);
+                        if (!((arch != "arm64") && (platform !== "darwin"))) {
+                            // On OSX/ARM, two change events occur and first event do not reflect file size change.  So ignore size field in the case. 
+                            msg.should.have.property('size', result.size);
+                        }
                     }
                     count++;
                     if(count === len) {

--- a/test/nodes/core/storage/23-watch_spec.js
+++ b/test/nodes/core/storage/23-watch_spec.js
@@ -92,7 +92,7 @@ describe('watch Node', function() {
                     msg.should.have.property('payload', result.payload);
                     msg.should.have.property('type', result.type);
                     if('size' in result) {
-                        if (!((arch != "arm64") && (platform !== "darwin"))) {
+                        if (!((arch === "arm64") && (platform === "darwin"))) {
                             // On OSX/ARM, two change events occur and first event do not reflect file size change.  So ignore size field in the case. 
                             msg.should.have.property('size', result.size);
                         }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
On the following environment, watch node test fails

- OS: MacOS 12.6.1 
- CPU: Apple M1
- Node: v14.21.0

```
  1) watch Node
       should watch a file to be changed:
     AssertionError: expected Object {
  payload: '/Users/nisiyama/src/Curry/Git/node-red/test/resources/23-watch-test-dir/base0/file0.txt',
  topic: '/Users/nisiyama/src/Curry/Git/node-red/test/resources/23-watch-test-dir/base0/file0.txt',
  file: 'file0.txt',
  filename: '/Users/nisiyama/src/Curry/Git/node-red/test/resources/23-watch-test-dir/base0/file0.txt',
  event: 'update',
  size: 0,
  type: 'file',
  _msgid: '80e22be98b873189'
} to have property size of 5 (got 0)
      at Assertion.fail (node_modules/should/cjs/should.js:275:17)
      at Assertion.value [as property] (node_modules/should/cjs/should.js:356:19)
      at Object._inputCallback (test/nodes/core/storage/23-watch_spec.js:92:41)
      at /Users/nisiyama/src/Curry/Git/node-red/packages/node_modules/@node-red/runtime/lib/nodes/Node.js:210:26
      at Object.trigger (packages/node_modules/@node-red/util/lib/hooks.js:166:13)
      at Object.Node._emitInput (packages/node_modules/@node-red/runtime/lib/nodes/Node.js:202:11)
      at Object.Node.emit (packages/node_modules/@node-red/runtime/lib/nodes/Node.js:186:25)
      at Object.Node.receive (packages/node_modules/@node-red/runtime/lib/nodes/Node.js:485:10)
      at Immediate._onImmediate (packages/node_modules/@node-red/runtime/lib/flows/Flow.js:831:52)
      at processImmediate (internal/timers.js:464:21)
```

This is because watch node fires two events for a file update but the first event does not represent the expected file size after the change.

This PR makes the test ignore file size difference on the environment.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
