### PR TITLE
Fix function setup tab layout

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.html
@@ -77,14 +77,15 @@
     <div id="func-tabs-content" style="min-height: calc(100% - 95px);">
 
         <div id="func-tab-config" style="display:none">
-            <div class="form-row">
-                <label for="node-input-outputs"><i class="fa fa-random"></i> <span data-i18n="function.label.outputs"></span></label>
-                <input id="node-input-outputs" style="width: 60px;" value="1">
-            </div>
-
-            <div class="form-row">
-                <label for="node-input-timeout"><i class="fa fa-clock-o"></i> <span data-i18n="function.label.timeout"></span></label>
-                <input id="node-input-timeout" style="width: 60px;" data-i18n="[placeholder]join.seconds">
+            <div>
+                <div class="form-row" style="display: inline-block; margin-right: 50px;">
+                    <label for="node-input-outputs"><i class="fa fa-random"></i> <span data-i18n="function.label.outputs"></span></label>
+                    <input id="node-input-outputs" style="width: 60px;" value="1">
+                </div>
+                <div class="form-row" style="display: inline-block;">
+                    <label for="node-input-timeout"><i class="fa fa-clock-o"></i> <span data-i18n="function.label.timeout"></span></label>
+                    <input id="node-input-timeout" style="width: 60px;" data-i18n="[placeholder]join.seconds">
+                </div>
             </div>
 
             <div class="form-row node-input-libs-row hide" style="margin-bottom: 0px;">


### PR DESCRIPTION
Fixes #4296 

Places the timeout/outputs options into a single row to make better use of the space.

<img width="325" alt="image" src="https://github.com/node-red/node-red/assets/51083/afe86489-b415-4e9e-9b98-94ef8d667418">
