### PR TITLE
2429 localizing a node status message

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -517,7 +517,7 @@ var RED = (function() {
             var node = RED.nodes.node(parts[1]);
             if (node) {
                 if (msg.hasOwnProperty("text") && msg.text !== null && /^[@a-zA-Z]/.test(msg.text)) {
-                    msg.text = node._(msg.text.toString(),{defaultValue:msg.text.toString()});
+                    msg.text = node._(msg.text.toString(),{defaultValue:msg.text.toString(), ...(msg.params || {})});
                 }
                 node.status = msg;
                 node.dirtyStatus = true;

--- a/packages/node_modules/@node-red/runtime/lib/api/comms.js
+++ b/packages/node_modules/@node-red/runtime/lib/api/comms.js
@@ -51,6 +51,10 @@ function handleStatusEvent(event) {
             fill: event.status.fill,
             shape: event.status.shape
         };
+        const params = event.status.params;
+        if(params && typeof params === "object" && !Array.isArray(params)){
+            status.params = params;
+        }
         publish("status/"+event.id,status,true);
     }
 }

--- a/test/unit/@node-red/runtime/lib/api/comms_spec.js
+++ b/test/unit/@node-red/runtime/lib/api/comms_spec.js
@@ -286,6 +286,27 @@ describe("runtime-api/comms", function() {
             }).catch(done);
         })
 
+        it('retains non-blank status message with parameters', function(done) {
+            eventHandlers['node-status']({
+                id: "node1234",
+                status: {
+                    text: "path.to.status.locale",
+                    params: {
+                        myParam0: "test"
+                    }
+                }
+            });
+            messages.should.have.length(0);
+            comms.addConnection({client: clientConnection}).then(function() {
+                return comms.subscribe({client: clientConnection, topic: "status/#"}).then(function() {
+                    messages.should.have.length(1);
+                    messages[0].should.have.property("topic","status/node1234");
+                    messages[0].should.have.property("data",{text:"path.to.status.locale", fill: undefined, shape: undefined, params: { myParam0: "test"} });
+                    done();
+                });
+            }).catch(done);
+        });
+
         it('retained messages get cleared',function(done) {
             eventHandlers['comms']({
                 topic: "my-event",


### PR DESCRIPTION

Second attempt...

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This PR introduces the `params` property to the status object within Node-RED's node API, enhancing the way status messages can be parameterized. This addition allows developers to send structured data alongside status text, facilitating more complex interactions and status handling in flows.

The type definitions for the Monaco Editor have been updated to include the new `params` property in a separate PR, please see [here](https://github.com/node-red/nr-monaco-build/pull/7).

If this PR is accepted, the [official documentation](https://nodered.org/docs/user-guide/writing-functions#adding-status) will need to be updated to reflect the new `params` property within the status object.

Thank you for considering this contribution. I look forward to your feedback and any further actions required on my part.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
