### PR TITLE
Revert "changed cloning library to rfdc for runtime module"

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
         "passport-http-bearer": "1.0.1",
         "passport-oauth2-client-password": "0.1.2",
         "raw-body": "2.5.2",
-        "rfdc": "^1.3.0",
         "semver": "7.5.4",
         "tar": "6.1.13",
         "tough-cookie": "4.1.3",

--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-const clone = require("rfdc")({proto:true, circles: true});
+const clone = require("clone");
 const redUtil = require("@node-red/util").util;
 const events = require("@node-red/util").events;
 const flowUtil = require("./util");

--- a/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Subflow.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-const clone = require("rfdc")({proto:true, circles: true});
+const clone = require("clone");
 const Flow = require('./Flow').Flow;
 const context = require('../nodes/context');
 const util = require("util");

--- a/packages/node_modules/@node-red/runtime/lib/flows/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/index.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-var clone = require("rfdc")({proto:true, circles: true});
+var clone = require("clone");
 
 var Flow = require('./Flow');
 

--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-const clone = require("rfdc")({proto:true, circles: true});
+const clone = require("clone");
 const redUtil = require("@node-red/util").util;
 const Log = require("@node-red/util").log;
 const typeRegistry = require("@node-red/registry");

--- a/packages/node_modules/@node-red/runtime/package.json
+++ b/packages/node_modules/@node-red/runtime/package.json
@@ -22,7 +22,6 @@
         "clone": "2.1.2",
         "express": "4.18.2",
         "fs-extra": "11.1.1",
-        "json-stringify-safe": "5.0.1",
-        "rfdc": "^1.3.0"
+        "json-stringify-safe": "5.0.1"
     }
 }


### PR DESCRIPTION
Reverts node-red/node-red#4352

Merged too quickly - breaking tests in `test/nodes/subflow/subflow_spec.js`