### PR TITLE
adding functionTimeout to settings

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.html
@@ -360,6 +360,10 @@
             name: {value:"_DEFAULT_"},
             func: {value:"\nreturn msg;"},
             outputs: {value:1},
+<<<<<<< Updated upstream
+=======
+            timeout:{value:RED.settings.functionTimeout},
+>>>>>>> Stashed changes
             noerr: {value:0,required:true,
                     validate: function(v, opt) {
                         if (!v) {

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -503,7 +503,8 @@ module.exports = function(RED) {
     RED.nodes.registerType("function",FunctionNode, {
         dynamicModuleList: "libs",
         settings: {
-            functionExternalModules: { value: true, exportable: true }
+            functionExternalModules: { value: true, exportable: true },
+            functionTimeout: { value:0, exportable: true }
         }
     });
     RED.library.register("functions");

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -454,6 +454,9 @@ module.exports = {
     /** Allow the Function node to load additional npm modules directly */
     functionExternalModules: true,
 
+    /** a default timeout for function node VM*/
+    functionTimeout:30,
+
     /** The following property can be used to set predefined values in Global Context.
      * This allows extra node modules to be made available with in Function node.
      * For example, the following:
@@ -464,6 +467,8 @@ module.exports = {
     functionGlobalContext: {
         // os:require('os'),
     },
+
+    
 
     /** The maximum number of messages nodes will buffer internally as part of their
      * operation. This applies across a range of nodes that operate on message sequences.

--- a/test/nodes/core/function/10-function_spec.js
+++ b/test/nodes/core/function/10-function_spec.js
@@ -1426,6 +1426,33 @@ describe('function node', function() {
 
 
 
+    it('check if default function settings grab', function(done) {
+        RED.seetings.functionTimeout = 0.01;
+        var flow = [{id:"n1",type:"function",wires:[["n2"]],func:"while(1==1){};\nreturn msg;"}];
+        helper.load(functionNode, flow, function() {
+            var n1 = helper.getNode("n1");
+            n1.receive({payload:"foo",topic: "bar"});
+            setTimeout(function() {
+                try {
+                    helper.log().called.should.be.true();
+                    var logEvents = helper.log().args.filter(function(evt) {
+                        return evt[0].type == "function";
+                    });
+                    logEvents.should.have.length(1);
+                    var msg = logEvents[0][0];
+                    msg.should.have.property('level', helper.log().ERROR);
+                    msg.should.have.property('id', 'n1');
+                    msg.should.have.property('type', 'function');
+                    should.equal(msg.msg.message, 'Script execution timed out after 10ms');
+                    delete RED.settings.functionExternalModules;
+                    done();
+                } catch(err) {
+                    done(err);
+                }
+            },50);
+        });
+    });
+
     describe("finalize function", function() {
 
         it('should execute', function(done) {


### PR DESCRIPTION
adding functionTimeout to settings

- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

adding a default timeout for funciton nodes in settings file

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass => does not work in dev atm => see bug:
Running "nyc:nodes" (nyc) task
node:internal/modules/cjs/loader:1305
      throw err;
      ^

Error [ERR_REQUIRE_ESM]: require() of ES Module C:\Users\kh\Documents\GitHub\node-red\packages\node_modules\node-red\node_modules\@babel\runtime\helpers\esm\applyDecoratedDescriptor.js not supported.
Instead change the require of applyDecoratedDescriptor.js in null to a dynamic import() which is available in all CommonJS modules.
    at NYC._readTranspiledSource (C:\Users\kh\Documents\GitHub\node-red\node_modules\nyc\index.js:156:28)
    at NYC.addFile (C:\Users\kh\Documents\GitHub\node-red\node_modules\nyc\index.js:146:25)
    at C:\Users\kh\Documents\GitHub\node-red\node_modules\nyc\index.js:170:12
    at Array.forEach (<anonymous>)
    at NYC.addAllFiles (C:\Users\kh\Documents\GitHub\node-red\node_modules\nyc\index.js:168:37)
    at Object.<anonymous> (C:\Users\kh\Documents\GitHub\node-red\node_modules\nyc\bin\nyc.js:37:21) {
  code: 'ERR_REQUIRE_ESM'
}

- [x] I have added suitable unit tests to cover the new/changed functionality
