### PR TITLE
Use editor path in generating localStorage keys

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/settings.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/settings.js
@@ -100,7 +100,7 @@ RED.settings = (function () {
     var init = function (options, done) {
         var accessTokenMatch = /[?&]access_token=(.*?)(?:$|&)/.exec(window.location.search);
         var path=window.location.pathname.slice(0,-1);
-        RED.settings.authTokensSuffix=path.replaceAll('/', '-');
+        RED.settings.authTokensSuffix=path.replace(/\//g, '-');
         if (accessTokenMatch) {
             var accessToken = accessTokenMatch[1];
             RED.settings.set("auth-tokens",{access_token: accessToken});

--- a/packages/node_modules/@node-red/editor-client/src/js/settings.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/settings.js
@@ -33,8 +33,8 @@ RED.settings = (function () {
         if (!hasLocalStorage()) {
             return;
         }
-        if (key === "auth-tokens") {
-            localStorage.setItem(key, JSON.stringify(value));
+        if (key.startsWith("auth-tokens")) {
+            localStorage.setItem(key+this.authTokensSuffix, JSON.stringify(value));
         } else {
             RED.utils.setMessageProperty(userSettings,key,value);
             saveUserSettings();
@@ -52,8 +52,8 @@ RED.settings = (function () {
         if (!hasLocalStorage()) {
             return undefined;
         }
-        if (key === "auth-tokens") {
-            return JSON.parse(localStorage.getItem(key));
+        if (key.startsWith("auth-tokens")) {
+            return JSON.parse(localStorage.getItem(key+this.authTokensSuffix));
         } else {
             var v;
             try { v = RED.utils.getMessageProperty(userSettings,key); } catch(err) {}
@@ -71,8 +71,8 @@ RED.settings = (function () {
         if (!hasLocalStorage()) {
             return;
         }
-        if (key === "auth-tokens") {
-            localStorage.removeItem(key);
+        if (key.startsWith("auth-tokens")) {
+            localStorage.removeItem(key+this.authTokensSuffix);
         } else {
             delete userSettings[key];
             saveUserSettings();
@@ -99,6 +99,8 @@ RED.settings = (function () {
 
     var init = function (options, done) {
         var accessTokenMatch = /[?&]access_token=(.*?)(?:$|&)/.exec(window.location.search);
+        var path=window.location.pathname.slice(0,-1);
+        RED.settings.authTokensSuffix=path.replaceAll('/', '-');
         if (accessTokenMatch) {
             var accessToken = accessTokenMatch[1];
             RED.settings.set("auth-tokens",{access_token: accessToken});


### PR DESCRIPTION

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

The approach reads the path from window.location in RED.settings.init(), removes the last character, replaces "/" with "-" and stores it a authTokensSuffix property. Whenever the key auth-tokens is read, set or removed this suffix is added to the localStorage key. This results i no api-changes and no changes when the editor runs in the root path and you may run as much instances as you like on a single host name.

The only, from my perspective minor, point of discussion is the the behavior, that the hole auth-tokens* "Namespace" for setting-keys gets "magic" while currently only the key auth-tokens itself has special meaning. I don't see a security issue because the sessions are initiated from the same operating system user, on the same browser, on the same computer. And as logout is still working as expected, it truly has to be the same person - so nothing is leaked when reviewing the localStorage.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
