### PR TITLE
Handle group-scoped nodes inside subflow

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
@@ -479,7 +479,7 @@ function remapSubflowNodes(nodes,nodeMap) {
                     }
                 }
             }
-            if ((node.type === 'complete' || node.type === 'catch' || node.type === 'status') && node.scope) {
+            if ((node.type === 'complete' || node.type === 'catch' || node.type === 'status') && Array.isArray(node.scope)) {
                 node.scope = node.scope.map(function(id) {
                     return nodeMap[id]?nodeMap[id].id:""
                 })


### PR DESCRIPTION
Fixes #4292

Wasn't coping with the fact `scope` might be an Array or now a String is group scoped.