### PR TITLE
Guard refresh of unknown subflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-help.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-help.js
@@ -158,8 +158,10 @@ RED.sidebar.help = (function() {
 
     function refreshSubflow(sf) {
         var item = treeList.treeList('get',"node-type:subflow:"+sf.id);
-        item.subflowLabel = sf._def.label().toLowerCase();
-        item.treeList.replaceElement(getNodeLabel({_def:sf._def,type:sf._def.label()}));
+        if (item) {
+            item.subflowLabel = sf._def.label().toLowerCase();
+            item.treeList.replaceElement(getNodeLabel({_def:sf._def,type:sf._def.label()}));
+        }
     }
 
     function hideTOC() {


### PR DESCRIPTION
Spotted an error in the console as a result of #4631 - where the import of flows happens before the help sidebar is populated with subflows. The newly emitted `subflows:change` event on import was triggering a refresh of help sidebar, which it wasn't ready for.

This fixes that.