### PR TITLE
Add Japanese translation for keyboard shortcut scope

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -491,6 +491,7 @@
         "unassigned": "未割当",
         "global": "グローバル",
         "workspace": "ワークスペース",
+        "editor": "編集ダイアログ",
         "selectAll": "全てのノードを選択",
         "selectNone": "選択を外す",
         "selectAllConnected": "接続されたノードを選択",


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I added a Japanese translation for the update, https://github.com/node-red/node-red/pull/4154.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality