### PR TITLE
Fix `validateNodeProperty` without validator provided

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -182,6 +182,17 @@ RED.editor = (function() {
                     error: err.message
                 });
             }
+        } else if (valid) {
+            // If the validator is not provided in node property => Check if the input has a validator
+            if ("category" in node._def) {
+                const isConfig = node._def.category === "config";
+                const prefix = isConfig ? "node-config-input" : "node-input";
+                const input = $("#"+prefix+"-"+property);
+                const isTypedInput = input.length > 0 && input.next(".red-ui-typedInput-container").length > 0;
+                if (isTypedInput) {
+                    valid = input.typedInput("validate");
+                }
+            }
         }
         if (valid && definition[property].type && RED.nodes.getType(definition[property].type) && !("validate" in definition[property])) {
             if (!value || value == "_ADD_") {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Fixes #4429

If no validator is provided in node property, the validation result is true which breaks the built-in validation of `typedInput`.

The solution that this PR adds is to check if the input is a `typedInput` and in this case call `typedInput("validate")`.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
