### PR TITLE
Add support for plugin (only) modules to the palette manager

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/admin/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/admin/index.js
@@ -91,6 +91,7 @@ module.exports = {
         // Plugins
         adminApp.get("/plugins", needsPermission("plugins.read"), plugins.getAll, apiUtil.errorHandler);
         adminApp.get("/plugins/messages", needsPermission("plugins.read"), plugins.getCatalogs, apiUtil.errorHandler);
+        adminApp.get(/^\/plugins\/((@[^\/]+\/)?[^\/]+)\/([^\/]+)$/,needsPermission("plugins.read"),plugins.getConfig,apiUtil.errorHandler);
 
         adminApp.get("/diagnostics", needsPermission("diagnostics.read"), diagnostics.getReport, apiUtil.errorHandler);
 

--- a/packages/node_modules/@node-red/editor-api/lib/admin/plugins.js
+++ b/packages/node_modules/@node-red/editor-api/lib/admin/plugins.js
@@ -40,5 +40,31 @@ module.exports = {
             console.log(err.stack);
             apiUtils.rejectHandler(req,res,err);
         })
+    },
+    getConfig: function(req, res) {
+
+        let opts = {
+            user: req.user,
+            module: req.params[0],
+            req: apiUtils.getRequestLogObject(req)
+        }
+
+        if (req.get("accept") === "application/json") {
+            runtimeAPI.nodes.getNodeInfo(opts.module).then(function(result) {
+                res.send(result);
+            }).catch(function(err) {
+                apiUtils.rejectHandler(req,res,err);
+            })
+        } else {
+            opts.lang = apiUtils.determineLangFromHeaders(req.acceptsLanguages());
+            if (/[^0-9a-z=\-\*]/i.test(opts.lang)) {
+                opts.lang = "en-US";
+            }
+            runtimeAPI.plugins.getPluginConfig(opts).then(function(result) {
+                return res.send(result);
+            }).catch(function(err) {
+                apiUtils.rejectHandler(req,res,err);
+            })
+        }
     }
 };

--- a/packages/node_modules/@node-red/editor-client/locales/de/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/de/editor.json
@@ -591,6 +591,8 @@
             },
             "nodeCount": "__label__ Node",
             "nodeCount_plural": "__label__ Nodes",
+            "pluginCount": "__count__ Plugin",
+            "pluginCount_plural": "__count__ Plugins",    
             "moduleCount": "__count__ Modul verfügbar",
             "moduleCount_plural": "__count__ Module verfügbar",
             "inuse": "In Gebrauch",

--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -609,6 +609,8 @@
             },
             "nodeCount": "__label__ node",
             "nodeCount_plural": "__label__ nodes",
+            "pluginCount": "__count__ plugin",
+            "pluginCount_plural": "__count__ plugins",
             "moduleCount": "__count__ module available",
             "moduleCount_plural": "__count__ modules available",
             "inuse": "in use",

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -124,7 +124,7 @@ RED.nodes = (function() {
             },
             removeNodeSet: function(id) {
                 var ns = nodeSets[id];
-                if (!ns) return {};
+                if (!ns) { return {} }
 
                 for (var j=0;j<ns.types.length;j++) {
                     delete typeToId[ns.types[j]];

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -124,6 +124,8 @@ RED.nodes = (function() {
             },
             removeNodeSet: function(id) {
                 var ns = nodeSets[id];
+                if (!ns) return {};
+
                 for (var j=0;j<ns.types.length;j++) {
                     delete typeToId[ns.types[j]];
                 }

--- a/packages/node_modules/@node-red/editor-client/src/js/plugins.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/plugins.js
@@ -1,6 +1,7 @@
 RED.plugins = (function() {
     var plugins = {};
     var pluginsByType = {};
+    var moduleList = {};
 
     function registerPlugin(id,definition) {
         plugins[id] = definition;
@@ -38,9 +39,43 @@ RED.plugins = (function() {
     function getPluginsByType(type) {
         return pluginsByType[type] || [];
     }
+
+    function setPluginList(list) {
+        for(let i=0;i<list.length;i++) {
+            let p = list[i];
+            addPlugin(p);
+        }
+    }
+
+    function addPlugin(p) {
+
+        moduleList[p.module] = moduleList[p.module] || {
+            name:p.module,
+            version:p.version,
+            local:p.local,
+            sets:{},
+            plugin: true,
+            id: p.id
+        };
+        if (p.pending_version) {
+            moduleList[p.module].pending_version = p.pending_version;
+        }
+        moduleList[p.module].sets[p.name] = p;
+
+        RED.events.emit("registry:plugin-module-added",p.module);
+    }
+
+    function getModule(module) {
+        return moduleList[module];
+    }
+
     return {
         registerPlugin: registerPlugin,
         getPlugin: getPlugin,
-        getPluginsByType: getPluginsByType
+        getPluginsByType: getPluginsByType,
+
+        setPluginList: setPluginList,
+        addPlugin: addPlugin,
+        getModule: getModule
     }
 })();

--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -25,6 +25,7 @@ var RED = (function() {
             cache: false,
             url: 'plugins',
             success: function(data) {
+                RED.plugins.setPluginList(data);
                 loader.reportProgress(RED._("event.loadPlugins"), 13)
                 RED.i18n.loadPluginCatalogs(function() {
                     loadPlugins(function() {
@@ -523,6 +524,41 @@ var RED = (function() {
                 node.dirtyStatus = true;
                 node.dirty = true;
                 RED.view.redrawStatus(node);
+            }
+        });
+        RED.comms.subscribe("notification/plugin/#",function(topic,msg) {
+            if (topic == "notification/plugin/added") {
+                RED.settings.refreshSettings(function(err, data) {
+                    let addedPlugins = [];
+                    msg.forEach(function(m) {
+                        let id = m.id;
+                        RED.plugins.addPlugin(m);
+
+                        m.plugins.forEach((p) => {
+                            addedPlugins.push(p.id);
+                        })
+
+                        RED.i18n.loadNodeCatalog(id, function() {
+                            var lang = localStorage.getItem("editor-language")||RED.i18n.detectLanguage();
+                            $.ajax({
+                                headers: {
+                                    "Accept":"text/html",
+                                    "Accept-Language": lang
+                                },
+                                cache: false,
+                                url: 'plugins/'+id,
+                                success: function(data) {
+                                    appendPluginConfig(data);
+                                }
+                            });
+                        });
+                    });
+                    if (addedPlugins.length) {
+                        let pluginList = "<ul><li>"+addedPlugins.map(RED.utils.sanitize).join("</li><li>")+"</li></ul>";
+                        // ToDo: Adapt notification (node -> plugin)
+                        RED.notify(RED._("palette.event.nodeAdded", {count:addedPlugins.length})+pluginList,"success");
+                    }
+                })
             }
         });
         RED.comms.subscribe("notification/node/#",function(topic,msg) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -248,86 +248,105 @@ RED.palette.editor = (function() {
             var moduleInfo = nodeEntries[module].info;
             var nodeEntry = nodeEntries[module].elements;
             if (nodeEntry) {
-                var activeTypeCount = 0;
-                var typeCount = 0;
-                var errorCount = 0;
-                nodeEntry.errorList.empty();
-                nodeEntries[module].totalUseCount = 0;
-                nodeEntries[module].setUseCount = {};
+                if (moduleInfo.plugin) {
+                    nodeEntry.enableButton.hide();
+                    nodeEntry.removeButton.show();
 
-                for (var setName in moduleInfo.sets) {
-                    if (moduleInfo.sets.hasOwnProperty(setName)) {
-                        var inUseCount = 0;
-                        var set = moduleInfo.sets[setName];
-                        var setElements = nodeEntry.sets[setName];
-                        if (set.err) {
-                            errorCount++;
-                            var errMessage = set.err;
-                            if (set.err.message) {
-                                errMessage = set.err.message;
-                            } else if (set.err.code) {
-                                errMessage = set.err.code;
+                    let pluginCount = 0;
+
+                    for (let setName in moduleInfo.sets) {
+                        if (moduleInfo.sets.hasOwnProperty(setName)) {
+                            let set = moduleInfo.sets[setName];
+                            if (set.plugins) {
+                                pluginCount += set.plugins.length;
                             }
-                            $("<li>").text(errMessage).appendTo(nodeEntry.errorList);
                         }
-                        if (set.enabled) {
-                            activeTypeCount += set.types.length;
-                        }
-                        typeCount += set.types.length;
-                        for (var i=0;i<moduleInfo.sets[setName].types.length;i++) {
-                            var t = moduleInfo.sets[setName].types[i];
-                            inUseCount += (typesInUse[t]||0);
-                            var swatch = setElements.swatches[t];
+                    }
+                    
+                    nodeEntry.setCount.text(RED._('palette.editor.pluginCount',{count:pluginCount,label:pluginCount}));
+
+                } else {
+                    var activeTypeCount = 0;
+                    var typeCount = 0;
+                    var errorCount = 0;
+                    nodeEntry.errorList.empty();
+                    nodeEntries[module].totalUseCount = 0;
+                    nodeEntries[module].setUseCount = {};
+
+                    for (var setName in moduleInfo.sets) {
+                        if (moduleInfo.sets.hasOwnProperty(setName)) {
+                            var inUseCount = 0;
+                            var set = moduleInfo.sets[setName];
+                            var setElements = nodeEntry.sets[setName];
+                            if (set.err) {
+                                errorCount++;
+                                var errMessage = set.err;
+                                if (set.err.message) {
+                                    errMessage = set.err.message;
+                                } else if (set.err.code) {
+                                    errMessage = set.err.code;
+                                }
+                                $("<li>").text(errMessage).appendTo(nodeEntry.errorList);
+                            }
                             if (set.enabled) {
-                                var def = RED.nodes.getType(t);
-                                if (def && def.color) {
-                                    swatch.css({background:RED.utils.getNodeColor(t,def)});
-                                    swatch.css({border: "1px solid "+getContrastingBorder(swatch.css('backgroundColor'))})
+                                activeTypeCount += set.types.length;
+                            }
+                            typeCount += set.types.length;
+                            for (var i=0;i<moduleInfo.sets[setName].types.length;i++) {
+                                var t = moduleInfo.sets[setName].types[i];
+                                inUseCount += (typesInUse[t]||0);
+                                var swatch = setElements.swatches[t];
+                                if (set.enabled) {
+                                    var def = RED.nodes.getType(t);
+                                    if (def && def.color) {
+                                        swatch.css({background:RED.utils.getNodeColor(t,def)});
+                                        swatch.css({border: "1px solid "+getContrastingBorder(swatch.css('backgroundColor'))})
+                                    }
                                 }
                             }
-                        }
-                        nodeEntries[module].setUseCount[setName] = inUseCount;
-                        nodeEntries[module].totalUseCount += inUseCount;
+                            nodeEntries[module].setUseCount[setName] = inUseCount;
+                            nodeEntries[module].totalUseCount += inUseCount;
 
-                        if (inUseCount > 0) {
-                            setElements.enableButton.text(RED._('palette.editor.inuse'));
-                            setElements.enableButton.addClass('disabled');
-                        } else {
-                            setElements.enableButton.removeClass('disabled');
-                            if (set.enabled) {
-                                setElements.enableButton.text(RED._('palette.editor.disable'));
+                            if (inUseCount > 0) {
+                                setElements.enableButton.text(RED._('palette.editor.inuse'));
+                                setElements.enableButton.addClass('disabled');
                             } else {
-                                setElements.enableButton.text(RED._('palette.editor.enable'));
+                                setElements.enableButton.removeClass('disabled');
+                                if (set.enabled) {
+                                    setElements.enableButton.text(RED._('palette.editor.disable'));
+                                } else {
+                                    setElements.enableButton.text(RED._('palette.editor.enable'));
+                                }
                             }
+                            setElements.setRow.toggleClass("red-ui-palette-module-set-disabled",!set.enabled);
                         }
-                        setElements.setRow.toggleClass("red-ui-palette-module-set-disabled",!set.enabled);
                     }
-                }
 
-                if (errorCount === 0) {
-                    nodeEntry.errorRow.hide()
-                } else {
-                    nodeEntry.errorRow.show();
-                }
-
-                var nodeCount = (activeTypeCount === typeCount)?typeCount:activeTypeCount+" / "+typeCount;
-                nodeEntry.setCount.text(RED._('palette.editor.nodeCount',{count:typeCount,label:nodeCount}));
-
-                if (nodeEntries[module].totalUseCount > 0) {
-                    nodeEntry.enableButton.text(RED._('palette.editor.inuse'));
-                    nodeEntry.enableButton.addClass('disabled');
-                    nodeEntry.removeButton.hide();
-                } else {
-                    nodeEntry.enableButton.removeClass('disabled');
-                    if (moduleInfo.local) {
-                        nodeEntry.removeButton.css('display', 'inline-block');
-                    }
-                    if (activeTypeCount === 0) {
-                        nodeEntry.enableButton.text(RED._('palette.editor.enableall'));
+                    if (errorCount === 0) {
+                        nodeEntry.errorRow.hide()
                     } else {
-                        nodeEntry.enableButton.text(RED._('palette.editor.disableall'));
+                        nodeEntry.errorRow.show();
                     }
-                    nodeEntry.container.toggleClass("disabled",(activeTypeCount === 0));
+
+                    var nodeCount = (activeTypeCount === typeCount)?typeCount:activeTypeCount+" / "+typeCount;
+                    nodeEntry.setCount.text(RED._('palette.editor.nodeCount',{count:typeCount,label:nodeCount}));
+
+                    if (nodeEntries[module].totalUseCount > 0) {
+                        nodeEntry.enableButton.text(RED._('palette.editor.inuse'));
+                        nodeEntry.enableButton.addClass('disabled');
+                        nodeEntry.removeButton.hide();
+                    } else {
+                        nodeEntry.enableButton.removeClass('disabled');
+                        if (moduleInfo.local) {
+                            nodeEntry.removeButton.css('display', 'inline-block');
+                        }
+                        if (activeTypeCount === 0) {
+                            nodeEntry.enableButton.text(RED._('palette.editor.enableall'));
+                        } else {
+                            nodeEntry.enableButton.text(RED._('palette.editor.disableall'));
+                        }
+                        nodeEntry.container.toggleClass("disabled",(activeTypeCount === 0));
+                    }
                 }
             }
             if (moduleInfo.pending_version) {
@@ -678,6 +697,33 @@ RED.palette.editor = (function() {
                 }
             }
         })
+
+        RED.events.on("registry:plugin-module-added", function(module) {
+
+            if (!nodeEntries.hasOwnProperty(module)) {
+                nodeEntries[module] = {info:RED.plugins.getModule(module)};
+                var index = [module];
+                for (var s in nodeEntries[module].info.sets) {
+                    if (nodeEntries[module].info.sets.hasOwnProperty(s)) {
+                        index.push(s);
+                        index = index.concat(nodeEntries[module].info.sets[s].types)
+                    }
+                }
+                nodeEntries[module].index = index.join(",").toLowerCase();
+                nodeList.editableList('addItem', nodeEntries[module]);
+            } else {
+                _refreshNodeModule(module);
+            }
+
+            for (var i=0;i<filteredList.length;i++) {
+                if (filteredList[i].info.id === module) {
+                    var installButton = filteredList[i].elements.installButton;
+                    installButton.addClass('disabled');
+                    installButton.text(RED._('palette.editor.installed'));
+                    break;
+                }
+            }
+        });
     }
 
     var settingsPane;
@@ -804,6 +850,7 @@ RED.palette.editor = (function() {
                         errorRow: errorRow,
                         errorList: errorList,
                         setCount: setCount,
+                        setButton: setButton,
                         container: container,
                         shade: shade,
                         versionSpan: versionSpan,
@@ -829,27 +876,36 @@ RED.palette.editor = (function() {
                         var setRow = $('<div>',{class:"red-ui-palette-module-set"}).appendTo(contentRow);
                         var buttonGroup = $('<div>',{class:"red-ui-palette-module-set-button-group"}).appendTo(setRow);
                         var typeSwatches = {};
-                        set.types.forEach(function(t) {
-                            var typeDiv = $('<div>',{class:"red-ui-palette-module-type"}).appendTo(setRow);
-                            typeSwatches[t] = $('<span>',{class:"red-ui-palette-module-type-swatch"}).appendTo(typeDiv);
-                            $('<span>',{class:"red-ui-palette-module-type-node"}).text(t).appendTo(typeDiv);
-                        })
-                        var enableButton = $('<a href="#" class="red-ui-button red-ui-button-small"></a>').appendTo(buttonGroup);
-                        enableButton.on("click", function(evt) {
-                            evt.preventDefault();
-                            if (object.setUseCount[setName] === 0) {
-                                var currentSet = RED.nodes.registry.getNodeSet(set.id);
-                                shade.show();
-                                var newState = !currentSet.enabled
-                                changeNodeState(set.id,newState,shade,function(xhr){
-                                    if (xhr) {
-                                        if (xhr.responseJSON) {
-                                            RED.notify(RED._('palette.editor.errors.'+(newState?'enable':'disable')+'Failed',{module: id,message:xhr.responseJSON.message}));
+                        if (set.types) {
+                            set.types.forEach(function(t) {
+                                var typeDiv = $('<div>',{class:"red-ui-palette-module-type"}).appendTo(setRow);
+                                typeSwatches[t] = $('<span>',{class:"red-ui-palette-module-type-swatch"}).appendTo(typeDiv);
+                                $('<span>',{class:"red-ui-palette-module-type-node"}).text(t).appendTo(typeDiv);
+                            })
+                            var enableButton = $('<a href="#" class="red-ui-button red-ui-button-small"></a>').appendTo(buttonGroup);
+                            enableButton.on("click", function(evt) {
+                                evt.preventDefault();
+                                if (object.setUseCount[setName] === 0) {
+                                    var currentSet = RED.nodes.registry.getNodeSet(set.id);
+                                    shade.show();
+                                    var newState = !currentSet.enabled
+                                    changeNodeState(set.id,newState,shade,function(xhr){
+                                        if (xhr) {
+                                            if (xhr.responseJSON) {
+                                                RED.notify(RED._('palette.editor.errors.'+(newState?'enable':'disable')+'Failed',{module: id,message:xhr.responseJSON.message}));
+                                            }
                                         }
-                                    }
-                                });
-                            }
-                        })
+                                    });
+                                }
+                            })    
+                        } else if (set.plugins) {
+                            set.plugins.forEach(function(p) {
+                                var typeDiv = $('<div>',{class:"red-ui-palette-module-type"}).appendTo(setRow);
+                                // typeSwatches[p.id] = $('<span>',{class:"red-ui-palette-module-type-swatch"}).appendTo(typeDiv);
+                                $('<span><i class="fa fa-puzzle-piece" aria-hidden="true"></i>  </span>',{class:"red-ui-palette-module-type-swatch"}).appendTo(typeDiv);
+                                $('<span>',{class:"red-ui-palette-module-type-node"}).text(p.id).appendTo(typeDiv);
+                            })
+                        }
 
                         object.elements.sets[set.name] = {
                             setRow: setRow,
@@ -1226,7 +1282,55 @@ RED.palette.editor = (function() {
                                                 }
                                             }
                                         ]
-                                    });                                }
+                                    });                                
+                                }
+                            } else {
+                                // dedicated list management for plugins
+                                if (entry.plugin) {
+
+                                    let e = nodeEntries[entry.name];
+                                    if (e) {
+                                        nodeList.editableList('removeItem', e);
+                                        delete nodeEntries[entry.name];
+                                    }
+
+                                    // We assume that a plugin that implements onremove
+                                    // cleans the editor accordingly of its left-overs.
+                                    let found_onremove = true;
+
+                                    let keys = Object.keys(entry.sets);
+                                    keys.forEach((key) => {
+                                        let set = entry.sets[key];
+                                        for (let i=0; i<set.plugins?.length; i++) {
+                                            let plgn = RED.plugins.getPlugin(set.plugins[i].id);
+                                            if (plgn && plgn.onremove  && typeof plgn.onremove === 'function') {
+                                                plgn.onremove();
+                                            } else {
+                                                if (plgn && plgn.onadd && typeof plgn.onadd === 'function') {
+                                                    // if there's no 'onadd', there shouldn't be any left-overs
+                                                    found_onremove = false;
+                                                }
+                                            }
+                                        }
+                                    });
+
+                                    if (!found_onremove) {
+                                        let removeNotify = RED.notify("Removed plugin " + entry.name + ". Please reload the editor to clear left-overs.",{
+                                            modal: true,
+                                            fixed: true,
+                                            type: 'warning',
+                                            buttons: [
+                                                {
+                                                    text: "Understood",
+                                                    class:"primary",
+                                                    click: function(e) {
+                                                        removeNotify.close();
+                                                    }
+                                                }
+                                            ]
+                                        });
+                                    }
+                                }        
                             }
                         })
                         notification.close();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -876,13 +876,14 @@ RED.palette.editor = (function() {
                         var setRow = $('<div>',{class:"red-ui-palette-module-set"}).appendTo(contentRow);
                         var buttonGroup = $('<div>',{class:"red-ui-palette-module-set-button-group"}).appendTo(setRow);
                         var typeSwatches = {};
+                        let enableButton;
                         if (set.types) {
                             set.types.forEach(function(t) {
                                 var typeDiv = $('<div>',{class:"red-ui-palette-module-type"}).appendTo(setRow);
                                 typeSwatches[t] = $('<span>',{class:"red-ui-palette-module-type-swatch"}).appendTo(typeDiv);
                                 $('<span>',{class:"red-ui-palette-module-type-node"}).text(t).appendTo(typeDiv);
                             })
-                            var enableButton = $('<a href="#" class="red-ui-button red-ui-button-small"></a>').appendTo(buttonGroup);
+                            enableButton = $('<a href="#" class="red-ui-button red-ui-button-small"></a>').appendTo(buttonGroup);
                             enableButton.on("click", function(evt) {
                                 evt.preventDefault();
                                 if (object.setUseCount[setName] === 0) {

--- a/packages/node_modules/@node-red/registry/lib/index.js
+++ b/packages/node_modules/@node-red/registry/lib/index.js
@@ -319,6 +319,7 @@ module.exports = {
     getPluginsByType: plugins.getPluginsByType,
     getPluginList: plugins.getPluginList,
     getPluginConfigs: plugins.getPluginConfigs,
+    getPluginConfig: plugins.getPluginConfig,
     exportPluginSettings: plugins.exportPluginSettings,
 
 

--- a/packages/node_modules/@node-red/registry/lib/installer.js
+++ b/packages/node_modules/@node-red/registry/lib/installer.js
@@ -28,6 +28,8 @@ const child_process = require('child_process');
 const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 let installerEnabled = false;
 
+const plugins = require("./plugins");
+
 let settings;
 const moduleRe = /^(@[^/@]+?[/])?[^/@]+?$/;
 const slashRe = process.platform === "win32" ? /\\|[/]/ : /[/]/;
@@ -330,10 +332,18 @@ function reportRemovedModules(removedNodes) {
     //comms.publish("node/removed",removedNodes,false);
     log.info(log._("server.removed-types"));
     for (var j=0;j<removedNodes.length;j++) {
-        for (var i=0;i<removedNodes[j].types.length;i++) {
+        for (var i=0;i<removedNodes[j].types?.length;i++) {
             log.info(" - "+(removedNodes[j].module?removedNodes[j].module+":":"")+removedNodes[j].types[i]);
         }
     }
+
+    log.info(log._("server.removed-plugins"));
+    for (let j=0;j<removedNodes.length;j++) {
+        for (var i=0;i<removedNodes[j].plugins?.length;i++) {
+            log.info(" - "+(removedNodes[j].module?removedNodes[j].module+":":"")+removedNodes[j].plugins[i].id);
+        }
+    }    
+
     return removedNodes;
 }
 
@@ -495,8 +505,12 @@ function uninstallModule(module) {
             } catch(err) {
                 return reject(new Error(log._("server.install.uninstall-failed",{name:module})));
             }
+            
+            // need to remove the plugins first, 
+            // as registry data necessary to perform this operation
+            var list = plugins.removeModule(module);
+            list = list.concat(registry.removeModule(module));
 
-            var list = registry.removeModule(module);
             log.info(log._("server.install.uninstalling",{name:module}));
 
             let triggerPayload = {

--- a/packages/node_modules/@node-red/registry/lib/plugins.js
+++ b/packages/node_modules/@node-red/registry/lib/plugins.js
@@ -39,6 +39,8 @@ function registerPlugin(nodeSetId,id,definition) {
         pluginSettings[id] = definition.settings;
     }
 
+    // reset the cache when a new plugin is incoming!
+    pluginConfigCache = {};
 
     if (definition.onadd && typeof definition.onadd === 'function') {
         definition.onadd();
@@ -55,29 +57,47 @@ function getPluginsByType(type) {
 }
 
 function getPluginConfigs(lang) {
+    // we're not re-using getPluginConfig() here,
+    // to avoid calling registry.getModuleList() multiple times!
+
     if (!pluginConfigCache[lang]) {
         var result = "";
-        var script = "";
         var moduleConfigs = registry.getModuleList();
         for (var module in moduleConfigs) {
             /* istanbul ignore else */
             if (moduleConfigs.hasOwnProperty(module)) {
-                var plugins = moduleConfigs[module].plugins;
-                for (var plugin in plugins) {
-                    if (plugins.hasOwnProperty(plugin)) {
-                        var config = plugins[plugin];
-                        if (config.enabled && !config.err && config.config) {
-                            result += "\n<!-- --- [red-plugin:"+config.id+"] --- -->\n";
-                            result += config.config;
-                        }
-                    }
-                }
+                result += get_config_of_plugins(moduleConfigs[module].plugins);
             }
         }
         pluginConfigCache[lang] = result;
     }
     return pluginConfigCache[lang];
 }
+
+function getPluginConfig(id, lang) {
+    let result = '';
+    let moduleConfigs = registry.getModuleList();
+    if (moduleConfigs.hasOwnProperty(id)) {
+        result = get_config_of_plugins(moduleConfigs[id].plugins);
+    }
+    return result;
+}
+
+// helper function to avoid code duplication
+function get_config_of_plugins(plugins) {
+    let result = '';
+    for (let plugin in plugins) {
+        if (plugins.hasOwnProperty(plugin)) {
+            let config = plugins[plugin];
+            if (config.enabled && !config.err && config.config) {
+                result += "\n<!-- --- [red-plugin:"+config.id+"] --- -->\n";
+                result += config.config;
+            }
+        }
+    }
+    return result;
+}
+
 function getPluginList() {
     var list = [];
     var moduleConfigs = registry.getModuleList();
@@ -142,12 +162,51 @@ function exportPluginSettings(safeSettings) {
     return safeSettings;
 }
 
+function removeModule(moduleId) {
+
+    // clean the (plugin) registry when a module is removed / uninstalled
+
+    let pluginList = [];
+    let module = registry.getModule(moduleId);
+    let keys = Object.keys(module.plugins ?? {});
+    keys.forEach( key => {
+        let _plugins = module.plugins[key].plugins ?? [];
+        _plugins.forEach( plugin => {
+            let id = plugin.id;
+
+            if (plugin.onremove && typeof plugin.onremove === 'function') {
+                plugin.onremove();
+            }
+
+            delete pluginToId[id];
+            delete plugins[id];
+            delete pluginSettings[id];
+            pluginConfigCache = {};
+
+            let psbtype = pluginsByType[plugin.type] ?? [];
+            for (let i=psbtype.length; i>0; i--) {
+                let pbt = psbtype[i-1];
+                if (pbt.id == id) {
+                    psbtype.splice(i-1, 1);
+                }
+            }
+        })
+
+        pluginList.push(registry.filterNodeInfo(module.plugins[key]));
+        
+    })
+
+    return pluginList;
+}
+
 module.exports = {
     init,
     registerPlugin,
     getPlugin,
     getPluginsByType,
     getPluginConfigs,
+    getPluginConfig,
     getPluginList,
-    exportPluginSettings
+    exportPluginSettings,
+    removeModule
 }

--- a/packages/node_modules/@node-red/registry/lib/registry.js
+++ b/packages/node_modules/@node-red/registry/lib/registry.js
@@ -401,7 +401,7 @@ function getModuleInfo(module) {
             m.nodes.push(nodeInfo);
         }
 
-        let plugins = Object.values(moduleConfigs[module].plugins);
+        let plugins = Object.values(moduleConfigs[module].plugins ?? {});
         plugins.forEach((plugin) => {
             let nodeInfo = filterNodeInfo(plugin);
             nodeInfo.version = m.version;

--- a/packages/node_modules/@node-red/registry/lib/registry.js
+++ b/packages/node_modules/@node-red/registry/lib/registry.js
@@ -386,7 +386,8 @@ function getModuleInfo(module) {
             local: moduleConfigs[module].local,
             user: moduleConfigs[module].user,
             path: moduleConfigs[module].path,
-            nodes: []
+            nodes: [],
+            plugins: []
         };
         if (moduleConfigs[module].dependencies) {
             m.dependencies = moduleConfigs[module].dependencies;
@@ -399,6 +400,14 @@ function getModuleInfo(module) {
             nodeInfo.version = m.version;
             m.nodes.push(nodeInfo);
         }
+
+        let plugins = Object.values(moduleConfigs[module].plugins);
+        plugins.forEach((plugin) => {
+            let nodeInfo = filterNodeInfo(plugin);
+            nodeInfo.version = m.version;
+            m.plugins.push(nodeInfo);
+        });
+
         return m;
     } else {
         return null;

--- a/packages/node_modules/@node-red/runtime/lib/api/plugins.js
+++ b/packages/node_modules/@node-red/runtime/lib/api/plugins.js
@@ -65,6 +65,25 @@ var api = module.exports = {
         runtime.log.audit({event: "plugins.configs.get"}, opts.req);
         return runtime.plugins.getPluginConfigs(opts.lang);
     },
+
+    /**
+    * Gets the editor content for one registered plugin
+    * @param {Object} opts
+    * @param {User} opts.user - the user calling the api
+    * @param {User} opts.user - the user calling the api
+    * @param {Object} opts.req - the request to log (optional)
+    * @return {Promise<NodeInfo>} - the plugin information
+    * @memberof @node-red/runtime_plugins
+    */
+    getPluginConfig: async function(opts) {
+        if (/[^0-9a-z=\-\*]/i.test(opts.lang)) {
+            throw new Error("Invalid language: "+opts.lang)
+            return;
+        }
+        runtime.log.audit({event: "plugins.configs.get"}, opts.req);
+        return runtime.plugins.getPluginConfig(opts.module, opts.lang);
+    },
+
     /**
     * Gets all registered module message catalogs
     * @param {Object} opts

--- a/packages/node_modules/@node-red/runtime/lib/nodes/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/index.js
@@ -173,7 +173,11 @@ function installModule(module,version,url) {
         if (info.pending_version) {
             events.emit("runtime-event",{id:"node/upgraded",retain:false,payload:{module:info.name,version:info.pending_version}});
         } else {
-            events.emit("runtime-event",{id:"node/added",retain:false,payload:info.nodes});
+            if (!info.nodes.length && info.plugins.length) {
+                events.emit("runtime-event",{id:"plugin/added",retain:false,payload:info.plugins});
+            } else {
+                events.emit("runtime-event",{id:"node/added",retain:false,payload:info.nodes});
+            }
         }
         return info;
     });

--- a/packages/node_modules/@node-red/runtime/lib/plugins.js
+++ b/packages/node_modules/@node-red/runtime/lib/plugins.js
@@ -7,5 +7,6 @@ module.exports = {
     getPluginsByType: registry.getPluginsByType,
     getPluginList: registry.getPluginList,
     getPluginConfigs: registry.getPluginConfigs,
+    getPluginConfig: registry.getPluginConfig,
     exportPluginSettings: registry.exportPluginSettings
 }

--- a/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
@@ -25,6 +25,7 @@
         "removing-modules": "Removing modules from config",
         "added-types": "Added node types:",
         "removed-types": "Removed node types:",
+        "removed-plugins": "Removed plugins:",
         "install": {
             "invalid": "Invalid module name",
             "installing": "Installing module: __name__, version: __version__",

--- a/test/unit/@node-red/registry/lib/installer_spec.js
+++ b/test/unit/@node-red/registry/lib/installer_spec.js
@@ -25,6 +25,7 @@ var NR_TEST_UTILS = require("nr-test-utils");
 var installer = NR_TEST_UTILS.require("@node-red/registry/lib/installer");
 var registry = NR_TEST_UTILS.require("@node-red/registry/lib/index");
 var typeRegistry = NR_TEST_UTILS.require("@node-red/registry/lib/registry");
+let pluginRegistry = NR_TEST_UTILS.require("@node-red/registry/lib/plugins");
 const { events, exec, log, hooks } =  NR_TEST_UTILS.require("@node-red/util");
 
 describe('nodes/registry/installer', function() {
@@ -65,6 +66,9 @@ describe('nodes/registry/installer', function() {
         }
         if (typeRegistry.setModulePendingUpdated.restore) {
             typeRegistry.setModulePendingUpdated.restore();
+        }
+        if (pluginRegistry.removeModule.restore) {
+            pluginRegistry.removeModule.restore();
         }
         if (fs.statSync.restore) {
             fs.statSync.restore();
@@ -501,6 +505,9 @@ describe('nodes/registry/installer', function() {
             var nodeInfo = [{module:"foo",types:["a"]}];
             var removeModule = sinon.stub(typeRegistry,"removeModule").callsFake(function(md) {
                 return nodeInfo;
+            });
+            let removePluginModule = sinon.stub(pluginRegistry,"removeModule").callsFake(function(md) {
+                return [];
             });
             var getModuleInfo = sinon.stub(registry,"getModuleInfo").callsFake(function(md) {
                 return {nodes:[]};


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes
This PR adds support for plugin-only modules to the palette manager. Closes #4271.

<img width="527" alt="image" src="https://github.com/node-red/node-red/assets/16342003/f99bda9e-0187-4a8d-9697-ea329ccb4a7d">

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality

## Details of implementation

Runtime:
- New runtime-event 'plugin/added', emitted only if a pure plugin module is installed.

Editor API:
- New endpoint '/plugins/<id>' to query for the config of a single plugin.
- Function 'getConfig' to return the config of a single plugin.

editor.json / runtime.json:
- Plugin specific messages.

Editor Client:
- New functions for plugin (registry) handling, following nodes schematic: setPluginList/addPlugin, getModule.
- New event "registry:plugin-module-added", signaling a (plugin) module was registered w/ addPlugin.
- New event subscription "notification/plugin/added", to query the added plugins config from the runtime (following nodes schematic).

Palette Editor (Client):
- Handler for "registry:plugin-module-added" to add plugin data to the various lists.
- Dedicated list management when adding & removing a plugin.
- Support for **new function "onremove", defined by the plugin (html), to remove itself from the client**.

Installer (runtime)
- In uninstallModule, remove plugin config from (plugin) registry.
- Log info in case of plugin removal.

Registry (runtime) / plugin
- New function to get the config of a single plugin.
- New function to remove the config of a single plugin.
- Support for **new function "onremove", defined by the plugin (js), to remove itself from the runtime**.

Registry (runtime)
- Adapt moduleInfo to handle as well plugins.