### PR TITLE
fix buffer viewer to handle 0b style binary

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/buffer.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/buffer.js
@@ -121,7 +121,7 @@
                         var i=0,l=bufferBinValue.length;
                         var c = 0;
                         for(i=0;i<l;i++) {
-                            var d = parseInt(bufferBinValue[i]);
+                            var d = parseInt(Number(bufferBinValue[i]));
                             if (!isString && (isNaN(d) || d < 0 || d > 255)) {
                                 valid = false;
                                 break;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Currently if you use the enhanced buffer editor to enter buffer vales that contain binary style string literals it fails to display them corectly - but does handle hex 0x style ok.
<img width="446" alt="Screenshot 2023-10-24 at 23 12 58" src="https://github.com/node-red/node-red/assets/5375409/a1292bbc-3f42-4e94-adbc-791faac9a2c6">


This is because parseInt doesn't handle 0b automatically - but Number( does so in this case it should be a better bet.

## Checklist


<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
