### PR TITLE
Clone objects types when getting env values

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -485,7 +485,7 @@ class Flow {
         }
         if (!key.startsWith("$parent.")) {
             if (this._env.hasOwnProperty(key)) {
-                return this._env[key]
+                return (Object.hasOwn(this._env[key], 'value') && this._env[key].__clone__) ? clone(this._env[key].value) : this._env[key]
             }
         } else {
                 key = key.substring(8);

--- a/packages/node_modules/@node-red/runtime/lib/flows/Group.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Group.js
@@ -41,7 +41,7 @@ class Group {
         }
         if (!key.startsWith("$parent.")) {
             if (this._env.hasOwnProperty(key)) {
-                return this._env[key]
+                return (Object.hasOwn(this._env[key], 'value') && this._env[key].__clone__) ? clone(this._env[key].value) : this._env[key]
             }
         } else {
             key = key.substring(8);

--- a/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
@@ -375,7 +375,7 @@ class Subflow extends Flow {
         }
         if (!key.startsWith("$parent.")) {
             if (this._env.hasOwnProperty(key)) {
-                return this._env[key]
+                return (Object.hasOwn(this._env[key], 'value') && this._env[key].__clone__) ? clone(this._env[key].value) : this._env[key]
             }
         } else {
             key = key.substring(8);

--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -102,6 +102,9 @@ async function evaluateEnvProperties(flow, env, credentials) {
             pendingEvaluations.push(new Promise((resolve, _) => {
                 redUtil.evaluateNodeProperty(value, 'jsonata', {_flow: flow}, null, (err, result) => {
                     if (!err) {
+                        if (typeof result  === 'object') {
+                            result = { value: result, __clone__: true}
+                        }
                         evaluatedEnv[name] = result
                     }
                     resolve()
@@ -109,6 +112,9 @@ async function evaluateEnvProperties(flow, env, credentials) {
             }))
         } else {
             value = redUtil.evaluateNodeProperty(value, type, {_flow: flow}, null, null);
+            if (typeof value  === 'object') {
+                value = { value: value, __clone__: true}
+            }
         }
         evaluatedEnv[name] = value
     }
@@ -138,8 +144,13 @@ async function evaluateEnvProperties(flow, env, credentials) {
                 }
             }}, null, null);
         }
+        if (typeof value  === 'object' && !value.__clone__) {
+            value = { value: value, __clone__: true}
+        }
         evaluatedEnv[name] = value
+
     }
+    // console.log(evaluatedEnv)
 
     return evaluatedEnv
 }


### PR DESCRIPTION
Fixes #4479

With the work to pre-evaluate env values on start, we no longer re-evaluate JSON each time it is retrieved. The problem this has caused for the linked issue is that we are now returning the same object each time - an object that can be mutated by a flow.

Env values are intended to be immutable.

This PR fixes it by cloning the env value if needed. It only does this for object types (inc Arrays) - but not for string/number/boolean types that don't need it.