### PR TITLE
Add NR_SUBFLOW_NAME/ID/PATH env vars

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
@@ -341,13 +341,13 @@ class Subflow extends Flow {
     getSetting(key) {
         const node = this.subflowInstance;
         if (node) {
-            if (key === "NR_NODE_NAME") {
+            if (key === "NR_NODE_NAME" || key === "NR_SUBFLOW_NAME") {
                 return node.name;
             }
-            if (key === "NR_NODE_ID") {
+            if (key === "NR_NODE_ID" || key === "NR_SUBFLOW_ID") {
                 return node.id;
             }
-            if (key === "NR_NODE_PATH") {
+            if (key === "NR_NODE_PATH" || key === "NR_SUBFLOW_PATH") {
                 return node._path;
             }
         }


### PR DESCRIPTION
Closes #4239

Adds the following env vars that will be available to nodes within a subflow.

 - `NR_SUBFLOW_NAME`
 - `NR_SUBFLOW_ID`
 - `NR_SUBFLOW_PATH`

They evaluate to the name/id/path of the subflow *instance*.