### PR TITLE
Reverse direction of tab scroll to expected direction

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
@@ -183,7 +183,7 @@ RED.tabs = (function() {
                     // Assume this is wheel event which might not trigger
                     // the scroll event, so do things manually
                     var sl = scrollContainer.scrollLeft();
-                    sl -= evt.originalEvent.deltaY;
+                    sl += evt.originalEvent.deltaY;
                     scrollContainer.scrollLeft(sl);
                 }
             })


### PR DESCRIPTION
Reverses the direction the tab bar scrolls when using the mouse scroll wheel. This should now match the behaviour of other apps.