### PR TITLE
Show quick-add dialog when draggin wire to empty space

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1894,7 +1894,18 @@ RED.view = (function() {
                 };
                 RED.history.push(historyEvent);
                 RED.nodes.dirty(true);
+            } else {
+                // Trigger quick add dialog
+                d3.event.stopPropagation();
+                clearSelection();
+                const point = d3.mouse(this);
+                var clickedGroup = getGroupAt(point[0], point[1]);
+                if (drag_lines.length > 0) {
+                    clickedGroup = clickedGroup || RED.nodes.group(drag_lines[0].node.g)
+                }
+                showQuickAddDialog({ position: point, group: clickedGroup });
             }
+
             hideDragLines();
         }
         if (lasso) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1455,9 +1455,6 @@ RED.view = (function() {
                 // auto select dropped node - so info shows (if visible)
                 clearSelection();
                 nn.selected = true;
-                if (targetGroup) {
-                    selectGroup(targetGroup,false);
-                }
                 movingSet.add(nn);
                 updateActiveNodes();
                 updateSelection();


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

This is a rework of #3858 that had the right idea, but removed support for detaching wires. Thanks to @dreamair for proposing this feature.

When dragging a wire from a node and releasing the mouse in empty space on the canvas, it will now show the quick-add dialog.

Previously we'd only do that if you held ctrl/cmd when dragging.

This also fixes an issue where, following a quick-add of a node in a group, we were selecting the group. This was appropriate behaviour before #4079, but not now.

