### PR TITLE
Ensure subflow instance node has g property set

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
@@ -212,6 +212,7 @@ class Subflow extends Flow {
         var subflowInstanceConfig = {
             id: this.subflowInstance.id,
             type: this.subflowInstance.type,
+            g: this.subflowInstance.g,
             z: this.subflowInstance.z,
             name: this.subflowInstance.name,
             wires: [],


### PR DESCRIPTION
Fixes #4533 

If the instance node doesn't get its `g` property set, the `group` level scoping of catch/status/complete nodes won't work as expected.