### PR TITLE
Ensure non-zero exit codes for errors

### DIFF
--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -148,7 +148,7 @@ try {
     } else {
         console.log(err);
     }
-    process.exit();
+    process.exit(1);
 }
 
 if (parsedArgs.define) {
@@ -182,7 +182,7 @@ if (parsedArgs.define) {
         }
     } catch (e) {
         console.log("Error processing -D option: "+e.message);
-        process.exit();
+        process.exit(1);
     }
 }
 


### PR DESCRIPTION
Fixes #4122 

There were two cases where we would `process.exit()` due to an error but not specify a non-zero exit code.