### PR TITLE
(convertNode) Do not create the credentials object if there is nothing to export

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1228,7 +1228,6 @@ RED.nodes = (function() {
                         }
                     }
                 } else if (n.credentials) {
-                    node.credentials = {};
                     // All other nodes have a well-defined list of possible credentials
                     for (var cred in n._def.credentials) {
                         if (n._def.credentials.hasOwnProperty(cred)) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

When `convertNode` receives a node with the `credentials` object, a loop checks for each credential whether it should be exported or not. If no credential is exported the function returns an empty object.
```js
// the node returned
{
  id: "some-id",
  type: "some-type",
  credentials: {}, // <- empty creds object
  ...
}
```

Which is likely to overwrite unmodified credentials - the object should not be returned.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
