### PR TITLE
Fix subflow module sending messages to debug sidebar

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/core/common/21-debug.html
@@ -378,7 +378,7 @@
                             return { id: id, label: RED.nodes.workspace(id).label } //flow id + name
                         } else {
                             const instanceNode = RED.nodes.node(id)
-                            const pathLabel = (instanceNode.name || RED.nodes.subflow(instanceNode.type.substring(8)).name)
+                            const pathLabel = (instanceNode.name || RED.nodes.subflow(instanceNode.type.substring(8))?.name || instanceNode.type)
                             return { id: id, label: pathLabel }
                         }
                     })


### PR DESCRIPTION
Fixes #4641

Recent changes to display the full path to a node that logs to the debug sidebar didn't work for subflow modules - as the subflow definition isn't loaded into the editor.

This handle that