### PR TITLE
Avoid login loops when autoLogin enabled but login fails

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/auth/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/index.js
@@ -205,9 +205,10 @@ function genericStrategy(adminApp,strategy) {
     passport.use(new strategy.strategy(options, verify));
 
     adminApp.get('/auth/strategy',
-        passport.authenticate(strategy.name, {session:false,
+        passport.authenticate(strategy.name, {
+            session:false,
             failureMessage: true,
-            failureRedirect: settings.httpAdminRoot
+            failureRedirect: settings.httpAdminRoot + '?session_message=Login Failed'
         }),
         completeGenerateStrategyAuth,
         handleStrategyError
@@ -221,7 +222,7 @@ function genericStrategy(adminApp,strategy) {
         passport.authenticate(strategy.name, {
             session:false,
             failureMessage: true,
-            failureRedirect: settings.httpAdminRoot
+            failureRedirect: settings.httpAdminRoot + '?session_message=Login Failed'
         }),
         completeGenerateStrategyAuth,
         handleStrategyError


### PR DESCRIPTION
Fixes #4363

When `autoLogin` was enabled, Node-RED will automatically redirect to the SSO login endpoint. If the login failed, we would reload the editor, and `autoLogin` would kick in again and fail to login - causing an endless loop.

There was already logic to break out of the loop if a `session_message` query parameter was provided - used in *some* SSO failure causes, but not the more common one described above. This PR adds that query param to other SSO handling routes so we do the right thing.