### PR TITLE
Dont clone the group nodes `node` array when saving edits

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -720,7 +720,10 @@ RED.editor = (function() {
                     if (typeof editing_node[d] === "string" || typeof editing_node[d] === "number") {
                         oldValues[d] = editing_node[d];
                     } else {
-                        oldValues[d] = $.extend(true,{},{v:editing_node[d]}).v;
+                        // Dont clone the group node `nodes` array
+                        if (editing_node.type !== 'group' || d !== "nodes") {
+                            oldValues[d] = $.extend(true,{},{v:editing_node[d]}).v;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
fixes #4198
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Skip cloning the nodes array of a group node since they cannot be changed by the edit dialog and the nodes array is not used in the below comparison to determine if the node has changed anyway.

And while this fixes the stack overflow, I wam unsure why the demo flow presented in the issue causes this while other group nodes are fine.

I did chek the nodes object for any circular refrences but didnt spot them!

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
