### PR TITLE
Fix palette filter background

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/palette.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/palette.scss
@@ -55,7 +55,7 @@
 .red-ui-palette-search {
     position: relative;
     overflow: hidden;
-    background: var(--red-ui-secondary-background);
+    background: var(--red-ui-form-input-background);
     text-align: center;
     height: 35px;
     padding: 3px;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Makes the background color of the palette's filter box match the background color of the input field inside that box.

<table>
<tr><td>Now
<td>Then
<tr><td><img width="205" alt="SCR-20230417-jrmn" src="https://user-images.githubusercontent.com/29807944/232538165-2e098a58-fd7e-4e9d-906f-e795edaff0b8.png">
<td><img width="207" alt="SCR-20230417-jszf" src="https://user-images.githubusercontent.com/29807944/232538222-9cbc58bd-2a7b-47ba-b90e-b5851a74a0cf.png">
</table>

**NOTE**: *A white background was used here to better show the issue.*

This won't have any impact on the default theme because the variable used in this PR also points to the same value - `$secondary-background`.

https://github.com/node-red/node-red/blob/master/packages/node_modules/%40node-red/editor-client/src/sass/colors.scss#L74

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
