### PR TITLE
Click on id in debug panel highlights node or flow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -503,6 +503,16 @@ RED.utils = (function() {
                 $('<span class="red-ui-debug-msg-type-string-swatch"></span>').css('backgroundColor',obj).appendTo(e);
             }
 
+            let n = RED.nodes.node(obj) ?? RED.nodes.workspace(obj);
+            if (n) {
+                if (options.node_selector && "function" == typeof options.node_selector) {
+                    e.css('cursor', 'pointer').on("click", function(evt) {
+                        evt.preventDefault();
+                        options.node_selector(n.id);
+                    })
+                }
+            }
+
         } else if (typeof obj === 'number') {
             e = $('<span class="red-ui-debug-msg-type-number"></span>').appendTo(entryObj);
 
@@ -609,6 +619,7 @@ RED.utils = (function() {
                                     exposeApi: exposeApi,
                                     // tools: tools // Do not pass tools down as we
                                                     // keep them attached to the top-level header
+                                    node_selector: options.node_selector,
                                 }
                             ).appendTo(row);
                         }
@@ -639,6 +650,7 @@ RED.utils = (function() {
                                                 exposeApi: exposeApi,
                                                 // tools: tools // Do not pass tools down as we
                                                                 // keep them attached to the top-level header
+                                                node_selector: options.node_selector,
                                             }
                                         ).appendTo(row);
                                     }
@@ -695,6 +707,7 @@ RED.utils = (function() {
                                 exposeApi: exposeApi,
                                 // tools: tools // Do not pass tools down as we
                                                 // keep them attached to the top-level header
+                                node_selector: options.node_selector,
                             }
                         ).appendTo(row);
                     }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -505,10 +505,10 @@ RED.utils = (function() {
 
             let n = RED.nodes.node(obj) ?? RED.nodes.workspace(obj);
             if (n) {
-                if (options.node_selector && "function" == typeof options.node_selector) {
+                if (options.nodeSelector && "function" == typeof options.nodeSelector) {
                     e.css('cursor', 'pointer').on("click", function(evt) {
                         evt.preventDefault();
-                        options.node_selector(n.id);
+                        options.nodeSelector(n.id);
                     })
                 }
             }
@@ -619,7 +619,7 @@ RED.utils = (function() {
                                     exposeApi: exposeApi,
                                     // tools: tools // Do not pass tools down as we
                                                     // keep them attached to the top-level header
-                                    node_selector: options.node_selector,
+                                    nodeSelector: options.nodeSelector,
                                 }
                             ).appendTo(row);
                         }
@@ -650,7 +650,7 @@ RED.utils = (function() {
                                                 exposeApi: exposeApi,
                                                 // tools: tools // Do not pass tools down as we
                                                                 // keep them attached to the top-level header
-                                                node_selector: options.node_selector,
+                                                nodeSelector: options.nodeSelector,
                                             }
                                         ).appendTo(row);
                                     }
@@ -707,7 +707,7 @@ RED.utils = (function() {
                                 exposeApi: exposeApi,
                                 // tools: tools // Do not pass tools down as we
                                                 // keep them attached to the top-level header
-                                node_selector: options.node_selector,
+                                nodeSelector: options.nodeSelector,
                             }
                         ).appendTo(row);
                     }

--- a/packages/node_modules/@node-red/nodes/core/common/lib/debug/debug-utils.js
+++ b/packages/node_modules/@node-red/nodes/core/common/lib/debug/debug-utils.js
@@ -643,7 +643,7 @@ RED.debug = (function() {
             path: path,
             sourceId: sourceNode&&sourceNode.id,
             rootPath: path,
-            node_selector: config.messageSourceClick,
+            nodeSelector: config.messageSourceClick,
         });
         // Do this in a separate step so the element functions aren't stripped
         debugMessage.appendTo(el);

--- a/packages/node_modules/@node-red/nodes/core/common/lib/debug/debug-utils.js
+++ b/packages/node_modules/@node-red/nodes/core/common/lib/debug/debug-utils.js
@@ -642,7 +642,8 @@ RED.debug = (function() {
             hideKey: false,
             path: path,
             sourceId: sourceNode&&sourceNode.id,
-            rootPath: path
+            rootPath: path,
+            node_selector: config.messageSourceClick,
         });
         // Do this in a separate step so the element functions aren't stripped
         debugMessage.appendTo(el);


### PR DESCRIPTION
## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

As [discussed in the forum](https://discourse.nodered.org/t/fr-pr-click-on-id-in-debug-panel-highlights-node-or-flow/82988/20), this PR adds the feature to highlight a node or flow when clicking in the debug panel on a value `typeof string`, that is identified as a node / flow id. The term _node_ here comprises all node types returned by `RED.nodes.nodes(<id>)`.


![highlight_node](https://github.com/node-red/node-red/assets/16342003/74869903-b02c-46a9-8b56-044cb0acc4d1)


This feature re-uses functionality already implemented and in use to highlight the emitting node of a debug message.
As the elements used to display debug messages are only created on demand (toplevel or when expanded), this feature is as well only injected on demand.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team. 👍 
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
