### PR TITLE
Fix use of spawn on windows with cmd files

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.js
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.js
@@ -20,6 +20,7 @@ module.exports = function(RED) {
     var exec = require('child_process').exec;
     var fs = require('fs');
     var isUtf8 = require('is-utf8');
+    const isWindows = process.platform === 'win32'
 
     function ExecNode(n) {
         RED.nodes.createNode(this,n);
@@ -85,9 +86,12 @@ module.exports = function(RED) {
                         }
                     });
                     var cmd = arg.shift();
+                    // Since 18.20.2/20.12.2, it is invalid to call spawn on Windows with a .bat/.cmd file
+                    // without using shell: true. 
+                    const opts = isWindows ? { ...node.spawnOpt, shell: true } : node.spawnOpt
                     /* istanbul ignore else  */
                     node.debug(cmd+" ["+arg+"]");
-                    child = spawn(cmd,arg,node.spawnOpt);
+                    child = spawn(cmd,arg,opts);
                     node.status({fill:"blue",shape:"dot",text:"pid:"+child.pid});
                     var unknownCommand = (child.pid === undefined);
                     if (node.timer !== 0) {

--- a/packages/node_modules/@node-red/registry/lib/externalModules.js
+++ b/packages/node_modules/@node-red/registry/lib/externalModules.js
@@ -273,7 +273,7 @@ async function installModule(moduleDetails) {
                 let extraArgs = triggerPayload.args || [];
                 let args = ['install', ...extraArgs, installSpec]
                 log.trace(NPM_COMMAND + JSON.stringify(args));
-                return exec.run(NPM_COMMAND, args, { cwd: installDir },true)
+                return exec.run(NPM_COMMAND, args, { cwd: installDir, shell: true },true)
             } else {
                 log.trace("skipping npm install");
             }

--- a/packages/node_modules/@node-red/registry/lib/installer.js
+++ b/packages/node_modules/@node-red/registry/lib/installer.js
@@ -25,12 +25,15 @@ const registryUtil = require("./util");
 const library = require("./library");
 const {exec,log,events,hooks} = require("@node-red/util");
 const child_process = require('child_process');
-const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-let installerEnabled = false;
 
+const isWindows = process.platform === 'win32'
+const npmCommand =  isWindows ? 'npm.cmd' : 'npm';
+
+let installerEnabled = false;
 let settings;
+
 const moduleRe = /^(@[^/@]+?[/])?[^/@]+?$/;
-const slashRe = process.platform === "win32" ? /\\|[/]/ : /[/]/;
+const slashRe = isWindows ? /\\|[/]/ : /[/]/;
 const pkgurlRe = /^(https?|git(|\+https?|\+ssh|\+file)):\/\//;
 const localtgzRe = /^([a-zA-Z]:|\/).+tgz$/;
 
@@ -225,7 +228,7 @@ async function installModule(module,version,url) {
                 let extraArgs = triggerPayload.args || [];
                 let args = ['install', ...extraArgs, installName]
                 log.trace(npmCommand + JSON.stringify(args));
-                return exec.run(npmCommand,args,{ cwd: installDir}, true)
+                return exec.run(npmCommand,args,{ cwd: installDir, shell: true }, true)
             } else {
                 log.trace("skipping npm install");
             }
@@ -260,7 +263,7 @@ async function installModule(module,version,url) {
                 log.warn("------------------------------------------");
                 e = new Error(log._("server.install.install-failed")+": "+err.toString());
                 if (err.hook === "postInstall") {
-                    return exec.run(npmCommand,["remove",module],{ cwd: installDir}, false).finally(() => {
+                    return exec.run(npmCommand,["remove",module],{ cwd: installDir, shell: true }, false).finally(() => {
                         throw e;
                     })
                 }
@@ -356,7 +359,7 @@ async function getModuleVersionFromNPM(module, version) {
     }
 
     return new Promise((resolve, reject) => {
-        child_process.execFile(npmCommand,['info','--json',installName],function(err,stdout,stderr) {
+        child_process.execFile(npmCommand,['info','--json',installName],{ shell: true },function(err,stdout,stderr) {
             try {
                 if (!stdout) {
                     log.warn(log._("server.install.install-failed-not-found",{name:module}));
@@ -511,7 +514,7 @@ function uninstallModule(module) {
                     let extraArgs = triggerPayload.args || [];
                     let args = ['remove', ...extraArgs, module]
                     log.trace(npmCommand + JSON.stringify(args));
-                    return exec.run(npmCommand,args,{ cwd: installDir}, true)
+                    return exec.run(npmCommand,args,{ cwd: installDir, shell: true }, true)
                 } else {
                     log.trace("skipping npm uninstall");
                 }
@@ -578,7 +581,7 @@ async function checkPrereq() {
         installerEnabled = false;
     } else {
         return new Promise(resolve => {
-            child_process.execFile(npmCommand,['-v'],function(err,stdout) {
+            child_process.execFile(npmCommand,['-v'],{ shell: true },function(err,stdout) {
                 if (err) {
                     log.info(log._("server.palette-editor.npm-not-found"));
                     installerEnabled = false;


### PR DESCRIPTION
Following the 18.20.2/20.12.2 node.js releases, it is no longer valid to call `child_process.spawn` with a `.cmd` or `.bat` file *without* using the `shell: true` option.

This PR updates our usage to include the `shell` option when appropriate.

It's hard to know exactly what impact this could have given the many and varied ways the exec node is used - so will need some testing to verify.