### PR TITLE
Allow blank env var substitutions

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -68,7 +68,7 @@ function mapEnvVarProperties(obj,prop,flow,config) {
         if (obj[prop][0] === "$" && (EnvVarPropertyRE_old.test(v) || EnvVarPropertyRE.test(v)) ) {
             const envVar = v.substring(2,v.length-1);
             const r = redUtil.getSetting(config, envVar, flow);
-            if (r !== undefined && r !== '') {
+            if (r !== undefined) {
                 obj[prop] = r
             }
         }


### PR DESCRIPTION
If an env var is a blank string (``FOO=""`), and is used in a property substitution (`${FOO}`), then we were not replacing it with a blank string.

This was a slightly intentional behaviour when we first introduced true env var support, but as they have expanded to be more widely used with subflow properties etc, then it makes sense to allow inserting a blank string if the env var is explicitly set to a blank string (rather than undefined).

Given this *might* be a change in behaviour for some obscure edge cases, I'm putting this in 4.0, rather than 3.x.