### PR TITLE
Deprecate synchronous access to jsonata

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/expression.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/expression.js
@@ -294,32 +294,37 @@
                         }
 
                         try {
-                            var result = expr.evaluate(legacyMode?{msg:parsedData}:parsedData);
-                            if (usesContext) {
-                                testResultEditor.setValue(RED._("expressionEditor.errors.context-unsupported"),-1);
-                                return;
-                            }
-                            if (usesEnv) {
-                                testResultEditor.setValue(RED._("expressionEditor.errors.env-unsupported"),-1);
-                                return;
-                            }
-                            if (usesMoment) {
-                                testResultEditor.setValue(RED._("expressionEditor.errors.moment-unsupported"),-1);
-                                return;
-                            }
-                            if (usesClone) {
-                                testResultEditor.setValue(RED._("expressionEditor.errors.clone-unsupported"),-1);
-                                return;
-                            }
-
-                            var formattedResult;
-                            if (result !== undefined) {
-                                formattedResult = JSON.stringify(result,null,4);
-                            } else {
-                                formattedResult = RED._("expressionEditor.noMatch");
-                            }
-                            testResultEditor.setValue(formattedResult,-1);
-                        } catch(err) {
+                            expr.evaluate(legacyMode?{msg:parsedData}:parsedData, (err, result) => {
+                                if (err) {
+                                    testResultEditor.setValue(RED._("expressionEditor.errors.eval",{message:err.message}),-1);
+                                } else {
+                                    if (usesContext) {
+                                        testResultEditor.setValue(RED._("expressionEditor.errors.context-unsupported"),-1);
+                                        return;
+                                    }
+                                    if (usesEnv) {
+                                        testResultEditor.setValue(RED._("expressionEditor.errors.env-unsupported"),-1);
+                                        return;
+                                    }
+                                    if (usesMoment) {
+                                        testResultEditor.setValue(RED._("expressionEditor.errors.moment-unsupported"),-1);
+                                        return;
+                                    }
+                                    if (usesClone) {
+                                        testResultEditor.setValue(RED._("expressionEditor.errors.clone-unsupported"),-1);
+                                        return;
+                                    }
+        
+                                    var formattedResult;
+                                    if (result !== undefined) {
+                                        formattedResult = JSON.stringify(result,null,4);
+                                    } else {
+                                        formattedResult = RED._("expressionEditor.noMatch");
+                                    }
+                                    testResultEditor.setValue(formattedResult,-1);
+                                }
+                            });
+                        } catch(err) {                            
                             testResultEditor.setValue(RED._("expressionEditor.errors.eval",{message:err.message}),-1);
                         }
                     }

--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.js
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.js
@@ -117,14 +117,21 @@ module.exports = function(RED) {
                         if (p.v) {
                             try {
                                 var exp = RED.util.prepareJSONataExpression(p.v, node);
-                                var val = RED.util.evaluateJSONataExpression(exp, msg);
-                                RED.util.setMessageProperty(msg, property, val, true);
-                            }
-                            catch  (err) {
+                                RED.util.evaluateJSONataExpression(exp, msg, (err, newValue) => {
+                                    if (err) {
+                                        errors.push(err.toString())
+                                    } else {
+                                        RED.util.setMessageProperty(msg,property,newValue,true);
+                                    }
+                                    evaluateProperty(doneEvaluating)
+                                });
+                            } catch (err) {
                                 errors.push(err.message);
+                                evaluateProperty(doneEvaluating)
                             }
+                        } else {
+                            evaluateProperty(doneEvaluating)
                         }
-                        evaluateProperty(doneEvaluating)
                     } else {
                         try {
                             RED.util.evaluateNodeProperty(value, valueType, node, msg, (err, newValue) => {

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -25,7 +25,7 @@ const moment = require("moment-timezone");
 const safeJSONStringify = require("json-stringify-safe");
 const util = require("util");
 const { hasOwnProperty } = Object.prototype;
-
+const log = require("./log")
 /**
  * Safely returns the object construtor name.
  * @return {String} the name of the object constructor if it exists, empty string otherwise.
@@ -671,8 +671,11 @@ function evaluateNodeProperty(value, type, node, msg, callback) {
     } else if (type === 'bool') {
         result = /^true$/i.test(value);
     } else if (type === 'jsonata') {
-        var expr = prepareJSONataExpression(value,node);
-        result = evaluateJSONataExpression(expr,msg);
+        var expr = prepareJSONataExpression(value, node);
+        result = evaluateJSONataExpression(expr, msg, callback);
+        if (callback) {
+            return
+        }
     } else if (type === 'env') {
         result = evaluateEnvProperty(value, node);
     }
@@ -767,6 +770,11 @@ function evaluateJSONataExpression(expr,msg,callback) {
                 })
             });
         }
+    } else {
+        log.warn('Deprecated API warning: Calls to RED.util.evaluateJSONataExpression must include a callback. '+
+                 'This will not be optional in Node-RED 4.0. Please identify the node from the following stack '+
+                 'and check for an update on npm. If none is available, please notify the node author.')
+        log.warn(new Error().stack)
     }
     return expr.evaluate(context, bindings, callback);
 }


### PR DESCRIPTION
JSONata 2.0 was released a while ago which brings significant performance improvements. However they have made their api async only.

This is a major breaking change we cannot make until 4.0, but we can prepare the ground now.

We provide `RED.util.evaluateJSONataExpression` as the utility function for working with JSONata. This takes an *optional* callback. To adopt JSONata 2.0, we have to make this callback required.

This PR adds a deprecation warning to the log if that function is called without a callback, along with a call to action to notify the node author:

```
    3 Mar 11:23:57 - [warn] Deprecated API warning: Calls to RED.util.evaluateJSONataExpression must include a callback. This will not be optional in Node-RED 4.0. Please identify the node from the following stack and check for an update on npm. If none is available, please notify the node author.
    3 Mar 11:23:57 - [warn] Error
        at Object.evaluateJSONataExpression (/Users/nol/code/node-red/node-red/packages/node_modules/@node-red/util/lib/util.js:777:10)
        at evaluateProperty (/Users/nol/code/node-red/node-red/packages/node_modules/@node-red/nodes/core/common/20-inject.js:120:52)
        at InjectNode._inputCallback (/Users/nol/code/node-red/node-red/packages/node_modules/@node-red/nodes/core/common/20-inject.js:159:13)
        at /Users/nol/code/node-red/node-red/packages/node_modules/@node-red/runtime/lib/nodes/Node.js:210:26
        at Object.trigger (/Users/nol/code/node-red/node-red/packages/node_modules/@node-red/util/lib/hooks.js:166:13)
        at InjectNode.Node._emitInput (/Users/nol/code/node-red/node-red/packages/node_modules/@node-red/runtime/lib/nodes/Node.js:202:11)
        at InjectNode.Node.emit (/Users/nol/code/node-red/node-red/packages/node_modules/@node-red/runtime/lib/nodes/Node.js:186:25)
        at InjectNode.Node.receive (/Users/nol/code/node-red/node-red/packages/node_modules/@node-red/runtime/lib/nodes/Node.js:494:10)
        at /Users/nol/code/node-red/node-red/packages/node_modules/@node-red/nodes/core/common/20-inject.js:191:26
        at Layer.handle [as handle_request] (/Users/nol/code/node-red/node-red/node_modules/express/lib/router/layer.js:95:5)
```

In our own code, we already *mostly* provided a callback to our `RED.util.evaluateJSONataExpression` calls, except for one instance in the Inject node that this PR fixes.

It also updates the in-browser jsonata evaluation to provide a callback.