### PR TITLE
Add editor scope to keyboard shortcut scope select

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -491,6 +491,7 @@
         "unassigned": "Unassigned",
         "global": "global",
         "workspace": "workspace",
+        "editor": "edit dialog",
         "selectAll": "Select all",
         "selectNone": "Select none",
         "selectAllConnected": "Select connected",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/keyboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/keyboard.js
@@ -491,7 +491,11 @@ RED.keyboard = (function() {
                 okButton.attr("disabled",!valid);
             });
 
-            var scopeSelect = $('<select><option value="*" data-i18n="keyboard.global"></option><option value="red-ui-workspace" data-i18n="keyboard.workspace"></option></select>').appendTo(scope);
+            var scopeSelect = $('<select>'+
+                '<option value="*" data-i18n="keyboard.global"></option>'+
+                '<option value="red-ui-workspace" data-i18n="keyboard.workspace"></option>'+
+                '<option value="red-ui-editor-stack" data-i18n="keyboard.editor"></option>'+
+                '</select>').appendTo(scope);
             scopeSelect.i18n();
             if (object.scope === "workspace") {
                 object.scope = "red-ui-workspace";


### PR DESCRIPTION
Fixes #4140 

The keyboard shortcut dialog doesn't provide all of the available 'scopes' when setting custom keyboard shortcuts.

This makes it impossible to add a shortcut scoped to just the edit dialog - something that *can* be done via keymap.json as it can specify any scope it wants.

This PR adds 'edit dialog' as an option when setting the shortcut scope:

<img width="577" alt="image" src="https://user-images.githubusercontent.com/51083/235206922-683018ff-0cf2-4dde-80e4-aaf8eced8df3.png">

This then allows 'escape' to be set as the shortcut for closing the tray, without it clashing with the existing predefined escape handler for clearing the selection within the workspace.