### PR TITLE
Dont handle shortcuts with both cmd+ctrl modifiers 

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/keyboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/keyboard.js
@@ -249,7 +249,10 @@ RED.keyboard = (function() {
         // One exception is shortcuts that include both Cmd and Ctrl. We don't
         // support them - but we need to make sure we don't block browser-specific
         // shortcuts (such as Cmd-Ctrl-F for fullscreen).
-        if ((evt.ctrlKey || evt.metaKey) && (evt.ctrlKey !== evt.metaKey)) {
+        if (evt.ctrlKey && evt.metaKey) {
+            return null; // dont handle both cmd+ctrl - let browser handle this
+        }
+        if (evt.ctrlKey || evt.metaKey) {
             slot = slot.ctrl;
         }
         if (slot && evt.shiftKey) {


### PR DESCRIPTION


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

In function `resolveKeyEvent`, return `null`  immediately if both modifiers are pressed - allowing the browser to handle the shortcut.

This permits mac shortcuts like full screen CMD+CTRL+F to operate correctly.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
