### PR TITLE
Fix search button in palette popover

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -171,23 +171,15 @@ RED.palette = (function() {
                 }
                 metaData += type;
 
+                const safeType = type.replace(/'/g,"\\'");
+                const searchType = type.indexOf(' ') > -1 ? '&quot;' + type + '&quot;' : type
+
                 if (/^subflow:/.test(type)) {
                     $('<button type="button" onclick="RED.workspaces.show(\''+type.substring(8).replace(/'/g,"\\'")+'\'); return false;" class="red-ui-button red-ui-button-small" style="float: right; margin-left: 5px;"><i class="fa fa-pencil"></i></button>').appendTo(popOverContent)
                 }
 
-                const safeType = type.replace(/'/g,"\\'");
-                const wrapStr = function (str) {
-                    if(str.indexOf(' ') >= 0) {
-                        return '"' + str + '"'
-                    }
-                    return str
-                }
+                $('<button type="button" onclick="RED.search.show(\'type:'+searchType+'\'); return false;" class="red-ui-button red-ui-button-small" style="float: right; margin-left: 5px;"><i class="fa fa-search"></i></button>').appendTo(popOverContent)
 
-                $('<button type="button"; return false;" class="red-ui-button red-ui-button-small" style="float: right; margin-left: 5px;"><i class="fa fa-search"></i></button>')
-                    .appendTo(popOverContent)
-                    .on('click', function() {
-                        RED.search.show('type:' + wrapStr(safeType))
-                    })
                 $('<button type="button" onclick="RED.sidebar.help.show(\''+safeType+'\'); return false;" class="red-ui-button red-ui-button-small" style="float: right; margin-left: 5px;"><i class="fa fa-book"></i></button>').appendTo(popOverContent)
 
                 $('<p>',{style:"font-size: 0.8em"}).text(metaData).appendTo(popOverContent);


### PR DESCRIPTION
Reported against 3.1.0-beta.2, the search button for any given node type could only be clicked once. Subsequent clicks did nothing until the editor was reloaded.

<img width="507" alt="image" src="https://user-images.githubusercontent.com/51083/223491330-a41abdfa-5bf8-4fa8-9400-dddfc20585d9.png">

The problem is the way the popover content is managed. When the popover hides its contents is removed from the DOM. When it gets shown again, the content is reattached to the DOM.

However this removes any event handlers registered on the elements - so the button only appears to work once.

One fix would be to properly `detach` rather than `remove` the popover content.

Instead I went with making the search button consistent in its implementation with the other buttons - adding the functionality inline via an `onclick` attribute.