### PR TITLE
Fix env evaluation when one env references another in the same object

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -112,6 +112,7 @@ async function evaluateEnvProperties(flow, env, credentials) {
     if (pendingEvaluations.length > 0) {
         await Promise.all(pendingEvaluations)
     }
+    // Now loop over the env types and evaluate them properly
     for (let i = 0; i < envTypes.length; i++) {
         let { name, value, type } = envTypes[i]
         // If an env-var wants to lookup itself, delegate straight to the parent
@@ -122,7 +123,17 @@ async function evaluateEnvProperties(flow, env, credentials) {
         if (evaluatedEnv.hasOwnProperty(value)) {
             value = evaluatedEnv[value]
         } else {
-            value = redUtil.evaluateNodeProperty(value, type, {_flow: flow}, null, null);
+            value = redUtil.evaluateNodeProperty(value, type, {_flow: {
+                // Provide a hook so when it tries to look up a flow setting,
+                // we can insert the just-evaluated value which hasn't yet
+                // been set on the flow object - otherwise delegate up to the flow
+                getSetting: function(name) {
+                    if (evaluatedEnv.hasOwnProperty(name)){
+                        return evaluatedEnv[name]
+                    }
+                    return flow.getSetting(name)
+                }
+            }}, null, null);
         }
         evaluatedEnv[name] = value
     }


### PR DESCRIPTION
Fixes #4342

When evaluating env vars in a Flow/Subflow/Group we defer evaluating `env` types to last as they might reference other env vars set at the same level.

However, when they are eventually evaluated, we're still in the call to evaluate the env vars - so the Flow/Subflow/Group object hasn't yet been updated with the evaluated values. So when the `env` evaluation is done and `flow.getSetting()` is called, it retrieves the unevaluated value... and if you can follow that then you get a 🥇 .

The fix is to hook into the `getSetting` call whilst evaluating the `env` property to return any just-evaluated values before delegating to the flow.