### PR TITLE
Add rfdc to @node-red/runtime package.json

### DIFF
--- a/packages/node_modules/@node-red/runtime/package.json
+++ b/packages/node_modules/@node-red/runtime/package.json
@@ -22,6 +22,7 @@
         "clone": "2.1.2",
         "express": "4.18.2",
         "fs-extra": "11.1.1",
-        "json-stringify-safe": "5.0.1"
+        "json-stringify-safe": "5.0.1",
+        "rfdc": "^1.3.0"
     }
 }


### PR DESCRIPTION
I realised seconds too late that #4352 added a dependency to the top-level package.json, but not to the inner package.json for the internal module that would depend on it.

This is one scenario our `scripts/verify-package-dependencies.js` tool doesn't spot - as it doesn't know the package is missing.