### PR TITLE
Dont use `subscriptionIdentifier` if broker doesnt support it

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -697,7 +697,8 @@ module.exports = function(RED) {
                 node.options.rejectUnauthorized = (node.verifyservercert == "true" || node.verifyservercert === true);
             }
         }
-
+        node.v5 = () => node.options && node.options.protocolVersion == 5
+        node.subscriptionIdentifiersAvailable = () => node.v5() && node.serverProperties && node.serverProperties.subscriptionIdentifiersAvailable
         n.autoConnect = n.autoConnect === "false" || n.autoConnect === false ? false : true;
         node.setOptions(n, true);
 
@@ -920,7 +921,12 @@ module.exports = function(RED) {
             };
             node.subscriptions[topic][ref] = sub;
             if (node.connected) {
+                const subIdsAvailable = node.subscriptionIdentifiersAvailable()
                 node._clientOn('message',sub.handler);
+                // if the broker doesn't support subscription identifiers (e.g. AWS core), then don't send them
+                if (options.properties && options.properties.subscriptionIdentifier && subIdsAvailable !== true) {
+                    delete options.properties.subscriptionIdentifier
+                }
                 node.client.subscribe(topic, options);
             }
         };


### PR DESCRIPTION

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

Prevent `subscriptionIdentifier` v5 property being included in subscription if the broker has stated it does not support it.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
