### PR TITLE
Add auto-complete for env vars

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -110,6 +110,10 @@
     }
 
     function getEnvVars (obj, envVars = {}) {
+        contextKnownKeys.env = contextKnownKeys.env || {}
+        if (contextKnownKeys.env[obj.id]) {
+            return contextKnownKeys.env[obj.id]
+        }
         let parent
         if (obj.type === 'tab' || obj.type === 'subflow') {
             RED.nodes.eachConfig(function (conf) {
@@ -130,9 +134,10 @@
                 envVars[env.name] = obj
             })
         }
+        contextKnownKeys.env[obj.id] = envVars
         return envVars
     }
-    RED.pp = getEnvVars
+
     const envAutoComplete = function (val) {
         const editStack = RED.editor.getEditStack()
         if (editStack.length === 0) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -108,7 +108,87 @@
             return matches;
         }
     }
-    
+
+    function getEnvVars (obj, envVars = {}) {
+        let parent
+        if (obj.type === 'tab' || obj.type === 'subflow') {
+            RED.nodes.eachConfig(function (conf) {
+                if (conf.type === "global-config") {
+                    parent = conf;
+                }
+            })
+        } else if (obj.g) {
+            parent = RED.nodes.group(obj.g)
+        } else if (obj.z) {
+            parent = RED.nodes.workspace(obj.z) || RED.nodes.subflow(obj.z)
+        }
+        if (parent) {
+            getEnvVars(parent, envVars)
+        }
+        if (obj.env) {
+            obj.env.forEach(env => {
+                envVars[env.name] = obj
+            })
+        }
+        return envVars
+    }
+    RED.pp = getEnvVars
+    const envAutoComplete = function (val) {
+        const editStack = RED.editor.getEditStack()
+        if (editStack.length === 0) {
+            done([])
+            return
+        }
+        const editingNode = editStack.pop()
+        if (!editingNode) {
+            return []
+        }
+        const envVarsMap = getEnvVars(editingNode)
+        const envVars = Object.keys(envVarsMap)
+        const matches = []
+        const i = val.lastIndexOf('${')
+        let searchKey = val
+        let isSubkey = false
+        if (i > -1) {
+            if (val.lastIndexOf('}') < i) {
+                searchKey = val.substring(i+2)
+                isSubkey = true
+            }
+        }
+        envVars.forEach(v => {
+            let valMatch = getMatch(v, searchKey);
+            if (valMatch.found) {
+                const optSrc = envVarsMap[v]
+                const element = $('<div>',{style: "display: flex"});
+                const valEl = $('<div/>',{style:"font-family: var(--red-ui-monospace-font); white-space:nowrap; overflow: hidden; flex-grow:1"});
+                valEl.append(generateSpans(valMatch))
+                valEl.appendTo(element)
+
+                if (optSrc) {
+                    const optEl = $('<div>').css({ "font-size": "0.8em" });
+                    let label
+                    if (optSrc.type === 'global-config') {
+                        label = RED._('sidebar.context.global')
+                    } else if (optSrc.type === 'group') {
+                        label = RED.utils.getNodeLabel(optSrc) || (RED._('sidebar.info.group') + ': '+optSrc.id)
+                    } else {
+                        label = RED.utils.getNodeLabel(optSrc) || optSrc.id
+                    }
+
+                    optEl.append(generateSpans({ match: label }));
+                    optEl.appendTo(element);
+                }
+                matches.push({
+                    value: isSubkey ? val + v + '}' : v,
+                    label: element,
+                    i: valMatch.index
+                });
+            }
+        })
+        matches.sort(function(A,B){return A.i-B.i})
+        return matches
+    }
+
     let contextKnownKeys = {}
     let contextCache = {}
     if (RED.events) {
@@ -118,9 +198,7 @@
         });
     }
 
-
     const contextAutoComplete = function(options) {
-
         const getContextKeysFromRuntime = function(scope, store, searchKey, done) {
             contextKnownKeys[scope] = contextKnownKeys[scope] || {}
             contextKnownKeys[scope][store] = contextKnownKeys[scope][store] || new Set()
@@ -365,7 +443,8 @@
         env: {
             value: "env",
             label: "env variable",
-            icon: "red/images/typedInput/env.svg"
+            icon: "red/images/typedInput/env.svg",
+            autoComplete: envAutoComplete
         },
         node: {
             value: "node",


### PR DESCRIPTION
This adds auto-complete for `env` typedInputs:

![ABlO6Zu0FR](https://github.com/node-red/node-red/assets/51083/d25e27ea-03cd-4d26-9343-6e43b2ae99a1)

It gathers valid completions from the node/group/flow/subflow/global-env-vars.

It's a bit inefficient currently as it has to re-gather that list of env vars each time it has to revaluate valid completions - but that's because we don't have a suitable point to do that initial gather at the start of an autoComplete session.