### PR TITLE
Prevent dbl-click opening node edit dialog with text selected

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -3369,6 +3369,9 @@ RED.view = (function() {
         }
         if (dblClickPrimed && mousedown_node == d && clickElapsed > 0 && clickElapsed < dblClickInterval) {
             mouse_mode = RED.state.DEFAULT;
+            // Avoid dbl click causing text selection.
+            d3.event.preventDefault()
+            document.getSelection().removeAllRanges()
             if (d.type != "subflow") {
                 if (/^subflow:/.test(d.type) && (d3.event.ctrlKey || d3.event.metaKey)) {
                     RED.workspaces.show(d.type.substring(8));


### PR DESCRIPTION
Fixes #3958

