### PR TITLE
Place subflow outputs/inputs relative to current view

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -46,7 +46,9 @@ RED.subflow = (function() {
         '</script>';
 
     function findAvailableSubflowIOPosition(subflow,isInput) {
-        var pos = {x:50,y:30};
+        const scrollPos = RED.view.scroll()
+        const scaleFactor = RED.view.scale()
+        var pos = { x: (scrollPos[0]/scaleFactor)+50, y: (scrollPos[1]/scaleFactor)+30 };
         if (!isInput) {
             pos.x += 110;
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4359,6 +4359,7 @@ RED.view = (function() {
                             this.__port__.setAttribute("transform","translate(-5,"+((d.h/2)-5)+")");
                             this.__outputOutput__.setAttribute("transform","translate(20,"+((d.h/2)-8)+")");
                             this.__outputNumber__.setAttribute("transform","translate(20,"+((d.h/2)+7)+")");
+                            this.__outputNumber__.textContent = d.i+1;
                         }
                         d.dirty = false;
                     }
@@ -6282,8 +6283,12 @@ RED.view = (function() {
             })
         },
         scroll: function(x,y) {
-            chart.scrollLeft(chart.scrollLeft()+x);
-            chart.scrollTop(chart.scrollTop()+y)
+            if (x !== undefined && y !== undefined) {
+                chart.scrollLeft(chart.scrollLeft()+x);
+                chart.scrollTop(chart.scrollTop()+y)
+            } else {
+                return [chart.scrollLeft(), chart.scrollTop()]
+            }
         },
         clickNodeButton: function(n) {
             if (n._def.button) {


### PR DESCRIPTION
Fixes #4111

When adding a new subflow input/output, the virtual node is now placed relative to the current view, rather than in the top left corner. This takes into account both scroll position and scale factor.

Also fixes the renumbering of output ports when one is deleted.