### PR TITLE
Add a close button to the restart-required notification

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -498,6 +498,15 @@ var RED = (function() {
                             ]
                         }
                     }
+                } else if (notificationId === 'restart-required') {
+                    options.buttons = [
+                        {
+                            text: RED._("common.label.close"),
+                            click: function() {
+                                persistentNotifications[notificationId].hideNotification();
+                            }
+                        }
+                    ]
                 }
                 if (!persistentNotifications.hasOwnProperty(notificationId)) {
                     persistentNotifications[notificationId] = RED.notify(text,options);


### PR DESCRIPTION
Fixes #4392

We didn't originally add a close button to this notification because the user needs to take action pretty soon.

However, in response to #4392, this PR adds a close button. It is still considered a 'persistent' notification - causing the warning triangle to be shown in the header that can be clicked to reopen the notification.