### PR TITLE
Add missing description label to comment node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/90-comment.html
+++ b/packages/node_modules/@node-red/nodes/core/common/90-comment.html
@@ -5,6 +5,7 @@
         <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
     </div>
     <div class="form-row node-text-editor-row">
+        <label for="node-input-info" data-i18n="editor:workspace.info" style="width:300px;"></label>
         <input type="hidden" id="node-input-info" autofocus="autofocus">
         <div style="height: 250px; min-height:150px;" class="node-text-editor" id="node-input-info-editor"></div>
     </div>


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This is just a small cosmetic fix. The comment node was missing a label for the description form field.

Now:

<img width="1602" alt="SCR-20240228-jqkp" src="https://github.com/node-red/node-red/assets/29807944/949fd2ec-b751-4c16-864d-6cc654194e22">

Then:

<img width="1602" alt="SCR-20240228-jqmx" src="https://github.com/node-red/node-red/assets/29807944/081f348b-17a7-4e56-8afc-dee5cd125aa5">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
