### PR TITLE
docs: Add closing paragraph tag

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/en-US/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/sequence/17-split.html
@@ -103,7 +103,7 @@
     <h4>Automatic mode</h4>
     <p>Automatic mode uses the <code>parts</code> property of incoming messages to
        determine how the sequence should be joined. This allows it to automatically
-       reverse the action of a <b>split</b> node.
+       reverse the action of a <b>split</b> node.</p>
 
     <h4>Manual mode</h4>
     <p>When configured to join in manual mode, the node is able to join sequences


### PR DESCRIPTION
Minor change that only improves xpath parsing.


- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

Parsing the doc broke due to xpath being strict. Now it doesn't fail as the opening `p` tag is closed.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
