### PR TITLE
Added editor feature for connecting multiple nodes to single node

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
@@ -840,6 +840,62 @@ RED.view.tools = (function() {
         }
     }
 
+    function wireMultipleToNode() {
+        if (RED.workspaces.isActiveLocked()) {
+            return
+        }
+        var selection = RED.view.selection();
+        if (selection.nodes) {
+            if (selection.nodes.length > 1) {
+                var targetNode = selection.nodes[selection.nodes.length - 1];
+                if (targetNode.inputs === 0) {
+                    return;
+                }
+                var i = 0;
+                var newLinks = [];
+                for (i = 0; i < selection.nodes.length - 1; i++) {
+                    var sourceNode = selection.nodes[i];
+                    if (sourceNode.outputs > 0) {
+                        
+                        // Wire the first output to the target that has no link to the target yet.
+                        // This allows for connecting all combinations of inputs/outputs. 
+                        // The user may then delete links quickly that aren't needed.
+                        var sourceConnectedOutports = RED.nodes.filterLinks({
+                            source: sourceNode,
+                            target: targetNode
+                        });
+
+                        // Get outport indices that have no link yet
+                        var sourceOutportIndices = Array.from({ length: sourceNode.outputs }, (_, i) => i);
+                        var sourceConnectedOutportIndices = sourceConnectedOutports.map( x => x.sourcePort );
+                        var sourceFreeOutportIndices = sourceOutportIndices.filter(x => !sourceConnectedOutportIndices.includes(x));
+
+                        // Does an unconnected source port exist?
+                        if( sourceFreeOutportIndices.length == 0 ) continue;
+                        
+                        // Connect the first free outport to the target
+                        var newLink = {
+                            source: sourceNode,
+                            target: targetNode,
+                            sourcePort: sourceFreeOutportIndices[0]
+                        }
+                        RED.nodes.addLink(newLink);
+                        newLinks.push(newLink);
+                    }
+                }
+                if (newLinks.length > 0) {
+                    RED.history.push({
+                        t: 'add',
+                        links: newLinks,
+                        dirty: RED.nodes.dirty()
+                    })
+                    RED.nodes.dirty(true);
+                    RED.view.redraw(true);
+                }
+            }
+        }
+    }
+
     /**
      * Splits selected wires and re-joins them with link-out+link-in
      * @param {Object || Object[]} wires The wire(s) to split and replace with link-out, link-in nodes.
@@ -1307,6 +1363,7 @@ RED.view.tools = (function() {
 
             RED.actions.add("core:wire-series-of-nodes", function() { wireSeriesOfNodes() })
             RED.actions.add("core:wire-node-to-multiple", function() { wireNodeToMultiple() })
+            RED.actions.add("core:wire-multiple-to-node", function() { wireMultipleToNode() })
 
             RED.actions.add("core:split-wire-with-link-nodes", function () { splitWiresWithLinkNodes() });
             RED.actions.add("core:split-wires-with-junctions", function () { addJunctionsToWires() });

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
@@ -871,7 +871,9 @@ RED.view.tools = (function() {
                         var sourceFreeOutportIndices = sourceOutportIndices.filter(x => !sourceConnectedOutportIndices.includes(x));
 
                         // Does an unconnected source port exist?
-                        if( sourceFreeOutportIndices.length == 0 ) continue;
+                        if (sourceFreeOutportIndices.length == 0) {
+                            continue;
+                        }
                         
                         // Connect the first free outport to the target
                         var newLink = {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This PR addresses the feature request made by me in the  [node-red forums](https://discourse.nodered.org/t/connect-one-or-multiple-selected-nodes-to-the-same-target-in-one-go/73662).

It allows the user to quickly connect multiple nodes' outputs to the input of a single node via a keyboard shortcut `wire-multiple-to-node`. This is the counterpart to the existing `wire-node-to-multiple` functionality.

The logic is as follows:
The user first selects the nodes that should be connected. The node that is selected last is the target node for the connections.
If a source node has already outputs that are connected to the target node, the first output port that doesn't have a connection to the target node is connected.

I've done some debugging in Chrome and it seems to work great. The implementation was straight-forward as I could mostly copy paste the code for the `wireNodeToMultiple()` function

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
