### PR TITLE
Increase workspace size to 8000x8000

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-navigator.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-navigator.js
@@ -17,9 +17,9 @@
 
  RED.view.navigator = (function() {
 
-     var nav_scale = 25;
-     var nav_width = 5000/nav_scale;
-     var nav_height = 5000/nav_scale;
+     var nav_scale = 50;
+     var nav_width = 8000/nav_scale;
+     var nav_height = 8000/nav_scale;
 
      var navContainer;
      var navBox;

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -30,8 +30,8 @@
   */
 
 RED.view = (function() {
-    var space_width = 5000,
-        space_height = 5000,
+    var space_width = 8000,
+        space_height = 8000,
         lineCurveScale = 0.75,
         scaleFactor = 1,
         node_width = 100,


### PR DESCRIPTION
We occasionally get asked to increase the size of a flow canvas.

It has been 5000x5000 since the start of the project and for some users, it isn't enough.

Generally I've felt that once you're using that much space in a single flow, you have other organisational options available to better structure your flows.

One proposal was to make the workspace an infinite canvas. That is still an option, but is actually quite hard to get right.

So far the sake of a quick fix, this increases the workspace to 8000x8000 - giving 2.5x more space.

