### PR TITLE
Add modules.install audit event when external module installed

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/externalModules.js
+++ b/packages/node_modules/@node-red/registry/lib/externalModules.js
@@ -283,6 +283,7 @@ async function installModule(moduleDetails) {
             const runtimeInstalledModules = settings.get("modules") || {};
             runtimeInstalledModules[moduleDetails.module] = moduleDetails;
             settings.set("modules",runtimeInstalledModules)
+            log.audit({event: "modules.install",module:moduleDetails.module, version:moduleDetails.version});
         }).catch(result => {
             var output = result.stderr || result.toString();
             var e;


### PR DESCRIPTION
This logs to the audit log whenever an external module is installed - similar to the existing `node.installed` event.

There is no sensible equivalent place for logging an uninstall.

This isn't done in the context of an http request, so we can't log who triggered it - that information can be derived from the preceding `flows.set` audit event that will contain the info.