### PR TITLE
let icons be settable by loading from server endpoint

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -101,7 +101,7 @@ RED.utils = (function() {
 
     renderer.code = function (code, lang) {
         if(lang === "mermaid") {
-            // mermaid diagram rendering 
+            // mermaid diagram rendering
             if (mermaidIsEnabled === undefined) {
                 if (RED.settings.markdownEditor &&
                     RED.settings.markdownEditor.mermaid) {
@@ -1118,6 +1118,22 @@ RED.utils = (function() {
         if (def.category === 'subflows') {
             return RED.settings.apiRootUrl+"icons/node-red/subflow.svg";
         }
+
+        if (node?.type) {
+            // this regex might be too restrictive/specific but got to start somewhere
+            const re = new RegExp("^\/"+node.type+"\/icon\/.*\.svg$","i");
+            if (typeof def.icon === "function") {
+                try {
+                    const di = def.icon.call(node);
+                    if (re.test(di)) { return RED.settings.authTokensSuffix.replace(/-/,'/') + di; }
+                }
+                catch(e) { console.log("Bad Icon",e) }
+            }
+            else {
+                if (re.test(def.icon)) { return RED.settings.authTokensSuffix.replace(/-/,'/') + def.icon; }
+            }
+        }
+
         return RED.settings.apiRootUrl+"icons/node-red/arrow-in.svg";
     }
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This PR lets editor node icons be createable (eg from a library) rather than purely static. They are only created at load time (so not fully dynamic... it's not a dashboard after all :-) .

They can then be set in the html file by creating an admin endpoint eg

   RED.httpAdmin.get('/example/icon/:id', (req, res) => { ...

and then called but something like

    icon: function() {return '/example/icon/' + this.name + '.svg' },

In this PR the server side does expect the node.type (in the lines above = example) and to end with .svg - but this can be discussed changed in the PR... 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
