### PR TITLE
Allow import of modules with subpath in specifier

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/externalModules.js
+++ b/packages/node_modules/@node-red/registry/lib/externalModules.js
@@ -98,7 +98,7 @@ function requireModule(module) {
     const parsedModule = parseModuleName(module);
 
     if (BUILTIN_MODULES.indexOf(parsedModule.module) !== -1) {
-        return require(parsedModule.module);
+        return require(parsedModule.module + parsedModule.subpath);
     }
     if (!knownExternalModules[parsedModule.module]) {
         const e = new Error("Module not allowed");
@@ -131,7 +131,7 @@ function importModule(module) {
     const parsedModule = parseModuleName(module);
 
     if (BUILTIN_MODULES.indexOf(parsedModule.module) !== -1) {
-        return import(parsedModule.module);
+        return import(parsedModule.module + parsedModule.subpath);
     }
     if (!knownExternalModules[parsedModule.module]) {
         const e = new Error("Module not allowed");
@@ -152,12 +152,13 @@ function importModule(module) {
 }
 
 function parseModuleName(module) {
-    var match = /((?:@[^/]+\/)?[^/@]+)(?:@([\s\S]+))?/.exec(module);
+    var match = /((?:@[^/]+\/)?[^/@]+)(\/[^/@]+)?(?:@([\s\S]+))?/.exec(module);
     if (match) {
         return {
             spec: module,
             module: match[1],
-            version: match[2],
+            subpath: match[2] || '',
+            version: match[3],
             builtin: BUILTIN_MODULES.indexOf(match[1]) !== -1,
             known: !!knownExternalModules[match[1]]
         }


### PR DESCRIPTION
Fixes #4446

This updates the module name parser to extract any possible subpath included so it gets imported properly.

For example:

 - `fs/promises` - `fs` is the module name, `/promises` is the subpath

This correctly parses when there is a scoped module and/or a version string included:

 - `@scope/module/subpath@1.2.3`
