### PR TITLE
Allow a theme to specifiy which theme mermaid should use

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -339,6 +339,8 @@ module.exports = {
                 }
                 theme.codeEditor = theme.codeEditor || {}
                 theme.codeEditor.options = Object.assign({}, themePlugin.monacoOptions, theme.codeEditor.options);
+
+                theme.mermaid = Object.assign({}, themePlugin.mermaidOptions, theme.mermaid)
             }
             activeThemeInitialised = true;
         }

--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -340,7 +340,7 @@ module.exports = {
                 theme.codeEditor = theme.codeEditor || {}
                 theme.codeEditor.options = Object.assign({}, themePlugin.monacoOptions, theme.codeEditor.options);
 
-                theme.mermaid = Object.assign({}, themePlugin.mermaidOptions, theme.mermaid)
+                theme.mermaid = Object.assign({}, themePlugin.mermaid, theme.mermaid)
             }
             activeThemeInitialised = true;
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/mermaid.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/mermaid.js
@@ -15,7 +15,8 @@ RED.editor.mermaid = (function () {
                     'vendor/mermaid/mermaid.min.js',
                     function (data, stat, jqxhr) {
                         mermaid.initialize({
-                            startOnLoad: false
+                            startOnLoad: false,
+                            theme: RED.settings.get('mermaid', {}).theme
                         })
                         loaded = true
                         while(pendingEvals.length > 0) {

--- a/packages/node_modules/@node-red/runtime/lib/api/settings.js
+++ b/packages/node_modules/@node-red/runtime/lib/api/settings.js
@@ -99,6 +99,9 @@ var api = module.exports = {
                     safeSettings.markdownEditor = runtime.settings.editorTheme.markdownEditor || {};
                     safeSettings.markdownEditor.mermaid = safeSettings.markdownEditor.mermaid || { enabled: true };
                 }
+                if (runtime.settings.editorTheme.mermaid) {
+                    safeSettings.mermaid = runtime.settings.editorTheme.mermaid
+                }
             }
             safeSettings.libraries = runtime.library.getLibraries();
             if (util.isArray(runtime.settings.paletteCategories)) {


### PR DESCRIPTION
Fixes #4274

Allows a theme to specify which built-in theme mermaid should use.

via `settings.js`:

```
editorTheme: {
   mermaid: {
      theme: "forest"
   }
}
```

via custom theme:

```
RED.plugins.registerPlugin("dark", {
    type: "node-red-theme",
    css: [
      "themes/dark/theme.min.css",
      "themes/dark/theme-customizations.min.css"
    ],
    mermaid: {
      theme: 'forest'
    }
  })
```
