### PR TITLE
fix group position after undo

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -586,11 +586,28 @@ RED.view = (function() {
 
                 var group = $(ui.helper).data("group");
                 if (group) {
+                    var oldX = group.x; 
+                    var oldY = group.y; 
                     RED.group.addToGroup(group, nn);
+                    var moveEvent = null;
+                    if ((group.x !== oldX) ||
+                        (group.y !== oldY)) {
+                        moveEvent = {
+                            t: "move",
+                            nodes: [{n: group,
+                                     ox: oldX, oy: oldY,
+                                     dx: group.x -oldX,
+                                     dy: group.y -oldY}],
+                            dirty: true
+                        };
+                    }
                     historyEvent = {
                         t: 'multi',
                         events: [historyEvent],
 
+                    };
+                    if (moveEvent) {
+                        historyEvent.events.push(moveEvent)
                     }
                     historyEvent.events.push({
                         t: "addToGroup",
@@ -1350,19 +1367,35 @@ RED.view = (function() {
                 RED.editor.validateNode(nn);
 
                 if (targetGroup) {
+                    var oldX = targetGroup.x; 
+                    var oldY = targetGroup.y; 
                     RED.group.addToGroup(targetGroup, nn);
+                    var moveEvent = null;
+                    if ((targetGroup.x !== oldX) ||
+                        (targetGroup.y !== oldY)) {
+                        moveEvent = {
+                            t: "move",
+                            nodes: [{n: targetGroup,
+                                     ox: oldX, oy: oldY,
+                                     dx: targetGroup.x -oldX,
+                                     dy: targetGroup.y -oldY}],
+                            dirty: true
+                        };
+                    }
                     if (historyEvent.t !== "multi") {
                         historyEvent = {
                             t:'multi',
                             events: [historyEvent]
-                        }
+                        };
                     }
                     historyEvent.events.push({
                         t: "addToGroup",
                         group: targetGroup,
                         nodes: nn
-                    })
-
+                    });
+                    if (moveEvent) {
+                        historyEvent.events.push(moveEvent);
+                    }
                 }
 
                 if (spliceLink) {
@@ -1698,6 +1731,7 @@ RED.view = (function() {
 
             // Check link splice or group-add
             if (movingSet.length() === 1 && movingSet.get(0).n.type !== "group") {
+            //}{//NIS
                 node = movingSet.get(0);
                 if (spliceActive) {
                     if (!spliceTimer) {
@@ -2057,10 +2091,24 @@ RED.view = (function() {
         if (mouse_mode == RED.state.MOVING_ACTIVE) {
             if (movingSet.length() > 0) {
                 var addedToGroup = null;
+                var moveEvent = null;
                 if (activeHoverGroup) {
+                    var oldX = activeHoverGroup.x; 
+                    var oldY = activeHoverGroup.y; 
                     for (var j=0;j<movingSet.length();j++) {
                         var n = movingSet.get(j);
                         RED.group.addToGroup(activeHoverGroup,n.n);
+                    }
+                    if ((activeHoverGroup.x !== oldX) ||
+                        (activeHoverGroup.y !== oldY)) {
+                        moveEvent = {
+                            t: "move",
+                            nodes: [{n: activeHoverGroup,
+                                     ox: oldX, oy: oldY,
+                                     dx: activeHoverGroup.x -oldX,
+                                     dy: activeHoverGroup.y -oldY}],
+                            dirty: true
+                        };
                     }
                     addedToGroup = activeHoverGroup;
 
@@ -2107,6 +2155,12 @@ RED.view = (function() {
                         historyEvent.addToGroup = addedToGroup;
                     }
                     RED.nodes.dirty(true);
+                    if (moveEvent) {
+                        historyEvent = {
+                            t: "multi",
+                            events: [moveEvent, historyEvent]
+                        };
+                    }
                     RED.history.push(historyEvent);
                 }
             }
@@ -3466,10 +3520,24 @@ RED.view = (function() {
                 updateActiveNodes();
             }
 
+            var moveEvent = null;
             if (activeHoverGroup) {
+                var oldX = activeHoverGroup.x; 
+                var oldY = activeHoverGroup.y; 
                 for (var j=0;j<movingSet.length();j++) {
                     var n = movingSet.get(j);
                     RED.group.addToGroup(activeHoverGroup,n.n);
+                }
+                if ((activeHoverGroup.x !== oldX) ||
+                    (activeHoverGroup.y !== oldY)) {
+                    moveEvent = {
+                        t: "move",
+                        nodes: [{n: activeHoverGroup,
+                                 ox: oldX, oy: oldY,
+                                 dx: activeHoverGroup.x -oldX,
+                                 dy: activeHoverGroup.y -oldY}],
+                        dirty: true
+                    };
                 }
                 historyEvent.addedToGroup = activeHoverGroup;
 
@@ -3479,7 +3547,6 @@ RED.view = (function() {
                 activeGroup.selected = true;
                 activeHoverGroup = null;
             }
-
             if (mouse_mode == RED.state.DETACHED_DRAGGING) {
                 var ns = [];
                 for (var j=0;j<movingSet.length();j++) {
@@ -3490,7 +3557,15 @@ RED.view = (function() {
                         n.n.moved = true;
                     }
                 }
-                RED.history.replace({t:"multi",events:[historyEvent,{t:"move",nodes:ns}],dirty: historyEvent.dirty})
+                var event = {t:"multi",events:[historyEvent,{t:"move",nodes:ns}],dirty: historyEvent.dirty};
+                if (moveEvent) {
+                    event.events.push(moveEvent);
+                }
+                RED.history.replace(event)
+            }
+            else if(moveEvent) {
+                var event = {t:"multi", events:[historyEvent, moveEvent], dirty: true};
+                RED.history.replace(event);
             }
 
             updateSelection();


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
When adding a node to a group, the group position changes in some case.
However, undoing the node addition do not restore the group position.
This PR try to fix the issue.

![画面録画 2023-02-03 時刻 17 31 54](https://user-images.githubusercontent.com/30289092/216551125-7058273b-e71c-4363-b7b0-cb3851e65adb.gif)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
