### PR TITLE
Modify node users info in config editor footer

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1231,7 +1231,11 @@ RED.editor = (function() {
                 })
 
                 if (node_def.hasUsers !== false) {
-                    $('<span><i class="fa fa-info-circle"></i> <span id="red-ui-editor-config-user-count"></span></span>').css("margin-left", "10px").appendTo(trayFooterLeft);
+                    // $('<span><i class="fa fa-info-circle"></i> <span id="red-ui-editor-config-user-count"></span></span>').css("margin-left", "10px").appendTo(trayFooterLeft);
+                    $('<button type="button" class="red-ui-button"><i class="fa fa-user"></i><span id="red-ui-editor-config-user-count"></span></button>').on('click', function() {
+                        RED.sidebar.info.outliner.search('uses:'+editing_config_node.id)
+                        RED.sidebar.info.show()
+                    }).appendTo(trayFooterLeft);
                 }
                 trayFooter.append('<span class="red-ui-tray-footer-right"><span id="red-ui-editor-config-scope-warning" data-i18n="[title]editor.errors.scopeChange"><i class="fa fa-warning"></i></span><select id="red-ui-editor-config-scope"></select></span>');
 
@@ -1289,7 +1293,8 @@ RED.editor = (function() {
                         });
                     }
                     if (node_def.hasUsers !== false) {
-                        $("#red-ui-editor-config-user-count").text(RED._("editor.nodesUse", {count:editing_config_node.users.length})).parent().show();
+                        $("#red-ui-editor-config-user-count").text(editing_config_node.users.length).parent().show();
+                        RED.popover.tooltip($("#red-ui-editor-config-user-count").parent(), function() { return RED._('editor.nodesUse',{count:editing_config_node.users.length})});
                     }
                     trayBody.i18n();
                     trayFooter.i18n();


### PR DESCRIPTION
Fixes #4497

The issue was the loack of horizontal space to have both the 'X nodes uses this config' message and the scope select box.

Previously there was just enough room, but 3.1 added the help button which has taken up the spare space.

I've modified the 'X nodes uses this config' to be a more compact button that when clicked filters the info sidebar to show the users of the node. The original text is shown as a tool tip when the button is hovered.

<img width="589" alt="image" src="https://github.com/node-red/node-red/assets/51083/122f1164-0bea-4918-b47c-6f1f4f21d04e">
