### PR TITLE
Hide node status background when there is no status to show

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4187,7 +4187,7 @@ RED.view = (function() {
                 nodeEl.__statusGroup__.style.display = "none";
             } else {
                 nodeEl.__statusGroup__.style.display = "inline";
-                let backgroundWidth = 12
+                let backgroundWidth = 15
                 var fill = status_colours[d.status.fill]; // Only allow our colours for now
                 if (d.status.shape == null && fill == null) {
                     backgroundWidth = 0
@@ -4207,7 +4207,11 @@ RED.view = (function() {
                     nodeEl.__statusLabel__.textContent = "";
                 }
                 const textSize = nodeEl.__statusLabel__.getBBox()
-                nodeEl.__statusBackground__.setAttribute('width', backgroundWidth + textSize.width + 6)
+                backgroundWidth += textSize.width
+                if (backgroundWidth > 0 && textSize.width > 0) {
+                    backgroundWidth += 6
+                }
+                nodeEl.__statusBackground__.setAttribute('width', backgroundWidth)
             }
             delete d.dirtyStatus;
         }
@@ -4619,8 +4623,8 @@ RED.view = (function() {
                 statusBackground.setAttribute("y",-1);
                 statusBackground.setAttribute("width",200);
                 statusBackground.setAttribute("height",13);
-                statusBackground.setAttribute("rx",1);
-                statusBackground.setAttribute("ry",1);
+                statusBackground.setAttribute("rx",2);
+                statusBackground.setAttribute("ry",2);
                 
                 statusEl.appendChild(statusBackground);
                 node[0][0].__statusBackground__ = statusBackground;


### PR DESCRIPTION
Fixes #4418

Ensures the node status background is hidden when there's nothing to show.