### PR TITLE
Option to disable MQTT topic unsubscribe on disconnect

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
@@ -653,7 +653,7 @@
                 this.protocolVersion = 4;
             }
             $("#node-config-input-cleansession").on("change", function() {
-                var useCleanSession = $("#node-config-input-cleansession").is(':checked');
+                const useCleanSession = $("#node-config-input-cleansession").is(':checked');
                 if(useCleanSession) {
                     $("div.form-row.mqtt-persistence").hide();
                 } else {

--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
@@ -489,17 +489,23 @@
             tls: {type:"tls-config",required: false,
                   label:RED._("node-red:mqtt.label.use-tls") },
             clientid: {value:"", validate: function(v, opt) {
-                var ok = false;
+                let ok = true;
                 if ($("#node-config-input-clientid").length) {
                     // Currently editing the node
-                    ok = $("#node-config-input-cleansession").is(":checked") || (v||"").length > 0;
+                    let needClientId = !$("#node-config-input-cleansession").is(":checked") || !$("#node-config-input-autoUnsubscribe").is(":checked")
+                    if (needClientId) {
+                        ok = (v||"").length > 0;
+                    }
                 } else {
-                    ok = (this.cleansession===undefined || this.cleansession) || (v||"").length > 0;
+                    let needClientId = !(this.cleansession===undefined || this.cleansession) || this.autoUnsubscribe;
+                    if (needClientId) {
+                        ok = (v||"").length > 0;
+                    }
                 }
-                if (ok) {
-                    return ok;
+                if (!ok) {
+                    return RED._("node-red:mqtt.errors.invalid-client-id");
                 }
-                return RED._("node-red:mqtt.errors.invalid-client-id");
+                return true;
             }},
             autoConnect: {value: true},
             usetls: {value: false},

--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
@@ -250,9 +250,9 @@
                         </label>
                     </div>
                     <div class="form-row mqtt-persistence">
-                        <label for="node-config-input-unsubscribeOnDisconnect" style="width: auto;">
-                            <input type="checkbox" id="node-config-input-unsubscribeOnDisconnect" style="position: relative;vertical-align: bottom; top: -2px; width: 15px;height: 15px;">
-                            <span id="node-config-input-unsubscribeOnDisconnect-label" data-i18n="mqtt.label.unsubscribeOnDisconnect"></span>
+                        <label for="node-config-input-autoUnsubscribe" style="width: auto;">
+                            <input type="checkbox" id="node-config-input-autoUnsubscribe" style="position: relative;vertical-align: bottom; top: -2px; width: 15px;height: 15px;">
+                            <span id="node-config-input-autoUnsubscribe-label" data-i18n="mqtt.label.autoUnsubscribe"></span>
                         </label>
                     </div>
                     <div class="form-row mqtt5">
@@ -511,7 +511,7 @@
                 label: RED._("node-red:mqtt.label.keepalive"),
                 validate:RED.validators.number(false)},
             cleansession: {value: true},
-            unsubscribeOnDisconnect: {value: true},
+            autoUnsubscribe: {value: true},
             birthTopic: {value:"", validate:validateMQTTPublishTopic},
             birthQos: {value:"0"},
             birthRetain: {value:"false"},
@@ -627,9 +627,9 @@
                 this.cleansession = true;
                 $("#node-config-input-cleansession").prop("checked",true);
             }
-            if (typeof this.unsubscribeOnDisconnect === 'undefined') {
-                this.unsubscribeOnDisconnect = true;
-                $("#node-config-input-unsubscribeOnDisconnect").prop("checked",true);
+            if (typeof this.autoUnsubscribe === 'undefined') {
+                this.autoUnsubscribe = true;
+                $("#node-config-input-autoUnsubscribe").prop("checked",true);
             }
             if (typeof this.usetls === 'undefined') {
                 this.usetls = false;

--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
@@ -249,6 +249,12 @@
                             <span id="node-config-input-cleansession-label" data-i18n="mqtt.label.cleansession"></span>
                         </label>
                     </div>
+                    <div class="form-row mqtt-persistence">
+                        <label for="node-config-input-unsubscribeOnDisconnect" style="width: auto;">
+                            <input type="checkbox" id="node-config-input-unsubscribeOnDisconnect" style="position: relative;vertical-align: bottom; top: -2px; width: 15px;height: 15px;">
+                            <span id="node-config-input-unsubscribeOnDisconnect-label" data-i18n="mqtt.label.unsubscribeOnDisconnect"></span>
+                        </label>
+                    </div>
                     <div class="form-row mqtt5">
                         <label style="width:auto" for="node-config-input-sessionExpiry"><span data-i18n="mqtt.label.sessionExpiry"></span></label>
                         <input type="number" min="0" id="node-config-input-sessionExpiry" style="width: 100px" >
@@ -505,6 +511,7 @@
                 label: RED._("node-red:mqtt.label.keepalive"),
                 validate:RED.validators.number(false)},
             cleansession: {value: true},
+            unsubscribeOnDisconnect: {value: true},
             birthTopic: {value:"", validate:validateMQTTPublishTopic},
             birthQos: {value:"0"},
             birthRetain: {value:"false"},
@@ -620,6 +627,10 @@
                 this.cleansession = true;
                 $("#node-config-input-cleansession").prop("checked",true);
             }
+            if (typeof this.unsubscribeOnDisconnect === 'undefined') {
+                this.unsubscribeOnDisconnect = true;
+                $("#node-config-input-unsubscribeOnDisconnect").prop("checked",true);
+            }
             if (typeof this.usetls === 'undefined') {
                 this.usetls = false;
                 $("#node-config-input-usetls").prop("checked",false);
@@ -635,6 +646,14 @@
             if (typeof this.protocolVersion === 'undefined') {
                 this.protocolVersion = 4;
             }
+            $("#node-config-input-cleansession").on("change", function() {
+                var useCleanSession = $("#node-config-input-cleansession").is(':checked');
+                if(useCleanSession) {
+                    $("div.form-row.mqtt-persistence").hide();
+                } else {
+                    $("div.form-row.mqtt-persistence").show();
+                }
+            });
             $("#node-config-input-protocolVersion").on("change", function() {
                 var v5 = $("#node-config-input-protocolVersion").val() == "5";
                 if(v5) {

--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -482,7 +482,7 @@ module.exports = function(RED) {
             setIfHasProperty(opts, node, "protocolVersion", init);
             setIfHasProperty(opts, node, "keepalive", init);
             setIfHasProperty(opts, node, "cleansession", init);
-            setIfHasProperty(opts, node, "unsubscribeOnDisconnect", init);
+            setIfHasProperty(opts, node, "autoUnsubscribe", init);
             setIfHasProperty(opts, node, "topicAliasMaximum", init);
             setIfHasProperty(opts, node, "maximumPacketSize", init);
             setIfHasProperty(opts, node, "receiveMaximum", init);
@@ -591,8 +591,8 @@ module.exports = function(RED) {
             if (typeof node.cleansession === 'undefined') {
                 node.cleansession = true;
             }
-            if (typeof node.unsubscribeOnDisconnect === 'undefined') {
-                node.unsubscribeOnDisconnect = true;
+            if (typeof node.autoUnsubscribe === 'undefined') {
+                node.autoUnsubscribe = true;
             }
 
             //use url or build a url from usetls://broker:port
@@ -664,7 +664,7 @@ module.exports = function(RED) {
             node.options.password = node.password;
             node.options.keepalive = node.keepalive;
             node.options.clean = node.cleansession;
-            node.options.unsubscribeOnDisconnect = node.unsubscribeOnDisconnect;
+            node.options.autoUnsubscribe = node.autoUnsubscribe;
             node.options.clientId = node.clientid || 'nodered_' + RED.util.generateId();
             node.options.reconnectPeriod = RED.settings.mqttReconnectTime||5000;
             delete node.options.protocolId; //V4+ default
@@ -1233,14 +1233,14 @@ module.exports = function(RED) {
             node.on('close', function(removed, done) {
                 if (node.brokerConn) {
                     if(node.isDynamic) {
-                        if (node.brokerConn.options.unsubscribeOnDisconnect) {
+                        if (node.brokerConn.options.autoUnsubscribe) {
                             Object.keys(node.dynamicSubs).forEach(function (topic) {
                                 node.brokerConn.unsubscribe(topic, node.id, removed);
                             });
                             node.dynamicSubs = {};
                         }
                     } else {
-                        if (node.brokerConn.options.unsubscribeOnDisconnect) {
+                        if (node.brokerConn.options.autoUnsubscribe) {
                             node.brokerConn.unsubscribe(node.topic, node.id, removed);
                         }
                     }

--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -482,6 +482,7 @@ module.exports = function(RED) {
             setIfHasProperty(opts, node, "protocolVersion", init);
             setIfHasProperty(opts, node, "keepalive", init);
             setIfHasProperty(opts, node, "cleansession", init);
+            setIfHasProperty(opts, node, "unsubscribeOnDisconnect", init);
             setIfHasProperty(opts, node, "topicAliasMaximum", init);
             setIfHasProperty(opts, node, "maximumPacketSize", init);
             setIfHasProperty(opts, node, "receiveMaximum", init);
@@ -590,6 +591,9 @@ module.exports = function(RED) {
             if (typeof node.cleansession === 'undefined') {
                 node.cleansession = true;
             }
+            if (typeof node.unsubscribeOnDisconnect === 'undefined') {
+                node.unsubscribeOnDisconnect = true;
+            }
 
             //use url or build a url from usetls://broker:port
             if (node.url && node.brokerurl !== node.url) {
@@ -660,6 +664,7 @@ module.exports = function(RED) {
             node.options.password = node.password;
             node.options.keepalive = node.keepalive;
             node.options.clean = node.cleansession;
+            node.options.unsubscribeOnDisconnect = node.unsubscribeOnDisconnect;
             node.options.clientId = node.clientid || 'nodered_' + RED.util.generateId();
             node.options.reconnectPeriod = RED.settings.mqttReconnectTime||5000;
             delete node.options.protocolId; //V4+ default
@@ -1228,12 +1233,16 @@ module.exports = function(RED) {
             node.on('close', function(removed, done) {
                 if (node.brokerConn) {
                     if(node.isDynamic) {
-                        Object.keys(node.dynamicSubs).forEach(function (topic) {
-                            node.brokerConn.unsubscribe(topic, node.id, removed);
-                        });
-                        node.dynamicSubs = {};
+                        if (node.brokerConn.options.unsubscribeOnDisconnect) {
+                            Object.keys(node.dynamicSubs).forEach(function (topic) {
+                                node.brokerConn.unsubscribe(topic, node.id, removed);
+                            });
+                            node.dynamicSubs = {};
+                        }
                     } else {
-                        node.brokerConn.unsubscribe(node.topic,node.id, removed);
+                        if (node.brokerConn.options.unsubscribeOnDisconnect) {
+                            node.brokerConn.unsubscribe(node.topic, node.id, removed);
+                        }
                     }
                     node.brokerConn.deregister(node, done, removed);
                     node.brokerConn = null;

--- a/packages/node_modules/@node-red/nodes/locales/de/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/de/messages.json
@@ -362,6 +362,7 @@
             "port": "Port",
             "keepalive": "Keep-Alive",
             "cleansession": "Bereinigte Sitzung (clean session) verwenden",
+            "unsubscribeOnDisconnect": "Abonnement bei Verbindungsende automatisch beenden",
             "cleanstart": "Verwende bereinigten Start",
             "use-tls": "TLS",
             "tls-config": "TLS-Konfiguration",

--- a/packages/node_modules/@node-red/nodes/locales/de/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/de/messages.json
@@ -362,7 +362,7 @@
             "port": "Port",
             "keepalive": "Keep-Alive",
             "cleansession": "Bereinigte Sitzung (clean session) verwenden",
-            "unsubscribeOnDisconnect": "Abonnement bei Verbindungsende automatisch beenden",
+            "autoUnsubscribe": "Abonnement bei Verbindungsende automatisch beenden",
             "cleanstart": "Verwende bereinigten Start",
             "use-tls": "TLS",
             "tls-config": "TLS-Konfiguration",

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -414,7 +414,7 @@
             "port": "Port",
             "keepalive": "Keep Alive",
             "cleansession": "Use clean session",
-            "unsubscribeOnDisconnect": "Automatically unsubscribe when disconnecting",
+            "autoUnsubscribe": "Automatically unsubscribe when disconnecting",
             "cleanstart": "Use clean start",
             "use-tls": "Use TLS",
             "tls-config": "TLS Configuration",

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -414,6 +414,7 @@
             "port": "Port",
             "keepalive": "Keep Alive",
             "cleansession": "Use clean session",
+            "unsubscribeOnDisconnect": "Automatically unsubscribe when disconnecting",
             "cleanstart": "Use clean start",
             "use-tls": "Use TLS",
             "tls-config": "TLS Configuration",

--- a/test/nodes/core/network/21-mqtt_spec.js
+++ b/test/nodes/core/network/21-mqtt_spec.js
@@ -53,7 +53,7 @@ describe('MQTT Nodes', function () {
                 mqttBroker.should.have.property('broker', BROKER_HOST);
                 mqttBroker.should.have.property('port', BROKER_PORT);
                 mqttBroker.should.have.property('brokerurl');
-                // mqttBroker.should.have.property('autoUnsubscribe', true);//default: true 
+                mqttBroker.should.have.property('autoUnsubscribe', true); //default: true
                 mqttBroker.should.have.property('autoConnect', false);//Set "autoConnect:false" in brokerOptions 
                 mqttBroker.should.have.property('options');
                 mqttBroker.options.should.have.property('clean', true);
@@ -96,8 +96,8 @@ describe('MQTT Nodes', function () {
                 mqttBroker.should.have.property('broker', BROKER_HOST);
                 mqttBroker.should.have.property('port', BROKER_PORT);
                 mqttBroker.should.have.property('brokerurl');
-                // mqttBroker.should.have.property('autoUnsubscribe', true);//default: true 
-                mqttBroker.should.have.property('autoConnect', false);//Set "autoConnect:false" in brokerOptions 
+                mqttBroker.should.have.property('autoUnsubscribe', true);
+                mqttBroker.should.have.property('autoConnect', false); //Set "autoConnect:false" in brokerOptions
                 mqttBroker.should.have.property('options');
                 mqttBroker.options.should.have.property('clean', false);
                 mqttBroker.options.should.have.property('clientId', 'clientid');


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

I had an issue with QoS 1+ messages did not get delivered after re-connecting to the broker. After digging around I figured out that NodeRed automatically unsubscribes from topics before disconnecting. After searching for solutions I found the discussion in #3452. Unfortunately, there was no pull-request with the proposed changes attached to the issue. I figured to give it a try implementing it myself.

I am aware that I did not fulfill the `I have discussed this change on the forum/slack team` requirement and that this PR might be rejected, but since there was already an discussion on the issue going on, I thought to give it a shot.

The only thing I couldn't figure out how to check if the node itself was removed from a flow. As you mentioned in the issue, it would still have to unsubscribe from the topics (even if the option is disabled) to prevent piling up messages which will never be collected by any client anymore.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
  - [x] I jumped on the discussion in issue #3452 
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
