### PR TITLE
Fix group selection when using lasso

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1927,10 +1927,6 @@ RED.view = (function() {
                     // group entirely within lasso
                     if (n.x > x && n.y > y && n.x + n.w < x2 && n.y + n.h < y2) {
                         selectGroup(n, true)
-                        // n.selected = true
-                        // n.dirty = true
-                        // var groupNodes = RED.group.getNodes(n,true);
-                        // groupNodes.forEach(gn => movingSet.add(gn))
                     }
                 }
             })

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -189,7 +189,13 @@ RED.view = (function() {
                     set.unshift(...removed)
                 }
             },
-            find: function(func) { return set.find(func) }
+            find: function(func) { return set.find(func) },
+            dump: function () {
+                console.log('MovingSet Contents')
+                api.forEach((n, i) => {
+                    console.log(`${i+1}\t${n.n.id}\t${n.n.type}`)
+                })
+            }
         }
         return api;
     })();
@@ -1920,10 +1926,11 @@ RED.view = (function() {
                 if (!movingSet.has(n) && !n.selected) {
                     // group entirely within lasso
                     if (n.x > x && n.y > y && n.x + n.w < x2 && n.y + n.h < y2) {
-                        n.selected = true
-                        n.dirty = true
-                        var groupNodes = RED.group.getNodes(n,true);
-                        groupNodes.forEach(gn => movingSet.add(gn))
+                        selectGroup(n, true)
+                        // n.selected = true
+                        // n.dirty = true
+                        // var groupNodes = RED.group.getNodes(n,true);
+                        // groupNodes.forEach(gn => movingSet.add(gn))
                     }
                 }
             })


### PR DESCRIPTION
When selecting a group via the lasso, the group object wasn't being added to the `movingSet`. This mean any action on the selection (delete, cut, copy etc) would not include the group.

This fix changes how the lasso selects a group to use the same code as clicking the group uses - rather than try to reinvent the wheel.