### PR TITLE
Fix undo of subflow env property edits

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -612,7 +612,10 @@ RED.deploy = (function() {
                 }
             });
             RED.nodes.eachSubflow(function (subflow) {
-                subflow.changed = false;
+                if (subflow.changed) {
+                    subflow.changed = false;
+                    RED.events.emit("subflows:change", subflow);
+                }
             });
             RED.nodes.eachWorkspace(function (ws) {
                 if (ws.changed || ws.added) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1623,8 +1623,8 @@ RED.editor = (function() {
                         }
 
                         if (!isSameObj(old_env, new_env)) {
-                            editing_node.env = new_env;
                             editState.changes.env = editing_node.env;
+                            editing_node.env = new_env;
                             editState.changed = true;
                         }
 


### PR DESCRIPTION
Undoing edits of subflow env properties was not working. This fixes that.