### PR TITLE
Ensure storage/util.writeFile handles concurrent write attempts

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/util.js
@@ -80,7 +80,6 @@ module.exports = {
     * the write hits disk.
     */
     writeFile: async function(path,content,backupPath) {
-        const reqId = Math.floor(Math.random()*1000)
         if (!writeFileLocks[path]) {
             writeFileLocks[path] = Promise.resolve()
         }

--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/util.js
@@ -71,30 +71,31 @@ function readFile(path,backupPath,emptyResponse,type) {
     });
 }
 
+const writeFileLocks = {}
+
 module.exports = {
     /**
     * Write content to a file using UTF8 encoding.
     * This forces a fsync before completing to ensure
     * the write hits disk.
     */
-    writeFile: function(path,content,backupPath) {
-        var backupPromise;
-        if (backupPath && fs.existsSync(path)) {
-            backupPromise = fs.copy(path,backupPath);
-        } else {
-            backupPromise = Promise.resolve();
+    writeFile: async function(path,content,backupPath) {
+        const reqId = Math.floor(Math.random()*1000)
+        if (!writeFileLocks[path]) {
+            writeFileLocks[path] = Promise.resolve()
         }
-
-        const dirname = fspath.dirname(path);
-        const tempFile = `${path}.$$$`;
-
-        return backupPromise.then(() => {
-            if (backupPath) {
+        const result = writeFileLocks[path].then(async () => {
+            var backupPromise;
+            if (backupPath && fs.existsSync(path)) {
+                await fs.copy(path,backupPath);
                 log.trace(`utils.writeFile - copied ${path} TO ${backupPath}`)
             }
-            return fs.ensureDir(dirname)
-        }).then(() => {
-            return new Promise(function(resolve,reject) {
+
+            const dirname = fspath.dirname(path);
+            const tempFile = `${path}.$$$`;
+            await fs.ensureDir(dirname)
+
+            await new Promise(function(resolve,reject) {
                 var stream = fs.createWriteStream(tempFile);
                 stream.on('open',function(fd) {
                     stream.write(content,'utf8',function() {
@@ -110,10 +111,11 @@ module.exports = {
                     log.warn(log._("storage.localfilesystem.fsync-fail",{path: tempFile, message: err.toString()}));
                     reject(err);
                 });
-            });
-        }).then(() => {
+            })
+            
             log.trace(`utils.writeFile - written content to ${tempFile}`)
-            return new Promise(function(resolve,reject) {
+            
+            await new Promise(function(resolve,reject) {
                 fs.rename(tempFile,path,err => {
                     if (err) {
                         log.warn(log._("storage.localfilesystem.fsync-fail",{path: path, message: err.toString()}));
@@ -122,8 +124,10 @@ module.exports = {
                     log.trace(`utils.writeFile - renamed ${tempFile} to ${path}`)
                     resolve();
                 })
-            });
-        });
+            })
+        })
+        writeFileLocks[path] = result.catch(() => {})
+        return result
     },
     readFile: readFile,
 


### PR DESCRIPTION
Fixes #4221 

This ensures concurrent calls to the `writeFile` utility function are serialised and handled in order. Due to the async nature of the work done, without this it was possible to hit errors (as per original issue) when multiple calls are made to update the same file.