### PR TITLE
Ensure global creds object is initialised when adding first cred

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/nodes/credentials.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/credentials.js
@@ -384,7 +384,8 @@ var api = module.exports = {
                     }
                 }
             } else if (nodeType === "global-config") {
-                const existingCredentialKeys = Object.keys(savedCredentials?.map || [])
+                savedCredentials.map = savedCredentials.map || {}
+                const existingCredentialKeys = Object.keys(savedCredentials.map)
                 const newCredentialKeys = Object.keys(newCreds?.map || [])
                 existingCredentialKeys.forEach(key => {
                     if (!newCreds.map?.[key]) {
@@ -396,7 +397,7 @@ var api = module.exports = {
                 })
                 newCredentialKeys.forEach(key => {
                     if (!/^has_/.test(key)) {
-                        if (!savedCredentials.map?.[key] || newCreds.map[key] !== '__PWRD__') {
+                        if (!savedCredentials.map[key] || newCreds.map[key] !== '__PWRD__') {
                             // This key either doesn't exist in current saved, or the
                             // value has been changed
                             savedCredentials.map[key] = newCreds.map[key]


### PR DESCRIPTION
Fixes #4560 

When adding the first credential value to `global-config`, it was hitting an undefined variables. All my local testing was with an existing flow that already had a global config object in the credential store.