### PR TITLE
fix: registry importModule function

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/externalModules.js
+++ b/packages/node_modules/@node-red/registry/lib/externalModules.js
@@ -144,7 +144,7 @@ function importModule(module) {
     // specific file that is loaded when the module is required/imported
     // As this won't be on the natural module search path, we use createRequire
     // to access the module
-    const modulePath = createRequire(moduleDir).resolve(module)
+    const modulePath = createRequire(moduleDir).resolve(parsedModule.module)
     // Import needs the full path to the module's main .js file
     // It also needs to be a file:// url for Windows
     const moduleUrl = url.pathToFileURL(modulePath);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Use `parsedModule.module` instead of `module`, `module` contains the version installed, therefore importing the module results in an error because the folder does not exists in `node_modules`. See screenshot.

<img width="919" alt="image" src="https://user-images.githubusercontent.com/12603425/207054041-8106134a-9720-46aa-95eb-225af7d4b3eb.png">

Bug introduced here > https://github.com/node-red/node-red/pull/3645

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
