### PR TITLE
Default filter to All Catalogues and show nodes for small lists

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -494,6 +494,7 @@ RED.palette.editor = (function() {
         // if there is only 1 catalog, hide the select
         if (catalogEntries.length > 1) {
             catalogSelection.prepend(`<option value="all">${RED._('palette.editor.allCatalogs')}</option>`)
+            catalogSelection.val('all')
             catalogSelection.removeAttr('disabled') // permit the user to select a catalog
         }
         // refresh the searchInput counter and trigger a change
@@ -523,7 +524,7 @@ RED.palette.editor = (function() {
     function refreshFilteredItems() {
         packageList.editableList('empty');
         var currentFilter = searchInput.searchBox('value').trim();
-        if (currentFilter === ""){
+        if (currentFilter === "" && loadedList.length > 20){
             packageList.editableList('addItem',{count:loadedList.length})
             return;
         }
@@ -893,7 +894,7 @@ RED.palette.editor = (function() {
                 delay: 300,
                 change: function() {
                     var searchTerm = $(this).val().trim().toLowerCase();
-                    if (searchTerm.length > 0) {
+                    if (searchTerm.length > 0 || loadedList.length < 20) {
                         filteredList = loadedList.filter(function(m) {
                             return (m.index.indexOf(searchTerm) > -1);
                         }).map(function(f) { return {info:f}});


### PR DESCRIPTION
Fixes #4315 

This makes two changes to the Palette Manager:

 - If there are multiple catalogues, the select box now defaults to 'All Catalogues' rather than the first in the list
 - If there are fewer than 20 entries in a catalogue, they are listed even with no search term entered. 