### PR TITLE
Fix image URLs for v3.0 tour

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/tours/3.0/welcome.js
+++ b/packages/node_modules/@node-red/editor-client/src/tours/3.0/welcome.js
@@ -17,7 +17,7 @@ export default {
                 "en-US": "Context Menu",
                 "ja": "コンテキストメニュー"
             },
-            image: 'images/context-menu.png',
+            image: '3.0/images/context-menu.png',
             description: {
                 "en-US": `<p>The editor now has its own context menu when you
                           right-click in the workspace.</p>
@@ -32,7 +32,7 @@ export default {
                 "en-US": "Wire Junctions",
                 "ja": "分岐点をワイヤーに追加"
             },
-            image: 'images/junction-slice.gif',
+            image: '3.0/images/junction-slice.gif',
             description: {
                 "en-US": `<p>To make it easier to route wires around your flows,
                              it is now possible to add junction nodes that give
@@ -48,7 +48,7 @@ export default {
                 "en-US": "Wire Junctions",
                 "ja": "分岐点をワイヤーに追加"
             },
-            image: 'images/junction-quick-add.png',
+            image: '3.0/images/junction-quick-add.png',
             description: {
                 "en-US": `<p>Junctions can also be added using the quick-add dialog.</p>
                           <p>The dialog is opened by holding the Ctrl (or Cmd) key when
@@ -62,7 +62,7 @@ export default {
                 "en-US": "Debug Path Tooltip",
                 "ja": "デバッグパスのツールチップ"
             },
-            image: 'images/debug-path-tooltip.png',
+            image: '3.0/images/debug-path-tooltip.png',
             description: {
                 "en-US": `<p>When hovering over a node name in the Debug sidebar, a
                              new tooltip shows the full location of the node.</p>
@@ -81,7 +81,7 @@ export default {
                 "en-US": "Continuous Search",
                 "ja": "連続した検索"
             },
-            image: 'images/continuous-search.png',
+            image: '3.0/images/continuous-search.png',
             description: {
                 "en-US": `<p>When searching for things in the editor, a new toolbar in
                              the workspace provides options to quickly jump between
@@ -94,7 +94,7 @@ export default {
                 "en-US": "New wiring actions",
                 "ja": "新しいワイヤー操作"
             },
-            image: "images/split-wire-with-links.gif",
+            image: "3.0/images/split-wire-with-links.gif",
             description: {
                 "en-US": `<p>A new action has been added that will replace a wire with a pair of connected Link nodes:</p>
                           <ul>


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
In Node-RED v3.1 beta.1, the welcome tour for v3.0 has no image due to the invalid path. Therefore, I fixed the image URLs.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
