### PR TITLE
Fix to add empty marker to empty group

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
@@ -613,6 +613,9 @@ RED.sidebar.info.outliner = (function() {
                 objects[n.id].children = missingParents[n.id];
                 delete missingParents[n.id]
             }
+            if (objects[n.id].children.length === 0) {
+                objects[n.id].children.push(getEmptyItem(n.id));
+            }
         }
         var parent = n.g||n.z||"__global__";
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Empty marker is shown in outliner when last node is removed from it.
However it is not shown when copy and pasting an empty group or loading
a flow containing it.
This PR try to fix the issue.

![スクリーンショット 2023-02-14 21 06 08](https://user-images.githubusercontent.com/30289092/218734788-c22ddc3f-70b4-4b24-bca4-f9431c4739e3.png)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
