### PR TITLE
Pass full error object in Function node and copy over cause property

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -438,10 +438,9 @@ module.exports = function(RED) {
 
                             //store the error in msg to be used in flows
                             msg.error = err;
-
-                            var line = 0;
-                            var errorMessage;
                             if (stack.length > 0) {
+                                let line = 0;
+                                let errorMessage;
                                 while (line < stack.length && stack[line].indexOf("ReferenceError") !== 0) {
                                     line++;
                                 }
@@ -455,11 +454,13 @@ module.exports = function(RED) {
                                         errorMessage += " (line "+lineno+", col "+cha+")";
                                     }
                                 }
+                                if (errorMessage) {
+                                    err.message = errorMessage
+                                }
                             }
-                            if (!errorMessage) {
-                                errorMessage = err.toString();
-                            }
-                            done(errorMessage);
+                            // Pass the whole error object so any additional properties
+                            // (such as cause) are preserved
+                            done(err);
                         }
                         else if (typeof err === "string") {
                             done(err);

--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -678,6 +678,9 @@ class Flow {
                 if (logMessage.hasOwnProperty('stack')) {
                     errorMessage.error.stack = logMessage.stack;
                 }
+                if (logMessage.hasOwnProperty('cause')) {
+                    errorMessage.error.cause = logMessage.cause;
+                }
                 targetCatchNode.receive(errorMessage);
                 handled = true;
             });

--- a/test/nodes/core/function/10-function_spec.js
+++ b/test/nodes/core/function/10-function_spec.js
@@ -390,7 +390,8 @@ describe('function node', function() {
                     msg.should.have.property('level', helper.log().ERROR);
                     msg.should.have.property('id', 'n1');
                     msg.should.have.property('type', 'function');
-                    msg.should.have.property('msg', 'ReferenceError: retunr is not defined (line 2, col 1)');
+                    msg.should.have.property('msg')
+                    msg.msg.message.should.equal('ReferenceError: retunr is not defined (line 2, col 1)');
                     done();
                 } catch(err) {
                     done(err);
@@ -659,7 +660,8 @@ describe('function node', function() {
                 msg.should.have.property('level', helper.log().ERROR);
                 msg.should.have.property('id', name);
                 msg.should.have.property('type', 'function');
-                msg.should.have.property('msg', 'Error: Callback must be a function');
+                msg.should.have.property('msg')
+                msg.msg.message.should.equal('Callback must be a function');
                 done();
             }
             catch (e) {


### PR DESCRIPTION
Fixes #4683

This does two things around error handling

1. preserves the `cause` property of any Error object passed to `node.error(...)`. This is a standard property of Error so reasonable to copy over.
2. updates Function node error handling to pass up the whole error object, not just the message string

The results of this will mean if an error thrown in a Function node includes a cause property it will be present on the message sent by a Catch node.