### PR TITLE
Replacing vm.createScript in favour of vm.Script

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -22,12 +22,6 @@ module.exports = function(RED) {
     var acorn = require("acorn");
     var acornWalk = require("acorn-walk");
 
-    if (vm.createScript == null) {
-      vm.createScript = (code, scriptName) => {
-        return new vm.Script(code, { filename: scriptName });
-      }
-    }
-
     function sendResults(node,send,_msgid,msgs,cloneFirstMessage) {
         if (msgs == null) {
             return;
@@ -380,7 +374,7 @@ module.exports = function(RED) {
                         iniOpt.breakOnSigint = true;
                     }
                 }
-                node.script = vm.createScript(functionText, createVMOpt(node, ""));
+                node.script = vm.Script(functionText, {filename: createVMOpt(node, "")});
                 if (node.fin && (node.fin !== "")) {
                     var finText = `(function () {
                         var node = {

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -374,7 +374,7 @@ module.exports = function(RED) {
                         iniOpt.breakOnSigint = true;
                     }
                 }
-                node.script = vm.Script(functionText, {filename: createVMOpt(node, "")});
+                node.script = new vm.Script(functionText, {filename: createVMOpt(node, "")});
                 if (node.fin && (node.fin !== "")) {
                     var finText = `(function () {
                         var node = {

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -374,7 +374,7 @@ module.exports = function(RED) {
                         iniOpt.breakOnSigint = true;
                     }
                 }
-                node.script = new vm.Script(functionText, {filename: createVMOpt(node, "")});
+                node.script = new vm.Script(functionText, createVMOpt(node, ""));
                 if (node.fin && (node.fin !== "")) {
                     var finText = `(function () {
                         var node = {

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -22,6 +22,12 @@ module.exports = function(RED) {
     var acorn = require("acorn");
     var acornWalk = require("acorn-walk");
 
+    if (vm.createScript == null) {
+      vm.createScript = (code, scriptName) => {
+        return new vm.Script(code, { filename: scriptName });
+      }
+    }
+
     function sendResults(node,send,_msgid,msgs,cloneFirstMessage) {
         if (msgs == null) {
             return;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

It seem's `vm.createScript` is deprecated, because it's not mentioned in the official docs. This PR replaces `vm.createScript` by `vm.Script`.

This was needed by myself to run node-red with [bun.sh](https://bun.sh). `vm.createScript` is not available in bun, because I think they missed it due of the missing documentation? Not sure.

The advantage of running node-red with bun is support of esm :)

I also opened a PR there to add support for `vm.createScript`: https://github.com/oven-sh/bun/issues/8312

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
