### PR TITLE
Handle credential env var evaluation when no value set

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -161,14 +161,14 @@ class Flow {
             for (let i = 0; i < configNodes.length; i++) {
                 const node = this.flow.configs[configNodes[i]]
                 if (node.type === 'global-config' && node.env) {
-                    const nodeEnv = await flowUtil.evaluateEnvProperties(this, node.env, credentials.get(node.id))
+                    const nodeEnv = await flowUtil.evaluateEnvProperties(this, node.env, credentials.get(node.id) || {})
                     this._env = { ...this._env, ...nodeEnv }
                 }
             }
         }
 
         if (this.env) {
-            this._env = { ...this._env, ...await flowUtil.evaluateEnvProperties(this, this.env, credentials.get(this.id)) }
+            this._env = { ...this._env, ...await flowUtil.evaluateEnvProperties(this, this.env, credentials.get(this.id) || {}) }
         }
 
         // Initialise the group objects. These must be done in the right order

--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -161,14 +161,14 @@ class Flow {
             for (let i = 0; i < configNodes.length; i++) {
                 const node = this.flow.configs[configNodes[i]]
                 if (node.type === 'global-config' && node.env) {
-                    const nodeEnv = await flowUtil.evaluateEnvProperties(this, node.env, credentials.get(node.id) || {})
+                    const nodeEnv = await flowUtil.evaluateEnvProperties(this, node.env, credentials.get(node.id))
                     this._env = { ...this._env, ...nodeEnv }
                 }
             }
         }
 
         if (this.env) {
-            this._env = { ...this._env, ...await flowUtil.evaluateEnvProperties(this, this.env, credentials.get(this.id) || {}) }
+            this._env = { ...this._env, ...await flowUtil.evaluateEnvProperties(this, this.env, credentials.get(this.id)) }
         }
 
         // Initialise the group objects. These must be done in the right order

--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -80,6 +80,7 @@ function mapEnvVarProperties(obj,prop,flow,config) {
 }
 
 async function evaluateEnvProperties(flow, env, credentials) {
+    credentials = credentials || {}
     const pendingEvaluations = []
     const evaluatedEnv = {}
     const envTypes = []


### PR DESCRIPTION
Reported in a [comment](https://github.com/node-red/node-red/issues/4342#issuecomment-1729516843), if an env var was of credential type, but no value set, an error was being hit.

This fixes that by ensuring the credentials object exists.