### PR TITLE
Handle false-like env vars properly

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.js
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.js
@@ -109,9 +109,8 @@ module.exports = function(RED) {
                 }
                 const p = props.shift()
                 const property = p.p;
-                const value = p.v ? p.v : '';
-                const valueType = p.vt ? p.vt : 'str';
-
+                const value = p.v !== undefined ? p.v : '';
+                const valueType = p.vt !== undefined ? p.vt : 'str';
                 if (property) {
                     if (valueType === "jsonata") {
                         if (p.v) {

--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -57,18 +57,20 @@ var EnvVarPropertyRE = /^\${(\S+)}$/;
 
 
 function mapEnvVarProperties(obj,prop,flow,config) {
-    var v = obj[prop];
+    const v = obj[prop];
     if (Buffer.isBuffer(v)) {
         return;
     } else if (Array.isArray(v)) {
-        for (var i=0;i<v.length;i++) {
+        for (let i=0;i<v.length;i++) {
             mapEnvVarProperties(v,i,flow,config);
         }
     } else if (typeof obj[prop] === 'string') {
         if (obj[prop][0] === "$" && (EnvVarPropertyRE_old.test(v) || EnvVarPropertyRE.test(v)) ) {
-            var envVar = v.substring(2,v.length-1);
-            var r = redUtil.getSetting(config, envVar, flow);
-            obj[prop] = r ? r : obj[prop];
+            const envVar = v.substring(2,v.length-1);
+            const r = redUtil.getSetting(config, envVar, flow);
+            if (r !== undefined && r !== '') {
+                obj[prop] = r
+            }
         }
     } else {
         for (var p in v) {


### PR DESCRIPTION
Fixes #4376 

This modifies how we handle falsey env var values.

From https://github.com/node-red/node-red/issues/4376#issuecomment-1789823618:

> This is one of the slightly historic mishandlings we have with env vars.
> 
> When working with 'normal' process env vars, we have always treated both `undefined` and a blank string to mean the env var isn't set. Otherwise we consider it is set.
> 
> As @dceejay highlights, we use a simple 'truthiness' test on this - which was fine for dealing with regular env vars that can only be strings.
> 
> When we introduced other types of value (boolean, number etc) we didn't consider their truthiness for this test.
> 
> We have two choices:
> 
> 1. modify the truthiness test to only look for `undefined`. This would mean a blank string env var would start evaluating as a blank string. That has the most risk in breaking a user's flows.
> 2. modify the test to look for just `undefined` and `""`. That would mean `false` and `0` would get inserted where they didn't before. I suspect that would have very little impact on existing flows.

For this fix, I went with option 2. In testing that, I found the Inject node wasn't passing through falsey values properly - which is also fixed.

I *think* this makes sense - not causing a change in behaviour that will impact anyone.