### PR TITLE
Ensure global-config nodes lookup cred values properly

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -161,7 +161,8 @@ class Flow {
             for (let i = 0; i < configNodes.length; i++) {
                 const node = this.flow.configs[configNodes[i]]
                 if (node.type === 'global-config' && node.env) {
-                    const nodeEnv = await flowUtil.evaluateEnvProperties(this, node.env, credentials.get(node.id))
+                    const globalCreds = credentials.get(node.id)?.map || {}
+                    const nodeEnv = await flowUtil.evaluateEnvProperties(this, node.env, globalCreds)
                     this._env = { ...this._env, ...nodeEnv }
                 }
             }

--- a/test/unit/@node-red/runtime/lib/flows/Flow_spec.js
+++ b/test/unit/@node-red/runtime/lib/flows/Flow_spec.js
@@ -1237,11 +1237,12 @@ describe('Flow', function() {
     })
 
     describe("#env", function () {
+        afterEach(() => {
+            delete process.env.V0;
+            delete process.env.V1;
+            credentials.get.restore?.()
+        })
         it("can instantiate a node with environment variable property values of group and tab", async function () {
-            after(function() {
-                delete process.env.V0;
-                delete process.env.V1;
-            })
             process.env.V0 = "gv0";
             process.env.V1 = "gv1";
             process.env.V3 = "gv3";
@@ -1285,10 +1286,6 @@ describe('Flow', function() {
         });
 
         it("can access environment variable property using $parent", async function () {
-            after(function() {
-                delete process.env.V0;
-                delete process.env.V1;
-            })
             process.env.V0 = "gv0";
             process.env.V1 = "gv1";
             var config = flowUtils.parseConfig([
@@ -1323,9 +1320,6 @@ describe('Flow', function() {
         });
 
         it("can define environment variable using JSONata", async function () {
-            after(function() {
-                delete process.env.V0;
-            })
             var config = flowUtils.parseConfig([
                 {id:"t1",type:"tab",env:[
                     {"name": "V0", value: "1+2", type: "jsonata"}
@@ -1348,9 +1342,6 @@ describe('Flow', function() {
         });
 
         it("can access global environment variables defined as JSONata values", async function () {
-            after(function() {
-                delete process.env.V0;
-            })
             var config = flowUtils.parseConfig([
                 {id:"t1",type:"tab",env:[
                     {"name": "V0", value: "1+2", type: "jsonata"}
@@ -1372,11 +1363,6 @@ describe('Flow', function() {
             await flow.stop()
         });
         it("global flow can access global-config defined environment variables", async function () {
-            after(function() {
-                delete process.env.V0;
-                credentials.get.restore()
-            })
-
             sinon.stub(credentials,"get").callsFake(function(id) {
                 if (id === 'gc') {
                     return { map: { GC_CRED: 'gc_cred' }}


### PR DESCRIPTION
Fixes #4396

The way `global-config` nodes store their credentials is slightly different to regular nodes - they get stored an extra level deep under a `map` propertry.

Rather than pick apart the logic of why that's the case, the fix here is to lookup under that key.

Also adds a test for same.