### PR TITLE
Fix require of dns module

### DIFF
--- a/packages/node_modules/node-red/lib/red.js
+++ b/packages/node_modules/node-red/lib/red.js
@@ -26,8 +26,8 @@ var server = null;
 var apiEnabled = false;
 
 const NODE_MAJOR_VERSION = process.versions.node.split('.')[0];
-if (NODE_MAJOR_VERSION > 14) {
-    const dns = require('node:dns');
+if (NODE_MAJOR_VERSION >= 16) {
+    const dns = require('dns');
     dns.setDefaultResultOrder('ipv4first');
 }
 


### PR DESCRIPTION
The existing check for `>14` would break if the user had Node 15 as what we really wanted was Node 16 or later. This updates the version check to reflect that.