### PR TITLE
Fix undo history of moves and post-deploy handling

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/history.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/history.js
@@ -706,11 +706,36 @@ RED.history = (function() {
 
     }
 
+    function markEventDirty (evt) {
+        // This isn't 100% thorough - just covers the main move/edit/delete cases
+        evt.dirty = true
+        if (evt.multi) {
+            for (let i = 0; i < evt.events.length-1; i++) {
+                markEventDirty(evt.events[i])
+            }
+        } else if (evt.t === 'move') {
+            for (let i=0;i<evt.nodes.length;i++) {
+                evt.nodes[i].moved = true
+            }
+        } else if (evt.t === 'edit') {
+            evt.changed = true
+        } else if (evt.t === 'delete') {
+            if (evt.nodes) {
+                for (let i=0;i<evt.nodes.length;i++) {
+                    evt.nodes[i].changed = true
+                }
+            }
+        }
+    }
     return {
-        //TODO: this function is a placeholder until there is a 'save' event that can be listened to
         markAllDirty: function() {
-            for (var i=0;i<undoHistory.length;i++) {
+            // A deploy has happened meaning any undo into the history will represent
+            // an undeployed change - regardless of what it was when the event was recorded.
+            // This goes back through the history any marks them all as being dirty events
+            // and also ensures individual node states are marked dirty
+            for (let i=0;i<undoHistory.length;i++) {
                 undoHistory[i].dirty = true;
+                markEventDirty(undoHistory[i])
             }
         },
         list: function() {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -2167,9 +2167,9 @@ RED.view = (function() {
                     if (n.ox !== n.n.x || n.oy !== n.n.y || addedToGroup) {
                         // This node has moved or added to a group
                         if (rehomedNodes.has(n)) {
-                            moveAndChangedGroupEvent.nodes.push({...n})
+                            moveAndChangedGroupEvent.nodes.push({...n, moved: n.n.moved})
                         } else {
-                            moveEvent.nodes.push({...n})
+                            moveEvent.nodes.push({...n, moved: n.n.moved})
                         }
                         n.n.dirty = true;
                         n.n.moved = true;


### PR DESCRIPTION
Applies two fixes to undo history:

1. if a node was moved multiple times, after a single undo, the change indicator was being cleared even through it was still 'dirty'.
2. after a deploy, doing an undo would revert the previous change, but not mark the item as changed

The first of these is fixed. The second is fixed for common cases (move/edit/delete), but not some of the edge-case history types.