### PR TITLE
Relax some node validators to allow undefined value

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/validators.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/validators.js
@@ -56,6 +56,9 @@ RED.validators = {
             if (options.allowBlank && v === '') {
                 return true
             }
+            if (options.allowUndefined && v === undefined) {
+                return true
+            }
             const result = RED.utils.validateTypedProperty(v, ptype, opt)
             if (result === true || opt) {
                 // Valid, or opt provided - return result as-is

--- a/packages/node_modules/@node-red/nodes/core/function/16-range.html
+++ b/packages/node_modules/@node-red/nodes/core/function/16-range.html
@@ -58,11 +58,8 @@
             round: {value:false},
             property: {value:"payload",required:true,
                        label:RED._("node-red:common.label.property"),
-                       validate: RED.validators.typedInput({ type: 'msg' })
+                       validate: RED.validators.typedInput({ type: 'msg', allowBlank: true })
                     },
-            
-            
-            // RED.validators.typedInput("propertyType", false)},
             name: {value:""}
         },
         inputs: 1,

--- a/packages/node_modules/@node-red/nodes/core/function/rbe.html
+++ b/packages/node_modules/@node-red/nodes/core/function/rbe.html
@@ -57,10 +57,10 @@
             septopics: {value:true},
             property: {value:"payload", required:true,
                        label:RED._("node-red:rbe.label.property"),
-                       validate: RED.validators.typedInput({ type: 'msg' })},
+                       validate: RED.validators.typedInput({ type: 'msg', allowUndefined: true })},
             topi: {value:"topic", required:true,
                    label:RED._("node-red:rbe.label.topic"),
-                   validate: RED.validators.typedInput({ type: 'msg' })}
+                   validate: RED.validators.typedInput({ type: 'msg', allowUndefined: true })}
         },
         inputs:1,
         outputs:1,

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-HTML.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-HTML.html
@@ -41,8 +41,8 @@
         color:"#DEBD5C",
         defaults: {
             name: {value:""},
-            property: {value:"payload", validate: RED.validators.typedInput({ type: 'msg' }) },
-            outproperty: {value:"payload", validate: RED.validators.typedInput({ type: 'msg' }) },
+            property: {value:"payload", validate: RED.validators.typedInput({ type: 'msg', allowUndefined: true }) },
+            outproperty: {value:"payload", validate: RED.validators.typedInput({ type: 'msg', allowUndefined: true }) },
             tag: {value:""},
             ret: {value:"html"},
             as: {value:"single"}

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-JSON.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-JSON.html
@@ -32,7 +32,7 @@
         defaults: {
             name: {value:""},
             property: {value:"payload",required:true,
-                       validate: RED.validators.typedInput({ type: 'msg' }),
+                       validate: RED.validators.typedInput({ type: 'msg', allowUndefined: true}),
                        label:RED._("node-red:json.label.property")},
             action: {value:""},
             pretty: {value:false}

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-XML.html
@@ -28,7 +28,7 @@
             name: {value:""},
             property: {value:"payload",required:true,
                        label:RED._("node-red:common.label.property"),
-                       validate: RED.validators.typedInput({ type: 'msg' })},
+                       validate: RED.validators.typedInput({ type: 'msg', allowUndefined: true })},
             attr: {value:""},
             chr: {value:""}
         },

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-YAML.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-YAML.html
@@ -16,7 +16,7 @@
         color:"#DEBD5C",
         defaults: {
             property: {value:"payload",required:true,
-                       validate: RED.validators.typedInput({ type: 'msg' }),
+                       validate: RED.validators.typedInput({ type: 'msg', allowUndefined: true }),
                        label:RED._("node-red:common.label.property")},
             name: {value:""}
         },


### PR DESCRIPTION
As a follow up to #4440, feedback from the community highlighted that the new validation was flagging errors with some existing nodes. Specifically, nodes that were deployed in an earlier version before a particular property was added to the node and not updated since.

We try to minimise disruption for users - so this PR relaxes the validation on these properties to allow their value to be undefined.