### PR TITLE
Use main branch as default in project feature

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/git/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/git/index.js
@@ -421,7 +421,10 @@ module.exports = {
         });
     },
     initRepo: function(cwd) {
-        return runGitCommand(["init"],cwd);
+        var args = ["init", "--initial-branch", "main"];
+        return runGitCommand(args, cwd).catch(function () {
+            return runGitCommand(["init"], cwd);
+        });
     },
     setUpstream: function(cwd,remoteBranch) {
         var args = ["branch","--set-upstream-to",remoteBranch];


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Currently, the `main` branch has been commonly used as a default name on GitHub, GitLab, and Apple Git. On the other hand, the latest git command still uses the `master` branch. Because this difference affects the UI on the history tab and project settings, it leads the confusion for some beginner users who start to use Git from Node-RED. To be the same name as possible, the code in this pull request uses an explicit name when executing the `git init` command.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality