### PR TITLE
Enable RED.view.select to select group by id

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -274,7 +274,7 @@ var RED = (function() {
                                 if (nodeToShow) {
                                     RED.view.reveal(nodeToShow.id)
                                     window.location.hash = currentHash
-                                    RED.view.select({ nodes: [nodeToShow] })
+                                    RED.view.select(nodeToShow.id)
                                     if (showEditDialog) {
                                         RED.editor.editGroup(nodeToShow)
                                     }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -6114,6 +6114,13 @@ RED.view = (function() {
                         selectedNode.dirty = true;
                         movingSet.clear();
                         movingSet.add(selectedNode);
+                    } else {
+                        selectedNode = RED.nodes.group(selection);
+                        if (selectedNode) {
+                            movingSet.clear();
+                            selectedGroups.clear()
+                            selectedGroups.add(selectedNode)
+                        }
                     }
                 } else if (selection) {
                     if (selection.nodes) {


### PR DESCRIPTION
Extends #4113 to tidy up the `RED.view.select` api to allow group selection by id.