### PR TITLE
Fix missing node icons in workspace

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4156,7 +4156,7 @@ RED.view = (function() {
                     }
                     var width = img.width * scaleFactor;
                     if (width > 20) {
-                        scalefactor *= 20/width;
+                        scaleFactor *= 20/width;
                         width = 20;
                     }
                     var height = img.height * scaleFactor;


### PR DESCRIPTION
PR #4491 had a regression in it that caused node icons to go missing if they were oversized. This fixes it. Hurrah.