### PR TITLE
Update workspaces.js to fix flow number counts are not separated for multiple projects when Projects feature is turned on.

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -20,7 +20,6 @@ RED.workspaces = (function() {
     const documentTitle = document.title;
 
     var activeWorkspace = 0;
-    var workspaceIndex = 0;
 
     var viewStack = [];
     var hideStack = [];
@@ -72,6 +71,7 @@ RED.workspaces = (function() {
             workspace_tabs.resize();
         } else {
             var tabId = RED.nodes.id();
+            var workspaceIndex = 0;
             do {
                 workspaceIndex += 1;
             } while ($("#red-ui-workspace-tabs li[flowname='"+RED._('workspace.defaultName',{number:workspaceIndex})+"']").size() !== 0);


### PR DESCRIPTION
Fixed issue that flow number counts are not separated for multiple projects when workspace is turned on.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

I'm new to pull requests, so sorry if I'm not following the guideline here,
when workspace turned on, I create multiple flow tabs on project1, then create and move to new project2 and create new flow tab. I expect new flow tab number will be "flow 2" but number is the next number after the project 1 flow number.
They appear to be mixed up between projects.

node-red@3.1.6
node.js v18.14.0

Thank you,

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
