### PR TITLE
Handle 204 in httprequest JSON

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
@@ -618,6 +618,7 @@ in your Node-RED user directory (${RED.settings.userDir}).
                     msg.payload = msg.payload.toString('utf8'); // txt
 
                     if (node.ret === "obj") {
+                        if (msg.statusCode == 204){msg.payload= "{}"}; 
                         try { msg.payload = JSON.parse(msg.payload); } // obj
                         catch(e) { node.warn(RED._("httpin.errors.json-error")); }
                     }

--- a/test/nodes/core/network/21-httprequest_spec.js
+++ b/test/nodes/core/network/21-httprequest_spec.js
@@ -557,7 +557,7 @@ describe('HTTP Request Node', function() {
                 var n2 = helper.getNode("n2");
                 n2.on("input", function(msg) {
                     try {
-                        msg.should.have.property('payload','');
+                        msg.should.have.property('payload',{});
                         msg.should.have.property('statusCode',204);
                         done();
                     } catch(err) {


### PR DESCRIPTION
If the http statusCode is 204 (Success, No Content) and the node return type is set to JSON this sets msg.payload as an empty json object so as to supress the JSON parse error
