### PR TITLE
add cancel operation to editableList

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
@@ -417,6 +417,9 @@
             } else {
                 return null;
             }
+        },
+        cancel: function() {
+            this.element.sortable("cancel");
         }
     });
 })(jQuery);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Node-RED beta-1 introduced locking flow feature.
However, this causes an issue in Node-RED Dashboards when changing the layout of widgets contained in a locked flow.

[This PR](https://github.com/node-red/node-red-dashboard/pull/799) is attempt to solve the issue.  It requires moving of items in `editableList` to be cancelled.   However, current `editableList` do not support it.   So, this PR adds support of `cancel` operation to `editableList`.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
