### PR TITLE
Hide trigger node repeat send  option if sending nothing

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/89-trigger.html
+++ b/packages/node_modules/@node-red/nodes/core/function/89-trigger.html
@@ -25,7 +25,7 @@
         <select id="node-then-type" style="width:70%;">
             <option value="block" data-i18n="trigger.wait-reset"></option>
             <option value="wait" data-i18n="trigger.wait-for"></option>
-            <option value="loop" data-i18n="trigger.wait-loop"></option>
+            <option id="node-trigger-wait-loop" value="loop" data-i18n="trigger.wait-loop"></option>
         </select>
     </div>
     <div class="form-row node-type-duration">
@@ -180,6 +180,13 @@
             if (this.op2type === 'val') {
                 $("#node-input-op2type").val('str');
             }
+
+            $("#node-input-op1").on("change", function() {
+                if ($("#node-input-op1type").val() === "nul") {
+                    $("#node-trigger-wait-loop").hide();
+                }
+                else { $("#node-trigger-wait-loop").show(); }
+            });
 
             var optionNothing = {value:"nul",label:this._("trigger.output.nothing"),hasValue:false};
             var optionPayload = {value:"pay",label:this._("trigger.output.existing"),hasValue:false};


### PR DESCRIPTION


<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

to address https://discourse.nodered.org/t/trigger-node-how-to-delay-and-repeat-message/74117/5
this fixes the UI so when send nothing is selected the option to repeat send is hidden.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
