### PR TITLE
Improve Catalogue visibility

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -586,6 +586,7 @@
         "editor": {
             "title": "Manage palette",
             "palette": "Palette",
+            "allCatalogs": "All Catalogs",
             "times": {
                 "seconds": "seconds ago",
                 "minutes": "minutes ago",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -472,7 +472,6 @@ RED.palette.editor = (function() {
      * @param {[{url:String, name:String, updated_at:String, modules_count:Number}]} catalogEntries
      */
     function updateCatalogFilter(catalogEntries, maxRetry = 3) {
-        console.log("updateCatalogFilter", catalogEntries, maxRetry)
         // clean up existing filters
         const catalogSelection = $('#red-catalogue-filter-select')
         if (catalogSelection.length === 0) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -478,7 +478,7 @@ RED.palette.editor = (function() {
         if (catalogSelection.length === 0) {
             // sidebar not yet loaded (red-catalogue-filter-select is not in dom)
             if (maxRetry > 0) {
-                console.log("updateCatalogFilter: sidebar not yet loaded, retrying in 100ms")
+               // console.log("updateCatalogFilter: sidebar not yet loaded, retrying in 100ms")
                 // try again in 100ms
                 setTimeout(() => {
                     updateCatalogFilter(catalogEntries, maxRetry - 1)

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -16,7 +16,7 @@
 RED.palette.editor = (function() {
 
     var disabled = false;
-
+    const catalogues = RED.settings.theme('palette.catalogues')||['https://catalogue.nodered.org/catalogue.json', 'http://192.168.86.130:3002/catalogue.json']
     var editorTabs;
     var filterInput;
     var searchInput;
@@ -232,6 +232,7 @@ RED.palette.editor = (function() {
 
 
     function _refreshNodeModule(module) {
+        console.log("refresh",module);
         if (!nodeEntries.hasOwnProperty(module)) {
             nodeEntries[module] = {info:RED.nodes.registry.getModule(module)};
             var index = [module];
@@ -421,7 +422,7 @@ RED.palette.editor = (function() {
             packageList.editableList('empty');
 
             $(".red-ui-palette-module-shade-status").text(RED._('palette.editor.loading'));
-            var catalogues = RED.settings.theme('palette.catalogues')||['https://catalogue.nodered.org/catalogue.json'];
+
             catalogueLoadStatus = [];
             catalogueLoadErrors = false;
             catalogueCount = catalogues.length;
@@ -431,8 +432,11 @@ RED.palette.editor = (function() {
             $("#red-ui-palette-module-install-shade").show();
             catalogueLoadStart = Date.now();
             var handled = 0;
-            catalogues.forEach(function(catalog,index) {
+            const catalogTypes = []
+            for (let index = 0; index < catalogues.length; index++) {
+                const catalog = catalogues[index];
                 $.getJSON(catalog, {_: new Date().getTime()},function(v) {
+                    catalogTypes.push(v);
                     handleCatalogResponse(null,catalog,index,v);
                     refreshNodeModuleList();
                 }).fail(function(jqxhr, textStatus, error) {
@@ -442,9 +446,19 @@ RED.palette.editor = (function() {
                     handled++;
                     if (handled === catalogueCount) {
                         searchInput.searchBox('change');
+                        console.log("adding types to typedInput", catalogTypes)
+                        const catalogSelection = $('#red-catalogue-filter-select')
+                        catalogSelection.empty()
+                        // loop through catalogTypes, and option per entry
+                        for (let index = 0; index < catalogTypes.length; index++) {
+                            const catalog = catalogTypes[index];
+                            catalogSelection.append(`<option value="${catalog.name}">${catalog.name}</option>`)
+                        }
+                        // select the 1st option
+                        catalogSelection.val(catalogSelection.find('option:first').val())
                     }
                 })
-            });
+            }
         }
     }
 
@@ -812,9 +826,9 @@ RED.palette.editor = (function() {
             content: installTab
         })
 
-        var toolBar = $('<div>',{class:"red-ui-palette-editor-toolbar"}).appendTo(installTab);
-
-        var searchDiv = $('<div>',{class:"red-ui-palette-search"}).appendTo(installTab);
+        const toolBar = $('<div>',{class:"red-ui-palette-editor-toolbar"}).appendTo(installTab);
+        
+        const searchDiv = $('<div>',{class:"red-ui-palette-search"}).appendTo(installTab);
         searchInput = $('<input type="text" data-i18n="[placeholder]palette.search"></input>')
             .appendTo(searchDiv)
             .searchBox({
@@ -836,14 +850,35 @@ RED.palette.editor = (function() {
                 }
             });
 
-        $('<span>').text(RED._("palette.editor.sort")+' ').appendTo(toolBar);
-        var sortGroup = $('<span class="button-group"></span>').appendTo(toolBar);
-        var sortRelevance = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle selected"><i class="fa fa-sort-amount-desc"></i></a>').appendTo(sortGroup);
-        var sortAZ = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle" data-i18n="palette.editor.sortAZ"></a>').appendTo(sortGroup);
-        var sortRecent = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle" data-i18n="palette.editor.sortRecent"></a>').appendTo(sortGroup);
+        // create a div, left aligned, to contain the label "catalog" and a dropdown select
+        const catalogGroup = $('<div>',{class:""}).appendTo(toolBar);
+        // const catalogSelection = $('<input id="red-catalogue-selection" />', { class: "node-input-header-name", type: "text", style: "width: 100%" }).appendTo(catalogGroup);
+        // append a regular select/options el to the catalogGroup
+        const catalogSelection = $('<select id="red-catalogue-filter-select">').appendTo(catalogGroup);
+        
+
+        // add a single dummy option "Loading..." to catalogSelection until the catalogues are loaded
+        catalogSelection.append($('<option>', { value: "loading", text: "Loading Catalogue List...", disabled: true, selected: true }));
+
+        // catalogSelection.typedInput({ types: [{ value: "loading", label: "Loading Catalogue List...", hasValue: false }] });
+
+        catalogSelection.on("change", function() {
+            var v = $(this).val();
+            console.log(v);
+            if (v === "all") {
+            }
+        })
+
+        const toolBarActions = $('<div>',{class:"red-ui-palette-editor-toolbar-actions"}).appendTo(toolBar);
+
+        $('<span>').text(RED._("palette.editor.sort")+' ').appendTo(toolBarActions);
+        const sortGroup = $('<span class="button-group"></span>').appendTo(toolBarActions);
+        const sortRelevance = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle selected"><i class="fa fa-sort-amount-desc"></i></a>').appendTo(sortGroup);
+        const sortAZ = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle" data-i18n="palette.editor.sortAZ"></a>').appendTo(sortGroup);
+        const sortRecent = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle" data-i18n="palette.editor.sortRecent"></a>').appendTo(sortGroup);
 
 
-        var sortOpts = [
+        const sortOpts = [
             {button: sortRelevance, func: sortModulesRelevance},
             {button: sortAZ, func: sortModulesAZ},
             {button: sortRecent, func: sortModulesRecent}
@@ -861,7 +896,7 @@ RED.palette.editor = (function() {
             });
         });
 
-        var refreshSpan = $('<span>').appendTo(toolBar);
+        var refreshSpan = $('<span>').appendTo(toolBarActions);
         var refreshButton = $('<a href="#" class="red-ui-sidebar-header-button"><i class="fa fa-refresh"></i></a>').appendTo(refreshSpan);
         refreshButton.on("click", function(e) {
             e.preventDefault();
@@ -871,7 +906,8 @@ RED.palette.editor = (function() {
         })
         RED.popover.tooltip(refreshButton,RED._("palette.editor.refresh"));
 
-        packageList = $('<ol>',{style:"position: absolute;top: 79px;bottom: 0;left: 0;right: 0px;"}).appendTo(installTab).editableList({
+        packageList = $('<ol>').appendTo(installTab).editableList({
+            class: "scrollable",
             addButton: false,
             scrollOnAdd: false,
             addItem: function(container,i,object) {
@@ -952,9 +988,10 @@ RED.palette.editor = (function() {
                 }
             }
         });
+        
 
         if (RED.settings.get('externalModules.palette.allowUpload', true) !== false) {
-            var uploadSpan = $('<span class="button-group">').prependTo(toolBar);
+            var uploadSpan = $('<span class="button-group">').prependTo(toolBarActions);
             var uploadButton = $('<button type="button" class="red-ui-sidebar-header-button red-ui-palette-editor-upload-button"><label><i class="fa fa-upload"></i><form id="red-ui-palette-editor-upload-form" enctype="multipart/form-data"><input name="tarball" type="file" accept=".tgz"></label></button>').appendTo(uploadSpan);
 
             var uploadInput = uploadButton.find('input[type="file"]');

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -17,6 +17,7 @@ RED.palette.editor = (function() {
 
     var disabled = false;
     let catalogues = []
+    const loadedCatalogs = []
     var editorTabs;
     let filterInput;
     let searchInput;
@@ -161,19 +162,6 @@ RED.palette.editor = (function() {
                 _refreshNodeModule(module);
             },100);
         }
-    }
-
-    function filterByCatalog(selectedCatalog) {
-        const catalogCount = $('#red-catalogue-filter-select option').length
-        if (catalogCount <= 1 || selectedCatalog === "all") {
-            loadedList = fullList.slice();
-        } else {
-            loadedList = fullList.filter(function(m) {
-                return (m.catalog.name === selectedCatalog);
-            })
-        }
-        refreshFilteredItems();
-        searchInput.searchBox('count',filteredList.length+" / "+loadedList.length);
     }
 
     function getContrastingBorder(rgbColor){
@@ -446,11 +434,11 @@ RED.palette.editor = (function() {
             $("#red-ui-palette-module-install-shade").show();
             catalogueLoadStart = Date.now();
             var handled = 0;
-            const catalogEntries = []
+            loadedCatalogs.length = 0; // clear the loadedCatalogs array
             for (let index = 0; index < catalogues.length; index++) {
                 const url = catalogues[index];
                 $.getJSON(url, {_: new Date().getTime()},function(v) {
-                    catalogEntries.push({ url: url, name: v.name, updated_at: v.updated_at, modules_count: (v.modules || []).length })
+                    loadedCatalogs.push({ index: index, url: url, name: v.name, updated_at: v.updated_at, modules_count: (v.modules || []).length })
                     handleCatalogResponse(null,{ url: url, name: v.name},index,v);
                     refreshNodeModuleList();
                 }).fail(function(jqxhr, textStatus, error) {
@@ -459,7 +447,9 @@ RED.palette.editor = (function() {
                 }).always(function() {
                     handled++;
                     if (handled === catalogueCount) {
-                        updateCatalogFilter(catalogEntries)
+                        //sort loadedCatalogs by e.index ascending
+                        loadedCatalogs.sort((a, b) => a.index - b.index)
+                        updateCatalogFilter(loadedCatalogs)
                     }
                 })
             }
@@ -492,9 +482,7 @@ RED.palette.editor = (function() {
         
         fullList = loadedList.slice()
         catalogSelection.empty() // clear the select list
-        // if there are more than 1 catalog, add an option to select all
-        if (catalogEntries.length > 1) {
-        }
+
         // loop through catalogTypes, and an option entry per catalog
         for (let index = 0; index < catalogEntries.length; index++) {
             const catalog = catalogEntries[index];
@@ -506,7 +494,6 @@ RED.palette.editor = (function() {
         // if there is only 1 catalog, hide the select
         if (catalogEntries.length > 1) {
             catalogSelection.prepend(`<option value="all">${RED._('palette.editor.allCatalogs')}</option>`)
-            catalogSelection.show()
             catalogSelection.removeAttr('disabled') // permit the user to select a catalog
         }
         // refresh the searchInput counter and trigger a change
@@ -519,6 +506,18 @@ RED.palette.editor = (function() {
             filterByCatalog(selectedCatalog);
             searchInput.searchBox('change');
         })
+    }
+
+    function filterByCatalog(selectedCatalog) {
+        if (loadedCatalogs.length <= 1 || selectedCatalog === "all") {
+            loadedList = fullList.slice();
+        } else {
+            loadedList = fullList.filter(function(m) {
+                return (m.catalog.name === selectedCatalog);
+            })
+        }
+        refreshFilteredItems();
+        searchInput.searchBox('count',filteredList.length+" / "+loadedList.length);
     }
 
     function refreshFilteredItems() {
@@ -910,7 +909,6 @@ RED.palette.editor = (function() {
 
         const catalogSelection = $('<select id="red-catalogue-filter-select">').appendTo(toolBar);
         catalogSelection.addClass('red-ui-palette-editor-catalogue-filter');
-        catalogSelection.hide() // hide the select until the catalogues have been loaded
  
         const toolBarActions = $('<div>',{class:"red-ui-palette-editor-toolbar-actions"}).appendTo(toolBar);
 
@@ -987,7 +985,7 @@ RED.palette.editor = (function() {
                     var metaRow = $('<div class="red-ui-palette-module-meta"></div>').appendTo(headerRow);
                     $('<span class="red-ui-palette-module-version"><i class="fa fa-tag"></i> '+entry.version+'</span>').appendTo(metaRow);
                     $('<span class="red-ui-palette-module-updated"><i class="fa fa-calendar"></i> '+formatUpdatedAt(entry.updated_at)+'</span>').appendTo(metaRow);
-                    if (catalogSelection.val() === 'all') {
+                    if (loadedCatalogs.length > 1) {
                         $('<span class="red-ui-palette-module-updated"><i class="fa fa-cubes"></i>' + (entry.catalog.name || entry.catalog.url) + '</span>').appendTo(metaRow);
                     }
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -16,15 +16,16 @@
 RED.palette.editor = (function() {
 
     var disabled = false;
-    const catalogues = RED.settings.theme('palette.catalogues')||['https://catalogue.nodered.org/catalogue.json', 'http://192.168.86.130:3002/catalogue.json']
+    let catalogues = []
     var editorTabs;
-    var filterInput;
-    var searchInput;
-    var nodeList;
-    var packageList;
-    var loadedList = [];
-    var filteredList = [];
-    var loadedIndex = {};
+    let filterInput;
+    let searchInput;
+    let nodeList;
+    let packageList;
+    let fullList = []
+    let loadedList = [];
+    let filteredList = [];
+    let loadedIndex = {};
 
     var typesInUse = {};
     var nodeEntries = {};
@@ -162,6 +163,18 @@ RED.palette.editor = (function() {
         }
     }
 
+    function filterByCatalog(selectedCatalog) {
+        const catalogCount = $('#red-catalogue-filter-select option').length
+        if (catalogCount <= 1 || selectedCatalog === "all") {
+            loadedList = fullList.slice();
+        } else {
+            loadedList = fullList.filter(function(m) {
+                return (m.catalog.name === selectedCatalog);
+            })
+        }
+        refreshFilteredItems();
+        searchInput.searchBox('count',filteredList.length+" / "+loadedList.length);
+    }
 
     function getContrastingBorder(rgbColor){
         var parts = /^rgba?\(\s*(\d+),\s*(\d+),\s*(\d+)[,)]/.exec(rgbColor);
@@ -370,10 +383,10 @@ RED.palette.editor = (function() {
     var activeSort = sortModulesRelevance;
 
     function handleCatalogResponse(err,catalog,index,v) {
+        const url = catalog.url
         catalogueLoadStatus.push(err||v);
         if (!err) {
             if (v.modules) {
-                var a = false;
                 v.modules = v.modules.filter(function(m) {
                     if (RED.utils.checkModuleAllowed(m.id,m.version,installAllowList,installDenyList)) {
                         loadedIndex[m.id] = m;
@@ -390,13 +403,14 @@ RED.palette.editor = (function() {
                             m.timestamp = 0;
                         }
                         m.index = m.index.join(",").toLowerCase();
+                        m.catalog = catalog;
+                        m.catalogIndex = index;
                         return true;
                     }
                     return false;
                 })
                 loadedList = loadedList.concat(v.modules);
             }
-            searchInput.searchBox('count',loadedList.length);
         } else {
             catalogueLoadErrors = true;
         }
@@ -405,7 +419,7 @@ RED.palette.editor = (function() {
         }
         if (catalogueLoadStatus.length === catalogueCount) {
             if (catalogueLoadErrors) {
-                RED.notify(RED._('palette.editor.errors.catalogLoadFailed',{url: catalog}),"error",false,8000);
+                RED.notify(RED._('palette.editor.errors.catalogLoadFailed',{url: url}),"error",false,8000);
             }
             var delta = 250-(Date.now() - catalogueLoadStart);
             setTimeout(function() {
@@ -417,6 +431,7 @@ RED.palette.editor = (function() {
 
     function initInstallTab() {
         if (loadedList.length === 0) {
+            fullList = [];
             loadedList = [];
             loadedIndex = {};
             packageList.editableList('empty');
@@ -432,34 +447,80 @@ RED.palette.editor = (function() {
             $("#red-ui-palette-module-install-shade").show();
             catalogueLoadStart = Date.now();
             var handled = 0;
-            const catalogTypes = []
+            const catalogEntries = []
             for (let index = 0; index < catalogues.length; index++) {
-                const catalog = catalogues[index];
-                $.getJSON(catalog, {_: new Date().getTime()},function(v) {
-                    catalogTypes.push(v);
-                    handleCatalogResponse(null,catalog,index,v);
+                const url = catalogues[index];
+                $.getJSON(url, {_: new Date().getTime()},function(v) {
+                    catalogEntries.push({ url: url, name: v.name, updated_at: v.updated_at, modules_count: (v.modules || []).length })
+                    handleCatalogResponse(null,{ url: url, name: v.name},index,v);
                     refreshNodeModuleList();
                 }).fail(function(jqxhr, textStatus, error) {
-                    console.warn("Error loading catalog",catalog,":",error);
-                    handleCatalogResponse(jqxhr,catalog,index);
+                    console.warn("Error loading catalog",url,":",error);
+                    handleCatalogResponse(jqxhr,url,index);
                 }).always(function() {
                     handled++;
                     if (handled === catalogueCount) {
-                        searchInput.searchBox('change');
-                        console.log("adding types to typedInput", catalogTypes)
-                        const catalogSelection = $('#red-catalogue-filter-select')
-                        catalogSelection.empty()
-                        // loop through catalogTypes, and option per entry
-                        for (let index = 0; index < catalogTypes.length; index++) {
-                            const catalog = catalogTypes[index];
-                            catalogSelection.append(`<option value="${catalog.name}">${catalog.name}</option>`)
-                        }
-                        // select the 1st option
-                        catalogSelection.val(catalogSelection.find('option:first').val())
+                        updateCatalogFilter(catalogEntries)
                     }
                 })
             }
         }
+    }
+
+    /**
+     * Refreshes the catalog filter dropdown and updates local variables
+     * @param {[{url:String, name:String, updated_at:String, modules_count:Number}]} catalogEntries
+     */
+    function updateCatalogFilter(catalogEntries, maxRetry = 3) {
+        console.log("updateCatalogFilter", catalogEntries, maxRetry)
+        // clean up existing filters
+        const catalogSelection = $('#red-catalogue-filter-select')
+        if (catalogSelection.length === 0) {
+            // sidebar not yet loaded (red-catalogue-filter-select is not in dom)
+            if (maxRetry > 0) {
+                console.log("updateCatalogFilter: sidebar not yet loaded, retrying in 100ms")
+                // try again in 100ms
+                setTimeout(() => {
+                    updateCatalogFilter(catalogEntries, maxRetry - 1)
+                }, 100);
+                return;
+            } 
+            return; // give up
+        }
+        catalogSelection.off("change") // remove any existing event handlers
+        catalogSelection.attr('disabled', 'disabled')
+        catalogSelection.empty()
+        catalogSelection.append($('<option>', { value: "loading", text: RED._('palette.editor.loading'), disabled: true, selected: true }));
+        
+        fullList = loadedList.slice()
+        catalogSelection.empty() // clear the select list
+        // if there are more than 1 catalog, add an option to select all
+        if (catalogEntries.length > 1) {
+        }
+        // loop through catalogTypes, and an option entry per catalog
+        for (let index = 0; index < catalogEntries.length; index++) {
+            const catalog = catalogEntries[index];
+            catalogSelection.append(`<option value="${catalog.name}">${catalog.name}</option>`)
+        }
+        // select the 1st option in the select list
+        catalogSelection.val(catalogSelection.find('option:first').val())
+        
+        // if there is only 1 catalog, hide the select
+        if (catalogEntries.length > 1) {
+            catalogSelection.prepend(`<option value="all">${RED._('palette.editor.allCatalogs')}</option>`)
+            catalogSelection.show()
+            catalogSelection.removeAttr('disabled') // permit the user to select a catalog
+        }
+        // refresh the searchInput counter and trigger a change
+        filterByCatalog(catalogSelection.val())
+        searchInput.searchBox('change');
+
+        // hook up the change event handler
+        catalogSelection.on("change", function() {
+            const selectedCatalog = $(this).val();
+            filterByCatalog(selectedCatalog);
+            searchInput.searchBox('change');
+        })
     }
 
     function refreshFilteredItems() {
@@ -476,7 +537,6 @@ RED.palette.editor = (function() {
         if (filteredList.length === 0) {
             packageList.editableList('addItem',{});
         }
-
         if (filteredList.length > 10) {
             packageList.editableList('addItem',{start:10,more:filteredList.length-10})
         }
@@ -506,6 +566,7 @@ RED.palette.editor = (function() {
     var updateDenyList = [];
 
     function init() {
+        catalogues = RED.settings.theme('palette.catalogues')||['https://catalogue.nodered.org/catalogue.json']
         if (RED.settings.get('externalModules.palette.allowInstall', true) === false) {
             return;
         }
@@ -815,7 +876,7 @@ RED.palette.editor = (function() {
                     $('<div>',{class:"red-ui-search-empty"}).text(RED._('search.empty')).appendTo(container);
                 }
             }
-        });
+        })
     }
 
     function createInstallTab(content) {
@@ -845,7 +906,6 @@ RED.palette.editor = (function() {
                         searchInput.searchBox('count',loadedList.length);
                         packageList.editableList('empty');
                         packageList.editableList('addItem',{count:loadedList.length});
-
                     }
                 }
             });

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -245,7 +245,6 @@ RED.palette.editor = (function() {
 
 
     function _refreshNodeModule(module) {
-        console.log("refresh",module);
         if (!nodeEntries.hasOwnProperty(module)) {
             nodeEntries[module] = {info:RED.nodes.registry.getModule(module)};
             var index = [module];

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -683,7 +683,8 @@ RED.palette.editor = (function() {
             });
 
 
-        nodeList = $('<ol>',{id:"red-ui-palette-module-list", style:"position: absolute;top: 35px;bottom: 0;left: 0;right: 0px;"}).appendTo(modulesTab).editableList({
+        nodeList = $('<ol>',{id:"red-ui-palette-module-list"}).appendTo(modulesTab).editableList({
+            class: "scrollable",
             addButton: false,
             scrollOnAdd: false,
             sort: function(A,B) {
@@ -818,8 +819,7 @@ RED.palette.editor = (function() {
     }
 
     function createInstallTab(content) {
-        var installTab = $('<div>',{class:"red-ui-palette-editor-tab hide"}).appendTo(content);
-
+        const installTab = $('<div>',{class:"red-ui-palette-editor-tab", style: "display: none;"}).appendTo(content);
         editorTabs.addTab({
             id: 'install',
             label: RED._('palette.editor.tab-install'),
@@ -850,32 +850,19 @@ RED.palette.editor = (function() {
                 }
             });
 
-        // create a div, left aligned, to contain the label "catalog" and a dropdown select
-        const catalogGroup = $('<div>',{class:""}).appendTo(toolBar);
-        // const catalogSelection = $('<input id="red-catalogue-selection" />', { class: "node-input-header-name", type: "text", style: "width: 100%" }).appendTo(catalogGroup);
-        // append a regular select/options el to the catalogGroup
-        const catalogSelection = $('<select id="red-catalogue-filter-select">').appendTo(catalogGroup);
-        
-
-        // add a single dummy option "Loading..." to catalogSelection until the catalogues are loaded
-        catalogSelection.append($('<option>', { value: "loading", text: "Loading Catalogue List...", disabled: true, selected: true }));
-
-        // catalogSelection.typedInput({ types: [{ value: "loading", label: "Loading Catalogue List...", hasValue: false }] });
-
-        catalogSelection.on("change", function() {
-            var v = $(this).val();
-            console.log(v);
-            if (v === "all") {
-            }
-        })
-
+        const catalogSelection = $('<select id="red-catalogue-filter-select">').appendTo(toolBar);
+        catalogSelection.addClass('red-ui-palette-editor-catalogue-filter');
+        catalogSelection.hide() // hide the select until the catalogues have been loaded
+ 
         const toolBarActions = $('<div>',{class:"red-ui-palette-editor-toolbar-actions"}).appendTo(toolBar);
 
         $('<span>').text(RED._("palette.editor.sort")+' ').appendTo(toolBarActions);
         const sortGroup = $('<span class="button-group"></span>').appendTo(toolBarActions);
         const sortRelevance = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle selected"><i class="fa fa-sort-amount-desc"></i></a>').appendTo(sortGroup);
-        const sortAZ = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle" data-i18n="palette.editor.sortAZ"></a>').appendTo(sortGroup);
-        const sortRecent = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle" data-i18n="palette.editor.sortRecent"></a>').appendTo(sortGroup);
+        const sortAZ = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle"><i class="fa fa-sort-alpha-asc"></i></a>').appendTo(sortGroup);
+        const sortRecent = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle"><i class="fa fa-calendar"></i></a>').appendTo(sortGroup);
+        RED.popover.tooltip(sortAZ,RED._("palette.editor.sortAZ"));
+        RED.popover.tooltip(sortRecent,RED._("palette.editor.sortRecent"));
 
 
         const sortOpts = [
@@ -942,6 +929,9 @@ RED.palette.editor = (function() {
                     var metaRow = $('<div class="red-ui-palette-module-meta"></div>').appendTo(headerRow);
                     $('<span class="red-ui-palette-module-version"><i class="fa fa-tag"></i> '+entry.version+'</span>').appendTo(metaRow);
                     $('<span class="red-ui-palette-module-updated"><i class="fa fa-calendar"></i> '+formatUpdatedAt(entry.updated_at)+'</span>').appendTo(metaRow);
+                    if (catalogSelection.val() === 'all') {
+                        $('<span class="red-ui-palette-module-updated"><i class="fa fa-cubes"></i>' + (entry.catalog.name || entry.catalog.url) + '</span>').appendTo(metaRow);
+                    }
 
                     var duplicateType = false;
                     if (entry.types && entry.types.length > 0) {

--- a/packages/node_modules/@node-red/editor-client/src/sass/palette-editor.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/palette-editor.scss
@@ -29,6 +29,13 @@
     box-sizing:border-box;
     background: var(--red-ui-secondary-background);
 
+    .red-ui-editableList.scrollable {
+        overflow-y: auto;
+        background-color: aqua;
+        // padding: 0 10px;
+        // box-sizing: border-box;
+        // height: calc(100% - 40px);
+    }
     .red-ui-editableList-container {
         border: none;
         border-radius: 0;
@@ -72,11 +79,8 @@
 
     }
     .red-ui-palette-editor-tab {
-        position:absolute;
-        top:35px;
-        left:0;
-        right:0;
-        bottom:0
+        display: flex;
+        flex-direction: column;
     }
     .red-ui-palette-editor-toolbar {
         background: var(--red-ui-primary-background);
@@ -84,6 +88,15 @@
         padding: 8px 10px;
         border-bottom: 1px solid var(--red-ui-primary-border-color);
         text-align: right;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 3px 12px;
+        .red-ui-palette-editor-toolbar-actions {
+            flex-shrink: 0;
+            flex-grow: 1;
+        }
     }
     .red-ui-palette-module-shade-status {
         color: var(--red-ui-secondary-text-color);

--- a/packages/node_modules/@node-red/editor-client/src/sass/palette-editor.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/palette-editor.scss
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-#red-ui-settings-tab-palette {
+ #red-ui-settings-tab-palette {
     height: 100%;
 }
 
@@ -28,13 +28,16 @@
     padding: 0;
     box-sizing:border-box;
     background: var(--red-ui-secondary-background);
+    display: flex;
+    flex-direction: column;
+
+    .red-ui-tabs {
+        flex-shrink: 0;
+        margin-bottom: 0;
+    }
 
     .red-ui-editableList.scrollable {
         overflow-y: auto;
-        background-color: aqua;
-        // padding: 0 10px;
-        // box-sizing: border-box;
-        // height: calc(100% - 40px);
     }
     .red-ui-editableList-container {
         border: none;
@@ -81,6 +84,7 @@
     .red-ui-palette-editor-tab {
         display: flex;
         flex-direction: column;
+        min-height: 0;
     }
     .red-ui-palette-editor-toolbar {
         background: var(--red-ui-primary-background);
@@ -96,6 +100,15 @@
         .red-ui-palette-editor-toolbar-actions {
             flex-shrink: 0;
             flex-grow: 1;
+        }
+        .red-ui-palette-editor-catalogue-filter {
+            width: unset;
+            margin: 0;
+            flex-shrink: 1;
+            flex-grow: 1;
+            font-size: 12px;
+            height: 26px;
+            padding: 1px;
         }
     }
     .red-ui-palette-module-shade-status {

--- a/packages/node_modules/@node-red/editor-client/src/sass/palette.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/palette.scss
@@ -54,7 +54,7 @@
 }
 .red-ui-palette-search {
     position: relative;
-    overflow: hidden;
+    // overflow: hidden;
     background: var(--red-ui-form-input-background);
     text-align: center;
     height: 35px;


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Proposed changes

1. Add catalogue selector to the palette install tab
2. Filter search to each catalogue or "All Catalogs"
3. If "All Catalogs" is selected, show which catalog the node comes from in the meta data

Notes:
* Removed `absolute` styling and changed sort texts to icons (see justifications below)
* Scrolling now occurs on the editable list instead of the whole panel.  (compounded CSS issues around `absolute` positioning caused scrolling of node lists to reveal empty panel in the vertical tab list - see also: justifications below)
* Checked theming - ok

Justification:
Due to addition of filter and possibility of longish catalogue names (e.g. "Node-RED Community catalogue") pushing the sorting / refresh buttons down a row AND the editable list having `absolute` positioning, some restructuring was necessary to avoid the search box being pushed below the list. The sort option texts "a-z" and "recent" were updated to `fa` icons (like the other sort option), the toolbar buttons were re-jigged into a flexbox to avoid individual buttons wrapping to the next line & a hand full of other unsightly artefacts (thanks @joepavitt) 

### Demos

#### Before
![image](https://github.com/node-red/node-red/assets/44235289/bdd7a9e1-76a8-495a-b09a-803488d06730)


#### After 

##### Themed

![image](https://github.com/node-red/node-red/assets/44235289/58ea5ab8-5477-4a28-b9d7-2ee7edc83c0c)


##### No catalogues specified in settings.js (i.e. using default Node-RED catalog)
_Apart from all the sort buttons now being icons, there is no visible difference - the dropdown catalog selection is not shown_

https://github.com/node-red/node-red/assets/44235289/77bfed37-704a-4074-a4cf-afb9687eaaf8


##### 3 working catalogues (Node-RED community catalog + 2 custom ones)
_Here you can see new catalogue selector in operation_

https://github.com/node-red/node-red/assets/44235289/a4e01a82-fd22-4b80-8083-28cc1518d315

##### 2 custom catalogues, 1 dead catalogue
_Note how the new catalog selection excludes the failed library listing_

https://github.com/node-red/node-red/assets/44235289/a13cdd67-4334-4e52-bf62-87d143e224cf






## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
