### PR TITLE
Allow options object on each httpStatic configuration

### DIFF
--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -427,6 +427,7 @@ httpsPromise.then(function(startupHttps) {
             const sp = settings.httpStatic[si];
             const filePath = sp.path;
             const thisRoot = sp.root || "/";
+            const options = sp.options;
             if(appUseMem[filePath + "::" + thisRoot]) {
                 continue;// this path and root already registered!
             }
@@ -434,7 +435,7 @@ httpsPromise.then(function(startupHttps) {
             if (settings.httpStaticAuth) {
                 app.use(thisRoot, basicAuthMiddleware(settings.httpStaticAuth.user, settings.httpStaticAuth.pass));
             }
-            app.use(thisRoot, express.static(filePath));
+            app.use(thisRoot, express.static(filePath, options));
         }
     }
 

--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -316,10 +316,10 @@ httpsPromise.then(function(startupHttps) {
             } else {
                 continue;
             }
-            sp.subRoot = formatRoot(sp.root);
+            sp.subRoot = formatRoot(sp.root || "/");
             sp.root = formatRoot(path.posix.join(settings.httpStaticRoot,sp.subRoot));
         }
-        settings.httpStatic = sanitised.length ? sanitised : false;    
+        settings.httpStatic = sanitised.length ? sanitised : false;
     }
 
     // if we got a port from command line, use it (even if 0)

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -223,10 +223,15 @@ module.exports = {
      * to move httpAdminRoot
      */
     //httpStatic: '/home/nol/node-red-static/', //single static source
-    /* OR multiple static sources can be created using an array of objects... */
+    /**
+     *  OR multiple static sources can be created using an array of objects...
+     *  Each object can also contain an options object for further configuration.
+     *  See https://expressjs.com/en/api.html#express.static for available options.
+     */
     //httpStatic: [
     //    {path: '/home/nol/pics/',    root: "/img/"},
     //    {path: '/home/nol/reports/', root: "/doc/"},
+    //    {path: '/home/nol/videos/',  root: "/vid/", options: {maxAge: '1d'}}
     //],
 
     /**
@@ -431,7 +436,7 @@ module.exports = {
                 enabled: true
             }
         },
-        
+
     },
 
 /*******************************************************************************


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.
-->
https://discourse.nodered.org/t/settings-js-httpstatic-feature-to-pass-options-to-express-static-non-breaking/76688

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Allows an options object to be passed to express.static when using the httpStatic feature set in settings.js.
This enables customization to the various headers and other settings which can help to better integrate with a reverse proxy such as nginx. https://expressjs.com/en/api.html#express.static

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
