### PR TITLE
Handle importing flow with existing subflow and instance node

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2217,7 +2217,7 @@ RED.nodes = (function() {
                                 set: registry.getNodeSet("node-red/unknown")
                             }
                         } else {
-                            if (createNewIds || options.importMap[n.id] === "copy") {
+                            if (subflow_denylist[parentId] || createNewIds || options.importMap[n.id] === "copy") {
                                 parentId = subflow.id;
                                 node.type = "subflow:"+parentId;
                                 node._def = registry.getNodeType(node.type);


### PR DESCRIPTION
Fixes #4545

When importing a flow that includes a pre-existing subflow definition *and* and instance of the subflow, the editor would correctly identify the existing subflow definition, however it was failing to re-associate the imported subflow instance with the existing subflow definition.

This fixes it be properly mapping the subflow instance's `type` to the existing subflow's type.