### PR TITLE
github: Request `npm run test` in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,5 +30,5 @@ the [forum](https://discourse.nodered.org) or
 
 - [ ] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
 - [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
-- [ ] I have run `grunt` to verify the unit tests pass
+- [ ] I have run `npm run test` to verify the unit tests pass
 - [ ] I have added suitable unit tests to cover the new/changed functionality


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Proposed changes

Due to the way grunt is installed, `grunt` might not work for the user locally. However, `npm run test` will succeed for them, as NPM knows where `grunt` is located to execute.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [-] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ :) ] I have run `grunt` to verify the unit tests pass
- [-] I have added suitable unit tests to cover the new/changed functionality
