### PR TITLE
Better distinguish between ctrl and meta keys on mac

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -302,11 +302,21 @@ RED.view = (function() {
         return api
     })()
 
+    const isMac = RED.utils.getBrowserInfo().os === 'mac'
+    // 'Control' is the main modifier key for mouse actions. On Windows,
+    // that is the standard Ctrl key. On Mac that is the Cmd key.
+    function isControlPressed (event) {
+        return (isMac && event.metaKey) || (!isMac && event.ctrlKey)
+    }
 
     function init() {
 
         chart = $("#red-ui-workspace-chart");
         chart.on('contextmenu', function(evt) {
+            if (RED.view.DEBUG) {
+                console.warn("contextmenu", { mouse_mode, event: d3.event });
+            }
+            mouse_mode = RED.state.DEFAULT
             evt.preventDefault()
             evt.stopPropagation()
             RED.contextMenu.show({
@@ -1190,7 +1200,7 @@ RED.view = (function() {
             lasso = null;
         }
         if (d3.event.touches || d3.event.button === 0) {
-            if ((mouse_mode === 0 || mouse_mode === RED.state.QUICK_JOINING) && (d3.event.metaKey || d3.event.ctrlKey) && !(d3.event.altKey || d3.event.shiftKey)) {
+            if ((mouse_mode === 0 || mouse_mode === RED.state.QUICK_JOINING) && isControlPressed(d3.event) && !(d3.event.altKey || d3.event.shiftKey)) {
                 // Trigger quick add dialog
                 d3.event.stopPropagation();
                 clearSelection();
@@ -1200,7 +1210,7 @@ RED.view = (function() {
                     clickedGroup = clickedGroup || RED.nodes.group(drag_lines[0].node.g)
                 }
                 showQuickAddDialog({ position: point, group: clickedGroup });
-            } else if (mouse_mode === 0 && !(d3.event.metaKey || d3.event.ctrlKey)) {
+            } else if (mouse_mode === 0 && !isControlPressed(d3.event)) {
                 // CTRL not being held
                 if (!d3.event.altKey) {
                     // ALT not held (shift is allowed) Trigger lasso
@@ -3540,7 +3550,7 @@ RED.view = (function() {
             d3.event.preventDefault()
             document.getSelection().removeAllRanges()
             if (d.type != "subflow") {
-                if (/^subflow:/.test(d.type) && (d3.event.ctrlKey || d3.event.metaKey)) {
+                if (/^subflow:/.test(d.type) && isControlPressed(d3.event)) {
                     RED.workspaces.show(d.type.substring(8));
                 } else {
                     RED.editor.edit(d);
@@ -3704,12 +3714,12 @@ RED.view = (function() {
             d.type !== 'junction'
         lastClickNode = mousedown_node;
      
-        if (d.selected && (d3.event.ctrlKey||d3.event.metaKey)) {
+        if (d.selected && isControlPressed(d3.event)) {
             mousedown_node.selected = false;
             movingSet.remove(mousedown_node);
         } else {
             if (d3.event.shiftKey) {
-                if (!(d3.event.ctrlKey||d3.event.metaKey)) {
+                if (!isControlPressed(d3.event)) {
                     clearSelection();
                 }
                 var clickPosition = (d3.event.offsetX/scaleFactor - mousedown_node.x)
@@ -3878,10 +3888,10 @@ RED.view = (function() {
         }
         mousedown_link = d;
 
-        if (!(d3.event.metaKey || d3.event.ctrlKey)) {
+        if (!isControlPressed(d3.event)) {
             clearSelection();
         }
-        if (d3.event.metaKey || d3.event.ctrlKey) {
+        if (isControlPressed(d3.event)) {
             if (!selectedLinks.has(mousedown_link)) {
                 selectedLinks.add(mousedown_link);
             } else {
@@ -3896,7 +3906,7 @@ RED.view = (function() {
         redraw();
         focusView();
         d3.event.stopPropagation();
-        if (!mousedown_link.link && movingSet.length() === 0 && (d3.event.touches || d3.event.button === 0) && selectedLinks.length() === 1 && selectedLinks.has(mousedown_link) && (d3.event.metaKey || d3.event.ctrlKey)) {
+        if (!mousedown_link.link && movingSet.length() === 0 && (d3.event.touches || d3.event.button === 0) && selectedLinks.length() === 1 && selectedLinks.has(mousedown_link) && isControlPressed(d3.event)) {
             d3.select(this).classed("red-ui-flow-link-splice",true);
             var point = d3.mouse(this);
             var clickedGroup = getGroupAt(point[0],point[1]);
@@ -3977,7 +3987,7 @@ RED.view = (function() {
         );
         lastClickNode = g;
 
-        if (g.selected && (d3.event.ctrlKey||d3.event.metaKey)) {
+        if (g.selected && isControlPressed(d3.event)) {
             selectedGroups.remove(g);
             d3.event.stopPropagation();
         } else {


### PR DESCRIPTION
Fixes #4206, #4205

Historically we have treated the Ctrl key and Mac's Cmd key as interchangeable when it comes to modifying mouse actions in the editor.

With the introduction of the Context Menu, this has lead to some unexpected user experiences - including the two issues linked above.

This PR modifies the logic is we better distinguish between the two when it matters. Essentially, we have the 'control' key modifier, which now maps to `ctrl` on Windows/Linux and `cmd` on Mac.

This keeps `ctrl` free for triggering the context menu - as per Apple's design guidelines.
