### PR TITLE
Add validators to any fields using msg-typed Input

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/validators.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/validators.js
@@ -40,9 +40,22 @@ RED.validators = {
             return opt ? RED._("validator.errors.invalid-regexp") : false;
         };
     },
-    typedInput: function(ptypeName,isConfig,mopt) {
+    typedInput: function(ptypeName, isConfig, mopt) {
+        let options = ptypeName
+        if (typeof ptypeName === 'string' ) {
+            options = {}
+            options.typeField = ptypeName
+            options.isConfig = isConfig
+            options.allowBlank = false
+        }
         return function(v, opt) {
-            var ptype = $("#node-"+(isConfig?"config-":"")+"input-"+ptypeName).val() || this[ptypeName];
+            let ptype = options.type
+            if (!ptype && options.typeField) {
+                ptype = $("#node-"+(options.isConfig?"config-":"")+"input-"+options.typeField).val() || this[options.typeField];
+            }
+            if (options.allowBlank && v === '') {
+                return true
+            }
             const result = RED.utils.validateTypedProperty(v, ptype, opt)
             if (result === true || opt) {
                 // Valid, or opt provided - return result as-is

--- a/packages/node_modules/@node-red/nodes/core/function/16-range.html
+++ b/packages/node_modules/@node-red/nodes/core/function/16-range.html
@@ -57,7 +57,12 @@
             action: {value:"scale"},
             round: {value:false},
             property: {value:"payload",required:true,
-                       label:RED._("node-red:common.label.property")},
+                       label:RED._("node-red:common.label.property"),
+                       validate: RED.validators.typedInput({ type: 'msg' })
+                    },
+            
+            
+            // RED.validators.typedInput("propertyType", false)},
             name: {value:""}
         },
         inputs: 1,

--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.html
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.html
@@ -56,7 +56,7 @@
         color:"darksalmon",
         defaults: {
             command: {value:""},
-            addpay: {value:""},
+            addpay: {value:"", validate: RED.validators.typedInput({ type: 'msg', allowBlank: true })},
             append: {value:""},
             useSpawn: {value:"false"},
             timer: {value:""},

--- a/packages/node_modules/@node-red/nodes/core/function/rbe.html
+++ b/packages/node_modules/@node-red/nodes/core/function/rbe.html
@@ -56,9 +56,11 @@
             inout: {value:"out"},
             septopics: {value:true},
             property: {value:"payload", required:true,
-                       label:RED._("node-red:rbe.label.property")},
+                       label:RED._("node-red:rbe.label.property"),
+                       validate: RED.validators.typedInput({ type: 'msg' })},
             topi: {value:"topic", required:true,
-                   label:RED._("node-red:rbe.label.topic")}
+                   label:RED._("node-red:rbe.label.topic"),
+                   validate: RED.validators.typedInput({ type: 'msg' })}
         },
         inputs:1,
         outputs:1,

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-HTML.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-HTML.html
@@ -41,8 +41,8 @@
         color:"#DEBD5C",
         defaults: {
             name: {value:""},
-            property: {value:"payload"},
-            outproperty: {value:"payload"},
+            property: {value:"payload", validate: RED.validators.typedInput({ type: 'msg' }) },
+            outproperty: {value:"payload", validate: RED.validators.typedInput({ type: 'msg' }) },
             tag: {value:""},
             ret: {value:"html"},
             as: {value:"single"}

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-JSON.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-JSON.html
@@ -32,6 +32,7 @@
         defaults: {
             name: {value:""},
             property: {value:"payload",required:true,
+                       validate: RED.validators.typedInput({ type: 'msg' }),
                        label:RED._("node-red:json.label.property")},
             action: {value:""},
             pretty: {value:false}

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-XML.html
@@ -27,7 +27,8 @@
         defaults: {
             name: {value:""},
             property: {value:"payload",required:true,
-                       label:RED._("node-red:common.label.property")},
+                       label:RED._("node-red:common.label.property"),
+                       validate: RED.validators.typedInput({ type: 'msg' })},
             attr: {value:""},
             chr: {value:""}
         },

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-YAML.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-YAML.html
@@ -16,6 +16,7 @@
         color:"#DEBD5C",
         defaults: {
             property: {value:"payload",required:true,
+                       validate: RED.validators.typedInput({ type: 'msg' }),
                        label:RED._("node-red:common.label.property")},
             name: {value:""}
         },

--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
@@ -57,7 +57,7 @@
             arraySplt: {value:1},
             arraySpltType: {value:"len"},
             stream: {value:false},
-            addname: {value:""}
+            addname: {value:"", validate: RED.validators.typedInput({ type: 'msg', allowBlank: true })}
         },
         inputs:1,
         outputs:1,
@@ -208,7 +208,22 @@
                 validate:RED.validators.typedInput("propertyType", false)
             },
             propertyType: { value:"msg"},
-            key: {value:"topic"},
+            key: {value:"topic", validate: (function () {
+                const typeValidator = RED.validators.typedInput({ type: 'msg' })
+                return function(v, opt) {
+                    const joinMode = $("#node-input-mode").val() || this.mode
+                    if (joinMode !== 'custom') {
+                        return true
+                    }
+                    const buildType = $("#node-input-build").val() || this.build
+                    if (buildType !== 'object') {
+                        return true
+                    } else {
+                        return typeValidator(v, opt)
+                    }
+                }
+                })()
+            },
             joiner: { value:"\\n"},
             joinerType: { value:"str"},
             accumulate: { value:"false" },

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.html
@@ -198,7 +198,7 @@
         category: 'storage',
         defaults: {
             name: {value:""},
-            filename: {value:""},
+            filename: {value:"", validate: RED.validators.typedInput({ typeField: 'filenameType' })},
             filenameType: {value:"str"},
             appendNewline: {value:true},
             createDir: {value:false},
@@ -297,7 +297,7 @@
         category: 'storage',
         defaults: {
             name: {value:""},
-            filename: {value:""},
+            filename: {value:"", validate: RED.validators.typedInput({ typeField: 'filenameType' }) },
             filenameType: {value:"str"},
             format: {value:"utf8"},
             chunk: {value:false},


### PR DESCRIPTION
Fixes #4429

Adds proper validation to any core node with a typedInput with `msg.` type - mostly.

There are a couple that remain that need some more logic (as they support multiple types), eg `sort` node. But this handles the bulk of them.