### PR TITLE
Add support of typeField property validation message

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -237,7 +237,13 @@ RED.editor = (function() {
             if (defaults[property].hasOwnProperty("format") && defaults[property].format !== "" && input[0].nodeName === "DIV") {
                 value = input.text();
             }
-            var valid = validateNodeProperty(node, defaults, property,value);
+            const isTypeField =
+                input.attr("type") === "hidden" &&
+                input.css("display") === "none" &&
+                input.attr("class") !== "red-ui-typedInput" &&
+                input.closest("div").find("input").length >= 2;
+            input = isTypeField ? input.closest("div").find("input[class='red-ui-typedInput']") : input;
+            var valid = validateNodeProperty(node, defaults, property, value);
             if (((typeof valid) === "string") || !valid) {
                 input.addClass("input-error");
                 input.next(".red-ui-typedInput-container").addClass("input-error");
@@ -245,9 +251,10 @@ RED.editor = (function() {
                     var tooltip = input.data("tooltip");
                     if (tooltip) {
                         tooltip.setContent(valid);
-                    }
-                    else {
-                        tooltip = RED.popover.tooltip(input, valid);
+                    } else {
+                        const typedInput = input.next(".red-ui-typedInput-container").find(".red-ui-typedInput-input-wrap");
+                        const target = typedInput.length > 0 ? typedInput : input;
+                        tooltip = RED.popover.tooltip(target, valid);
                         input.data("tooltip", tooltip);
                     }
                 }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

This PR is an extension of #4449 and was discussed inside.

If an input is builded with typedInput and contains the typeField option:

```js
$("#node-input-path").typedInput({
    default: "str",
    typeField: "#node-input-pathType",
    types: ["str", "msg"],
});
```

and node properties contains a validator for typeField:

```js
defaults: {
    path: {
        value: "",
        ...
    },
    pathType: {
        value: "str",
        validate: RED.validators.regex(/^str$/),
        ...
    }, ...
}
```

This PR adds a validation tooltip message to the field if the typeField validation is not correct.

In the example, validation only accepts the type `str` not `msg`:
<img width="536" alt="Capture d’écran 2023-11-27 à 11 27 14" src="https://github.com/node-red/node-red/assets/92022724/42cd1e14-a195-42b1-9bbf-821624017d94">

Note: the message on the screenshot is not the message that the example should produce

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
