### PR TITLE
Only save settings once during node load process

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/loader.js
+++ b/packages/node_modules/@node-red/registry/lib/loader.js
@@ -143,6 +143,12 @@ function loadModuleFiles(modules) {
         return loadNodeSetList(pluginList);
     }).then(function() {
         return loadNodeSetList(nodeList);
+    }).then(function () {
+        if (settings.available()) {
+            return registry.saveNodeList();
+        } else {
+            return
+        }
     })
 }
 
@@ -436,7 +442,7 @@ async function loadPlugin(plugin) {
         return plugin;
     }
 }
-
+let invocation = 0
 function loadNodeSetList(nodes) {
     var promises = [];
     nodes.forEach(function(node) {
@@ -451,13 +457,7 @@ function loadNodeSetList(nodes) {
         }
     });
 
-    return Promise.all(promises).then(function() {
-        if (settings.available()) {
-            return registry.saveNodeList();
-        } else {
-            return;
-        }
-    });
+    return Promise.all(promises)
 }
 
 function addModule(module) {


### PR DESCRIPTION
Fixes #4381 

When loading nodes and plugins, the code was triggering a save to `.config.nodes.json` twice - the first time after the nodes are loaded, and again after plugins are loaded.

The code checks what is being written to see if it matches what's already there - to avoid needless file writing. However, due to the two-step process, the first call is missing the plugin info so will not match what is already in the file. The second call, with the full information, doesn't match the just-written partial update so triggers another file write.

The fix is to move the settings save to after both node and plugin loading is complete - so it is done just once with the full information that will match what is already there if nothing has changed.  