### PR TITLE
fix hide subflow tooltip

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -55,6 +55,7 @@
         "dropFlowHere": "Drop the flow here",
         "addFlow": "Add flow",
         "addFlowToRight": "Add flow to the right",
+        "closeFlow": "Close flow",
         "hideFlow": "Hide flow",
         "hideOtherFlows": "Hide other flows",
         "showAllFlows": "Show all flows (__count__ hidden)",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -55,6 +55,7 @@
         "dropFlowHere": "ここにフローをドロップしてください",
         "addFlow": "フローの追加",
         "addFlowToRight": "右側にフローを追加",
+        "closeFlow": "フローを閉じる",
         "hideFlow": "フローを非表示",
         "hideOtherFlows": "他のフローを非表示",
         "showAllFlows": "全てのフローを表示",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
@@ -829,7 +829,7 @@ RED.tabs = (function() {
                         event.preventDefault();
                         removeTab(tab.id);
                     });
-                    RED.popover.tooltip(closeLink,RED._("workspace.hideFlow"));
+                    RED.popover.tooltip(closeLink,RED._("workspace.closeFlow"));
                 }
                 // if (tab.hideable) {
                 //     li.addClass("red-ui-tabs-closeable")


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Tooltip for closing button of subflow tab is shown as `Hide flow`.  
But, it actually closes the tab.
This PR try to fix the tooltip text.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
