### PR TITLE
Add one click deploy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ started.
 2. `node-red`
 3. Open <http://localhost:1880>
 
+Or you can self-host Node-RED in one-click on [Dome](https://app.trydome.io/signup?package=nodered):
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=nodered)
+
 ## Getting Help
 
 More documentation can be found [here](https://nodered.org/docs).


### PR DESCRIPTION
Hey!

We build this one-click deploy link for your users who may not know how to stand up their own infrastructure to easily self-host this.

After deployment, users receive a link like this, which can then be CNAME-ed to any domain:
https://852a6dd848da60444cca3bcb97ce76c0c3daf7d4.dome.tools/

Take it for a test run—we're eager to receive your feedback! We're more than willing to maintain this for the long haul, if this is valuable for your users.