### PR TITLE
Fix handling of subflow config-node select type in sf module

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -1280,14 +1280,20 @@ RED.subflow = (function() {
                     var nodePropValue = nodeProp;
                     if (prop.ui && prop.ui.type === "cred") {
                         nodePropType = "cred";
+                    } else if (prop.ui && prop.ui.type === "conf-types") {
+                        nodePropType = prop.value.type
                     } else {
                         switch(typeof nodeProp) {
                             case "string": nodePropType = "str"; break;
                             case "number": nodePropType = "num"; break;
                             case "boolean": nodePropType = "bool"; nodePropValue = nodeProp?"true":"false"; break;
                             default:
-                            nodePropType = nodeProp.type;
-                            nodePropValue = nodeProp.value;
+                                if (nodeProp) {
+                                    nodePropType = nodeProp.type;
+                                    nodePropValue = nodeProp.value;
+                                } else {
+                                    nodePropType = 'str'
+                                }
                         }
                     }
                     var item = {


### PR DESCRIPTION
Reported here: https://discourse.nodered.org/t/node-red-4-0-0-beta-1-released/86433/18?u=knolleary

Fixes handling of when a subflow is published as a module that has a config-node property type.