### PR TITLE
Fix jsonata expression test ui

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/expression.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/expression.js
@@ -294,7 +294,7 @@
                         }
 
                         try {
-                            expr.evaluate(legacyMode?{msg:parsedData}:parsedData, (err, result) => {
+                            expr.evaluate(legacyMode?{msg:parsedData}:parsedData, null, (err, result) => {
                                 if (err) {
                                     testResultEditor.setValue(RED._("expressionEditor.errors.eval",{message:err.message}),-1);
                                 } else {


### PR DESCRIPTION
Missed off an argument when updating `expr.evaluate(...)` to take a callback.