### PR TITLE
Remove duplicated messages in the message catalog

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -701,8 +701,7 @@
             "copyItemUrl": "Copy item url",
 	    "copyURL2Clipboard": "Copied url to clipboard",
             "showFlow": "Show",
-            "hideFlow": "Hide",
-            "find": "Find in workspace"
+            "hideFlow": "Hide"
         },
         "help": {
             "name": "Help",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -701,8 +701,7 @@
             "copyItemUrl": "要素のURLをコピー",
             "copyURL2Clipboard": "URLをクリップボードにコピーしました",
             "showFlow": "表示",
-            "hideFlow": "非表示",
-            "find": "ワークスペース内を検索"
+            "hideFlow": "非表示"
         },
         "help": {
             "name": "ヘルプ",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -1317,6 +1317,7 @@
         "distribute-selection-vertically": "選択を上下に整列",
         "wire-series-of-nodes": "ノードを一続きに接続",
         "wire-node-to-multiple": "ノードを複数に接続",
+        "wire-multiple-to-node": "複数からノードへ接続",
         "split-wire-with-link-nodes": "ワイヤーをlinkノードで分割",
         "generate-node-names": "ノード名を生成",
         "show-user-settings": "ユーザ設定を表示",


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I removed duplicated definitions, `"find": "Find in workspace"` in the message catalog.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
