### PR TITLE
Fix test cases of JSON node

### DIFF
--- a/test/nodes/core/parsers/70-JSON_spec.js
+++ b/test/nodes/core/parsers/70-JSON_spec.js
@@ -173,7 +173,7 @@ describe('JSON node', function() {
                         });
                         logEvents.should.have.length(1);
                         logEvents[0][0].should.have.a.property('msg');
-                        logEvents[0][0].msg.should.startWith("Unexpected token o");
+                        logEvents[0][0].msg.should.match(/^Unexpected token (o|'o')/);
                         logEvents[0][0].should.have.a.property('level',helper.log().ERROR);
                         done();
                     } catch(err) { done(err) }
@@ -199,7 +199,7 @@ describe('JSON node', function() {
                         });
                         logEvents.should.have.length(1);
                         logEvents[0][0].should.have.a.property('msg');
-                        logEvents[0][0].msg.should.startWith("Unexpected token o");
+                        logEvents[0][0].msg.should.match(/^Unexpected token (o|'o')/);
                         logEvents[0][0].should.have.a.property('level',helper.log().ERROR);
                         done();
                     } catch(err) { done(err) }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
During development, the `npm test` command always fails in my Node.js v20 environment.

```
2444 passing (2m)
  59 pending
  2 failing

  1) JSON node
       should log an error if asked to parse an invalid json string:
     AssertionError: expected 'Unexpected token \'o\', "foo" is not valid JSON' to start with 'Unexpected token o'
      at Assertion.fail (node_modules/should/cjs/should.js:275:17)
      at Assertion.value [as startWith] (node_modules/should/cjs/should.js:356:19)
      at Timeout._onTimeout (test/nodes/core/parsers/70-JSON_spec.js:176:52)
      at listOnTimeout (node:internal/timers:573:17)
      at process.processTimers (node:internal/timers:514:7)

  2) JSON node
       should log an error if asked to parse an invalid json string in a buffer:
     AssertionError: expected 'Unexpected token \'o\', "{"name":foo}" is not valid JSON' to start with 'Unexpected token o'
      at Assertion.fail (node_modules/should/cjs/should.js:275:17)
      at Assertion.value [as startWith] (node_modules/should/cjs/should.js:356:19)
      at Timeout._onTimeout (test/nodes/core/parsers/70-JSON_spec.js:202:52)
      at listOnTimeout (node:internal/timers:573:17)
      at process.processTimers (node:internal/timers:514:7)
```

After my investigation, I found that the error message of `JSON.parse()` has changed from Node.js v19 as follows.

```
$ nvm use 18
$ node -e 'JSON.parse("foo")'
-> SyntaxError: Unexpected token o in JSON at position 1

$ nvm use 19
$ node -e 'JSON.parse("foo")'
-> SyntaxError: Unexpected token 'o', "foo" is not valid JSON

$ nvm use 20
$ node -e 'JSON.parse("foo")'
-> SyntaxError: Unexpected token 'o', "foo" is not valid JSON
```

The current `dev` branch for v3.1 is not required for this change, but it will be needed in the future release soon.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality