### PR TITLE
Remove coveralls reporting as it is failing builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Run tests
       run: |
         npm run test
-    - name: Publish to coveralls.io
-      if: ${{ matrix.node-version == 14 }}
-      uses: coverallsapp/github-action@v1.1.2
-      with:
-        github-token: ${{ github.token }}
+    # - name: Publish to coveralls.io
+    #   if: ${{ matrix.node-version == 14 }}
+    #   uses: coverallsapp/github-action@v1.1.2
+    #   with:
+    #     github-token: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 http://nodered.org
 
 [![Build Status](https://github.com/node-red/node-red/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/node-red/node-red/actions?query=branch%3Amaster)
-[![Coverage Status](https://coveralls.io/repos/node-red/node-red/badge.svg?branch=master)](https://coveralls.io/r/node-red/node-red?branch=master)
 
 Low-code programming for event-driven applications.
 


### PR DESCRIPTION
Coveralls reporting is failing across all builds at the moment.

This removes that step from the build. Will revisit in the future.