### PR TITLE
Split node: avoid duplicate done call for buffer split

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -251,7 +251,9 @@ module.exports = function(RED) {
                         }
                         else {
                             node.buffer = buff.slice(p,buff.length);
-                            node.pendingDones.push(done);
+                            if (node.buffer.length > 0) {
+                                node.pendingDones.push(done);
+                            }
                         }
                         if (node.buffer.length == 0) {
                             done();


### PR DESCRIPTION
Fixes #3982

When splitting buffers in a stream, the node stores any 'left-over' bits following the split to be joined with the next message in the stream. It stored the `done` event until that left-over bit was made whole.

However, if there were no left-over bits (length === 0), it was storing `done` for later *and* calling `done`.

The fix is to not store the `done` for later if there is no left-over bit.

But, this does also raise a question of a difference in behaviour between string and buffer modes. I think for String streams, it always calls done after splitting, regardless of any left-over bits... whereas for Buffer streams, as described above, it waits until left-overs are handled.

This could do with tidying up, but needs more investigation and test cases to properly figure out the 'expected' behaviour.