### PR TITLE
Handle unknown node reference inside subflow module

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
@@ -248,7 +248,7 @@ class Subflow extends Flow {
                     for (j=0;j<wires.length;j++) {
                         if (wires[j].id != self.subflowDef.id) {
                             node = self.node_map[wires[j].id];
-                            if (node._originalWires) {
+                            if (node && node._originalWires) {
                                 node.wires = clone(node._originalWires);
                             }
                         }
@@ -265,8 +265,10 @@ class Subflow extends Flow {
                             subflowInstanceModified = true;
                         } else {
                             node = self.node_map[wires[j].id];
-                            node.wires[wires[j].port] = node.wires[wires[j].port].concat(newWires[i]);
-                            modifiedNodes[node.id] = node;
+                            if (node) {
+                                node.wires[wires[j].port] = node.wires[wires[j].port].concat(newWires[i]);
+                                modifiedNodes[node.id] = node;
+                            }
                         }
                     }
                 }
@@ -294,10 +296,14 @@ class Subflow extends Flow {
                         this.node._updateWires(subflowInstanceConfig.wires);
                     } else {
                         var node = self.node_map[wires[j].id];
-                        if (!node._originalWires) {
-                            node._originalWires = clone(node.wires);
+                        if (node) {
+                            if (!node._originalWires) {
+                                node._originalWires = clone(node.wires);
+                            }
+                            node.wires[wires[j].port] = (node.wires[wires[j].port]||[]).concat(this.subflowInstance.wires[i]);
+                        } else {
+                            this.error("Unknown node referenced inside subflow: " + wires[j].id)
                         }
-                        node.wires[wires[j].port] = (node.wires[wires[j].port]||[]).concat(this.subflowInstance.wires[i]);
                     }
                 }
             }
@@ -313,11 +319,15 @@ class Subflow extends Flow {
                     this.node._updateWires(subflowInstanceConfig.wires);
                 } else {
                     var node = self.node_map[wires[j].id];
-                    if (!node._originalWires) {
-                        node._originalWires = clone(node.wires);
+                    if (node) {
+                        if (!node._originalWires) {
+                            node._originalWires = clone(node.wires);
+                        }
+                        node.wires[wires[j].port] = (node.wires[wires[j].port]||[]);
+                        node.wires[wires[j].port].push(subflowStatusId);
+                    } else {
+                        this.error("Unknown node referenced inside subflow: " + wires[j].id)
                     }
-                    node.wires[wires[j].port] = (node.wires[wires[j].port]||[]);
-                    node.wires[wires[j].port].push(subflowStatusId);
                 }
             }
         }


### PR DESCRIPTION
Fixes #4369

If a subflow module contains unrecognised node references (see #4369 for an example), we were logging an unhelpful error. This improves matters to identify the subflow and node at fault.