### PR TITLE
let settings.httpNodeAuth accept single middleware or array of middlewares

### DIFF
--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -408,9 +408,15 @@ httpsPromise.then(function(startupHttps) {
     if (settings.httpAdminRoot !== false) {
         app.use(settings.httpAdminRoot,RED.httpAdmin);
     }
+
     if (settings.httpNodeRoot !== false && settings.httpNodeAuth) {
-        app.use(settings.httpNodeRoot,basicAuthMiddleware(settings.httpNodeAuth.user,settings.httpNodeAuth.pass));
+        if (typeof settings.httpNodeAuth === "function" || Array.isArray(settings.httpNodeAuth)) {
+            app.use(settings.httpNodeRoot, settings.httpNodeAuth);
+        } else {
+            app.use(settings.httpNodeRoot, basicAuthMiddleware(settings.httpNodeAuth.user, settings.httpNodeAuth.pass));
+        }
     }
+
     if (settings.httpNodeRoot !== false) {
         app.use(settings.httpNodeRoot,RED.httpNode);
     }


### PR DESCRIPTION


<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This change allows us to use our own authentication middleware in substitution for the built-in basic-auth middleware at the top level of RED.httpNode. The property httpNodeAuth in settings.js can receive a value that is a middleware function or array of middleware functions or fallback to using the built-in basic-auth. This change is backwards compatible. It was discussed on the forum @ https://discourse.nodered.org/t/httpnode-top-level-middleware-to-replace-basic-auth/85654/1

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
