### PR TITLE
Highlight errors in config node sidebar

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
@@ -158,6 +158,10 @@ RED.sidebar.config = (function() {
                 entry.data('node',node.id);
                 nodeDiv.data('node',node.id);
                 var label = $('<div class="red-ui-palette-label"></div>').text(labelText).appendTo(nodeDiv);
+
+                if (!node.valid) {
+                    nodeDiv.addClass("red-ui-palette-node-config-invalid")
+                }
                 if (node.d) {
                     nodeDiv.addClass("red-ui-palette-node-config-disabled");
                     $('<i class="fa fa-ban"></i>').prependTo(label);

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
@@ -113,6 +113,9 @@ ul.red-ui-sidebar-node-config-list li.red-ui-palette-node-config-type {
         margin-right: 5px;
     }
 }
+.red-ui-palette-node-config-invalid {
+    border-color: var(--red-ui-node-border-unknown)
+}
 .red-ui-sidebar-node-config-filter-info {
     position: absolute;
     top: 0;


### PR DESCRIPTION
Fixes #4397

This highlights any config nodes with errors in the config node sidebar.

<img width="304" alt="image" src="https://github.com/node-red/node-red/assets/51083/b1a81756-bf9a-4929-905f-b6f57cdb6f1b">


Relying purely on a coloured border isn't idea but is a quick win. Ideally, we'd have the change/error badges consistent with the main workspace, but they are SVG artefacts and the config node sidebar is pure html. I may come back to refine this, but this moves things forward.

It reuses the CSS for unknown nodes so should be compatible with existing themes.