### PR TITLE
Ensure no node credentials are included when exporting to clipboard

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1468,7 +1468,7 @@ RED.nodes = (function() {
                 }
             }
             if (node.type !== "subflow") {
-                var convertedNode = RED.nodes.convertNode(node);
+                var convertedNode = RED.nodes.convertNode(node, { credentials: false });
                 for (var d in node._def.defaults) {
                     if (node._def.defaults[d].type) {
                         var nodeList = node[d];
@@ -1501,7 +1501,7 @@ RED.nodes = (function() {
                     nns = nns.concat(createExportableNodeSet(node.nodes, exportedIds, exportedSubflows, exportedConfigNodes));
                 }
             } else {
-                var convertedSubflow = convertSubflow(node);
+                var convertedSubflow = convertSubflow(node, { credentials: false });
                 nns.push(convertedSubflow);
             }
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -731,7 +731,7 @@ RED.clipboard = (function() {
                 nodes.unshift(parentNode);
                 nodes = RED.nodes.createExportableNodeSet(nodes);
             } else if (type === 'full') {
-                nodes = RED.nodes.createCompleteNodeSet(false);
+                nodes = RED.nodes.createCompleteNodeSet({ credentials: false });
             }
             if (nodes !== null) {
                 if (format === "red-ui-clipboard-dialog-export-fmt-full") {


### PR DESCRIPTION
For a node that has *just* been added to the editor with credentials, the editor still has its credentials in memory. If the node was exported in that state, the credentials were included.

This fix ensures credentials are never included in an export.