### PR TITLE
Show change indicator on subflow tabs

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -547,12 +547,16 @@ RED.nodes = (function() {
              * @param {String} z tab id
              */
             checkTabState: function (z) {
-                const ws = workspaces[z]
+                const ws = workspaces[z] || subflows[z]
                 if (ws) {
                     const contentsChanged = tabDirtyMap[z].size > 0 || tabDeletedNodesMap[z].size > 0
                     if (Boolean(ws.contentsChanged) !== contentsChanged) {
                         ws.contentsChanged = contentsChanged
-                        RED.events.emit("flows:change", ws);
+                        if (ws.type === 'tab') {
+                            RED.events.emit("flows:change", ws);
+                        } else {
+                            RED.events.emit("subflows:change", ws);
+                        }
                     }
                 }
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -662,6 +662,9 @@ RED.workspaces = (function() {
         RED.events.on("flows:change", (ws) => {
             $("#red-ui-tab-"+(ws.id.replace(".","-"))).toggleClass('red-ui-workspace-changed',!!(ws.contentsChanged || ws.changed || ws.added));
         })
+        RED.events.on("subflows:change", (ws) => {
+            $("#red-ui-tab-"+(ws.id.replace(".","-"))).toggleClass('red-ui-workspace-changed',!!(ws.contentsChanged || ws.changed || ws.added));
+        })
 
         hideWorkspace();
     }


### PR DESCRIPTION
Fixes #4626

Plumbs the `subflows:change` event up properly so we show the change indicator on subflow tabs

<img width="233" alt="image" src="https://github.com/node-red/node-red/assets/51083/af77c382-6c81-443d-a77d-c72ad94e9f90">
