### PR TITLE
Fix icon scaling for non .svg icons

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4155,10 +4155,15 @@ RED.view = (function() {
                         scaleFactor = 30/largestEdge;
                     }
                     var width = img.width * scaleFactor;
+                    if (width > 20) {
+                        scalefactor *= 20/width;
+                        width = 20;
+                    }
                     var height = img.height * scaleFactor;
                     icon.attr("width",width);
                     icon.attr("height",height);
                     icon.attr("x",15-width/2);
+                    icon.attr("y",(30-height)/2);
                 }
                 icon.attr("xlink:href",iconUrl);
                 icon.style("display",null);


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
In case a contrib node uses an oversized icon in non-`.svg` format, the size of this icon might change when pulling the node from the palette to the editor view:

![icon_size](https://github.com/node-red/node-red/assets/16342003/4f026394-1301-4e5a-baf2-a9424e1f7467)

This PR modifies the scaling algorithm - for that particular case - to ensure the size of the icon stays as it is in the palette:

![icon_size_2](https://github.com/node-red/node-red/assets/16342003/8677ffa5-2ee8-4505-a27a-b4f922e0b8a4)

Fix for #4490.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
