### PR TITLE
Add support for installing ESM module nodes

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/loader.js
+++ b/packages/node_modules/@node-red/registry/lib/loader.js
@@ -358,7 +358,7 @@ function loadNodeSet(node) {
     try {
         var loadPromise = null;
         var r = require(node.file);
-        r = r.__esModule ? r.default : r
+        r = r.__esModule ? r.default : r;
         if (typeof r === "function") {
 
             var red = registryUtil.createNodeApi(node);

--- a/packages/node_modules/@node-red/registry/lib/loader.js
+++ b/packages/node_modules/@node-red/registry/lib/loader.js
@@ -66,7 +66,7 @@ function loadModuleTypeFiles(module, type) {
                     moduleFn = parts.slice(0,nmi+2).join(path.sep);
                 }
                 if (!moduleFn) {
-                    // shortcut - skip calling statSync on empty string 
+                    // shortcut - skip calling statSync on empty string
                     break; // Module not found, don't attempt to load its nodes
                 }
                 try {
@@ -372,7 +372,6 @@ function loadNodeSet(node) {
     } catch(err) {
         node.err = err;
         var stack = err.stack;
-        var message;
         if (stack) {
             var filePath = node.file;
             try {
@@ -463,7 +462,6 @@ async function loadPlugin(plugin) {
         console.log(err);
         plugin.err = err;
         var stack = err.stack;
-        var message;
         if (stack) {
             var i = stack.indexOf(plugin.file);
             if (i > -1) {
@@ -477,7 +475,7 @@ async function loadPlugin(plugin) {
         return plugin;
     }
 }
-let invocation = 0
+
 function loadNodeSetList(nodes) {
     var promises = [];
     nodes.forEach(function(node) {
@@ -499,7 +497,6 @@ function addModule(module) {
     if (!settings.available()) {
         throw new Error("Settings unavailable");
     }
-    var nodes = [];
     var existingInfo = registry.getModuleInfo(module);
     if (existingInfo) {
         // TODO: nls

--- a/packages/node_modules/@node-red/registry/lib/loader.js
+++ b/packages/node_modules/@node-red/registry/lib/loader.js
@@ -356,10 +356,19 @@ function loadNodeSet(node) {
     } else {
     }
     try {
-        var r = require(node.file);
-        // Babel related workaround, references in comment below.
-        r = r.__esModule ? r.default : r;
-        return createLoadPromise(node, r);
+        let importPromise = import(node.file);
+        return importPromise
+            .then(function(moduleNamespaceObject) {
+                // CJS will always have default, ESM might have default. (details in note below)
+                let r = moduleNamespaceObject.default ? moduleNamespaceObject.default : moduleNamespaceObject;
+                // Babel related workaround, references in comment below.
+                r = r.__esModule ? r.default : r;
+                return createLoadPromise(node, r);
+            })
+            .catch(function(err) {
+                node.err = err;
+                return Promise.resolve(node);
+            });
     } catch(err) {
         node.err = err;
         var stack = err.stack;
@@ -383,6 +392,12 @@ function loadNodeSet(node) {
         }
         return Promise.resolve(node);
     }
+
+    // Notes on default:
+    // https://nodejs.org/api/esm.html#import-expressions
+    // "When importing CommonJS modules, the module.exports object is provided as the default export."
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import
+    // "The module namespace object is a sealed object ... with the default export available as a key called `default`."
 
     // Notes on __esModule:
     // Workaround originally added in commit 326f3469, merged in pull request #3669.

--- a/packages/node_modules/@node-red/registry/lib/loader.js
+++ b/packages/node_modules/@node-red/registry/lib/loader.js
@@ -17,6 +17,7 @@
 var fs = require("fs-extra");
 var path = require("path");
 var semver = require("semver");
+const { pathToFileURL } = require('node:url');
 
 var localfilesystem = require("./localfilesystem");
 var registry = require("./registry");
@@ -356,7 +357,8 @@ function loadNodeSet(node) {
     } else {
     }
     try {
-        let importPromise = import(node.file);
+        const modulePath = pathToFileURL(node.file).href;
+        const importPromise = import(modulePath);
         return importPromise
             .then(function(moduleNamespaceObject) {
                 // CJS will always have default, ESM might have default. (details in note below)

--- a/packages/node_modules/@node-red/registry/lib/loader.js
+++ b/packages/node_modules/@node-red/registry/lib/loader.js
@@ -356,30 +356,9 @@ function loadNodeSet(node) {
     } else {
     }
     try {
-        var loadPromise = null;
         var r = require(node.file);
         r = r.__esModule ? r.default : r;
-        if (typeof r === "function") {
-
-            var red = registryUtil.createNodeApi(node);
-            var promise = r(red);
-            if (promise != null && typeof promise.then === "function") {
-                loadPromise = promise.then(function() {
-                    node.enabled = true;
-                    node.loaded = true;
-                    return node;
-                }).catch(function(err) {
-                    node.err = err;
-                    return node;
-                });
-            }
-        }
-        if (loadPromise == null) {
-            node.enabled = true;
-            node.loaded = true;
-            loadPromise = Promise.resolve(node);
-        }
-        return loadPromise;
+        return createLoadPromise(node, r);
     } catch(err) {
         node.err = err;
         var stack = err.stack;
@@ -402,6 +381,31 @@ function loadNodeSet(node) {
             }
         }
         return Promise.resolve(node);
+    }
+
+    function createLoadPromise(node, r) {
+        var loadPromise = null;
+        if (typeof r === "function") {
+
+            var red = registryUtil.createNodeApi(node);
+            var promise = r(red);
+            if (promise != null && typeof promise.then === "function") {
+                loadPromise = promise.then(function () {
+                    node.enabled = true;
+                    node.loaded = true;
+                    return node;
+                }).catch(function (err) {
+                    node.err = err;
+                    return node;
+                });
+            }
+        }
+        if (loadPromise == null) {
+            node.enabled = true;
+            node.loaded = true;
+            loadPromise = Promise.resolve(node);
+        }
+        return loadPromise;
     }
 }
 

--- a/packages/node_modules/@node-red/registry/lib/loader.js
+++ b/packages/node_modules/@node-red/registry/lib/loader.js
@@ -357,6 +357,7 @@ function loadNodeSet(node) {
     }
     try {
         var r = require(node.file);
+        // Babel related workaround, references in comment below.
         r = r.__esModule ? r.default : r;
         return createLoadPromise(node, r);
     } catch(err) {
@@ -382,6 +383,14 @@ function loadNodeSet(node) {
         }
         return Promise.resolve(node);
     }
+
+    // Notes on __esModule:
+    // Workaround originally added in commit 326f3469, merged in pull request #3669.
+    // Related links:
+    // https://github.com/nodejs/node/issues/40891
+    // https://github.com/evanw/esbuild/issues/1591
+    // https://babeljs.io/docs/babel-plugin-transform-modules-commonjs
+    // https://stackoverflow.com/questions/50943704/whats-the-purpose-of-object-definepropertyexports-esmodule-value-0
 
     function createLoadPromise(node, r) {
         var loadPromise = null;

--- a/test/unit/@node-red/registry/lib/loader_spec.js
+++ b/test/unit/@node-red/registry/lib/loader_spec.js
@@ -626,7 +626,7 @@ describe("red/nodes/registry/loader",function() {
                 node.enabled.should.be.true();
                 nodes.registerType.called.should.be.false();
                 node.should.have.property('err');
-                node.err.toString().should.eql("Error: fail to require (line:1)");
+                node.err.toString().should.eql("Error: fail to require");
 
                 done();
             }).catch(function(err) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Currently node-red fails when attempting to install a node written as an ESM module, e.g.

```text
19 Sep 18:59:53 - [info] Server now running at http://127.0.0.1:1880/
19 Sep 18:59:53 - [info] Starting flows
19 Sep 18:59:53 - [info] Started flows
19 Sep 19:01:05 - [info] Installing module: @hlovdal/node-red-lowercase-in-typescript, version: 1.0.0
19 Sep 19:01:12 - [info] Installed module: @hlovdal/node-red-lowercase-in-typescript
19 Sep 19:01:12 - [info] Added node types:
19 Sep 19:01:12 - [info]  - @hlovdal/node-red-lowercase-in-typescript:lower-case : Error [ERR_REQUIRE_ESM]: require() of ES Module .../.node-red/node_modules/@hlovdal/node-red-lowercase-in-typescript/src/lower-case.js from .../node-red/packages/node_modules/@node-red/registry/lib/loader.js not supported.
Instead change the require of lower-case.js in .../node-red/packages/node_modules/@node-red/registry/lib/loader.js to a dynamic import() which is available in all CommonJS modules.
```

This pull request fixes that by using [dynamic `import()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) instead of `require`.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the [forum](https://discourse.nodered.org/t/adding-support-for-installing-esm-module-nodes/81438)/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
