### PR TITLE
Http static middleware

### DIFF
--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -423,6 +423,11 @@ httpsPromise.then(function(startupHttps) {
     // }
     if (settings.httpStatic) {
         let appUseMem = {};
+        let httpStaticMiddleware = (req, res, next) => next()
+        if (typeof settings.httpStaticMiddleware === 'function' || isArray(settings.httpStaticMiddleware)) {
+          httpStaticMiddleware = settings.httpStaticMiddleware
+        }
+    
         for (let si = 0; si < settings.httpStatic.length; si++) {
             const sp = settings.httpStatic[si];
             const filePath = sp.path;
@@ -434,7 +439,7 @@ httpsPromise.then(function(startupHttps) {
             if (settings.httpStaticAuth) {
                 app.use(thisRoot, basicAuthMiddleware(settings.httpStaticAuth.user, settings.httpStaticAuth.pass));
             }
-            app.use(thisRoot, express.static(filePath));
+            app.use(thisRoot, httpStaticMiddleware, express.static(filePath));
         }
     }
 

--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -424,7 +424,7 @@ httpsPromise.then(function(startupHttps) {
     if (settings.httpStatic) {
         let appUseMem = {};
         let httpStaticMiddleware = (req, res, next) => next()
-        if (typeof settings.httpStaticMiddleware === 'function' || isArray(settings.httpStaticMiddleware)) {
+        if (typeof settings.httpStaticMiddleware === 'function' || Array.isArray(settings.httpStaticMiddleware)) {
           httpStaticMiddleware = settings.httpStaticMiddleware
         }
     

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -239,6 +239,18 @@ module.exports = {
      */
     //httpStaticRoot: '/static/',
 
+    /** The following property can be used to add a custom middleware function
+     * in front of all static files. This allows custom authentication to be
+     * applied to all http in nodes, or any other sort of common request processing.
+     * It can be a single function or an array of middleware functions.
+     */
+    // httpStaticMiddleware: [
+    //   require('compression')({ threshold: 0}),
+    //   function(req,res,next) {
+    //     // for example
+    //     next();
+    //   },
+    // ],
 /*******************************************************************************
  * Runtime Settings
  *  - lang


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)

## Proposed changes

Adds `httpStaticMiddleware` as a new optional setting that works in the same way as the existing `httpNodeMiddleware` and `httpAdminMiddleware` setting, but is applied to the HTTP Static routes.


This will allow, for example, for custom http headers to be added to all static routes.

The example in the settings file does this:
```js
httpStaticMiddleware: [
  require('compression')({ threshold: 0 }),
  function(req,res,next) {
    res.set('X-Frame-Options', 'sameorigin');
    next();
  },
],
```
which can be enable compression for all static contents and also restrict how the static iframed into other pages.


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
