### PR TITLE
fix single subscription mqtt node status

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -366,6 +366,16 @@ module.exports = function(RED) {
         }
     }
 
+    function updateStatus(node, allNodes) {
+        let setStatus = setStatusDisconnected
+        if(node.connecting) {
+            setStatus = setStatusConnecting
+        } else if(node.connected) {
+            setStatus = setStatusConnected
+        }
+        setStatus(node, allNodes)
+    }
+
     function setStatusDisconnected(node, allNodes) {
         if(allNodes) {
             for (var id in node.users) {
@@ -697,13 +707,17 @@ module.exports = function(RED) {
             if (Object.keys(node.users).length === 1) {
                 if(node.autoConnect) {
                     node.connect();
+                    //update nodes status
+                    setTimeout(function() {
+                        updateStatus(node, true)
+                    }, 1)
                 }
             }
         };
 
-        node.deregister = function(mqttNode,done) {
+        node.deregister = function(mqttNode, done, autoDisconnect) {
             delete node.users[mqttNode.id];
-            if (!node.closing && node.connected && Object.keys(node.users).length === 0) {
+            if (autoDisconnect && !node.closing && node.connected && Object.keys(node.users).length === 0) {
                 node.disconnect();
             }
             done();
@@ -1220,7 +1234,7 @@ module.exports = function(RED) {
                     } else {
                         node.brokerConn.unsubscribe(node.topic,node.id, removed);
                     }
-                    node.brokerConn.deregister(node, done);
+                    node.brokerConn.deregister(node, done, removed);
                     node.brokerConn = null;
                 } else {
                     done();
@@ -1283,9 +1297,9 @@ module.exports = function(RED) {
                 node.status({fill:"green",shape:"dot",text:"node-red:common.status.connected"});
             }
             node.brokerConn.register(node);
-            node.on('close', function(done) {
+            node.on('close', function(removed, done) {
                 if (node.brokerConn) {
-                    node.brokerConn.deregister(node,done);
+                    node.brokerConn.deregister(node, done, removed)
                     node.brokerConn = null;
                 } else {
                     done();


### PR DESCRIPTION
fixes #3927 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## What problem does it address? 
When deploying an edit, the nodes `close` handler is called  & this deregisters the association with the broker node as expected. When only 1 MQTT node exists, at this point, the broker has `0` associations and it auto disconnects.
When the deployment is completed, the node is re-registered but due to the speed of this action, the broker has not yet "called back" with its disconnected state - meaning the node beleieves it is already connected. Then, after a few ms, the broker disconnected event comes through causing the connection to be closed.

If the single node is edited once more, the connection is restored correctly because it is already disconnected & the `connect` function progresses past the `canConnect` check.

see #3927 for further detail

## Proposed changes

* Dont disconnect client from broker if the single MQTT-IN node was not removed (only edited)
* Call new function `updateStatus` after call to connect to mop up any change of state


## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
