### PR TITLE
npm: Remove production flag on npm invocation

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/externalModules.js
+++ b/packages/node_modules/@node-red/registry/lib/externalModules.js
@@ -263,7 +263,7 @@ async function installModule(moduleDetails) {
             "module": moduleDetails.module,
             "version": moduleDetails.version,
             "dir": installDir,
-            "args": ["--production","--engine-strict"]
+            "args": ["--omit=dev","--engine-strict"]
         }
         return hooks.trigger("preInstall", triggerPayload).then((result) => {
             // preInstall passed

--- a/packages/node_modules/@node-red/registry/lib/installer.js
+++ b/packages/node_modules/@node-red/registry/lib/installer.js
@@ -215,7 +215,7 @@ async function installModule(module,version,url) {
             "dir": installDir,
             "isExisting": isExisting,
             "isUpgrade": isUpgrade,
-            "args": ['--no-audit','--no-update-notifier','--no-fund','--save','--save-prefix=~','--production','--engine-strict']
+            "args": ['--no-audit','--no-update-notifier','--no-fund','--save','--save-prefix=~','--omit=dev','--engine-strict']
         }
 
         return hooks.trigger("preInstall", triggerPayload).then((result) => {


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

When installing packages the `--production` flag used to be added to the arguments that `npm` received. As npm wants developers to use the `--omit=dev` flag instead it warned users on STDERR. Standard error was captured by Node-RED and output to the logs as being an error. This caught users off-guard and they expected something to have gone wrong.

With this change the `--omit=dev` is used instead, to remove the warning.

This change works for NPM of version 8 and beyond[1], included in Node.JS 16. This change will not work on NPM version 6[2] which is included in Node.JS 14[3].

[1]: https://docs.npmjs.com/cli/v8/commands/npm-install#omit
[2]: https://docs.npmjs.com/cli/v6/commands/npm-install
[3]: https://nodejs.org/en/download/releases#looking-for-latest-release-of-a-version-branch


Note this PR depends on dropping NodeJS 14, and thus: https://github.com/node-red/node-red/pull/4306

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
   - [ ] I've discussed with Nick through other communication channels 
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
