### PR TITLE
Clear link-call timeouts when node is closed

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/60-link.js
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.js
@@ -248,6 +248,14 @@ module.exports = function(RED) {
             }
         });
 
+        this.on("close", function () {
+            for (const event of Object.values(messageEvents)) {
+                if (event.ts) {
+                    clearTimeout(event.ts)
+                }
+            }
+        })
+
         this.returnLinkMessage = function(eventId, msg) {
             if (Array.isArray(msg._linkSource) && msg._linkSource.length === 0) {
                 delete msg._linkSource;


### PR DESCRIPTION
Fixes #3959

This ensures Link-Call nodes clean up any of its timeouts when the node is closed.