### PR TITLE
Fix broken text input in the switch node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.html
@@ -103,6 +103,11 @@
             } else if (type === "istype") {
                 r.v = rule.find(".node-input-rule-type-value").typedInput('type');
                 r.vt = rule.find(".node-input-rule-type-value").typedInput('type');
+                if (r.vt === "number") {
+                    r.vt = "num";
+                } else {
+                    r.vt = "str";
+                }
             } else if (type === "jsonata_exp") {
                 r.v = rule.find(".node-input-rule-exp-value").typedInput('value');
                 r.vt = rule.find(".node-input-rule-exp-value").typedInput('type');

--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.html
@@ -103,11 +103,7 @@
             } else if (type === "istype") {
                 r.v = rule.find(".node-input-rule-type-value").typedInput('type');
                 r.vt = rule.find(".node-input-rule-type-value").typedInput('type');
-                if (r.vt === "number") {
-                    r.vt = "num";
-                } else {
-                    r.vt = "str";
-                }
+                r.vt = (r.vt === "number") ? "num" : "str";
             } else if (type === "jsonata_exp") {
                 r.v = rule.find(".node-input-rule-exp-value").typedInput('value');
                 r.vt = rule.find(".node-input-rule-exp-value").typedInput('type');


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Fixed #4241. In the switch node, the previous type is applied to the added text input. As of now, in the "is type of" rule, I think that only the number type should be copied to the second rule and others are string type. Could you check this handling?

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality