### PR TITLE
Debounce node-removed notifications

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -534,6 +534,10 @@ var RED = (function() {
                 RED.view.redrawStatus(node);
             }
         });
+
+        let pendingNodeRemovedNotifications = []
+        let pendingNodeRemovedTimeout
+
         RED.comms.subscribe("notification/node/#",function(topic,msg) {
             var i,m;
             var typeList;
@@ -571,8 +575,15 @@ var RED = (function() {
                     m = msg[i];
                     info = RED.nodes.removeNodeSet(m.id);
                     if (info.added) {
-                        typeList = "<ul><li>"+m.types.map(RED.utils.sanitize).join("</li><li>")+"</li></ul>";
-                        RED.notify(RED._("palette.event.nodeRemoved", {count:m.types.length})+typeList,"success");
+                        pendingNodeRemovedNotifications = pendingNodeRemovedNotifications.concat(m.types.map(RED.utils.sanitize))
+                        if (pendingNodeRemovedTimeout) {
+                            clearTimeout(pendingNodeRemovedTimeout)
+                        }
+                        pendingNodeRemovedTimeout = setTimeout(function () {
+                            typeList = "<ul><li>"+pendingNodeRemovedNotifications.join("</li><li>")+"</li></ul>";
+                            RED.notify(RED._("palette.event.nodeRemoved", {count:pendingNodeRemovedNotifications.length})+typeList,"success");
+                            pendingNodeRemovedNotifications = []
+                        }, 200)
                     }
                 }
                 loadIconList();


### PR DESCRIPTION
Fixes #4413

Debounces notifications so they don't flood the screen when uninstalling a module with lots of node sets in.