### PR TITLE
Combine existing env vars when merging groups

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
@@ -401,7 +401,7 @@ RED.group = (function() {
                 }
             }
             var existingGroup;
-
+            var mergedEnv = {}
             // Second pass, ungroup any groups in the selection and add their contents
             // to the selection
             for (var i=0; i<selection.nodes.length; i++) {
@@ -409,6 +409,11 @@ RED.group = (function() {
                 if (n.type === "group") {
                     if (!existingGroup) {
                         existingGroup = n;
+                    }
+                    if (n.env && n.env.length > 0) {
+                        n.env.forEach(env => {
+                            mergedEnv[env.name] = env
+                        })
                     }
                     ungroupHistoryEvent.groups.push(n);
                     nodes = nodes.concat(ungroup(n));
@@ -427,6 +432,7 @@ RED.group = (function() {
                     group.style = existingGroup.style;
                     group.name = existingGroup.name;
                 }
+                group.env = Object.values(mergedEnv)
                 RED.view.select({nodes:[group]})
             }
             historyEvent.events.push({

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -232,6 +232,63 @@ RED.view = (function() {
         return api
     })();
 
+    const selectedGroups = (function() {
+        let groups = new Set()
+        const api = {
+            add: function(g, includeNodes, addToMovingSet) {
+                groups.add(g)
+                if (!g.selected) {
+                    g.selected = true;
+                    g.dirty = true;
+                }
+                if (addToMovingSet !== false) {
+                    movingSet.add(g);
+                }
+                if (includeNodes) {
+                    var currentSet = new Set(movingSet.nodes());
+                    var allNodes = RED.group.getNodes(g,true);
+                    allNodes.forEach(function(n) {
+                        if (!currentSet.has(n)) {
+                            movingSet.add(n)
+                        }
+                        n.dirty = true;
+                    })
+                }
+                selectedLinks.clearUnselected()
+            },
+            remove: function(g) {
+                groups.delete(g)
+                if (g.selected) {
+                    g.selected = false;
+                    g.dirty = true;
+                }
+                const allNodes = RED.group.getNodes(g,true);
+                const nodeSet = new Set(allNodes);
+                nodeSet.add(g);
+                for (let i = movingSet.length()-1; i >= 0; i -= 1) {
+                    const msn = movingSet.get(i);
+                    if (nodeSet.has(msn.n) || msn.n === g) {
+                        msn.n.selected = false;
+                        msn.n.dirty = true;
+                        movingSet.remove(msn.n,i)
+                    }
+                }
+                selectedLinks.clearUnselected()
+            },
+            length: () => groups.length,
+            forEach: (func) => { groups.forEach(func) },
+            toArray: () => [...groups],
+            clear: function () {
+                groups.forEach(g => {
+                    g.selected = false
+                    g.dirty = true
+                })
+                groups.clear()
+            }
+        }
+        return api
+    })()
+
 
     function init() {
 
@@ -1136,7 +1193,7 @@ RED.view = (function() {
         var touchTrigger = options.touchTrigger;
 
         if (targetGroup) {
-            selectGroup(targetGroup,false);
+            selectedGroups.add(targetGroup,false);
             RED.view.redraw();
         }
 
@@ -1462,7 +1519,7 @@ RED.view = (function() {
                 clearSelection();
                 nn.selected = true;
                 if (targetGroup) {
-                    selectGroup(targetGroup,false);
+                    selectedGroups.add(targetGroup,false);
                 }
                 movingSet.add(nn);
                 updateActiveNodes();
@@ -1926,7 +1983,7 @@ RED.view = (function() {
                 if (!movingSet.has(n) && !n.selected) {
                     // group entirely within lasso
                     if (n.x > x && n.y > y && n.x + n.w < x2 && n.y + n.h < y2) {
-                        selectGroup(n, true)
+                        selectedGroups.add(n, true)
                     }
                 }
             })
@@ -2276,7 +2333,7 @@ RED.view = (function() {
         clearSelection();
         activeGroups.forEach(function(g) {
             if (!g.g) {
-                selectGroup(g, true);
+                selectedGroups.add(g, true);
                 if (!g.selected) {
                     g.selected = true;
                     g.dirty = true;
@@ -2346,10 +2403,7 @@ RED.view = (function() {
         }
         movingSet.clear();
         selectedLinks.clear();
-        activeGroups.forEach(function(g) {
-            g.selected = false;
-            g.dirty = true;
-        })
+        selectedGroups.clear();
     }
 
     var lastSelection = null;
@@ -3438,7 +3492,7 @@ RED.view = (function() {
             if (!groupNodeSelectPrimed && !d.selected && d.g && RED.nodes.group(d.g).selected) {
                 clearSelection();
 
-                selectGroup(RED.nodes.group(d.g), false);
+                selectedGroups.add(RED.nodes.group(d.g), false);
 
                 mousedown_node.selected = true;
                 movingSet.add(mousedown_node);
@@ -3859,14 +3913,14 @@ RED.view = (function() {
         lastClickNode = g;
 
         if (g.selected && (d3.event.ctrlKey||d3.event.metaKey)) {
-            deselectGroup(g);
+            selectedGroups.remove(g);
             d3.event.stopPropagation();
         } else {
             if (!g.selected) {
                 if (!d3.event.ctrlKey && !d3.event.metaKey) {
                     clearSelection();
                 }
-                selectGroup(g,true);//!wasSelected);
+                selectedGroups.add(g,true);//!wasSelected);
             }
 
             if (d3.event.button != 2) {
@@ -3882,45 +3936,6 @@ RED.view = (function() {
         d3.event.stopPropagation();
     }
 
-    function selectGroup(g, includeNodes, addToMovingSet) {
-        if (!g.selected) {
-            g.selected = true;
-            g.dirty = true;
-        }
-        if (addToMovingSet !== false) {
-            movingSet.add(g);
-        }
-        if (includeNodes) {
-            var currentSet = new Set(movingSet.nodes());
-            var allNodes = RED.group.getNodes(g,true);
-            allNodes.forEach(function(n) {
-                if (!currentSet.has(n)) {
-                    movingSet.add(n)
-                }
-                n.dirty = true;
-            })
-        }
-        selectedLinks.clearUnselected()
-    }
-
-    function deselectGroup(g) {
-        if (g.selected) {
-            g.selected = false;
-            g.dirty = true;
-        }
-        const allNodes = RED.group.getNodes(g,true);
-        const nodeSet = new Set(allNodes);
-        nodeSet.add(g);
-        for (let i = movingSet.length()-1; i >= 0; i -= 1) {
-            const msn = movingSet.get(i);
-            if (nodeSet.has(msn.n) || msn.n === g) {
-                msn.n.selected = false;
-                msn.n.dirty = true;
-                movingSet.remove(msn.n,i)
-            }
-        }
-        selectedLinks.clearUnselected()
-    }
     function getGroupAt(x, y, ignoreSelected) {
         // x,y expected to be in node-co-ordinate space
         var candidateGroups = {};
@@ -5901,11 +5916,10 @@ RED.view = (function() {
         if (movingSet.length() > 0) {
             movingSet.forEach(function(n) {
                 if (n.n.type !== 'group') {
-                allNodes.add(n.n);
+                    allNodes.add(n.n);
                 }
             });
         }
-        var selectedGroups = activeGroups.filter(function(g) { return g.selected });
         selectedGroups.forEach(function(g) {
             var groupNodes = RED.group.getNodes(g,true);
             groupNodes.forEach(function(n) {
@@ -6114,7 +6128,7 @@ RED.view = (function() {
                                 n.dirty = true;
                                 movingSet.add(n);
                             } else {
-                                selectGroup(n,true);
+                                selectedGroups.add(n,true);
                             }
                         })
                     }


### PR DESCRIPTION
Closes #4101

This ensures that when two groups are merged (using the `core:merge-selection-to-group`), any existing env vars on those groups are maintained.

Whilst testing the initial fix I realised you couldn't control which group was considered the primary group from which any existing style is taken. It would always use the oldest group.

This PR fixes that as well by changing how group selection is tracked; keeping an ordered list of selected groups so we know which was selected first.