### PR TITLE
Update outdated Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,20 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out node-red repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             path: 'node-red'
       - name: Check out node-red-docker repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             repository: 'node-red/node-red-docker'
             path: 'node-red-docker'
       - name: Check out node-red.github.io repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             repository: 'node-red/node-red.github.io'
             path: 'node-red.github.io'
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
             node-version: '16'
       - run: node ./node-red/.github/scripts/update-node-red-docker.js

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         node-version: [16, 18, 20]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Github Actions are scripts based running on nodejs. They are also need updates and go regularly out of service and may break your CI. See [blog news](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

`peter-evans/create-pull-request@v2` was intentionally not updated, since I am not familiar with it and I want to avoid breaking the ongoing release of node-red 3.1.

Release notes:
https://github.com/actions/checkout/releases/tag/v4.0.0

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
