### PR TITLE
Fix importing connected link nodes into a subflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2302,7 +2302,7 @@ RED.nodes = (function() {
             // get added
             if (activeSubflow && /^link /.test(n.type) && n.links) {
                 n.links = n.links.filter(function(id) {
-                    var otherNode = RED.nodes.node(id);
+                    const otherNode = node_map[id] || RED.nodes.node(id);
                     return (otherNode && otherNode.z === activeWorkspace)
                 });
             }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

When importing a set of connected link nodes into a subflow, we have some code that ensures we don't end up with link nodes connected from inside to outside of a subflow.

The code was checking the other end of the link and ensuring it was also in the subflow. However it didn't consider nodes being imported at the same time.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
