### PR TITLE
Ctrl-Enter does not close tray (Monaco) #4377

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
@@ -966,12 +966,10 @@ RED.editor.codeEditor.monaco = (function() {
 
         //Unbind ctrl-Enter (default action is to insert a newline in editor) This permits the shortcut to close the tray.
         try {
-            ed._standaloneKeybindingService.addDynamicKeybinding(
-                '-editor.action.insertLineAfter', // command ID prefixed by '-'
-                null, // keybinding
-                () => {} // need to pass an empty handler
-            );
-        } catch (error) { }
+            monaco.editor.addKeybindingRule({keybinding: 0, command: "-editor.action.insertLineAfter"});
+        } catch (error) {
+            console.warn(error)
+        }
 
         ed.nodered = {
             refreshModuleLibs: refreshModuleLibs //expose this for function node externalModules refresh


### PR DESCRIPTION
## Types of changes

- [x ] Bugfix (non-breaking change which fixes an issue)

## Proposed changes

Address [issue 4377](https://github.com/node-red/node-red/issues/4377)
Where the Monaco code editor steals Ctrl-Enter, so that shortcut cannot instead be used to close the tray.
Code changed as per @Steve-Mcl suggestion.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
