### PR TITLE
Handle undefined linkType value for existing link-call nodes

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.html
@@ -275,7 +275,7 @@
                 value: [],
                 type: "link in[]",
                 validate: function (v, opt) {
-                    if ((this.linkType === "static" && v.length > 0)
+                    if (((this.linkType || "static") === "static" && v.length > 0)
                       || this.linkType === "dynamic") {
                         return true;
                     }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)

Reported on the forum, after upgrading to 3.1.0, an existing `link call` node was showing a validation error. This was because the validation expected `linkType` to be set. For old flows, that value could be `undefined` which ought to have been good enough to imply `static`.

This modifies the validation so it treats `undefined` as `static`.

One side-effect we'll live with is that on editing such a node and clicking 'done' without having made changes, will cause the value to get set to 'static' - and mark the node as dirty. This sometimes causes complaints in the community, but it's a fleeting moment to deal with it.