### PR TITLE
help: Template might be a better fit to create multiline strings

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/en-US/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/common/20-inject.html
@@ -36,5 +36,5 @@ greater than one day you should consider using a scheduler node that can cope wi
 <p><b>Note</b>: The <i>"Interval between times"</i> and <i>"at a specific time"</i> options use the standard cron system.
 This means that 20 minutes will be at the next hour, 20 minutes past and 40 minutes past - not in 20 minutes time.
 If you want every 20 minutes from now - use the <i>"interval"</i> option.</p>
-<p><b>Note</b>: To include a newline in a string you must use a Function node to create the payload.</p>
+<p><b>Note</b>: To include a newline in a string you must use the Function or Template node to create the payload.</p>
 </script>


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Proposed changes

The inject node doesn't create multiline strings as the help text explains. While there's indeed many ways to circumvent this, the Template node might be more "low-code" than the function node is.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
