### PR TITLE
fix to allow es11 for jshint check

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,5 +15,5 @@
     "shadow": true,     // allow variable shadowing (re-use of names...)
     "sub": true,        // don't warn that foo['bar'] should be written as foo.bar
     "proto": true,      // allow setting of __proto__ in node < v0.12,
-    "esversion": 6      // allow es6
+    "esversion": 11      // allow es11(ES2020)
 }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->
From Node-RED 3.0, Node version changed to Node 14 or later.
It supports almost all features of ES2020 (es11) according to [this site](https://node.green/).
But JSHint rule checked by grunt is restricted to ES2015(es6).
This causes `locking-flow` branch fail in checking by grunt.
This PR try to fix the issue by updating target ES version to es11.

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
