### PR TITLE
Fix mqtt nodes not reconnecting on modified-flows deploy

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -295,7 +295,7 @@ module.exports = function(RED) {
                         /* mute error - it simply isnt JSON, just leave payload as a string */
                     }
                 }
-            } //else { 
+            } //else {
                 //leave as buffer
             //}
         }
@@ -357,7 +357,7 @@ module.exports = function(RED) {
                         return;
                     }
                     done(err);
-                }); 
+                });
             } else {
                 done();
             }
@@ -718,9 +718,10 @@ module.exports = function(RED) {
         node.deregister = function(mqttNode, done, autoDisconnect) {
             delete node.users[mqttNode.id];
             if (autoDisconnect && !node.closing && node.connected && Object.keys(node.users).length === 0) {
-                node.disconnect();
+                node.disconnect(done);
+            } else {
+                done();
             }
-            done();
         };
         node.canConnect = function() {
             return !node.connected && !node.connecting;
@@ -854,7 +855,7 @@ module.exports = function(RED) {
             let waitEnd = (client, ms) => {
                 return new Promise( (resolve, reject) => {
                     node.closing = true;
-                    if(!client) { 
+                    if(!client) {
                         resolve();
                      } else {
                         const t = setTimeout(() => {
@@ -1033,7 +1034,7 @@ module.exports = function(RED) {
 
         /**
          * Add event handlers to the MQTT.js client and track them so that
-         * we do not remove any handlers that the MQTT client uses internally.  
+         * we do not remove any handlers that the MQTT client uses internally.
          * Use {@link node._clientRemoveListeners `node._clientRemoveListeners`} to remove handlers
          * @param {string} event The name of the event
          * @param {function} handler The handler for this event
@@ -1041,11 +1042,11 @@ module.exports = function(RED) {
          node._clientOn = function(event, handler) {
             node.clientListeners.push({event, handler})
             node.client.on(event, handler)
-        } 
+        }
 
         /**
-         * Remove event handlers from the MQTT.js client & only the events 
-         * that we attached in {@link node._clientOn `node._clientOn`}.  
+         * Remove event handlers from the MQTT.js client & only the events
+         * that we attached in {@link node._clientOn `node._clientOn`}.
          * * If `event` is omitted, then all events matching `handler` are removed
          * * If `handler` is omitted, then all events named `event` are removed
          * * If both parameters are omitted, then all events are removed


### PR DESCRIPTION
This fixes an issue reported on slack where the MQTT nodes would not always reconnect following a modified-flows type deploy.

### Steps to recreate

1. Create a flow with a single MQTT Subscriber node, connected to a *remote* broker, with function node and debug node.
2. Setup something outside of Node-RED to publish regularly to the same topic
3. Deploy and verify the publishes are arriving in debug
4. Modify the Function node (add a newline.. anything to cause it to be marked dirty)
5. To a Modified-Flows type deploy
6. See the messages stop arriving in Debug

I found it important to use a remote broker in order to increase the time taken to disconnect, and so to hit the necessary timing window.

### Cause

When an MQTT In/Out node deregisters itself as part of stopping, if it was the last node using the broker node, the broker node starts to disconnect. However the MQTT In/Out node doesn't wait for the disconnect to complete.

The flow is restarted, the MQTT In/Out re-registers itself, finds the broker node is still connected, so no further action is taken. The previous disconnect *then* completes - leaving the broker node disconnected.

### Fix

The call to deregister from the broker node includes a `done` callback that was always being called instantly. This PR changes it to call done once the disconnect completes (if a disconnect is triggered).

I appreciate we've had issues in this area before. I've looked through the blame history of this bit of code to see I've I'm just putting back something that caused previous issues - however I can't see anything obvious.
