### PR TITLE
Ensure subflow instances keep track of their groups

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
@@ -73,9 +73,20 @@ class Subflow extends Flow {
             id: subflowInstance.id,
             configs: {},
             nodes: {},
+            groups: {},
             subflows: {}
         }
 
+        if (subflowDef.groups) {
+            // Clone all of the subflow group definitions and give them new IDs
+            for (i in subflowDef.groups) {
+                if (subflowDef.groups.hasOwnProperty(i)) {
+                    node = createNodeInSubflow(subflowInstance.id,subflowDef.groups[i]);
+                    node_map[node._alias] = node;
+                    subflowInternalFlowConfig.groups[node.id] = node;
+                }
+            }
+        }
         if (subflowDef.configs) {
             // Clone all of the subflow config node definitions and give them new IDs
             for (i in subflowDef.configs) {


### PR DESCRIPTION
Fixes #4456 

Subflows were not updating their internal record of their groups, meaning any attempt to lookup env vars would fail as they have to access the group objects.