### PR TITLE
Let debug node status msg length be settable via settings

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.js
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.js
@@ -5,6 +5,7 @@ module.exports = function(RED) {
     const fs = require("fs-extra");
     const path = require("path");
     var debuglength = RED.settings.debugMaxLength || 1000;
+    var statuslength = RED.settings.debugStatusLength || 32;
     var useColors = RED.settings.debugUseColors || false;
     util.inspect.styles.boolean = "red";
     const { hasOwnProperty } = Object.prototype;
@@ -164,7 +165,7 @@ module.exports = function(RED) {
                             }
                         }
 
-                        if (st.length > 32) { st = st.substr(0,32) + "..."; }
+                        if (st.length > statuslength) { st = st.substr(0,statuslength) + "..."; }
 
                         var newStatus = {fill:fill, shape:shape, text:st};
                         if (JSON.stringify(newStatus) !== node.oldState) { // only send if we have to

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -449,6 +449,7 @@ module.exports = {
  *  - ui (for use with Node-RED Dashboard)
  *  - debugUseColors
  *  - debugMaxLength
+ *  - debugStatusLength
  *  - execMaxBufferSize
  *  - httpRequestTimeout
  *  - mqttReconnectTime
@@ -503,6 +504,9 @@ module.exports = {
 
     /** The maximum length, in characters, of any message sent to the debug sidebar tab */
     debugMaxLength: 1000,
+
+    /** The maximum length, in characters, of status messages under the debug node */
+    //debugStatusLength: 32,
 
     /** Maximum buffer size for the exec node. Defaults to 10Mb */
     //execMaxBufferSize: 10000000,


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
As per title this simple PR lets the length of status messages under the debug node be settable by the user in setting.js rather than being fixed to 32 chars. Default remains 32 chars.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
