### PR TITLE
Ensure global-config credential env vars are merged on deploy

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/env-var.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/env-var.js
@@ -71,7 +71,7 @@ RED.envVar = (function() {
                 };
                 if (item.name.trim() !== "") {
                     new_env.push(item);
-                    if ((item.type === "cred") && (item.value !== "__PWRD__")) {
+                    if (item.type === "cred") {
                         credentials.map[item.name] = item.value;
                         credentials.map["has_"+item.name] = (item.value !== "");
                         item.value = "__PWRD__";

--- a/packages/node_modules/@node-red/runtime/lib/nodes/credentials.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/credentials.js
@@ -384,10 +384,27 @@ var api = module.exports = {
                     }
                 }
             } else if (nodeType === "global-config") {
-                if (JSON.stringify(savedCredentials.map) !== JSON.stringify(newCreds.map)) {
-                    savedCredentials.map = newCreds.map;
-                    dirty = true;
-                }
+                const existingCredentialKeys = Object.keys(savedCredentials?.map || [])
+                const newCredentialKeys = Object.keys(newCreds?.map || [])
+                existingCredentialKeys.forEach(key => {
+                    if (!newCreds.map?.[key]) {
+                        // This key doesn't exist in the new credentials list - remove
+                        delete savedCredentials.map[key]
+                        delete savedCredentials.map[`has_${key}`]
+                        dirty = true
+                    }
+                })
+                newCredentialKeys.forEach(key => {
+                    if (!/^has_/.test(key)) {
+                        if (!savedCredentials.map?.[key] || newCreds.map[key] !== '__PWRD__') {
+                            // This key either doesn't exist in current saved, or the
+                            // value has been changed
+                            savedCredentials.map[key] = newCreds.map[key]
+                            savedCredentials.map[`has_${key}`] = newCreds.map[`has_${key}`]
+                            dirty = true
+                        }
+                    }
+                })
             } else {
                 var dashedType = nodeType.replace(/\s+/g, '-');
                 var definition = credentialsDef[dashedType];


### PR DESCRIPTION
Fixes #4508

When deploying changes to a `global-config` node that included credential type properties, it was only sending changed values. This would cause any pre-existing value to be dropped.

This PR ensures the values are merged properly without losing anything.