### PR TITLE
Ensure group w/h are imported if present

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2198,6 +2198,12 @@ RED.nodes = (function() {
                         }
                         node._config.x = node.x;
                         node._config.y = node.y;
+                        if (n.hasOwnProperty('w')) {
+                            node.w = n.w
+                        }
+                        if (n.hasOwnProperty('h')) {
+                            node.h = n.h
+                        }
                     } else if (n.type.substring(0,7) === "subflow") {
                         var parentId = n.type.split(":")[1];
                         var subflow = subflow_denylist[parentId]||subflow_map[parentId]||getSubflow(parentId);


### PR DESCRIPTION
Fixes #4044

The w/h properties of a group node were not being imported. That meant if a group was on a tab not visible in the editor, it would not get its w/h properties set before the next deploy happened.

This fix ensures any provided w/h values are set on the group when imported.