### PR TITLE
Fix broken subflow icon and overflowed name in quick add dialog

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/search.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/search.scss
@@ -109,6 +109,7 @@
     .red-ui-search-result-node-label {
         color: var(--red-ui-secondary-text-color);
         width: 240px;
+        overflow-wrap: anywhere;
     }
 }
 

--- a/packages/node_modules/@node-red/editor-client/src/sass/search.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/search.scss
@@ -108,6 +108,7 @@
     }
     .red-ui-search-result-node-label {
         color: var(--red-ui-secondary-text-color);
+        width: 240px;
     }
 }
 


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Fixed #4127.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality