### PR TITLE
Comment node: Clarify where the text will appear

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/en-US/common/90-comment.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/common/90-comment.html
@@ -18,5 +18,5 @@
     <p>A node you can use to add comments to your flows.</p>
     <h3>Details</h3>
     <p>The edit panel will accept Markdown syntax. The text will be rendered into
-    this information side panel.</p>
+    the information side panel.</p>
 </script>


### PR DESCRIPTION
The text will appear in the information tab of the side panel and not in the help tab of the side panel.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

Textual change.

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

The location of the text of the comment node will appear in the help tab of the side panel and not in the information tab of the side panel. This change makes that more clear.
<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
