### PR TITLE
Ensure typeSearch handles undefined node definitions

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js
@@ -323,7 +323,7 @@ RED.typeSearch = (function() {
         }
     }
     function applyFilter(filter,type,def) {
-        return !filter ||
+        return !def || !filter ||
             (
                 (!filter.spliceMultiple) &&
                 (!filter.type || type === filter.type) &&


### PR DESCRIPTION
Fixes #4415

The Quick Add dialog has a hard-coded list of common nodes - inject/change/switch etc. If any have been excluded, we need to make sure we don't try to show them in the list.