### PR TITLE
Add tooltip to relevance sort button in user settings UI

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -627,6 +627,7 @@
             "tab-nodes": "Nodes",
             "tab-install": "Install",
             "sort": "sort:",
+            "sortRelevance": "relevance",
             "sortAZ": "a-z",
             "sortRecent": "recent",
             "more": "+ __count__ more",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -627,6 +627,7 @@
             "tab-nodes": "現在のノード",
             "tab-install": "ノードを追加",
             "sort": "並べ替え:",
+            "sortRelevance": "関連順",
             "sortAZ": "辞書順",
             "sortRecent": "日付順",
             "more": "+ さらに __count__ 個",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -917,6 +917,7 @@ RED.palette.editor = (function() {
         const sortRelevance = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle selected"><i class="fa fa-sort-amount-desc"></i></a>').appendTo(sortGroup);
         const sortAZ = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle"><i class="fa fa-sort-alpha-asc"></i></a>').appendTo(sortGroup);
         const sortRecent = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle"><i class="fa fa-calendar"></i></a>').appendTo(sortGroup);
+        RED.popover.tooltip(sortRelevance,RED._("palette.editor.sortRelevance"));
         RED.popover.tooltip(sortAZ,RED._("palette.editor.sortAZ"));
         RED.popover.tooltip(sortRecent,RED._("palette.editor.sortRecent"));
 


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
In the user settings UI, the `a-z` and `recent` buttons have tooltips but the `relevance` button doesn't have it. In this pull request, I added the tooltip to the relevance button like following screenshot.

<img width="440" alt="Screenshot 2023-08-20 at 16 27 12" src="https://github.com/node-red/node-red/assets/20310935/05710929-b00c-478a-91ac-5abdf59c3cce">

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
