### PR TITLE
Performance : make CSV export way faster by not re-allocating and handling huge string

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/parsers/70-CSV.js
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-CSV.js
@@ -63,7 +63,7 @@ module.exports = function(RED) {
                         if (!(notemplate && (msg.hasOwnProperty("parts") && msg.parts.hasOwnProperty("index") && msg.parts.index > 0))) {
                             template = clean(node.template);
                         }
-                        var ou = "";
+                        const ou = [];
                         if (!Array.isArray(msg.payload)) { msg.payload = [ msg.payload ]; }
                         if (node.hdrout !== "none" && node.hdrSent === false) {
                             if ((template.length === 1) && (template[0] === '')) {
@@ -74,7 +74,7 @@ module.exports = function(RED) {
                                     template = Object.keys(msg.payload[0]);
                                 }
                             }
-                            ou += template.map(v => v.indexOf(node.sep)!==-1 ? '"'+v+'"' : v).join(node.sep) + node.ret;
+                            ou.push(template.map(v => v.indexOf(node.sep)!==-1 ? '"'+v+'"' : v).join(node.sep));
                             if (node.hdrout === "once") { node.hdrSent = true; }
                         }
                         for (var s = 0; s < msg.payload.length; s++) {
@@ -93,7 +93,7 @@ module.exports = function(RED) {
                                         msg.payload[s][t] = node.quo + msg.payload[s][t].toString() + node.quo;
                                     }
                                 }
-                                ou += msg.payload[s].join(node.sep) + node.ret;
+                                ou.push(msg.payload[s].join(node.sep));
                             }
                             else {
                                 if ((template.length === 1) && (template[0] === '') && (msg.hasOwnProperty("columns"))) {
@@ -105,6 +105,7 @@ module.exports = function(RED) {
                                         node.warn(RED._("csv.errors.obj_csv"));
                                         tmpwarn = false;
                                     }
+                                    const row = [];
                                     for (var p in msg.payload[0]) {
                                         /* istanbul ignore else */
                                         if (msg.payload[s].hasOwnProperty(p)) {
@@ -118,21 +119,22 @@ module.exports = function(RED) {
                                                 }
                                                 if (q.indexOf(node.quo) !== -1) { // add double quotes if any quotes
                                                     q = q.replace(/"/g, '""');
-                                                    ou += node.quo + q + node.quo + node.sep;
+                                                    row.push(node.quo + q + node.quo);
                                                 }
                                                 else if (q.indexOf(node.sep) !== -1 || p.indexOf("\n") !== -1) { // add quotes if any "commas" or "\n"
-                                                    ou += node.quo + q + node.quo + node.sep;
+                                                    row.push(node.quo + q + node.quo);
                                                 }
-                                                else { ou += q + node.sep; } // otherwise just add
+                                                else { row.push(q); } // otherwise just add
                                             }
                                         }
                                     }
-                                    ou = ou.slice(0,-1) + node.ret;
+                                    ou.push(row.join(node.sep)); // add separator
                                 }
                                 else {
+                                    const row = [];
                                     for (var t=0; t < template.length; t++) {
                                         if (template[t] === '') {
-                                            ou += node.sep;
+                                            row.push('');
                                         }
                                         else {
                                             var tt = template[t];
@@ -146,19 +148,20 @@ module.exports = function(RED) {
                                             p = RED.util.ensureString(p);
                                             if (p.indexOf(node.quo) !== -1) { // add double quotes if any quotes
                                                 p = p.replace(/"/g, '""');
-                                                ou += node.quo + p + node.quo + node.sep;
+                                                row.push(node.quo + p + node.quo);
                                             }
                                             else if (p.indexOf(node.sep) !== -1 || p.indexOf("\n") !== -1) { // add quotes if any "commas" or "\n"
-                                                ou += node.quo + p + node.quo + node.sep;
+                                                row.push(node.quo + p + node.quo);
                                             }
-                                            else { ou += p + node.sep; } // otherwise just add
+                                            else { row.push(p); } // otherwise just add
                                         }
                                     }
-                                    ou = ou.slice(0,-1) + node.ret; // remove final "comma" and add "newline"
+                                    ou.push(row.join(node.sep)); // add separator
                                 }
                             }
                         }
-                        msg.payload = ou;
+                        // join lines, don't forget to add the last new line
+                        msg.payload = ou.join(node.ret) + node.ret;
                         msg.columns = template.map(v => v.indexOf(',')!==-1 ? '"'+v+'"' : v).join(',');
                         if (msg.payload !== '') { send(msg); }
                         done();


### PR DESCRIPTION

## Types of changes

The change is to improve massively the problematic performance of the CSV node while exporting CSV from JS object

I consider this a bug fix due to the poor performance of the current implementation on fairly big payloads

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

I did not take the time to create an actual ticket before-hand and apologize for that.

## Proposed changes

By not using string.slice(0,-1) but rather joining smaller array that includes the separator only when required, the performance of the node is improved at by 2 to 3 order when handling big JS object

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality

## Performance number

Since this PR is about improving the node performance, we need to understand the actual performance of the node, and how it now compares before/after the fix.

Here is the flow used for the following data :

```json
[[{"id":"f1d31f03.48da08","type":"inject","z":"4e2ac6b5.d48208","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"500","payload":"","payloadType":"date","x":360,"y":3360,"wires":[["c12bdabb.f06d7"]]},{"id":"c12bdabb.f06d7","type":"function","z":"4e2ac6b5.d48208","name":"build long array","func":"let payload = [\n    {\n        \"dbd5\": \"23080413430901\",\n        \"dat2\": \"ASTRG1\",\n        \"fhl9\": 1\n    },\n    {\n        \"dbd5\": \"23080413430901\",\n        \"dat2\": \"ASTRG2\",\n        \"fhl9\": \"010031\"\n    },\n    {\n        \"dbd5\": \"23080413430901\",\n        \"dat2\": \"ASTRG4\",\n        \"fhl9\": \"230804134309\"\n    },\n    {\n        \"dbd5\": \"23080413430901\",\n        \"dat2\": \"ASTRG5\",\n        \"fhl9\": 672\n    },\n    {\n        \"dbd5\": \"23080413430901\",\n        \"dat2\": \"ASTRG6\",\n        \"fhl9\": 1310\n    },\n    {\n        \"dbd5\": \"23080413430901\",\n        \"dat2\": \"ASTRG7\",\n        \"fhl9\": 0\n    },\n    {\n        \"dbd5\": \"23080413430901\",\n        \"dat2\": \"ASTRG8\",\n        \"fhl9\": \"C\"\n    },\n    {\n        \"dbd5\": \"23080413430901\",\n        \"dat2\": \"ASTRG3\",\n        \"fhl9\": 1\n    },\n    {\n        \"dbd5\": \"23080413431002\",\n        \"dat2\": \"ASTRG1\",\n        \"fhl9\": 2\n    },\n    {\n        \"dbd5\": \"23080413431002\",\n        \"dat2\": \"ASTRG2\",\n        \"fhl9\": \"010031\"\n    },\n    {\n        \"dbd5\": \"23080413431002\",\n        \"dat2\": \"ASTRG4\",\n        \"fhl9\": \"230804134310\"\n    },\n    {\n        \"dbd5\": \"23080413431002\",\n        \"dat2\": \"ASTRG5\",\n        \"fhl9\": 672\n    },\n    {\n        \"dbd5\": \"23080413431002\",\n        \"dat2\": \"ASTRG6\",\n        \"fhl9\": 1310\n    },\n    {\n        \"dbd5\": \"23080413431002\",\n        \"dat2\": \"ASTRG7\",\n        \"fhl9\": 0\n    },\n    {\n        \"dbd5\": \"23080413431002\",\n        \"dat2\": \"ASTRG8\",\n        \"fhl9\": \"C\"\n    },\n    {\n        \"dbd5\": \"23080413431002\",\n        \"dat2\": \"ASTRG3\",\n        \"fhl9\": 1\n    },\n    {\n        \"dbd5\": \"23080413431103\",\n        \"dat2\": \"ASTRG1\",\n        \"fhl9\": 3\n    },\n    {\n        \"dbd5\": \"23080413431103\",\n        \"dat2\": \"ASTRG2\",\n        \"fhl9\": \"010031\"\n    },\n    {\n        \"dbd5\": \"23080413431103\",\n        \"dat2\": \"ASTRG4\",\n        \"fhl9\": \"230804134311\"\n    },\n    {\n        \"dbd5\": \"23080413431103\",\n        \"dat2\": \"ASTRG5\",\n        \"fhl9\": 672\n    }\n]\n\nconst mult = msg.topic;\n\nlet array = [];\n\nfor (let index = 0; index < mult; index++) {\n    array.push(...payload)\n}\n\nmsg.payload = array;\nmsg.start = Date.now();\nnode.send(msg);","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":560,"y":3360,"wires":[["c0355eb0.128b88"]]},{"id":"48ae2f1b.c4f84","type":"comment","z":"4e2ac6b5.d48208","name":"500x","info":"","x":310,"y":3320,"wires":[]},{"id":"f0d849d8.3c5f","type":"inject","z":"4e2ac6b5.d48208","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"5000","payload":"","payloadType":"date","x":360,"y":3280,"wires":[["c12bdabb.f06d7"]]},{"id":"3222da4e.06b0f6","type":"comment","z":"4e2ac6b5.d48208","name":"5000x","info":"","x":310,"y":3240,"wires":[]},{"id":"c0355eb0.128b88","type":"csv","z":"4e2ac6b5.d48208","name":"","sep":",","hdrin":"","hdrout":"none","multi":"one","ret":"\\n","temp":"","skip":"0","strings":true,"include_empty_strings":"","include_null_values":"","x":730,"y":3360,"wires":[["95421023.bf6f78"]]},{"id":"95421023.bf6f78","type":"function","z":"4e2ac6b5.d48208","name":"to result","func":"msg.payload = {\n    duration : Date.now() - msg.start,\n    outputSizeMB : msg.payload.length / (1024*1024) \n}\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":880,"y":3360,"wires":[["72045619.792198"]]},{"id":"72045619.792198","type":"debug","z":"4e2ac6b5.d48208","name":"","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","statusVal":"","statusType":"auto","x":1050,"y":3360,"wires":[]}]
```

Note : additionnal multiplier of payload was used to have a more precise/broader view

The flow output nice informations :

```json
{"duration":56,"outputSizeMB":2.5527000427246094}
```

duration is in ms and outputSizeMB is the length of the resulting string (in MB).

I know we're working with big payload here, but this never was an issue for really small payload (few hundreds bytes/kb are mostly "fine")

Here are the performance difference, the scale is log in both X and Y axis.

X is the size of the file in MB. (first point is at 0.23 which is 230kb)

Y is the duration reported in ms.

![image](https://github.com/node-red/node-red/assets/3913349/f28d691b-fa7f-4af0-ad5c-43737a38f983)

What this means is that for the same computationnal cost, we used to output a 230kb csv in around half a second (~380ms)

Now we can instead do it way faster (in the 10s of ms) or export a 23mb csv for the same duration.

In the graph we clearly see the scaling is different, that is because the slice is O(bytes) for each lines, meaning we're O(bytes*line), where the join is somewhat constant in speed because it depends only on the byte on the same line count, meaning the scaling is O(line)

Old node scaling being O(n^2):
![image](https://github.com/node-red/node-red/assets/3913349/61ccfb42-91de-412d-97b3-af3f26ab7a36)

New node scaling being mostly linear (and noisy cause the function is to fast)
![image](https://github.com/node-red/node-red/assets/3913349/1ce7ce19-b4c1-4b01-8766-556e88be4db2)

