### PR TITLE
Capture workspace dirty state when quick-adding junction

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1398,6 +1398,7 @@ RED.view = (function() {
                     }
                     historyEvent = {
                         t:'add',
+                        dirty: RED.nodes.dirty(),
                         junctions:[nn]
                     }
                 } else {


### PR DESCRIPTION
Fixes #4282

This ensures an undo of quick-add junction restores the correct workspace dirty state.