### PR TITLE
Retain Palette categories collapsed and filter to localStorage

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -676,10 +676,12 @@ RED.palette = (function() {
         });
 
         const collapse = JSON.parse(localStorage.getItem("palette-collapse") || "[]");
-        setTimeout(function () {
+        const callback = function () {
             collapse.forEach((category) => categoryContainers[category]?.close());
             $("#red-ui-palette-search input").searchBox("value", (localStorage.getItem("palette-filter") || ""));
-        }, 1000);
+            RED.events.off("runtime-state", callback);
+        };
+        RED.events.on("runtime-state", callback);
     }
     function togglePalette(state) {
         if (!state) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -35,6 +35,8 @@ RED.palette = (function() {
     var categoryContainers = {};
     var sidebarControls;
 
+    let lastState = { filter: "", collapsed: [] };
+
     function createCategory(originalCategory,rootCategory,category,ns) {
         if ($("#red-ui-palette-base-category-"+rootCategory).length === 0) {
             createCategoryContainer(originalCategory,rootCategory, ns+":palette.label."+rootCategory);
@@ -73,15 +75,16 @@ RED.palette = (function() {
                 $("#red-ui-palette-header-"+category+" i").addClass("expanded");
             },
             toggle: function() {
-                const collapse = JSON.parse(localStorage.getItem("palette-collapse") || "[]");
                 if (catDiv.hasClass("red-ui-palette-open")) {
                     categoryContainers[category].close();
-                    collapse.push(category);
+                    if (!lastState.collapsed.includes(category)) {
+                        lastState.collapsed.push(category);
+                    }
                 } else {
                     categoryContainers[category].open();
-                    collapse.splice(collapse.indexOf(category), 1);
+                    lastState.collapsed.splice(lastState.collapsed.indexOf(category), 1);
                 }
-                localStorage.setItem("palette-collapse", JSON.stringify(collapse.filter((c, i, array) => array.indexOf(c) === i)));
+                savePaletteState();
             }
         };
 
@@ -600,13 +603,12 @@ RED.palette = (function() {
 
         RED.events.on("subflows:change",refreshSubflow);
 
-
-
         $("#red-ui-palette-search input").searchBox({
             delay: 100,
             change: function() {
                 filterChange($(this).val());
-                localStorage.setItem("palette-filter", $(this).val());
+                lastState.filter = $(this).val();
+                savePaletteState();
             }
         });
 
@@ -675,14 +677,33 @@ RED.palette = (function() {
             }
         });
 
-        const collapse = JSON.parse(localStorage.getItem("palette-collapse") || "[]");
-        const callback = function () {
-            collapse.forEach((category) => categoryContainers[category]?.close());
-            $("#red-ui-palette-search input").searchBox("value", (localStorage.getItem("palette-filter") || ""));
-            RED.events.off("runtime-state", callback);
-        };
-        RED.events.on("runtime-state", callback);
+        try {
+            const stateFromStorage = JSON.parse(localStorage.getItem("palette-state") || "{}");
+
+            for (const prop in stateFromStorage) {
+                if (Object.prototype.hasOwnProperty.call(lastState, prop)) {
+                    lastState[prop] = stateFromStorage[prop];
+                }
+            }
+
+            // Remove old/unknown category from localStorage
+            lastState.collapsed = lastState.collapsed.filter((c, i, a) => a.indexOf(c) === i && categoryContainers[c]);
+
+            const callback = function () {
+                // Hide categories previously hidded
+                lastState.collapsed.forEach((category) => categoryContainers[category].close());
+                // Apply the category filter
+                $("#red-ui-palette-search input").searchBox("value", lastState.filter);
+                RED.events.off("runtime-state", callback);
+            };
+
+            savePaletteState();
+            RED.events.on("runtime-state", callback);
+        } catch (error) {
+            console.error("Unexpected error loading palette state from localStorage: ", error);
+        }
     }
+
     function togglePalette(state) {
         if (!state) {
             $("#red-ui-main-container").addClass("red-ui-palette-closed");
@@ -702,6 +723,15 @@ RED.palette = (function() {
         })
         return categories;
     }
+
+    function savePaletteState() {
+        try {
+            localStorage.setItem("palette-state", JSON.stringify(lastState));
+        } catch (error) {
+            console.error("Unexpected error saving palette state to localStorage: ", error);
+        }
+    }
+
     return {
         init: init,
         add:addNodeType,

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -73,11 +73,15 @@ RED.palette = (function() {
                 $("#red-ui-palette-header-"+category+" i").addClass("expanded");
             },
             toggle: function() {
+                const collapse = JSON.parse(localStorage.getItem("palette-collapse") || "[]");
                 if (catDiv.hasClass("red-ui-palette-open")) {
                     categoryContainers[category].close();
+                    collapse.push(category);
                 } else {
                     categoryContainers[category].open();
+                    collapse.splice(collapse.indexOf(category), 1);
                 }
+                localStorage.setItem("palette-collapse", JSON.stringify(collapse.filter((c, i, array) => array.indexOf(c) === i)));
             }
         };
 
@@ -602,8 +606,9 @@ RED.palette = (function() {
             delay: 100,
             change: function() {
                 filterChange($(this).val());
+                localStorage.setItem("palette-filter", $(this).val());
             }
-        })
+        });
 
         sidebarControls = $('<div class="red-ui-sidebar-control-left"><i class="fa fa-chevron-left"></i></div>').appendTo($("#red-ui-palette"));
         RED.popover.tooltip(sidebarControls,RED._("keyboard.togglePalette"),"core:toggle-palette");
@@ -669,6 +674,12 @@ RED.palette = (function() {
                 togglePalette(state);
             }
         });
+
+        const collapse = JSON.parse(localStorage.getItem("palette-collapse") || "[]");
+        setTimeout(function () {
+            collapse.forEach((category) => categoryContainers[category]?.close());
+            $("#red-ui-palette-search input").searchBox("value", (localStorage.getItem("palette-filter") || ""));
+        }, 1000);
     }
     function togglePalette(state) {
         if (!state) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Use browser localStorage to retain the current collapsed/expanded state of the palette.
Use browser localStorage to retain the current palette filter state.

The request comes from the [forum](https://discourse.nodered.org/t/retain-current-palette-collapse-and-filter/85884).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
