### PR TITLE
Add validators for complete and link call nodes

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/24-complete.html
+++ b/packages/node_modules/@node-red/nodes/core/common/24-complete.html
@@ -18,7 +18,16 @@
         color:"#c0edc0",
         defaults: {
             name: {value:""},
-            scope: {value:[], type:"*[]"},
+            scope: {
+                value: [],
+                type: "*[]",
+                validate: function (v, opt) {
+                    if (v.length > 0) {
+                        return true;
+                    }
+                    return RED._("node-red:complete.errors.scopeUndefined");
+                }
+            },
             uncaught: {value:false}
         },
         inputs:0,

--- a/packages/node_modules/@node-red/nodes/core/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.html
@@ -1,4 +1,3 @@
-
 <script type="text/html" data-template-name="link in">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
@@ -272,7 +271,17 @@
         color:"#ddd",//"#87D8CF",
         defaults: {
             name: { value: "" },
-            links: { value: [], type:"link in[]" },
+            links: {
+                value: [],
+                type: "link in[]",
+                validate: function (v, opt) {
+                    if ((this.linkType === "static" && v.length > 0)
+                      || this.linkType === "dynamic") {
+                        return true;
+                    }
+                    return RED._("node-red:link.errors.linkUndefined");
+                }
+            },
             linkType: { value:"static" },
             timeout: {
                 value: "30",

--- a/packages/node_modules/@node-red/nodes/core/common/60-link.js
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.js
@@ -164,10 +164,10 @@ module.exports = function(RED) {
                     if (returnNode && returnNode.returnLinkMessage) {
                         returnNode.returnLinkMessage(messageEvent.id, msg);
                     } else {
-                        node.warn(RED._("link.error.missingReturn"))
+                        node.warn(RED._("link.errors.missingReturn"));
                     }
                 } else {
-                    node.warn(RED._("link.error.missingReturn"))
+                    node.warn(RED._("link.errors.missingReturn"));
                 }
                 done();
             } else if (mode === "link") {

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -184,8 +184,9 @@
         "staticLinkCall": "Fixed target",
         "dynamicLinkCall": "Dynamic target (msg.target)",
         "dynamicLinkLabel": "Dynamic",
-        "error": {
-            "missingReturn": "Missing return node information"
+        "errors": {
+            "missingReturn": "Missing return node information",
+            "linkUndefined": "link undefined"
         }
     },
     "tls": {

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -119,7 +119,10 @@
         }
     },
     "complete": {
-        "completeNodes": "complete: __number__"
+        "completeNodes": "complete: __number__",
+        "errors": {
+            "scopeUndefined": "scope undefined"
+        }
     },
     "debug": {
         "output": "Output",

--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -184,8 +184,9 @@
         "staticLinkCall": "対象を固定で指定",
         "dynamicLinkCall": "対象を動的に指定 (msg.target)",
         "dynamicLinkLabel": "動的",
-        "error": {
-            "missingReturn": "返却するノードの情報が存在しません"
+        "errors": {
+            "missingReturn": "返却するノードの情報が存在しません",
+            "linkUndefined": "リンクが未定義"
         }
     },
     "tls": {

--- a/packages/node_modules/@node-red/nodes/locales/ja/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/ja/messages.json
@@ -119,7 +119,10 @@
         }
     },
     "complete": {
-        "completeNodes": "complete: __number__"
+        "completeNodes": "complete: __number__",
+        "errors": {
+            "scopeUndefined": "スコープが未定義"
+        }
     },
     "debug": {
         "output": "対象",


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Some nodes with validators have guided users to set appropriate settings. For example, an `http-in` node with an error triangle is easy to understand the lack of the URL path. To guide users in the same style, I added the validators for complete and link call nodes.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality