### PR TITLE
Extend typedInput "num" type validity check to NaN, binary, octal & hex

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -182,7 +182,9 @@
             valueLabel: contextLabel
         },
         str: {value:"str",label:"string",icon:"red/images/typedInput/az.svg"},
-        num: {value:"num",label:"number",icon:"red/images/typedInput/09.svg",validate:/^[+-]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?$/},
+        num: {value:"num",label:"number",icon:"red/images/typedInput/09.svg",validate: function(v) {
+            return (true === RED.utils.validateTypedProperty(v, "num"));
+        } },
         bool: {value:"bool",label:"boolean",icon:"red/images/typedInput/bool.svg",options:["true","false"]},
         json: {
             value:"json",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -921,7 +921,7 @@ RED.utils = (function() {
                 error = RED._("validator.errors.invalid-prop")
             }
         } else if (propertyType === 'num') {
-            if (!/^[+-]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?$/.test(propertyValue)) {
+            if (!/^NaN$|^[+-]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?$|^[+-]?(0b|0B)[01]+$|^[+-]?(0o|0O)[0-7]+$|^[+-]?(0x|0X)[0-9a-fA-F]+$/.test(propertyValue)) {
                 error = RED._("validator.errors.invalid-num")
             }
         } else if (propertyType === 'jsonata') {


### PR DESCRIPTION

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Based on a [forum exchange](https://discourse.nodered.org/t/set-number-value-to-nan-in-change-inject-node/81589), this PR extends the validity checks for typedInput fields of type 'number'.

The following additional formats will pass the check:

- `NaN`
- Binary values, e.g.: `0b10101` or `0B11101`
- Octal values, e.g.: `0o1357` or `0O2468`
- Hex values, e.g.: 0x25aF or 0X69Cd

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
