### PR TITLE
Remember compact/pretty flow export user choice

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -656,7 +656,12 @@ RED.clipboard = (function() {
         $("#red-ui-clipboard-dialog-tab-library-name").val("flows.json").select();
 
         dialogContainer.i18n();
+        
         var format = RED.settings.flowFilePretty ? "red-ui-clipboard-dialog-export-fmt-full" : "red-ui-clipboard-dialog-export-fmt-mini";
+        const userFormat = RED.settings.get("editor.dialog.export.pretty")
+        if (userFormat === false || userFormat === true) {
+            format = userFormat ? "red-ui-clipboard-dialog-export-fmt-full" : "red-ui-clipboard-dialog-export-fmt-mini";
+        }
 
         $("#red-ui-clipboard-dialog-export-fmt-group > a").on("click", function(evt) {
             evt.preventDefault();
@@ -672,7 +677,8 @@ RED.clipboard = (function() {
                 var nodes = JSON.parse(flow);
 
                 format = $(this).attr('id');
-                if (format === 'red-ui-clipboard-dialog-export-fmt-full') {
+                const pretty = format === "red-ui-clipboard-dialog-export-fmt-full";
+                if (pretty) {
                     flow = JSON.stringify(nodes,null,4);
                 } else {
                     flow = JSON.stringify(nodes);
@@ -681,6 +687,7 @@ RED.clipboard = (function() {
                 setTimeout(function() { $("#red-ui-clipboard-dialog-export-text").scrollTop(0); },50);
 
                 $("#red-ui-clipboard-dialog-export-text").trigger("focus");
+                RED.settings.set("editor.dialog.export.pretty", pretty)
             }
         });
 


### PR DESCRIPTION
closes #3849

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Saving flow is a specific format is not necessarily how a user wants to export a flow, especially when pasting to a forum/slack thread.

This PR remembers the user choice and reselects that mode in the export dialog.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
