### PR TITLE
Invalid JSONata Inject node test passing condition

### DIFF
--- a/test/nodes/core/common/20-inject_spec.js
+++ b/test/nodes/core/common/20-inject_spec.js
@@ -854,7 +854,7 @@ describe('inject node', function() {
             });
             n1.on("call:error", function(err) {
                 count++;
-                if (count == 2) {
+                if (count == 1) {
                     done();
                 }
             });


### PR DESCRIPTION
This test would sometimes run twice, causing the author to increase its catch count to 2 before considering the test complete. However even one pass proves the node is behaving as expected, and it always runs at least once. I have left the conditional statement in so it can be changed in future.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

At least since October last year, this unit test has caused many PRs to be flagged as failing where most of their commits have nothing to do with the Inject node. This resolves the issue caused by this test and causes it to pass - since the Inject node does exhibit the correct behavior. The test did not accurately reflect this.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
