### PR TITLE
Guard against node.broker being undefined

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -612,7 +612,7 @@ module.exports = function(RED) {
                 node.brokerurl = node.url;
             } else {
                 // if the broker is ws:// or wss:// or tcp://
-                if (node.broker.indexOf("://") > -1) {
+                if ((typeof node.broker  === 'string') && node.broker.indexOf("://") > -1) {
                     node.brokerurl = node.broker;
                     // Only for ws or wss, check if proxy env var for additional configuration
                     if (node.brokerurl.indexOf("wss://") > -1 || node.brokerurl.indexOf("ws://") > -1) {


### PR DESCRIPTION
Fixes #4380

As the user can pass in a new value of `broker` without any validation, this ensures its a string before we try treating it as such.
