### PR TITLE
Add link to node help in node edit dialog footer

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1045,6 +1045,13 @@ RED.editor = (function() {
 
                 var trayFooterLeft = $('<div class="red-ui-tray-footer-left"></div>').appendTo(trayFooter)
 
+                var helpButton = $('<button type="button" class="red-ui-button"><i class="fa fa-book"></button>').on("click", function(evt) {
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    RED.sidebar.help.show(editing_node.type);
+                }).appendTo(trayFooterLeft);
+                RED.popover.tooltip(helpButton, RED._("sidebar.help.showHelp"));
+
                 $('<input id="node-input-node-disabled" type="checkbox">').prop("checked",!!node.d).appendTo(trayFooterLeft).toggleButton({
                     enabledIcon: "fa-circle-thin",
                     disabledIcon: "fa-ban",
@@ -1189,6 +1196,13 @@ RED.editor = (function() {
                 var trayFooter = tray.find(".red-ui-tray-footer");
 
                 var trayFooterLeft = $('<div class="red-ui-tray-footer-left"></div>').appendTo(trayFooter)
+
+                var helpButton = $('<button type="button" class="red-ui-button"><i class="fa fa-book"></button>').on("click", function(evt) {
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    RED.sidebar.help.show(editing_config_node.type);
+                }).appendTo(trayFooterLeft);
+                RED.popover.tooltip(helpButton, RED._("sidebar.help.showHelp"));
 
                 $('<input id="node-config-input-node-disabled" type="checkbox">').prop("checked",!!editing_config_node.d).appendTo(trayFooterLeft).toggleButton({
                     enabledIcon: "fa-circle-thin",

--- a/packages/node_modules/@node-red/editor-client/src/sass/editor.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/editor.scss
@@ -87,16 +87,18 @@
         padding: 0px 8px;
         height: 26px;
         line-height: 26px;
-        &.toggle:not(.selected) {
+        &.toggle.selected {
             color: var(--red-ui-workspace-button-color-selected) !important;
-            background: var(--red-ui-workspace-button-background-active);
+            background: var(--red-ui-workspace-button-background) !important;
         }
     }
 
     .red-ui-tray-footer-left {
-        display:inline-block;
         margin-right: 20px;
         float:left;
+        & :not(:first-child) {
+            margin-left: 5px
+        }
     }
     .red-ui-tray-footer-right {
         float: right;


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

Adds a button to the footer of the node/config-node edit dialogs that will open the help for the node in the help sidebar.

<img width="347" alt="image" src="https://user-images.githubusercontent.com/51083/220176423-64a40f21-5b1f-40c5-8b97-21b1d047d822.png">
