### PR TITLE
Ensure junction appears when filtering quick-add list

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js
@@ -362,6 +362,7 @@ RED.typeSearch = (function() {
                 items.push({type:t,def: def, label:getTypeLabel(t,def)});
             }
         });
+        items.push({ type: 'junction', def: { inputs:1, outputs: 1, label: 'junction', type: 'junction'}, label: 'junction' })
         items.sort(sortTypeLabels);
 
         var commonCount = 0;


### PR DESCRIPTION
Fixes #4294

The list of types in the quick-add dialog includes a set of 'common' options at the top. These are duplicate entries shown at the top of the list.

When applying a filter, the code ignores the common entries - this means we don't get duplicate results (the 'common' entry and the regular entry).

The 'junction' node is added as a common entry, but wasn't being added to the main list. This meant, when filtering, the junction entry would not appear.

The fix is to include a junction entry in the main list.