### PR TITLE
Let msg.reset  reset Tcp request node connection when in stay connected mode

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
@@ -547,8 +547,14 @@ module.exports = function(RED) {
 
         this.on("input", function(msg, nodeSend, nodeDone) {
             var i = 0;
-            if ((!Buffer.isBuffer(msg.payload)) && (typeof msg.payload !== "string")) {
+            if (msg.payload !== undefined && (!Buffer.isBuffer(msg.payload)) && (typeof msg.payload !== "string")) {
                 msg.payload = msg.payload.toString();
+            }
+
+            if (node.out === "sit" && msg?.reset === true && node?.last_id && clients[node.last_id]) {
+                node.status({});
+                clients[node.last_id].client.destroy();
+                delete clients[node.last_id];
             }
 
             var host = node.server || msg.host;
@@ -627,7 +633,9 @@ module.exports = function(RED) {
                             clients[connection_id].connecting = false;
                             let event;
                             while (event = dequeue(clients[connection_id].msgQueue)) {
-                                clients[connection_id].client.write(event.msg.payload);
+                                if (event.msg.payload !== undefined) {
+                                    clients[connection_id].client.write(event.msg.payload);
+                                }
                                 event.nodeDone();
                             }
                             if (node.out === "time" && node.splitc < 0) {

--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
@@ -831,7 +831,9 @@ module.exports = function(RED) {
             else if (!clients[connection_id].connecting && clients[connection_id].connected) {
                 if (clients[connection_id] && clients[connection_id].client) {
                     let event = dequeue(clients[connection_id].msgQueue)
-                    clients[connection_id].client.write(event.msg.payload);
+                    if (event.msg.payload !== undefined ) {
+                        clients[connection_id].client.write(event.msg.payload);
+                    }
                     event.nodeDone();
                 }
             }

--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
@@ -411,23 +411,33 @@ module.exports = function(RED) {
                 if (msg._session && msg._session.type == "tcp") {
                     var client = connectionPool[msg._session.id];
                     if (client) {
-                        if (Buffer.isBuffer(msg.payload)) {
-                            client.write(msg.payload);
-                        } else if (typeof msg.payload === "string" && node.base64) {
-                            client.write(Buffer.from(msg.payload,'base64'));
-                        } else {
-                            client.write(Buffer.from(""+msg.payload));
+                        if (msg?.reset === true) {
+                            client.destroy();
+                        }
+                        else {
+                            if (Buffer.isBuffer(msg.payload)) {
+                                client.write(msg.payload);
+                            } else if (typeof msg.payload === "string" && node.base64) {
+                                client.write(Buffer.from(msg.payload,'base64'));
+                            } else {
+                                client.write(Buffer.from(""+msg.payload));
+                            }
                         }
                     }
                 }
                 else {
                     for (var i in connectionPool) {
-                        if (Buffer.isBuffer(msg.payload)) {
-                            connectionPool[i].write(msg.payload);
-                        } else if (typeof msg.payload === "string" && node.base64) {
-                            connectionPool[i].write(Buffer.from(msg.payload,'base64'));
-                        } else {
-                            connectionPool[i].write(Buffer.from(""+msg.payload));
+                        if (msg?.reset === true) {
+                            connectionPool[i].destroy();
+                        }
+                        else {
+                            if (Buffer.isBuffer(msg.payload)) {
+                                connectionPool[i].write(msg.payload);
+                            } else if (typeof msg.payload === "string" && node.base64) {
+                                connectionPool[i].write(Buffer.from(msg.payload,'base64'));
+                            } else {
+                                connectionPool[i].write(Buffer.from(""+msg.payload));
+                            }
                         }
                     }
                 }
@@ -551,14 +561,28 @@ module.exports = function(RED) {
                 msg.payload = msg.payload.toString();
             }
 
-            if (node.out === "sit" && msg?.reset === true && node?.last_id && clients[node.last_id]) {
-                node.status({});
-                clients[node.last_id].client.destroy();
-                delete clients[node.last_id];
-            }
-
             var host = node.server || msg.host;
             var port = node.port || msg.port;
+
+            if (node.out === "sit" && msg?.reset) {
+                if (msg.reset === true) { // kill all connections
+                    for (var cl in clients) {
+                        if (clients[cl].hasOwnProperty("client")) {
+                            clients[cl].client.destroy();
+                            delete clients[cl];
+                        }
+                    }
+                }
+                if (typeof(msg.reset) === "string" && msg.reset.includes(":")) {  // just kill connection host:port
+                    if (clients.hasOwnProperty(msg.reset) && clients[msg.reset].hasOwnProperty("client")) {
+                        clients[msg.reset].client.destroy();
+                        delete clients[msg.reset];
+                    }
+                }
+                const cc = Object.keys(clients).length;
+                node.status({fill:"green",shape:cc===0?"ring":"dot",text:RED._("tcpin.status.connections",{count:cc})});
+                if ((host === undefined || port === undefined) && !msg.hasOwnProperty("payload")) { return; }
+            }
 
             // Store client information independently
             // the clients object will have:
@@ -627,7 +651,8 @@ module.exports = function(RED) {
                     clients[connection_id].connecting = true;
                     clients[connection_id].client.connect(connOpts, function() {
                         //node.log(RED._("tcpin.errors.client-connected"));
-                        node.status({fill:"green",shape:"dot",text:"common.status.connected"});
+                        // node.status({fill:"green",shape:"dot",text:"common.status.connected"});
+                        node.status({fill:"green",shape:"dot",text:RED._("tcpin.status.connections",{count:Object.keys(clients).length})});
                         if (clients[connection_id] && clients[connection_id].client) {
                             clients[connection_id].connected = true;
                             clients[connection_id].connecting = false;

--- a/packages/node_modules/@node-red/nodes/locales/en-US/network/31-tcpin.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/network/31-tcpin.html
@@ -40,6 +40,8 @@
     returned characters into a fixed buffer, match a specified character before returning,
     wait a fixed timeout from first reply and then return, sit and wait for data, or send then close the connection
     immediately, without waiting for a reply.</p>
+    <p>If in sit and wait mode (remain connected) you can send <code>msg.reset = true;</code> to force a break in
+    the connection and an automatic reconnection.</p>
     <p>The response will be output in <code>msg.payload</code> as a buffer, so you may want to .toString() it.</p>
     <p>If you leave tcp host or port blank they must be set by using the <code>msg.host</code> and <code>msg.port</code> properties in every message sent to the node.</p>
 </script>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/network/31-tcpin.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/network/31-tcpin.html
@@ -30,6 +30,8 @@
     before being sent.</p>
     <p>If <code>msg._session</code> is not present the payload is
     sent to <b>all</b> connected clients.</p>
+    <p>In Reply-to mode, setting <code>msg.reset = true</code> will reset the connection
+        specified by _session.id, or all connections if no _session.id is specified.</p>
     <p><b>Note: </b>On some systems you may need root or administrator access
     to access ports below 1024.</p>
 </script>
@@ -40,7 +42,7 @@
     returned characters into a fixed buffer, match a specified character before returning,
     wait a fixed timeout from first reply and then return, sit and wait for data, or send then close the connection
     immediately, without waiting for a reply.</p>
-    <p>If in sit and wait mode (remain connected) you can send <code>msg.reset = true;</code> to force a break in
+    <p>If in sit and wait mode (remain connected) you can send <code>msg.reset = true</code> or <code>msg.reset = "host:port"</code> to force a break in
     the connection and an automatic reconnection.</p>
     <p>The response will be output in <code>msg.payload</code> as a buffer, so you may want to .toString() it.</p>
     <p>If you leave tcp host or port blank they must be set by using the <code>msg.host</code> and <code>msg.port</code> properties in every message sent to the node.</p>


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This PR lets `msg.reset = true; ` (boolean)  reset the tcp-request node when it is set to remain connected. This allows the user to "kick" the connection if required so it forces a reconnect - or also allows them to send msg.host and/or msg.port to connect to a different server instead.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
