### PR TITLE
Add missing nls labels to context menu

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
@@ -168,8 +168,8 @@ RED.contextMenu = (function () {
 
             menuItems.push(
                 null,
-                { onselect: 'core:undo', disabled: RED.history.list().length === 0 },
-                { onselect: 'core:redo', disabled: RED.history.listRedo().length === 0 },
+                { onselect: 'core:undo', label: RED._("keyboard.undoChange"), disabled: RED.history.list().length === 0 },
+                { onselect: 'core:redo', label: RED._("keyboard.redoChange"), disabled: RED.history.listRedo().length === 0 },
                 null,
                 { onselect: 'core:cut-selection-to-internal-clipboard', label: RED._("keyboard.cutNode"), disabled: !canEdit || !hasSelection },
                 { onselect: 'core:copy-selection-to-internal-clipboard', label: RED._("keyboard.copyNode"), disabled: !hasSelection },
@@ -177,7 +177,7 @@ RED.contextMenu = (function () {
                 { onselect: 'core:delete-selection', disabled: !canEdit || !canDelete },
                 { onselect: 'core:delete-selection-and-reconnect', label: RED._('keyboard.deleteReconnect'), disabled: !canEdit || !canDelete },
                 { onselect: 'core:show-export-dialog', label: RED._("menu.label.export") },
-                { onselect: 'core:select-all-nodes' },
+                { onselect: 'core:select-all-nodes', label: RED._("keyboard.selectAll") },
             )
         }
 


### PR DESCRIPTION
Fixes #4334

Some of the context menu entries didn't have explicit catalog entires for their action. This updates them to use the existing nls labels for the corresponding action.