### PR TITLE
Fix "EADDRINUSE" error

### DIFF
--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -458,7 +458,7 @@ httpsPromise.then(function(startupHttps) {
     RED.start().then(function() {
         if (settings.httpAdminRoot !== false || settings.httpNodeRoot !== false || settings.httpStatic) {
             server.on('error', function(err) {
-                if (err.errno === "EADDRINUSE") {
+                if (err.code === "EADDRINUSE") {
                     RED.log.error(RED.log._("server.unable-to-listen", {listenpath:getListenPath()}));
                     RED.log.error(RED.log._("server.port-in-use"));
                 } else {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

It is necessary to partially modify the EADDRINUSE error handling code that occurs when ports are duplicated. 

In node-red/red.js file, the if conditional statement that occurs when ports are duplicated is incorrect. The EADDRINUSE error is the "code" property of the err object, but is currently conditional on the "errno" property. 

So EADDRINUSE errors are caught in Uncaught Exception.

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
