### PR TITLE
i18n item URL copy notification & add Japanese message

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -684,7 +684,8 @@
             "globalConfig": "Global Configuration Nodes",
             "triggerAction": "Trigger action",
             "find": "Find in workspace",
-            "copyItemUrl": "Copy item url"
+            "copyItemUrl": "Copy item url",
+	    "copyURL2Clipboard": "Copied url to clipboard"
         },
         "help": {
             "name": "Help",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -683,7 +683,8 @@
             "empty": "空",
             "globalConfig": "グローバル設定ノード",
             "triggerAction": "アクションを実行",
-            "find": "ワークスペース内を検索"
+            "find": "ワークスペース内を検索",
+	    "copyURL2Clipboard": "URLをクリップボードにコピーしました"
         },
         "help": {
             "name": "ヘルプ",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
@@ -1211,7 +1211,7 @@ RED.view.tools = (function() {
                 url += '/edit'
             }
             if (RED.clipboard.copyText(url)) {
-                RED.notify('Copied url to clipboard', { timeout: 2000 })
+                RED.notify(RED._("sidebar.info.copyURL2Clipboard"), { timeout: 2000 })
             }
         }
     }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Notification message of copy item URL is not i18n ready.
This PR tries to make it i18n ready and adds Japanese message.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
