### PR TITLE
Ensure node buttons are redrawn when flow lock state is changed

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -728,19 +728,8 @@ RED.workspaces = (function() {
             RED.history.push(historyEvent);
             RED.events.emit("flows:change",workspace);
             RED.nodes.dirty(true);
-            // RED.sidebar.config.refresh();
-            // var selection = RED.view.selection();
-            // if (!selection.nodes && !selection.links && workspace.id === activeWorkspace) {
-            //     RED.sidebar.info.refresh(workspace);
-            // }
-            // if (changes.hasOwnProperty('disabled')) {
-            //     RED.nodes.eachNode(function(n) {
-            //         if (n.z === workspace.id) {
-            //             n.dirty = true;
-            //         }
-            //     });
-            //     RED.view.redraw();
-            // }
+            RED.nodes.filterNodes({z:workspace.id}).forEach(n => n.dirty = true)
+            RED.view.redraw(true);
         }
     }
 


### PR DESCRIPTION
When locking/unlocking a flow, we weren't redrawing the flow to update the enabled/disabled node buttons.

This fix ensures we mark the nodes as dirty so they get redrawn in the correct state.