### PR TITLE
Remove junctions from parent group when deleting

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -2646,6 +2646,16 @@ RED.view = (function() {
                         var result = RED.nodes.removeJunction(node)
                         removedJunctions.push(node);
                         removedLinks = removedLinks.concat(result.links);
+                        if (node.g) {
+                            var group = RED.nodes.group(node.g);
+                            if (selectedGroups.indexOf(group) === -1) {
+                                // Don't use RED.group.removeFromGroup as that emits
+                                // a change event on the node - but we're deleting it
+                                var index = group.nodes.indexOf(node);
+                                group.nodes.splice(index,1);
+                                RED.group.markDirty(group);
+                            }
+                        }
                     } else {
                         if (node.direction === "out") {
                             removedSubflowOutputs.push(node);


### PR DESCRIPTION
Remove junction from groups node list if it is present.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Resolves Issue "Deleted junctions reappear on copy/paste #4164"

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
