### PR TITLE
Fix JSONata in file nodes

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.js
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.js
@@ -68,9 +68,12 @@ module.exports = function(RED) {
                     node.error(err,msg);
                     return done();
                 } else {
-                    filename = value;
+                    processMsg2(msg,nodeSend,value,done);
                 }
             });
+       }
+
+       function processMsg2(msg,nodeSend,filename,done) {
             filename = filename || "";
             msg.filename = filename;
             var fullFilename = filename;


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Generating file a path using the JSONata in the file node doesn't work in the Node-RED 3.1.0-beta.
In this pull request, I tried to fix it.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality