### PR TITLE
Allow Inject node to work with async context stores

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.js
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.js
@@ -95,45 +95,64 @@ module.exports = function(RED) {
         }
 
         this.on("input", function(msg, send, done) {
-            var errors = [];
-            var props = this.props;
+            const errors = [];
+            let props = this.props;
             if (msg.__user_inject_props__ && Array.isArray(msg.__user_inject_props__)) {
                 props = msg.__user_inject_props__;
             }
             delete msg.__user_inject_props__;
-            props.forEach(p => {
-                var property = p.p;
-                var value = p.v ? p.v : '';
-                var valueType = p.vt ? p.vt : 'str';
+            props = [...props]
+            function evaluateProperty(doneEvaluating) {
+                if (props.length === 0) { 
+                    doneEvaluating()
+                    return
+                }
+                const p = props.shift()
+                const property = p.p;
+                const value = p.v ? p.v : '';
+                const valueType = p.vt ? p.vt : 'str';
 
-                if (!property) return;
-
-                if (valueType === "jsonata") {
-                    if (p.v) {
-                        try {
-                            var exp = RED.util.prepareJSONataExpression(p.v, node);
-                            var val = RED.util.evaluateJSONataExpression(exp, msg);
-                            RED.util.setMessageProperty(msg, property, val, true);
+                if (property) {
+                    if (valueType === "jsonata") {
+                        if (p.v) {
+                            try {
+                                var exp = RED.util.prepareJSONataExpression(p.v, node);
+                                var val = RED.util.evaluateJSONataExpression(exp, msg);
+                                RED.util.setMessageProperty(msg, property, val, true);
+                            }
+                            catch  (err) {
+                                errors.push(err.message);
+                            }
                         }
-                        catch  (err) {
-                            errors.push(err.message);
+                        evaluateProperty(doneEvaluating)
+                    } else {
+                        try {
+                            RED.util.evaluateNodeProperty(value, valueType, node, msg, (err, newValue) => {
+                                if (err) {
+                                    errors.push(err.toString())
+                                } else {
+                                    RED.util.setMessageProperty(msg,property,newValue,true);
+                                }
+                                evaluateProperty(doneEvaluating)
+                            })
+                        } catch (err) {
+                            errors.push(err.toString());
+                            evaluateProperty(doneEvaluating)
                         }
                     }
-                    return;
+                } else {
+                    evaluateProperty(doneEvaluating)
                 }
-                try {
-                    RED.util.setMessageProperty(msg,property,RED.util.evaluateNodeProperty(value, valueType, this, msg),true);
-                } catch (err) {
-                    errors.push(err.toString());
-                }
-            });
-
-            if (errors.length) {
-                done(errors.join('; '));
-            } else {
-                send(msg);
-                done();
             }
+           
+            evaluateProperty(() => {
+                if (errors.length) {
+                    done(errors.join('; '));
+                } else {
+                    send(msg);
+                    done();
+                }
+            })
         });
     }
 


### PR DESCRIPTION
Fixes #4014

The Inject node was using `RED.util.evaluateNodeProperty()` in synchronous-only mode. This meant it couldn't be used with async-only context stores.

I've searched through the other nodes and cannot find any others that are doing this.