### PR TITLE
Fix connection keep-alive in http request node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
@@ -23,6 +23,8 @@ module.exports = async function(RED) {
     const { v4: uuid } = require('uuid');
     const crypto = require('crypto');
     const URL = require("url").URL
+    const http = require("http")
+    const https = require("https")
     var mustache = require("mustache");
     var querystring = require("querystring");
     var cookie = require("cookie");
@@ -65,16 +67,27 @@ in your Node-RED user directory (${RED.settings.userDir}).
     function HTTPRequest(n) {
         RED.nodes.createNode(this,n);
         checkNodeAgentPatch();
-        var node = this;
-        var nodeUrl = n.url;
-        var isTemplatedUrl = (nodeUrl||"").indexOf("{{") != -1;
-        var nodeMethod = n.method || "GET";
-        var paytoqs = false;
-        var paytobody = false;
-        var redirectList = [];
-        var sendErrorsToCatch = n.senderr;
+        const node = this;
+        const nodeUrl = n.url;
+        const isTemplatedUrl = (nodeUrl||"").indexOf("{{") != -1;
+        const nodeMethod = n.method || "GET";
+        let paytoqs = false;
+        let paytobody = false;
+        let redirectList = [];
+        const sendErrorsToCatch = n.senderr;
         node.headers = n.headers || [];
-        var nodeHTTPPersistent = n["persist"];
+        const useKeepAlive = n["persist"];
+        let agents = null
+        if (useKeepAlive) {
+            agents = {
+                http: new http.Agent({ keepAlive: true }),
+                https: new https.Agent({ keepAlive: true })
+            }
+            node.on('close', function () {
+                agents.http.destroy()
+                agents.https.destroy()
+            })
+        }
         if (n.tls) {
             var tlsNode = RED.nodes.getNode(n.tls);
         }
@@ -560,11 +573,13 @@ in your Node-RED user directory (${RED.settings.userDir}).
                     opts.agent = {
                         http: new HttpProxyAgent(proxyOptions),
                         https: new HttpsProxyAgent(proxyOptions)
-                    };
-
+                    }
                 } else {
                     node.warn("Bad proxy url: "+ prox);
                 }
+            }
+            if (useKeepAlive && !opts.agent) {
+                opts.agent = agents
             }
             if (tlsNode) {
                 opts.https = {};


### PR DESCRIPTION
Keep-Alive handling was broken when we moved to `got`. This fixes it. Need to apply custom http/https agents with the keepAlive flag set (`request` used to take care of that for you).