### PR TITLE
HTML node: add option for collecting attributes and content

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/parsers/70-HTML.html
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-HTML.html
@@ -14,6 +14,7 @@
             <option value="html" data-i18n="html.output.html"></option>
             <option value="text" data-i18n="html.output.text"></option>
             <option value="attr" data-i18n="html.output.attr"></option>
+            <option value="compl" data-i18n="html.output.compl"></option>
             <!-- <option value="val">return the value from a form element</option> -->
         </select>
     </div>
@@ -27,6 +28,10 @@
     <div class="form-row">
         <label for="node-input-outproperty">&nbsp;</label>
         <span data-i18n="html.label.in" style="padding-left:8px; padding-right:2px; vertical-align:-1px;"></span> <input type="text" id="node-input-outproperty" style="width:64%">
+    </div>
+    <div id='html-prefix-row' class="form-row" style="display: none;">
+        <label for="node-input-chr" style="width: 230px;"><i class="fa fa-tag"></i> <span data-i18n="html.label.prefix"></span></label>
+        <input type="text" id="node-input-chr" style="text-align:center; width: 40px;" placeholder="_">
     </div>
     <br/>
     <div class="form-row">
@@ -45,7 +50,8 @@
             outproperty: {value:"payload", validate: RED.validators.typedInput({ type: 'msg', allowUndefined: true }) },
             tag: {value:""},
             ret: {value:"html"},
-            as: {value:"single"}
+            as: {value:"single"},
+            chr: { value: "_" }
         },
         inputs:1,
         outputs:1,
@@ -59,6 +65,13 @@
         oneditprepare: function() {
             $("#node-input-property").typedInput({default:'msg',types:['msg']});
             $("#node-input-outproperty").typedInput({default:'msg',types:['msg']});
+            $('#node-input-ret').on( 'change', () => {
+                if ( $('#node-input-ret').val() == "compl" ) {
+                    $('#html-prefix-row').show()
+                } else {
+                    $('#html-prefix-row').hide()
+                }
+            });
         }
     });
 </script>

--- a/packages/node_modules/@node-red/nodes/core/parsers/70-HTML.js
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-HTML.js
@@ -25,6 +25,7 @@ module.exports = function(RED) {
         this.tag = n.tag;
         this.ret = n.ret || "html";
         this.as = n.as || "single";
+        this.chr = n.chr || "_";
         var node = this;
         this.on("input", function(msg,send,done) {
             var value = RED.util.getMessageProperty(msg,node.property);
@@ -47,6 +48,11 @@ module.exports = function(RED) {
                             if (node.ret === "attr") {
                                 pay2 = Object.assign({},this.attribs);
                             }
+                            if (node.ret === "compl") {
+                                var bse = {}
+                                bse[node.chr] = $(this).html().trim()
+                                pay2 = Object.assign(bse, this.attribs);
+                            }
                             //if (node.ret === "val")  { pay2 = $(this).val(); }
                             /* istanbul ignore else */
                             if (pay2) {
@@ -68,6 +74,11 @@ module.exports = function(RED) {
                             if (node.ret === "attr") {
                                 var attribs = Object.assign({},this.attribs);
                                 pay.push( attribs );
+                            }
+                            if (node.ret === "compl") {
+                                var bse = {}
+                                bse[node.chr] = $(this).html().trim()
+                                pay.push( Object.assign(bse, this.attribs) )
                             }
                             //if (node.ret === "val")  { pay.push( $(this).val() ); }
                         }

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -887,12 +887,14 @@
         "label": {
             "select": "Selector",
             "output": "Output",
-            "in": "in"
+            "in": "in",
+            "prefix": "Property name for HTML content"
         },
         "output": {
             "html": "the html content of the elements",
             "text": "only the text content of the elements",
-            "attr": "an object of any attributes of the elements"
+            "attr": "an object of any attributes of the elements",
+            "compl": "an object of any attributes of the elements and html contents"
         },
         "format": {
             "single": "as a single message containing an array",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Add a fourth option to the HTML node to collect attributes and html content together. At the moment, it is only possible to either have the attributes or the content of matching elements. This adds an option have both.

Discussed in the [forum](https://discourse.nodered.org/t/question-about-html-node/84298).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass

all passed but errored out on:
```
Running "nyc:all" (nyc) task
Fatal error: spawn nyc ENOENT
```

- [ ] I have added suitable unit tests to cover the new/changed functionality
