### PR TITLE
changed cloning library to rfdc in runtime/lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
         "passport-http-bearer": "1.0.1",
         "passport-oauth2-client-password": "0.1.2",
         "raw-body": "2.5.2",
+        "rfdc": "^1.3.1",
         "semver": "7.5.4",
         "tar": "6.1.13",
         "tough-cookie": "4.1.3",

--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-const clone = require("clone");
+const clone = require("rfdc")({proto:true, circles: true});
 const redUtil = require("@node-red/util").util;
 const events = require("@node-red/util").events;
 const flowUtil = require("./util");

--- a/packages/node_modules/@node-red/runtime/lib/flows/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/index.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-var clone = require("clone");
+const clone = require("rfdc")({proto:true, circles: true});
 
 var Flow = require('./Flow');
 

--- a/packages/node_modules/@node-red/runtime/lib/flows/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/index.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-const clone = require("rfdc")({proto:true, circles: true});
+const clone = require("rfdc/default");
 
 var Flow = require('./Flow');
 

--- a/packages/node_modules/@node-red/runtime/lib/flows/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/index.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-const clone = require("rfdc/default");
+const clone = require("rfdc")({proto:true, circles: true});
 
 var Flow = require('./Flow');
 

--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-const clone = require("clone");
+const clone = require("rfdc")({proto:true, circles: true});
 const redUtil = require("@node-red/util").util;
 const Log = require("@node-red/util").log;
 const typeRegistry = require("@node-red/registry");


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

switched cloning library from github.com/pvorb/clone to github.com/davidmarkclements/rfdc in runtime, to improve modify performance for large number of nodes (in 1000s). Original discussion on [discource](https://discourse.nodered.org/t/cloning-performance-using-rfdc-instead-of-clone/81288/9). Previous [PR 4352](https://github.com/node-red/node-red/pull/4352) had to be reverted as it was breaking some new test cases. This PR is more contained (previous PR had more files), and passes those tests.

Flame graph - before:
![Before-2024-03-11_13 29 20](https://github.com/node-red/node-red/assets/35643369/983c80cd-861e-485b-baa3-2b30001d3f25)

Flame graph - after:
![After-2024-03-11_13 27 22](https://github.com/node-red/node-red/assets/35643369/0bd5cd4d-aafb-45d1-96e2-40459e592456)

Each profile run was for 12 seconds, which contained 2 `PUT /flow/:flowid` requests.

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality

All tests passed (using github actions - configured for nodejs versions 18 & 20)
```
  2510 passing (2m)
  59 pending


Done.

=============================== Coverage summary ===============================
Statements   : 69.34% ( 11949/17233 )
Branches     : 62.45% ( 6730/10776 )
Functions    : 65.05% ( 1632/2509 )
Lines        : 69.44% ( 11577/16671 )
================================================================================

Done.
```