### PR TITLE
Reset workspace index when clearing nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "mermaid": "^10.4.0",
         "minami": "1.2.3",
         "mocha": "9.2.2",
-        "node-red-node-test-helper": "^0.3.2",
+        "node-red-node-test-helper": "^0.3.3",
         "nodemon": "2.0.20",
         "proxy": "^1.0.2",
         "sass": "1.62.1",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -491,6 +491,11 @@ RED.workspaces = (function() {
         createWorkspaceTabs();
         RED.events.on("sidebar:resize",workspace_tabs.resize);
 
+        RED.events.on("workspace:clear", () => {
+            // Reset the index used to generate new flow names
+            workspaceIndex = 0
+        })
+
         RED.actions.add("core:show-next-tab",function() {
             var oldActive = activeWorkspace;
             workspace_tabs.nextTab();

--- a/test/nodes/core/network/21-httprequest_spec.js
+++ b/test/nodes/core/network/21-httprequest_spec.js
@@ -60,6 +60,7 @@ describe('HTTP Request Node', function() {
     function startServer(done) {
         testPort += 1;
         testServer = stoppable(http.createServer(testApp));
+        const promises = []
         testServer.listen(testPort,function(err) {
             testSslPort += 1;
             console.log("ssl port", testSslPort);
@@ -82,13 +83,16 @@ describe('HTTP Request Node', function() {
             };
             testSslServer = stoppable(https.createServer(sslOptions,testApp));
             console.log('> start testSslServer')
-            testSslServer.listen(testSslPort, function(err){
-                if (err) {
-                    console.log(err);
-                } else {
-                    console.log("started testSslServer");
-                }
-            });
+            promises.push(new Promise((resolve, reject) => {
+                testSslServer.listen(testSslPort, function(err){
+                    console.log(' done testSslServer')
+                    if (err) {
+                        reject(err)
+                    } else {
+                        resolve()
+                    }
+                });
+            }))
 
             testSslClientPort += 1;
             var sslClientOptions = {
@@ -98,11 +102,17 @@ describe('HTTP Request Node', function() {
                 requestCert: true
             };
             testSslClientServer = stoppable(https.createServer(sslClientOptions, testApp));
-            console.log('> start testSslClientServer.listen')
-            testSslClientServer.listen(testSslClientPort, function(err){
-                console.log("ssl-client", err)
-            });
-
+            console.log('> start testSslClientServer')
+            promises.push(new Promise((resolve, reject) => {
+                testSslClientServer.listen(testSslClientPort, function(err){
+                    console.log(' done testSslClientServer')
+                    if (err) {
+                        reject(err)
+                    } else {
+                        resolve()
+                    }
+                });
+            }))
             testProxyPort += 1;
             testProxyServer = stoppable(httpProxy(http.createServer()))
 
@@ -112,9 +122,16 @@ describe('HTTP Request Node', function() {
                 }
             })
             console.log('> testProxyServer')
-            testProxyServer.listen(testProxyPort, function(err) {
-                console.log('testProxyServer start', err)
-            })
+            promises.push(new Promise((resolve, reject) => {
+                testProxyServer.listen(testProxyPort, function(err) {
+                    console.log(' done testProxyServer')
+                    if (err) {
+                        reject(err)
+                    } else {
+                        resolve()
+                    }
+                })
+            }))
 
             testProxyAuthPort += 1
             testProxyServerAuth = stoppable(httpProxy(http.createServer()))
@@ -137,11 +154,18 @@ describe('HTTP Request Node', function() {
                 }
             })
             console.log('> testProxyServerAuth')
-            testProxyServerAuth.listen(testProxyAuthPort, function(err) {
-                console.log('testProxyServerAuth start', err)
-            })
+            promises.push(new Promise((resolve, reject) => {
+                testProxyServerAuth.listen(testProxyAuthPort, function(err) {
+                    console.log(' done testProxyServerAuth')
+                    if (err) {
+                        reject(err)
+                    } else {
+                        resolve()
+                    }
+                })
+            }))
 
-            done(err);
+            Promise.all(promises).then(() => { done() }).catch(done)
         });
     }
 

--- a/test/nodes/core/network/21-httprequest_spec.js
+++ b/test/nodes/core/network/21-httprequest_spec.js
@@ -81,6 +81,7 @@ describe('HTTP Request Node', function() {
                 */
             };
             testSslServer = stoppable(https.createServer(sslOptions,testApp));
+            console.log('> start testSslServer')
             testSslServer.listen(testSslPort, function(err){
                 if (err) {
                     console.log(err);
@@ -97,6 +98,7 @@ describe('HTTP Request Node', function() {
                 requestCert: true
             };
             testSslClientServer = stoppable(https.createServer(sslClientOptions, testApp));
+            console.log('> start testSslClientServer.listen')
             testSslClientServer.listen(testSslClientPort, function(err){
                 console.log("ssl-client", err)
             });
@@ -109,7 +111,10 @@ describe('HTTP Request Node', function() {
                     res.setHeader("x-testproxy-header", "foobar")
                 }
             })
-            testProxyServer.listen(testProxyPort)
+            console.log('> testProxyServer')
+            testProxyServer.listen(testProxyPort, function(err) {
+                console.log('testProxyServer start', err)
+            })
 
             testProxyAuthPort += 1
             testProxyServerAuth = stoppable(httpProxy(http.createServer()))
@@ -131,7 +136,10 @@ describe('HTTP Request Node', function() {
                     res.setHeader("x-testproxy-header", "foobar")
                 }
             })
-            testProxyServerAuth.listen(testProxyAuthPort)
+            console.log('> testProxyServerAuth')
+            testProxyServerAuth.listen(testProxyAuthPort, function(err) {
+                console.log('testProxyServerAuth start', err)
+            })
 
             done(err);
         });
@@ -429,7 +437,11 @@ describe('HTTP Request Node', function() {
             if (err) {
                 done(err);
             }
-            helper.startServer(done);
+            console.log('> helper.startServer')
+            helper.startServer(function(err) {
+                console.log('> helper started')
+                done(err)
+            });
         });
     });
 


### PR DESCRIPTION
Fixes #4600

This is an alternative fix to #4601 - which resets the workspace index only when nodes are cleared. This event is triggered when switching projects - and a couple other scenarios where its probably sensible to reset the index.