### PR TITLE
Handle undefined default export when importing module

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -315,7 +315,7 @@ module.exports = function(RED) {
                     var spec = module.module;
                     if (spec && (spec !== "")) {
                         moduleLoadPromises.push(RED.import(module.module).then(lib => {
-                            sandbox[vname] = lib.default;
+                            sandbox[vname] = lib.default || lib;
                         }).catch(err => {
                             node.error(RED._("function.error.moduleLoadError",{module:module.spec, error:err.toString()}))
                             throw err;


### PR DESCRIPTION
Fixes #4536

If an ESM module doesn't define a `default` export, the Function wasn't exposing anything the module had to share.

This is a quick fix that if `default` is not defined it exposes the whole module to the Function node.