### PR TITLE
Force IPv4 name resolution to have priority

### DIFF
--- a/packages/node_modules/node-red/lib/red.js
+++ b/packages/node_modules/node-red/lib/red.js
@@ -25,9 +25,15 @@ var api = require("@node-red/editor-api");
 var server = null;
 var apiEnabled = false;
 
+const NODE_MAJOR_VERSION = process.versions.node.split('.')[0];
+if (NODE_MAJOR_VERSION > 14) {
+    const dns = require('node:dns');
+    dns.setDefaultResultOrder('ipv4first');
+}
+
 function checkVersion(userSettings) {
     var semver = require('semver');
-    if (!semver.satisfies(process.version,">=8.9.0")) {
+    if (!semver.satisfies(process.version,">=12.0.0")) {
         // TODO: in the future, make this a hard error.
         // var e = new Error("Unsupported version of Node.js");
         // e.code = "unsupported_version";


### PR DESCRIPTION
to fix Issue #4010
and others (eg) email node server connect fails, and some reported on SO

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This change forces the dns to prioritise ipv4 over ipv6 (node18 has set this other way round - which is causing user issues - eg Issue #4010  - and maybe this https://stackoverflow.com/questions/75200314/node-red-install-fails?noredirect=1#comment132702598_75200314 - and also several recent email node failures to connect to email servers. 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
