### PR TITLE
Remove unnecessary check for clientid if autoUnsub set

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.html
@@ -492,12 +492,12 @@
                 let ok = true;
                 if ($("#node-config-input-clientid").length) {
                     // Currently editing the node
-                    let needClientId = !$("#node-config-input-cleansession").is(":checked") || !$("#node-config-input-autoUnsubscribe").is(":checked")
+                    let needClientId = !$("#node-config-input-cleansession").is(":checked")
                     if (needClientId) {
                         ok = (v||"").length > 0;
                     }
                 } else {
-                    let needClientId = !(this.cleansession===undefined || this.cleansession) || this.autoUnsubscribe;
+                    let needClientId = !(this.cleansession===undefined || this.cleansession)
                     if (needClientId) {
                         ok = (v||"").length > 0;
                     }


### PR DESCRIPTION
Fixes #4291 

I'm fairly sure the validation for a blank clientid doesn't need to check the autoUnsub flag. Using the clean session flag is enough for a check.