### PR TITLE
Add count to join and batch node labels

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
@@ -224,7 +224,12 @@
         outputs:1,
         icon: "join.svg",
         label: function() {
-            return this.name||this._("join.join");
+            var nam = this.name||this._("join.join");
+            if (this.mode === "custom" && !isNaN(Number(this.count))) {
+                nam += " "+this.count;
+                if (this.accumulate === true) { nam+= "+"; }
+            }
+            return nam;
         },
         labelStyle: function() {
             return this.name?"node_label_italic":"";

--- a/packages/node_modules/@node-red/nodes/core/sequence/19-batch.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/19-batch.html
@@ -107,7 +107,14 @@
         outputs:1,
         icon: "batch.svg",
         label: function() {
-            return this.name||this._("batch.batch");;
+            var nam = this.name||this._("batch.batch");
+            if (this.mode === "count" && !isNaN(Number(this.count))) {
+                nam += " "+this.count;
+            }
+            if (this.mode === "interval" && !isNaN(Number(this.interval))) {
+                nam += " "+this.interval+"s";
+            }
+            return nam;
         },
         labelStyle: function() {
             return this.name ? "node_label_italic" : "";


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This PR adds the configured count number to the join node when in manual mode. It also adds a + if set to "and all subsequent messages" mode.
It also adds the count to the batch node label, or the timeout value when in timeout mode.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
