### PR TITLE
Support i18n of lock/unlock buttons in flow property UI

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -25,7 +25,9 @@
             "disable": "Disable",
             "upload": "Upload",
             "lock": "Lock",
-            "unlock": "Unlock"
+            "unlock": "Unlock",
+            "locked": "Locked",
+            "unlocked": "Unlocked"
         },
         "type": {
             "string": "string",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -25,7 +25,9 @@
             "disable": "無効",
             "upload": "アップロード",
             "lock": "固定",
-            "unlock": "固定を解除"
+            "unlock": "固定を解除",
+            "locked": "固定済み",
+            "unlocked": "固定なし"
         },
         "type": {
             "string": "文字列",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -1378,6 +1378,9 @@
         "copy-item-url": "要素のURLをコピー",
         "copy-item-edit-url": "要素の編集URLをコピー",
         "move-flow-to-start": "フローを先頭に移動",
-        "move-flow-to-end": "フローを末尾に移動"
+        "move-flow-to-end": "フローを末尾に移動",
+        "lock-flow": "フローを固定",
+        "unlock-flow": "フローの固定を解除",
+        "show-node-help": "ノードのヘルプを表示"
     }
 }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1922,9 +1922,9 @@ RED.editor = (function() {
                     workspace.locked = false;
                 }
                 $('<input id="node-input-locked" type="checkbox">').prop("checked",workspace.locked).appendTo(trayFooterRight).toggleButton({
-                    enabledLabel: 'Unlocked',
+                    enabledLabel: RED._("common.label.unlocked"),
                     enabledIcon: "fa-unlock-alt",
-                    disabledLabel: 'Locked',
+                    disabledLabel: RED._("common.label.locked"),
                     disabledIcon: "fa-lock",
                     invertState: true
                 })


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I found that the lock and unlock buttons on the flow property UI have English messages in other language environments.
Therefore, in this pull request, I added the commit to support the internationalization of the button label.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality