### PR TITLE
Use build status icon of GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 http://nodered.org
 
-[![Build Status](https://travis-ci.org/node-red/node-red.svg?branch=master)](https://travis-ci.org/node-red/node-red)
+[![Build Status](https://github.com/node-red/node-red/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/node-red/node-red/actions?query=branch%3Amaster)
 [![Coverage Status](https://coveralls.io/repos/node-red/node-red/badge.svg?branch=master)](https://coveralls.io/r/node-red/node-red?branch=master)
 
 Low-code programming for event-driven applications.


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I noticed that the build status icon of Travis CI is not available as the following screenshot.

<img width="250" alt="Screenshot 2023-04-02 at 0 53 47" src="https://user-images.githubusercontent.com/20310935/229301131-d2436fd0-1215-4da3-8e1f-bd89d5cd5b8b.png">

Based on the following document about the GitHub Actions icon and I changed it.
https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality