### PR TITLE
fix httprequest error on MacOS/ARM

### DIFF
--- a/test/nodes/core/network/21-httprequest_spec.js
+++ b/test/nodes/core/network/21-httprequest_spec.js
@@ -2322,7 +2322,7 @@ describe('HTTP Request Node', function() {
                     var n2 = helper.getNode("n2");
                     n2.on('input', function(msg) {
                         try{
-                            msg.payload.should.equal(`RequestError: Parse Error: Missing expected CR after header value : http://localhost:${port}/`)
+                            msg.payload.should.startWith(`RequestError: Parse Error:`)
                             done()
                         } catch (err) {
                             done(err)


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
On the following environment, watch node test fails

- OS: MacOS 12.6.1 
- CPU: Apple M1
- Node: v14.21.0

```
  1) HTTP Request Node
       should parse broken headers
         should reject broken headers:
     AssertionError: expected 'RequestError: Parse Error: Invalid header value char : http://localhost:10234/' to start with 'RequestError: Parse Error:/'
      at Assertion.fail (node_modules/should/cjs/should.js:275:17)
      at Assertion.value [as startWith] (node_modules/should/cjs/should.js:356:19)
      at Object._inputCallback (test/nodes/core/network/21-httprequest_spec.js:2325:48)
      at /Users/nisiyama/src/Curry/Git/node-red/packages/node_modules/@node-red/runtime/lib/nodes/Node.js:210:26
      at Object.trigger (packages/node_modules/@node-red/util/lib/hooks.js:166:13)
      at Object.Node._emitInput (packages/node_modules/@node-red/runtime/lib/nodes/Node.js:202:11)
      at Object.Node.emit (packages/node_modules/@node-red/runtime/lib/nodes/Node.js:186:25)
      at Object.Node.receive (packages/node_modules/@node-red/runtime/lib/nodes/Node.js:485:10)
      at Immediate._onImmediate (packages/node_modules/@node-red/runtime/lib/flows/Flow.js:831:52)
      at processImmediate (internal/timers.js:464:21)
```

This is due to the slight difference on error messages.
This PR try to ignore comparing such differences.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
