### PR TITLE
Add support for httpStatic middleware

### DIFF
--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -302,7 +302,7 @@ httpsPromise.then(function(startupHttps) {
         settings.httpNodeAuth = settings.httpNodeAuth || settings.httpAuth;
     }
 
-    if(settings.httpStatic) {
+    if (settings.httpStatic) {
         settings.httpStaticRoot = formatRoot(settings.httpStaticRoot || "/");
         const statics = Array.isArray(settings.httpStatic) ? settings.httpStatic : [settings.httpStatic];
         const sanitised = [];
@@ -414,13 +414,7 @@ httpsPromise.then(function(startupHttps) {
     if (settings.httpNodeRoot !== false) {
         app.use(settings.httpNodeRoot,RED.httpNode);
     }
-    // if (settings.httpStatic) {
-    //     settings.httpStaticAuth = settings.httpStaticAuth || settings.httpAuth;
-    //     if (settings.httpStaticAuth) {
-    //         app.use("/",basicAuthMiddleware(settings.httpStaticAuth.user,settings.httpStaticAuth.pass));
-    //     }
-    //     app.use("/",express.static(settings.httpStatic));
-    // }
+
     if (settings.httpStatic) {
         let appUseMem = {};
         for (let si = 0; si < settings.httpStatic.length; si++) {
@@ -428,12 +422,16 @@ httpsPromise.then(function(startupHttps) {
             const filePath = sp.path;
             const thisRoot = sp.root || "/";
             const options = sp.options;
+            const middleware = sp.middleware;
             if(appUseMem[filePath + "::" + thisRoot]) {
                 continue;// this path and root already registered!
             }
             appUseMem[filePath + "::" + thisRoot] = true;
             if (settings.httpStaticAuth) {
                 app.use(thisRoot, basicAuthMiddleware(settings.httpStaticAuth.user, settings.httpStaticAuth.pass));
+            }
+            if (middleware) {
+                app.use(thisRoot, middleware)
             }
             app.use(thisRoot, express.static(filePath, options));
         }


### PR DESCRIPTION
- [x] New feature (non-breaking change which adds functionality)

This is an alternative proposal to #4125 that appears to have stalled.

Rather than add `httpStaticMiddleware` as a top level property, this follows the lead of #4109 to support a `middleware` property on the `httpStatic` object:

```
httpStatic: [
    {
            path: '/opt/static/',
            root: '/private/',
            middleware: myCustomHttpMiddleware
    }
]
```