### PR TITLE
Client/Editor Events: fix off-in-on pattern emulating once

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/events.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/events.js
@@ -39,15 +39,16 @@
              console.warn(evt,args);
          }
          if (handlers[evt]) {
-             for (var i=0;i<handlers[evt].length;i++) {
+             let cpyHandlers = [...handlers[evt]];
+          
+             for (var i=0;i<cpyHandlers.length;i++) {
                  try {
-                     handlers[evt][i].apply(null, args);
+                     cpyHandlers[i].apply(null, args);
                  } catch(err) {
                      console.warn("RED.events.emit error: ["+evt+"] "+(err.toString()));
                      console.warn(err);
                  }
              }
-
          }
      }
      return {


### PR DESCRIPTION

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This fixes an issue when RED.events.off(..) is called in a RED.events.on(..) callback:

```
let cb = () => {
  RED.events.off("event-name", cb)
  ....
}
RED.events.on("event-name", cb)
```

This pattern emulates a once(..), i.e., execute a callback once-only for an event.

Discussed in [Forum](https://discourse.nodered.org/t/event-offing-an-on-event-to-perform-only-once/83726)

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
```
  2451 passing (3m)
  59 pending


Done.

=============================== Coverage summary ===============================
Statements   : 69.06% ( 11565/16746 )
Branches     : 61.9% ( 6382/10310 )
Functions    : 65.01% ( 1620/2492 )
Lines        : 69.19% ( 11215/16210 )
================================================================================
```
- [ ] I have added suitable unit tests to cover the new/changed functionality
