### PR TITLE
Handle missing subflow when loading flows into the editor

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2095,16 +2095,27 @@ RED.nodes = (function() {
                     } else if (n.type.substring(0,7) === "subflow") {
                         var parentId = n.type.split(":")[1];
                         var subflow = subflow_denylist[parentId]||subflow_map[parentId]||getSubflow(parentId);
-                        if (createNewIds || options.importMap[n.id] === "copy") {
-                            parentId = subflow.id;
-                            node.type = "subflow:"+parentId;
-                            node._def = registry.getNodeType(node.type);
-                            delete node.i;
+                        if (!subflow){
+                            node._def = {
+                                color:"#fee",
+                                defaults: {},
+                                label: "unknown: "+n.type,
+                                labelStyle: "red-ui-flow-node-label-italic",
+                                outputs: n.outputs|| (n.wires && n.wires.length) || 0,
+                                set: registry.getNodeSet("node-red/unknown")
+                            }
+                        } else {
+                            if (createNewIds || options.importMap[n.id] === "copy") {
+                                parentId = subflow.id;
+                                node.type = "subflow:"+parentId;
+                                node._def = registry.getNodeType(node.type);
+                                delete node.i;
+                            }
+                            node.name = n.name;
+                            node.outputs = subflow.out.length;
+                            node.inputs = subflow.in.length;
+                            node.env = n.env;
                         }
-                        node.name = n.name;
-                        node.outputs = subflow.out.length;
-                        node.inputs = subflow.in.length;
-                        node.env = n.env;
                     } else if (n.type === 'junction') {
                          node._def = {defaults:{}}
                          node._config.x = node.x

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -45,11 +45,13 @@ RED.editor = (function() {
         var hasChanged;
         if (node.type.indexOf("subflow:")===0) {
             subflow = RED.nodes.subflow(node.type.substring(8));
-            isValid = subflow.valid;
-            hasChanged = subflow.changed;
-            if (isValid === undefined) {
-                isValid = validateNode(subflow);
+            if (subflow){
+                isValid = subflow.valid;
                 hasChanged = subflow.changed;
+                if (isValid === undefined) {
+                    isValid = validateNode(subflow);
+                    hasChanged = subflow.changed;
+                }
             }
             validationErrors = validateNodeProperties(node, node._def.defaults, node);
             node.valid = isValid && validationErrors.length === 0;

--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -199,7 +199,9 @@ function parseConfig(config) {
                if (subflowDetails) {
                    var subflowType = subflowDetails[1]
                    n.subflow = subflowType;
-                   if (flow.subflows[subflowType]) flow.subflows[subflowType].instances.push(n)
+                   if (flow.subflows[subflowType]) {
+                       flow.subflows[subflowType].instances.push(n)
+                   }
                }
                if (container) {
                    container.nodes[n.id] = n;

--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -199,7 +199,7 @@ function parseConfig(config) {
                if (subflowDetails) {
                    var subflowType = subflowDetails[1]
                    n.subflow = subflowType;
-                   flow.subflows[subflowType].instances.push(n)
+                   if (flow.subflows[subflowType]) flow.subflows[subflowType].instances.push(n)
                }
                if (container) {
                    container.nodes[n.id] = n;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
In our application we use our own storage plugin to save the flows in a database.
Due to this way of saving data we sometimes run in the problem that the flows are retrieved without including the subflow.
This results in node-red not starting / opening at all without displaying an error.

The following changes result in node-red being able to open and display the subflow as a missing flow type
![image](https://user-images.githubusercontent.com/26113706/233963922-4c6a0812-ef8e-45b7-b766-9370699c8fac.png)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
