### PR TITLE
Add validation and error handling on subflow instance properties

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1025,7 +1025,22 @@ RED.nodes = (function() {
         RED.nodes.registerType("subflow:"+sf.id, {
             defaults:{
                 name:{value:""},
-                env:{value:[]}
+                env:{value:[], validate: function(value) {
+                    const errors = []
+                    if (value) {
+                        value.forEach(env => {
+                            const r = RED.utils.validateTypedProperty(env.value, env.type)
+                            if (r !== true) {
+                                errors.push(env.name+': '+r)
+                            }
+                        })
+                    }
+                    if (errors.length === 0) {
+                        return true
+                    } else {
+                        return errors
+                    }
+                }}
             },
             icon: function() { return sf.icon||"subflow.svg" },
             category: sf.category || "subflows",

--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -106,14 +106,22 @@ async function evaluateEnvProperties(flow, env, credentials) {
                             result = { value: result, __clone__: true}
                         }
                         evaluatedEnv[name] = result
+                    } else {
+                        evaluatedEnv[name] = undefined
+                        flow.error(`Error evaluating env property '${name}': ${err.toString()}`)
                     }
                     resolve()
                 });
             }))
         } else {
-            value = redUtil.evaluateNodeProperty(value, type, {_flow: flow}, null, null);
-            if (typeof value  === 'object') {
-                value = { value: value, __clone__: true}
+            try {
+                value = redUtil.evaluateNodeProperty(value, type, {_flow: flow}, null, null);
+                if (typeof value  === 'object') {
+                    value = { value: value, __clone__: true}
+                }
+            } catch (err) {
+                value = undefined
+                flow.error(`Error evaluating env property '${name}': ${err.toString()}`)
             }
         }
         evaluatedEnv[name] = value


### PR DESCRIPTION
Fixes #4625 

This adds error handling in the runtime if a subflow instance has invalid properties - such as malformed JSON.

It also adds validation on the env vars with the editor itself. Note this only applies to the subflow instance node. If the parent subflow has errors, they don't get surfaced as cleanly... but they do get surfaced.