### PR TITLE
Prevent opening locked node's edit dialog

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -503,7 +503,7 @@ RED.clipboard = (function() {
         $("#red-ui-clipboard-dialog-import-text").on("keyup", validateImport);
         $("#red-ui-clipboard-dialog-import-text").on('paste',function() { setTimeout(validateImport,10)});
 
-        if (RED.workspaces.active() === 0 || RED.workspaces.isActiveLocked()) {
+        if (RED.workspaces.active() === 0 || RED.workspaces.isLocked()) {
             $("#red-ui-clipboard-dialog-import-opt-current").addClass('disabled').removeClass("selected");
             $("#red-ui-clipboard-dialog-import-opt-new").addClass("selected");
         } else {
@@ -1278,7 +1278,7 @@ RED.clipboard = (function() {
             RED.keyboard.add("#red-ui-drop-target", "escape" ,hideDropTarget);
 
             $('#red-ui-workspace-chart').on("dragenter",function(event) {
-                if (!RED.workspaces.isActiveLocked() && (
+                if (!RED.workspaces.isLocked() && (
                     $.inArray("text/plain",event.originalEvent.dataTransfer.types) != -1 ||
                      $.inArray("Files",event.originalEvent.dataTransfer.types) != -1)) {
                     $("#red-ui-drop-target").css({display:'table'}).focus();
@@ -1288,7 +1288,7 @@ RED.clipboard = (function() {
             $('#red-ui-drop-target').on("dragover",function(event) {
                 if ($.inArray("text/plain",event.originalEvent.dataTransfer.types) != -1 ||
                      $.inArray("Files",event.originalEvent.dataTransfer.types) != -1 ||
-                        RED.workspaces.isActiveLocked()) {
+                        RED.workspaces.isLocked()) {
                     event.preventDefault();
                 }
             })
@@ -1296,7 +1296,7 @@ RED.clipboard = (function() {
                 hideDropTarget();
             })
             .on("drop",function(event) {
-                if (!RED.workspaces.isActiveLocked()) {
+                if (!RED.workspaces.isLocked()) {
                     try {
                         if ($.inArray("text/plain",event.originalEvent.dataTransfer.types) != -1) {
                             var data = event.originalEvent.dataTransfer.getData("text/plain");

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
@@ -28,7 +28,7 @@ RED.contextMenu = (function () {
             const isMultipleLinks = !hasSelection && hasLinks && wireLinks.length > 1
             const canDelete = hasSelection || hasLinks
             const isGroup = hasSelection && selection.nodes.length === 1 && selection.nodes[0].type === 'group'
-            const canEdit = !RED.workspaces.isActiveLocked()
+            const canEdit = !RED.workspaces.isLocked()
             const canRemoveFromGroup = hasSelection && !!selection.nodes[0].g
             const isAllGroups = hasSelection && selection.nodes.filter(n => n.type !== 'group').length === 0
             const hasGroup = hasSelection && selection.nodes.filter(n => n.type === 'group' ).length > 0

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -860,6 +860,7 @@ RED.editor = (function() {
     function showEditDialog(node, defaultTab) {
         if (buildingEditDialog) { return }
         buildingEditDialog = true;
+        if (node.z && RED.workspaces.isLocked(node.z)) { return }
         var editing_node = node;
         var removeInfoEditorOnClose = false;
         var skipInfoRefreshOnClose = false;
@@ -1154,6 +1155,8 @@ RED.editor = (function() {
         var node_def = RED.nodes.getType(type);
         var editing_config_node = RED.nodes.node(id);
         var activeEditPanes = [];
+
+        if (editing_config_node && editing_config_node.z && RED.workspaces.isLocked(editing_config_node.z)) { return }
 
         var configNodeScope = ""; // default to global
         var activeSubflow = RED.nodes.subflow(RED.workspaces.active());
@@ -1708,6 +1711,7 @@ RED.editor = (function() {
     function showEditGroupDialog(group, defaultTab) {
         if (buildingEditDialog) { return }
         buildingEditDialog = true;
+        if (group.z && RED.workspaces.isLocked(group.z)) { return }
         var editing_node = group;
         editStack.push(group);
         RED.view.state(RED.state.EDITING);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
@@ -188,7 +188,7 @@ RED.group = (function() {
             var activateMerge = false;
             var activateRemove = false;
             var singleGroupSelected = false;
-            var locked = RED.workspaces.isActiveLocked()
+            var locked = RED.workspaces.isLocked()
 
             if (activateGroup) {
                 singleGroupSelected = selection.nodes.length === 1 && selection.nodes[0].type === 'group';
@@ -266,7 +266,7 @@ RED.group = (function() {
         }
     }
     function pasteGroupStyle() {
-        if (RED.workspaces.isActiveLocked()) { return }
+        if (RED.workspaces.isLocked()) { return }
         if (RED.view.state() !== RED.state.DEFAULT) { return }
         if (groupStyleClipboard) {
             var selection = RED.view.selection();
@@ -301,7 +301,7 @@ RED.group = (function() {
     }
 
     function groupSelection() {
-        if (RED.workspaces.isActiveLocked()) { return }
+        if (RED.workspaces.isLocked()) { return }
         if (RED.view.state() !== RED.state.DEFAULT) { return }
         var selection = RED.view.selection();
         if (selection.nodes) {
@@ -320,7 +320,7 @@ RED.group = (function() {
         }
     }
     function ungroupSelection() {
-        if (RED.workspaces.isActiveLocked()) { return }
+        if (RED.workspaces.isLocked()) { return }
         if (RED.view.state() !== RED.state.DEFAULT) { return }
         var selection = RED.view.selection();
         if (selection.nodes) {
@@ -344,7 +344,7 @@ RED.group = (function() {
     }
 
     function ungroup(g) {
-        if (RED.workspaces.isActiveLocked()) { return }
+        if (RED.workspaces.isLocked()) { return }
         var nodes = [];
         var parentGroup = RED.nodes.group(g.g);
         g.nodes.forEach(function(n) {
@@ -371,7 +371,7 @@ RED.group = (function() {
     }
 
     function mergeSelection() {
-        if (RED.workspaces.isActiveLocked()) { return }
+        if (RED.workspaces.isLocked()) { return }
         if (RED.view.state() !== RED.state.DEFAULT) { return }
         var selection = RED.view.selection();
         if (selection.nodes) {
@@ -441,7 +441,7 @@ RED.group = (function() {
     }
 
     function removeSelection() {
-        if (RED.workspaces.isActiveLocked()) { return }
+        if (RED.workspaces.isLocked()) { return }
         if (RED.view.state() !== RED.state.DEFAULT) { return }
         var selection = RED.view.selection();
         if (selection.nodes) {
@@ -469,7 +469,7 @@ RED.group = (function() {
         }
     }
     function createGroup(nodes) {
-        if (RED.workspaces.isActiveLocked()) { return }
+        if (RED.workspaces.isLocked()) { return }
         if (nodes.length === 0) {
             return;
         }
@@ -575,7 +575,7 @@ RED.group = (function() {
         markDirty(group);
     }
     function removeFromGroup(group, nodes, reparent) {
-        if (RED.workspaces.isActiveLocked()) { return }
+        if (RED.workspaces.isLocked()) { return }
         if (!Array.isArray(nodes)) {
             nodes = [nodes];
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -573,7 +573,7 @@ RED.subflow = (function() {
             }
         });
         RED.events.on("view:selection-changed",function(selection) {
-            if (!selection.nodes || RED.workspaces.isActiveLocked()) {
+            if (!selection.nodes || RED.workspaces.isLocked()) {
                 RED.menu.setDisabled("menu-item-subflow-convert",true);
             } else {
                 RED.menu.setDisabled("menu-item-subflow-convert",false);
@@ -636,7 +636,7 @@ RED.subflow = (function() {
     }
 
     function convertToSubflow() {
-        if (RED.workspaces.isActiveLocked()) {
+        if (RED.workspaces.isLocked()) {
             return
         }
         var selection = RED.view.selection();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
@@ -39,7 +39,7 @@ RED.view.tools = (function() {
     }
 
     function alignToGrid() {
-        if (RED.workspaces.isActiveLocked()) {
+        if (RED.workspaces.isLocked()) {
             return
         }
         var selection = RED.view.selection();
@@ -90,7 +90,7 @@ RED.view.tools = (function() {
     }
 
     function moveSelection(dx,dy) {
-        if (RED.workspaces.isActiveLocked()) {
+        if (RED.workspaces.isLocked()) {
             return
         }
         if (moving_set === null) {
@@ -159,7 +159,7 @@ RED.view.tools = (function() {
     }
 
     function setSelectedNodeLabelState(labelShown) {
-        if (RED.workspaces.isActiveLocked()) {
+        if (RED.workspaces.isLocked()) {
             return
         }
         var selection = RED.view.selection();
@@ -448,7 +448,7 @@ RED.view.tools = (function() {
     }
 
     function alignSelectionToEdge(direction) {
-        // if (RED.workspaces.isActiveLocked()) {
+        // if (RED.workspaces.isLocked()) {
         //     return
         // }
         var selection = RED.view.selection();
@@ -552,7 +552,7 @@ RED.view.tools = (function() {
     }
 
     function distributeSelection(direction) {
-        if (RED.workspaces.isActiveLocked()) {
+        if (RED.workspaces.isLocked()) {
             return
         }
         var selection = RED.view.selection();
@@ -713,7 +713,7 @@ RED.view.tools = (function() {
     }
 
     function reorderSelection(dir) {
-        if (RED.workspaces.isActiveLocked()) {
+        if (RED.workspaces.isLocked()) {
             return
         }
         var selection = RED.view.selection();
@@ -752,7 +752,7 @@ RED.view.tools = (function() {
     }
 
     function wireSeriesOfNodes() {
-        if (RED.workspaces.isActiveLocked()) {
+        if (RED.workspaces.isLocked()) {
             return
         }
         var selection = RED.view.selection();
@@ -795,7 +795,7 @@ RED.view.tools = (function() {
     }
 
     function wireNodeToMultiple() {
-        if (RED.workspaces.isActiveLocked()) {
+        if (RED.workspaces.isLocked()) {
             return
         }
         var selection = RED.view.selection();
@@ -841,7 +841,7 @@ RED.view.tools = (function() {
     }
 
     function wireMultipleToNode() {
-        if (RED.workspaces.isActiveLocked()) {
+        if (RED.workspaces.isLocked()) {
             return
         }
         var selection = RED.view.selection();
@@ -903,7 +903,7 @@ RED.view.tools = (function() {
      * @param {Object || Object[]} wires The wire(s) to split and replace with link-out, link-in nodes.
      */
     function splitWiresWithLinkNodes(wires) {
-        if (RED.workspaces.isActiveLocked()) {
+        if (RED.workspaces.isLocked()) {
             return
         }
         let wiresToSplit = wires || (RED.view.selection().links && RED.view.selection().links.filter(e => !e.link));
@@ -1074,7 +1074,7 @@ RED.view.tools = (function() {
      * @param {{ renameBlank: boolean, renameClash: boolean, generateHistory: boolean }} options Possible options are `renameBlank`, `renameClash` and `generateHistory`
      */
     function generateNodeNames(node, options) {
-        if (RED.workspaces.isActiveLocked()) {
+        if (RED.workspaces.isLocked()) {
             return
         }
         options = Object.assign({
@@ -1147,7 +1147,7 @@ RED.view.tools = (function() {
     }
 
     function addJunctionsToWires(wires) {
-        if (RED.workspaces.isActiveLocked()) {
+        if (RED.workspaces.isLocked()) {
             return
         }
         let wiresToSplit = wires || (RED.view.selection().links && RED.view.selection().links.filter(e => !e.link));

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -671,7 +671,7 @@ RED.view = (function() {
         RED.actions.add("core:copy-selection-to-internal-clipboard",copySelection);
         RED.actions.add("core:cut-selection-to-internal-clipboard",function(){copySelection(true);deleteSelection();});
         RED.actions.add("core:paste-from-internal-clipboard",function(){
-            if (RED.workspaces.isActiveLocked()) {
+            if (RED.workspaces.isLocked()) {
                 return
             }
             importNodes(clipboard,{generateIds: clipboardSource === 'copy', generateDefaultNames: clipboardSource === 'copy'});
@@ -2549,7 +2549,7 @@ RED.view = (function() {
     }
 
     function editSelection() {
-        if (RED.workspaces.isActiveLocked()) { return }
+        if (RED.workspaces.isLocked()) { return }
         if (movingSet.length() > 0) {
             var node = movingSet.get(0).n;
             if (node.type === "subflow") {
@@ -2883,7 +2883,7 @@ RED.view = (function() {
 
 
     function detachSelectedNodes() {
-        if (RED.workspaces.isActiveLocked()) { return }
+        if (RED.workspaces.isLocked()) { return }
         var selection = RED.view.selection();
         if (selection.nodes) {
             const {newLinks, removedLinks} = RED.nodes.detachNodes(selection.nodes);
@@ -3465,7 +3465,7 @@ RED.view = (function() {
         }
         if (dblClickPrimed && mousedown_node == d && clickElapsed > 0 && clickElapsed < dblClickInterval) {
             mouse_mode = RED.state.DEFAULT;
-            if (RED.workspaces.isActiveLocked()) {
+            if (RED.workspaces.isLocked()) {
                 clickElapsed = 0;
                 d3.event.stopPropagation();
                 return
@@ -4009,7 +4009,7 @@ RED.view = (function() {
         if (RED.view.DEBUG) {
             console.warn("groupMouseUp", { mouse_mode, event: d3.event });
         }
-        if (RED.workspaces.isActiveLocked()) { return }
+        if (RED.workspaces.isLocked()) { return }
         if (dblClickPrimed && mousedown_group == g && clickElapsed > 0 && clickElapsed < dblClickInterval) {
             mouse_mode = RED.state.DEFAULT;
             RED.editor.editGroup(g);
@@ -4233,7 +4233,7 @@ RED.view = (function() {
     function showTouchMenu(obj,pos) {
         var mdn = mousedown_node;
         var options = [];
-        const isActiveLocked = RED.workspaces.isActiveLocked()
+        const isActiveLocked = RED.workspaces.isLocked()
         options.push({name:"delete",disabled:(isActiveLocked || movingSet.length()===0 && selectedLinks.length() === 0),onselect:function() {deleteSelection();}});
         options.push({name:"cut",disabled:(isActiveLocked || movingSet.length()===0),onselect:function() {copySelection(true);deleteSelection();}});
         options.push({name:"copy",disabled:(isActiveLocked || movingSet.length()===0),onselect:function() {copySelection();}});

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -160,7 +160,7 @@ RED.workspaces = (function() {
             }
         });
 
-        let isCurrentLocked = RED.workspaces.isActiveLocked()
+        let isCurrentLocked = RED.workspaces.isLocked()
         if (tab) {
             isCurrentLocked = tab.locked
         }
@@ -833,8 +833,9 @@ RED.workspaces = (function() {
         active: function() {
             return activeWorkspace
         },
-        isActiveLocked: function() {
-            var ws = RED.nodes.workspace(activeWorkspace) || RED.nodes.subflow(activeWorkspace)
+        isLocked: function(id) {
+            id = id || activeWorkspace
+            var ws = RED.nodes.workspace(id) || RED.nodes.subflow(id)
             return ws && ws.locked
         },
         selection: function() {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

When on a locked flow, this prevents a node's edit dialog from being opened via any means. In 3.1-beta.1 is was reported that the Info sidebar provided a route to open a node's edit dialog even if its flow was locked.