### PR TITLE
Do not flag env var in num typedInput as error

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -906,7 +906,10 @@ RED.utils = (function() {
      * @returns true if valid, String if invalid
      */
     function validateTypedProperty(propertyValue, propertyType, opt) {
-
+        if (propertyValue && /^\${[^}]+}$/.test(propertyValue)) {
+            // Allow ${ENV_VAR} value
+            return true
+        }
         let error
         if (propertyType === 'json') {
             try {

--- a/packages/node_modules/@node-red/editor-client/src/js/validators.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/validators.js
@@ -16,8 +16,20 @@
 RED.validators = {
     number: function(blankAllowed,mopt){
         return function(v, opt) {
-            if ((blankAllowed&&(v===''||v===undefined)) || (v!=='' && !isNaN(v))) {
-                return true;
+            if (blankAllowed && (v === '' || v === undefined)) {
+                return true
+            }
+            if (v !== '') {
+                if (/^NaN$|^[+-]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?$|^[+-]?(0b|0B)[01]+$|^[+-]?(0o|0O)[0-7]+$|^[+-]?(0x|0X)[0-9a-fA-F]+$/.test(v)) {
+                    return true
+                }
+                if (/^\${[^}]+}$/.test(v)) {
+                    // Allow ${ENV_VAR} value
+                    return true
+                }
+            }
+            if (!isNaN(v)) {
+                return true
             }
             if (opt && opt.label) {
                 return RED._("validator.errors.invalid-num-prop", {

--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.html
@@ -227,26 +227,34 @@
             name: {value:""},
             props:{value:[{p:"payload"},{p:"topic",vt:"str"}], validate:function(v, opt) {
                     if (!v || v.length === 0) { return true }
+                    const errors = []
                     for (var i=0;i<v.length;i++) {
+                        if (/^\${[^}]+}$/.test(v[i].v)) {
+                            // Allow ${ENV_VAR} value
+                            continue
+                        }
                         if (/msg|flow|global/.test(v[i].vt)) {
                             if (!RED.utils.validatePropertyExpression(v[i].v)) {
-                                return RED._("node-red:inject.errors.invalid-prop", { prop: 'msg.'+v[i].p, error: v[i].v });
+                                errors.push(RED._("node-red:inject.errors.invalid-prop", { prop: 'msg.'+v[i].p, error: v[i].v }))
                             }
                         } else if (v[i].vt === "jsonata") {
                             try{ jsonata(v[i].v); }
                             catch(e){
-                                return RED._("node-red:inject.errors.invalid-jsonata", { prop: 'msg.'+v[i].p, error: e.message });
+                                errors.push(RED._("node-red:inject.errors.invalid-jsonata", { prop: 'msg.'+v[i].p, error: e.message }))
                             }
                         } else if (v[i].vt === "json") {
                             try{ JSON.parse(v[i].v); }
                             catch(e){
-                                return RED._("node-red:inject.errors.invalid-json", { prop: 'msg.'+v[i].p, error: e.message });
+                                errors.push(RED._("node-red:inject.errors.invalid-json", { prop: 'msg.'+v[i].p, error: e.message }))
                             }
                         } else if (v[i].vt === "num"){
                             if (!/^[+-]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?$/.test(v[i].v)) {
-                                return RED._("node-red:inject.errors.invalid-prop", { prop: 'msg.'+v[i].p, error: v[i].v });
+                                errors.push(RED._("node-red:inject.errors.invalid-prop", { prop: 'msg.'+v[i].p, error: v[i].v }))
                             }
                         }
+                    }
+                    if (errors.length > 0) {
+                        return errors
                     }
                     return true;
                 }
@@ -254,7 +262,7 @@
             repeat: {
                 value:"", validate: function(v, opt) {
                     if ((v === "") ||
-                        (RED.validators.number(v) &&
+                        (RED.validators.number()(v) &&
                          (v >= 0) && (v <= 2147483))) {
                         return true;
                     }
@@ -263,7 +271,7 @@
             },
             crontab: {value:""},
             once: {value:false},
-            onceDelay: {value:0.1},
+            onceDelay: {value:0.1, validate: RED.validators.number(true)},
             topic: {value:""},
             payload: {value:"", validate: RED.validators.typedInput("payloadType", false) },
             payloadType: {value:"date"},


### PR DESCRIPTION
Fixes #3795 

Allows TypedInput number fields to include `${env var}` when validating the contents.

Also
 - fixes up reporting multiple errors in the Inject node
 - adds more number validation to inject node
 - extends #4371 validation to built-in validator