### PR TITLE
Generate stable ids for subflow instance internal nodes

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
@@ -474,7 +474,7 @@ class Subflow extends Flow {
  */
 function createNodeInSubflow(subflowInstanceId, def) {
     let node = clone(def);
-    let nid = redUtil.generateId();
+    let nid = `${subflowInstanceId}-${node.id}` //redUtil.generateId();
     // console.log("Create Node In subflow",node._alias, "--->",nid, "(",node.type,")")
     // node_map[node.id] = node;
     node._alias = node.id;

--- a/packages/node_modules/@node-red/runtime/lib/nodes/context/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/context/index.js
@@ -589,17 +589,28 @@ function deleteContext(id,flowId) {
  * If flowConfig is undefined, all flow/node contexts will be removed
  **/
 function clean(flowConfig) {
-    flowConfig = flowConfig || { allNodes: {} };
-    var promises = [];
-    for(var plugin in stores){
-        if(stores.hasOwnProperty(plugin)){
-            promises.push(stores[plugin].clean(Object.keys(flowConfig.allNodes)));
-        }
+    flowConfig = flowConfig || { allNodes: {}, subflows: {} };
+    const knownNodes = new Set(Object.keys(flowConfig.allNodes))
+
+    // We need to alias all of the subflow instance contents
+    for (const subflow of Object.values(flowConfig.subflows)) {
+        subflow.instances.forEach(instance => {
+            for (const nodeId of Object.keys(subflow.nodes || {})) {
+                knownNodes.add(`${instance.id}-${nodeId}`)
+            }
+            for (const nodeId of Object.keys(subflow.configs || {})) {
+                knownNodes.add(`${instance.id}-${nodeId}`)
+            }
+        })
     }
-    for (var id in contexts) {
-        if (contexts.hasOwnProperty(id) && id !== "global") {
+    var promises = [];
+    for (const store of Object.values(stores)){
+        promises.push(store.clean(Array.from(knownNodes)));
+    }
+    for (const id of Object.keys(contexts)) {
+        if (id !== "global") {
             var idParts = id.split(":");
-            if (!flowConfig.allNodes.hasOwnProperty(idParts[0])) {
+            if (!knownNodes.has(idParts[0])) {
                 delete contexts[id];
             }
         }


### PR DESCRIPTION
Fixes #3996 #3889

This PR does two things:

1. when instantiating a subflow, rather than generate random ids for the instances, it uses `${subflowInstance.id}-{$node.id}`.
2. when clearing context of removed nodes, it now properly accounts for these subflow instance nodes so they don't get cleared away.

Item 1 will address other requests around having stable ids for nodes inside subflow instances.