### PR TITLE
Fix hidden tab count

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -135,9 +135,7 @@ RED.workspaces = (function() {
                 ids = [ids]
             }
             ids.forEach(id => {
-                if (RED.nodes.workspace(id)) {
-                    hiddenFlows.add(id)
-                }
+                hiddenFlows.add(id)
             })
         }
         const hiddenflowCount = hiddenFlows.size;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
When tabs are hidden, number of the hidden tabs are shown in menu item as `Show all flows (N hidden)`.
However, while subflow tabs can be hidden from menu such as `Hide flow` or `Hide all flows`, they are not counted as hidden.
This PR try to fix the number of hidden subflows included in the menu.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
