### PR TITLE
Fix saving of conf-type properties in module packaged subflows

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -1363,7 +1363,7 @@ RED.subflow = (function() {
                         break;
                     case "conf-types":
                         item.value = input.val()
-                        item.type = data.parent.value;
+                        item.type = "conf-type"
                 }
                 if (ui.type === "cred" || item.type !== data.parent.type || item.value !== data.parent.value) {
                     env.push(item);

--- a/packages/node_modules/@node-red/registry/lib/subflow.js
+++ b/packages/node_modules/@node-red/registry/lib/subflow.js
@@ -88,7 +88,7 @@ function generateSubflowConfig(subflow) {
                     this.credentials['has_' + prop.name] = (this.credentials[prop.name] !== "");
                 } else {
                     switch(prop.type) {
-                        case "str": this[prop.name] = prop.value||""; break;
+                        case "str": case "conf-type": this[prop.name] = prop.value||""; break;
                         case "bool": this[prop.name] = (typeof prop.value === 'boolean')?prop.value:prop.value === "true" ; break;
                         case "num": this[prop.name] = (typeof prop.value === 'number')?prop.value:Number(prop.value); break;
                         default:


### PR DESCRIPTION
When a subflow was packaged as a module, and had a `conf-type` env property, the format used to save the value didn't match what the edit dialog expected - so it would always reset to the 'default' value on reopen.

Given the type does not need any special handling in the runtime we can store as just the string value.