### PR TITLE
Add tooltip to text diff button

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
@@ -989,9 +989,10 @@ RED.diff = (function() {
             }
             if (localNode && remoteNode && typeof localNode[d] === "string") {
                 if (/\n/.test(localNode[d]) || /\n/.test(remoteNode[d])) {
-                    $('<button class="red-ui-button red-ui-button-small red-ui-diff-text-diff-button"><i class="fa fa-file-o"> <i class="fa fa-caret-left"></i> <i class="fa fa-caret-right"></i> <i class="fa fa-file-o"></i></button>').on("click", function() {
+                    var textDiff = $('<button class="red-ui-button red-ui-button-small red-ui-diff-text-diff-button"><i class="fa fa-file-o"> <i class="fa fa-caret-left"></i> <i class="fa fa-caret-right"></i> <i class="fa fa-file-o"></i></button>').on("click", function() {
                         showTextDiff(localNode[d],remoteNode[d]);
                     }).appendTo(propertyNameCell);
+                    RED.popover.tooltip(textDiff, RED._("diff.compareChanges"));
                 }
             }
 


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
While writing [my blog about the project feature](https://kazuhitoyokoi.medium.com/using-version-control-for-node-red-flows-ce8585df7870#:~:text=in%20the%20tree%20view%20of%20the%20template%20node%2C%20there%20is%20a%20button%20highlighted%20by%20the%20red%20rectangle%20above%20to%20show%20the%20details%20of%20the%20differentiation.%20after%20clicking%20the%20button%2C%20you%20can%20see%20the%20differentiation%20between%20the%20lines.), I thought that the text diff button should have a tooltip like the following screenshot.

<img width="1440" alt="Screenshot 2023-07-29 at 16 38 45" src="https://github.com/node-red/node-red/assets/20310935/364e14e2-85ba-43a8-94b7-4b0da1963250">

With this tooltip, users can understand the function of the button before clicking and opening the text diff UI.
So, I submitted this pull request to add the tooltip.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
