### PR TITLE
Add tooltip for show/hide button on info sidebar

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -683,6 +683,8 @@
             "empty": "empty",
             "globalConfig": "Global Configuration Nodes",
             "triggerAction": "Trigger action",
+            "showFlow": "Show",
+            "hideFlow": "Hide",
             "find": "Find in workspace"
         },
         "help": {

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -683,6 +683,8 @@
             "empty": "空",
             "globalConfig": "グローバル設定ノード",
             "triggerAction": "アクションを実行",
+            "showFlow": "表示",
+            "hideFlow": "非表示",
             "find": "ワークスペース内を検索"
         },
         "help": {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
@@ -135,6 +135,10 @@ RED.sidebar.info.outliner = (function() {
                     RED.workspaces.show(n.id, null, true);
                 }
             });
+            RED.popover.tooltip(toggleVisibleButton, function () {
+                var isHidden = !div.hasClass("red-ui-info-outline-item-hidden");
+                return RED._("sidebar.info." + (isHidden ? "hideFlow" : "showFlow"));
+            });
         }
         if (n.type !== 'subflow') {
             var toggleButton = $('<button type="button" class="red-ui-info-outline-item-control-disable red-ui-button red-ui-button-small"><i class="fa fa-circle-thin"></i><i class="fa fa-ban"></i></button>').appendTo(controls).on("click",function(evt) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
The enable/disable button (and lock/unlock button in Node-RED v3.1) on the info sidebar has a tooltip. On the other hand, the show/hide button has no tooltip. Because users cannot understand the action of this button until clicking it, I newly added the tooltip in this pull request.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality