### PR TITLE
Timer testing fix

### DIFF
--- a/test/nodes/core/function/10-function_spec.js
+++ b/test/nodes/core/function/10-function_spec.js
@@ -1718,9 +1718,10 @@ describe('function node', function() {
     describe("init function", function() {
 
         it('should delay handling messages until init completes', function(done) {
+            const timeout_ms = 200;
             var flow = [{id:"n1",type:"function",wires:[["n2"]],initialize: `
                 return new Promise((resolve,reject) => {
-                    setTimeout(resolve,200)
+                    setTimeout(resolve, ${timeout_ms});
                 })`,
                 func:"return msg;"
             },
@@ -1733,9 +1734,9 @@ describe('function node', function() {
                     msg.delta = Date.now() - msg.payload;
                     receivedMsgs.push(msg)
                     if (receivedMsgs.length === 5) {
-                        var errors = receivedMsgs.filter(msg => msg.delta < 200)
+                        var errors = receivedMsgs.filter(msg => msg.delta < timeout_ms)
                         if (errors.length > 0) {
-                            done(new Error(`Message received before init completed - was ${msg.delta} expected >300`))
+                            done(new Error(`Message received before init completed - was ${msg.delta} expected >${timeout_ms}`))
                         } else {
                             done();
                         }

--- a/test/nodes/core/function/10-function_spec.js
+++ b/test/nodes/core/function/10-function_spec.js
@@ -1718,13 +1718,13 @@ describe('function node', function() {
     describe("init function", function() {
 
         it('should delay handling messages until init completes', function(done) {
-            const timeout_ms = 200;
+            const timeoutMS = 200;
             // Since helper.load uses process.nextTick timers might occasionally finish
             // a couple of milliseconds too early, so give some leeway to the check.
-            const timeout_check_margin = 5;
+            const timeoutCheckMargin = 5;
             var flow = [{id:"n1",type:"function",wires:[["n2"]],initialize: `
                 return new Promise((resolve,reject) => {
-                    setTimeout(resolve, ${timeout_ms});
+                    setTimeout(resolve, ${timeoutMS});
                 })`,
                 func:"return msg;"
             },
@@ -1738,9 +1738,9 @@ describe('function node', function() {
                     receivedMsgs.push(msg)
                     if (receivedMsgs.length === 5) {
                         let deltas = receivedMsgs.map(msg => msg.delta);
-                        var errors = deltas.filter(delta => delta < (timeout_ms - timeout_check_margin))
+                        var errors = deltas.filter(delta => delta < (timeoutMS - timeoutCheckMargin))
                         if (errors.length > 0) {
-                            done(new Error(`Message received before init completed - delta values ${JSON.stringify(deltas)} expected to be > ${timeout_ms - timeout_check_margin}`))
+                            done(new Error(`Message received before init completed - delta values ${JSON.stringify(deltas)} expected to be > ${timeoutMS - timeoutCheckMargin}`))
                         } else {
                             done();
                         }

--- a/test/nodes/core/function/10-function_spec.js
+++ b/test/nodes/core/function/10-function_spec.js
@@ -1719,6 +1719,9 @@ describe('function node', function() {
 
         it('should delay handling messages until init completes', function(done) {
             const timeout_ms = 200;
+            // Since helper.load uses process.nextTick timers might occasionally finish
+            // a couple of milliseconds too early, so give some leeway to the check.
+            const timeout_check_margin = 5;
             var flow = [{id:"n1",type:"function",wires:[["n2"]],initialize: `
                 return new Promise((resolve,reject) => {
                     setTimeout(resolve, ${timeout_ms});
@@ -1735,9 +1738,9 @@ describe('function node', function() {
                     receivedMsgs.push(msg)
                     if (receivedMsgs.length === 5) {
                         let deltas = receivedMsgs.map(msg => msg.delta);
-                        var errors = deltas.filter(delta => delta < timeout_ms)
+                        var errors = deltas.filter(delta => delta < (timeout_ms - timeout_check_margin))
                         if (errors.length > 0) {
-                            done(new Error(`Message received before init completed - delta values ${JSON.stringify(deltas)} expected to be > ${timeout_ms}`))
+                            done(new Error(`Message received before init completed - delta values ${JSON.stringify(deltas)} expected to be > ${timeout_ms - timeout_check_margin}`))
                         } else {
                             done();
                         }

--- a/test/nodes/core/function/10-function_spec.js
+++ b/test/nodes/core/function/10-function_spec.js
@@ -1734,9 +1734,10 @@ describe('function node', function() {
                     msg.delta = Date.now() - msg.payload;
                     receivedMsgs.push(msg)
                     if (receivedMsgs.length === 5) {
-                        var errors = receivedMsgs.filter(msg => msg.delta < timeout_ms)
+                        let deltas = receivedMsgs.map(msg => msg.delta);
+                        var errors = deltas.filter(delta => delta < timeout_ms)
                         if (errors.length > 0) {
-                            done(new Error(`Message received before init completed - was ${msg.delta} expected >${timeout_ms}`))
+                            done(new Error(`Message received before init completed - delta values ${JSON.stringify(deltas)} expected to be > ${timeout_ms}`))
                         } else {
                             done();
                         }


### PR DESCRIPTION
(This is the result of my investigation into why the test "should delay handling messages until init completes" in `test/nodes/core/function/10-function_spec.js` fails occasionally.)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

The library `node-red-node-test-helper` uses `process.nextTick` which might trigger executing callbacks slightly before normal, and thus causing the test to fail. The remedy is to add a tiny threshold margin of say 5ms, e.g. when the timeout period is 200ms then accept it being run for only 195ms. Through my testing I have never noticed a lower `msg.delta` value than 198.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality

## Summary

The test makes use of `helper.load` whose implementation in the [`node-red-node-test-helper` library](node_modules/node-red-node-test-helper) contains the following:

```javascript
        const self = this;
        PROXY_METHODS.forEach(methodName => {
            const spy = this._sandbox.spy(self._NodePrototype, methodName);
            self._NodePrototype[methodName] = new Proxy(spy, {
                apply: (target, thisArg, args) => {
                    const retval = Reflect.apply(target, thisArg, args);
                    process.nextTick(function(call) { return () => {
                            self._NodePrototype.emit.call(thisArg, `call:${methodName}`, call);
                    }}(spy.lastCall));
                    return retval;
                }
            });
        });
```

Adding some debug print to the test and to node-red-node-test-helper makes the output from running the test looks like

```text
    init function
Hello from load
Goodbye from load, initPromises.length = 0
Hello from getFlows
Hello from initialize
Hello from Promise
Hello from redNodes.registerType helper
Hello from setTimeout
Hello from func
Hello from func
Hello from func
Hello from func
Hello from func
Hello from apply send
Goodbye from apply send undefined
Hello from apply send
Goodbye from apply send undefined
Hello from apply send
Goodbye from apply send undefined
Hello from apply send
Goodbye from apply send undefined
Hello from apply send
Goodbye from apply send undefined
Hello from input msg0 204
Hello from setImmediate send, delta = 4
Hello from input msg1 205
Hello from setImmediate send, delta = 3
Hello from input msg2 205
Hello from setImmediate send, delta = 3
Hello from input msg3 204
Hello from setImmediate send, delta = 2
Hello from input msg4 204
Delta max - min: 1
      ✔ should delay handling messages until init completes (224ms)
```

and the `send` function is one of the `PROXY_METHODS` intercepted above. While I am not an expert in all the details of exactly how the event loop works in node.js, I am quite certain that the thing that causes the test to fail is the use of `process.nextTick` since it puts callbacks into the execution pipeline immediately and thus occasionally might run callbacks slightly before they naturally should have been run.

Further details:
https://youtu.be/u1kqx6AenYw?t=1113
https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick#process-nexttick
https://nodejs.org/api/process.html#process_process_nexttick_callback_args

### Testing

I did some experiments with replacing `process.nextTick` with

* `setImmediate(...)`
* `Promise.resolve(...).then(...)`
* `setTimeout(..., 0, ...)`

and the results were

* `setImmediate` - lower failure rate, around half the failure rate of `process.nextTick`.
* `Promise.resolve` - 8 failures out of 253 tests (3%).
* `setTimeout` - ZERO failures out of 712 tests.

which clearly indicates that all the non-timeout methods might jump the queue ahead of timers slightly from time to time.

I have no idea of what the implications of these modifications might be for other test scenarios so I am not going to suggest permanently modifying node-red-node-test-helper, I only did this for testing the impact on the sporadically failing test.


### Error message

The original Error message was slightly misleading since it only printed the last delta value even though it might have been an earlier delta value that was too low and triggered the error condition. So I fixed it to print all the delta values.

```text
     Error: Message received before init completed - delta values [199,199,199,200,200] expected to be > 200
     Error: Message received before init completed - delta values [198,199,199,199,199] expected to be > 200
     Error: Message received before init completed - delta values [200,199,200,200,200] expected to be > 200
     Error: Message received before init completed - delta values [199,200,200,200,200] expected to be > 200
     Error: Message received before init completed - delta values [199,200,200,199,200] expected to be > 200
```

### Values

The spread of difference in `msg.delta` values is typically low, the vast majority is the same or just 1ms in difference.

```shell
$ awk '/^Delta max/{ A[$5]++ } END {total=0; for (i in A) {total += A[i]} for (i in A) {printf "%d %3d %5.1f%%\n", i, A[i], 100*A[i]/total; }}' typescript-delta-debug5 | sort
0  30  20.3%
1  92  62.2%
2   3   2.0%
3  11   7.4%
4  11   7.4%
5   1   0.7%
$
```

while the value of actual `msg.delta` varies a bit more

```shell
$ awk '/Hello from input msg/{ A[$5]++ } END {total=0; for (i in A) {total += A[i]} for (i in A) {printf "%d %3d %5.1f%%\n", i, A[i], 100*A[i]/total; }}' typescript-delta-debug5 | sort
198   2   0.3%
199  16   2.2%
200  20   2.7%
201  18   2.4%
202  22   3.0%
203  64   8.6%
204 233  31.5%
205 150  20.3%
206  91  12.3%
207  52   7.0%
208  38   5.1%
209  14   1.9%
210  12   1.6%
211   7   0.9%
212   1   0.1%
$
```
