### PR TITLE
Avoid creating empty global-config node if not needed

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/env-var.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/env-var.js
@@ -50,7 +50,11 @@ RED.envVar = (function() {
         var new_env = [];
         var items = list.editableList('items');
         var credentials = gconf ? gconf.credentials : null;
-
+        if (!gconf && list.editableList('length') === 0) {
+            // No existing global-config node and nothing in the list,
+            // so no need to do anything more
+            return
+        }
         if (!credentials) {
             credentials = {
                 _ : {},
@@ -77,6 +81,12 @@ RED.envVar = (function() {
         });
         if (gconf === null) {
             gconf = getGlobalConf(true);
+        }
+        if (!gconf.credentials) {
+            gconf.credentials = {
+                _ : {},
+                map: {}
+            };
         }
         if ((JSON.stringify(new_env) !== JSON.stringify(gconf.env)) ||
             (JSON.stringify(credentials) !== JSON.stringify(gconf.credentials))) {


### PR DESCRIPTION
The current code would create a `global-config` node whenever the settings dialog is closed, even if there was nothing to save in it. This cause the deploy button to become active unexpectedly.

This skips creating the config node if there's nothing to store in it.