### PR TITLE
Hide import/export context menu if disabled in theme

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
@@ -118,10 +118,16 @@ RED.contextMenu = (function () {
                     onselect: 'core:split-wire-with-link-nodes',
                     disabled: !canEdit || !hasLinks
                 },
-                null,
-                { onselect: 'core:show-import-dialog', label: RED._('common.label.import')},
-                { onselect: 'core:show-examples-import-dialog', label: RED._('menu.label.importExample') }
+                null
             )
+            if (RED.settings.theme("menu.menu-item-import-library", true)) {
+                insertOptions.push(
+                    { onselect: 'core:show-import-dialog', label: RED._('common.label.import')},
+                    { onselect: 'core:show-examples-import-dialog', label: RED._('menu.label.importExample') }
+                )
+            }
+
+
             if (hasSelection && canEdit) {
                 const nodeOptions = []
                 if (!hasMultipleSelection && !isGroup) {
@@ -194,8 +200,14 @@ RED.contextMenu = (function () {
                 { onselect: 'core:paste-from-internal-clipboard', label: RED._("keyboard.pasteNode"), disabled: !canEdit || !RED.view.clipboard() },
                 { onselect: 'core:delete-selection', label: RED._('keyboard.deleteSelected'), disabled: !canEdit || !canDelete },
                 { onselect: 'core:delete-selection-and-reconnect', label: RED._('keyboard.deleteReconnect'), disabled: !canEdit || !canDelete },
-                { onselect: 'core:show-export-dialog', label: RED._("menu.label.export") },
-                { onselect: 'core:select-all-nodes', label: RED._("keyboard.selectAll") },
+            )
+            if (RED.settings.theme("menu.menu-item-export-library", true)) {
+                menuItems.push(
+                    { onselect: 'core:show-export-dialog', label: RED._("menu.label.export") }
+                )
+            }
+            menuItems.push(
+                { onselect: 'core:select-all-nodes', label: RED._("keyboard.selectAll") }
             )
         }
 


### PR DESCRIPTION
Fixes #4617 

Ensures the context menu honours the `menu.menu-item-export-library` and `menu.menu-item-import-library` options that could be used to disable the import/export menu options.