### PR TITLE
Show scrollbar in notification dialog only when needed

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/notifications.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/notifications.scss
@@ -32,7 +32,7 @@
     color: var(--red-ui-primary-text-color);
     border: 1px solid var(--red-ui-notification-border-default);
     border-left-width: 16px;
-    overflow: scroll;
+    overflow: auto;
     max-height: 80vh;
     .ui-dialog-buttonset {
         margin-top: 20px;


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
The pull request, https://github.com/node-red/node-red/pull/4035 is helpful to click the button on the notification dialog but the scrollbar area always exists in other dialogs. It seems to affect the layout of the dialog like the following screenshot.

<img width="626" alt="Screenshot 2023-02-04 at 11 15 13" src="https://user-images.githubusercontent.com/20310935/216741407-4d1ae6f4-cf3b-4f04-8a2e-0e5d8c9f17a2.png">

In this pull request, the dialog uses the scrollbar area only when it is needed.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
