### PR TITLE
fix(runtime): ensure storageModule.saveSettings is works anyway

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/settings.js
+++ b/packages/node_modules/@node-red/runtime/lib/settings.js
@@ -58,6 +58,7 @@ var persistentSettings = {
                 userSettings = globalSettings.users || {};
             }
             else {
+                globalSettings = {};
                 userSettings = {};
             }
         });


### PR DESCRIPTION
Ensure that storageModule.saveSettings works when storageModule.getSettings is empty.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Enable storageModule https://nodered.org/docs/api/storage/methods/#storagegetsettings

When Node-RED initializes upon startup, `storageModule.getSettings` is empty, causing `storageModule.saveSettings` to save an empty string. Consequently, after a container restart, the nodes are lost.


https://github.com/node-red/node-red/blob/f0a9b0cf69646177755203a11415982dfa83b87e/packages/node_modules/%40node-red/runtime/lib/settings.js#L56

```js
    set: function(prop,value) {
        if (prop === 'users') {
            throw new Error("Do not access user settings directly. Use settings.setUserSettings");
        }
        if (localSettings.hasOwnProperty(prop)) {
            throw new Error(log._("settings.property-read-only", {prop:prop}));
        }
        //pr comment: globalSettings may be empty string and skip the code
        if (globalSettings === null) {
            throw new Error(log._("settings.not-available"));
        }
        var current = globalSettings[prop];
        globalSettings[prop] = clone(value);
        try {
            assert.deepEqual(current,value);
        } catch(err) {
           // pr comment:  it will save the empty string
            return storage.saveSettings(clone(globalSettings));
        }
        return Promise.resolve();
    },
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
