### PR TITLE
Include top level property name when copying path from context

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-context.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-context.js
@@ -232,7 +232,7 @@ RED.sidebar.context = (function() {
                                     typeHint: data.format,
                                     sourceId: id+"."+k,
                                     tools: tools,
-                                    path: ""
+                                    path: k
                                 }).appendTo(propRow.children()[1]);
                             }
                         })
@@ -278,7 +278,7 @@ RED.sidebar.context = (function() {
                                                     typeHint: data.format,
                                                     sourceId: id+"."+k,
                                                     tools: tools,
-                                                    path: ""
+                                                    path: k
                                                 }).appendTo(propRow.children()[1]);
                                             }
                                         });
@@ -299,7 +299,7 @@ RED.sidebar.context = (function() {
                         typeHint: v.format,
                         sourceId: id+"."+k,
                         tools: tools,
-                        path: ""
+                        path: k
                     }).appendTo(propRow.children()[1]);
                     if (contextStores.length > 1) {
                         $("<span>",{class:"red-ui-sidebar-context-property-storename"}).text(v.store).appendTo($(propRow.children()[0]))


### PR DESCRIPTION
Fixes #4485

