### PR TITLE
Fix broken text input in the switch node (again)

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.html
@@ -103,7 +103,6 @@
             } else if (type === "istype") {
                 r.v = rule.find(".node-input-rule-type-value").typedInput('type');
                 r.vt = rule.find(".node-input-rule-type-value").typedInput('type');
-                r.vt = (r.vt === "number") ? "num" : "str";
             } else if (type === "jsonata_exp") {
                 r.v = rule.find(".node-input-rule-exp-value").typedInput('value');
                 r.vt = rule.find(".node-input-rule-exp-value").typedInput('type');
@@ -218,7 +217,11 @@
                         if (i > 0) {
                             var lastRule = $("#node-input-rule-container").editableList('getItemAt',i-1);
                             var exportedRule = exportRule(lastRule.element);
-                            opt.r.vt = exportedRule.vt;
+                            if (exportedRule.t === "istype") {
+                                opt.r.vt = (exportedRule.vt === "number") ? "num" : "str";
+                            } else {
+                                opt.r.vt = exportedRule.vt;
+                            }
                             opt.r.v = "";
                             // We could copy the value over as well and preselect it (see the 'activeElement' code below)
                             // But not sure that feels right. Is copying over the last value 'expected' behaviour?


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I found that the previous fix in https://github.com/node-red/node-red/pull/4242 leads to another issue, https://github.com/node-red/node-red/issues/4272 because the current `vt` value is changed to `num` or `str`. Therefore, the code in this pull request changes the `vt` value when the second rule is added only.

I tested the following rules.

### Reopening switch node property
| Rule                   | 3.1.0-beta.3 | 3.1.0-beta.4 | This PR |
| ---------------------- | ------ | ------ | ----- |
| is of type 'string'    | OK     | Broken | OK    |
| is of type 'number'    | OK     | Broken | OK    |
| is of type 'undefined' | OK     | Broken | OK    |

### Adding 2nd rule
| Rule                   | 3.1.0-beta.3 | 3.1.0-beta.4 | This PR |
| ---------------------- | ------ | ------ | ----- |
| is of type 'string'    | Broken | OK     | OK    |
| is of type 'number'    | Broken | OK     | OK    |
| is of type 'undefined' | Broken | OK     | OK    |

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
