### PR TITLE
Remove version info from theme endpoint

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -27,8 +27,7 @@ var defaultContext = {
         tabicon: {
             icon: "red/images/node-red-icon-black.svg",
             colour: "#8f0000"
-        },
-        version: require(path.join(__dirname,"../../package.json")).version
+        }
     },
     header: {
         title: "Node-RED",


### PR DESCRIPTION
Fixes #4170

This removes the Node-RED version from the `/theme` endpoint.

This endpoint is unsecured, so provides this information to all visitors to the page.

The same information is also available under the `/settings` endpoint - which is only accessible to logged-in users.

I can find nothing that uses `RED.settings.theme('version')` in the core of Node-RED, so I don't see a good reason to keep it there.