### PR TITLE
fix .red-ui-notification class

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/notifications.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/notifications.scss
@@ -32,7 +32,8 @@
     color: var(--red-ui-primary-text-color);
     border: 1px solid var(--red-ui-notification-border-default);
     border-left-width: 16px;
-    overflow: hidden;
+    overflow: scroll;
+    max-height: 80vh;
     .ui-dialog-buttonset {
         margin-top: 20px;
         margin-bottom: 10px;


### PR DESCRIPTION
if flows stopped due to missing too many node types manage-project-dep button displays none. Like this

![ffe3b0fb20f7f647d7f87650aca15d4](https://user-images.githubusercontent.com/23259661/215514560-31477955-8e45-4ce2-90d6-2b377a46f7c3.png)

after fixed:

![c1840609cb6a2476cb631ebcdeae5c1](https://user-images.githubusercontent.com/23259661/216209869-ec5e8d50-ccba-403f-9880-e4aedb1cd54f.png)

