### PR TITLE
Fix switch validation of typeof field

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.html
@@ -176,14 +176,17 @@
                     for (var i=0;i<rules.length;i++) {
                         const opt = { label: RED._('node-red:switch.label.rule')+' '+(i+1) }
                         const r = rules[i];
-                        if (r.hasOwnProperty('v')) {
-                            if ((msg = RED.utils.validateTypedProperty(r.v,r.vt,opt)) !== true) {
-                                errors.push(msg)
+                        if (r.t !== 'istype') {
+                            if (r.hasOwnProperty('v')) {
+                                if ((msg = RED.utils.validateTypedProperty(r.v,r.vt,opt)) !== true) {
+                                    errors.push(msg)
+                                }
                             }
-                        }
-                        if (r.hasOwnProperty('v2')) {
-                            if ((msg = RED.utils.validateTypedProperty(r.v2,r.v2t,opt)) !== true) {
-                                errors.push(msg)
+                            if (r.hasOwnProperty('v2')) {
+                                if ((msg = RED.utils.validateTypedProperty(r.v2,r.v2t,opt)) !== true) {
+                                    console.log('HERE2', msg)
+                                    errors.push(msg)
+                                }
                             }
                         }
                     }

--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.html
@@ -184,7 +184,6 @@
                             }
                             if (r.hasOwnProperty('v2')) {
                                 if ((msg = RED.utils.validateTypedProperty(r.v2,r.v2t,opt)) !== true) {
-                                    console.log('HERE2', msg)
                                     errors.push(msg)
                                 }
                             }


### PR DESCRIPTION
Fixes #4464

The typeof check in the switch node doesn't need to validate the configuration as they are hardcoded options. The way the rule stores its configuration was making the validator want to look for an actual json string in the config, whereas it is simply the string `json`.