### PR TITLE
Improve background-deploy notification handling

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -372,6 +372,7 @@
             "deleted": "deleted",
             "flowDeleted": "flow deleted",
             "flowAdded": "flow added",
+            "moved": "moved",
             "movedTo": "moved to __id__",
             "movedFrom": "moved from __id__"
         },

--- a/packages/node_modules/@node-red/editor-client/src/js/history.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/history.js
@@ -29,7 +29,14 @@ RED.history = (function() {
         }
         return RED.nodes.junction(id);
     }
-
+    function ensureUnlocked(id, flowsToLock) {
+        const flow = id && (RED.nodes.workspace(id) || RED.nodes.subflow(id) || null);
+        const isLocked = flow ? flow.locked : false;
+        if (flow && isLocked) {
+            flow.locked = false;
+            flowsToLock.add(flow)
+        }
+    }
     function undoEvent(ev) {
         var i;
         var len;
@@ -78,21 +85,14 @@ RED.history = (function() {
                     RED.nodes.dirty(false);
 
                     const flowsToLock = new Set()
-                    function ensureUnlocked(id) {
-                        const flow = id && (RED.nodes.workspace(id) || RED.nodes.subflow(id) || null);
-                        const isLocked = flow ? flow.locked : false;
-                        if (flow && isLocked) {
-                            flow.locked = false;
-                            flowsToLock.add(flow)
-                        }
-                    }
+                    
                     imported.nodes.forEach(function(n) {
                         if (ev.changed[n.id]) {
-                            ensureUnlocked(n.z)
+                            ensureUnlocked(n.z, flowsToLock)
                             n.changed = true;
                         }
                         if (ev.moved[n.id]) {
-                            ensureUnlocked(n.z)
+                            ensureUnlocked(n.z, flowsToLock)
                             n.moved = true;
                         }
                     })

--- a/packages/node_modules/@node-red/editor-client/src/js/history.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/history.js
@@ -59,18 +59,53 @@ RED.history = (function() {
                         t: 'replace',
                         config: RED.nodes.createCompleteNodeSet(),
                         changed: {},
-                        rev: RED.nodes.version()
+                        moved: {},
+                        complete: true,
+                        rev: RED.nodes.version(),
+                        dirty: RED.nodes.dirty()
                     };
+                    var selectedTab = RED.workspaces.active();
+                    inverseEv.config.forEach(n => {
+                        const node = RED.nodes.node(n.id)
+                        if (node) {
+                            inverseEv.changed[n.id] = node.changed
+                            inverseEv.moved[n.id] = node.moved
+                        }
+                    })
                     RED.nodes.clear();
                     var imported = RED.nodes.import(ev.config);
+                    // Clear all change flags from the import
+                    RED.nodes.dirty(false);
+
+                    const flowsToLock = new Set()
+                    function ensureUnlocked(id) {
+                        const flow = id && (RED.nodes.workspace(id) || RED.nodes.subflow(id) || null);
+                        const isLocked = flow ? flow.locked : false;
+                        if (flow && isLocked) {
+                            flow.locked = false;
+                            flowsToLock.add(flow)
+                        }
+                    }
                     imported.nodes.forEach(function(n) {
                         if (ev.changed[n.id]) {
+                            ensureUnlocked(n.z)
                             n.changed = true;
-                            inverseEv.changed[n.id] = true;
                         }
+                        if (ev.moved[n.id]) {
+                            ensureUnlocked(n.z)
+                            n.moved = true;
+                        }
+                    })
+                    flowsToLock.forEach(flow => {
+                        flow.locked = true
                     })
 
                     RED.nodes.version(ev.rev);
+                    RED.view.redraw(true);
+                    RED.palette.refresh();
+                    RED.workspaces.refresh();
+                    RED.workspaces.show(selectedTab, true);
+                    RED.sidebar.config.refresh();
                 } else {
                     var importMap = {};
                     ev.config.forEach(function(n) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -34,6 +34,8 @@ RED.deploy = (function() {
 
     var currentDiff = null;
 
+    var activeBackgroundDeployNotification;
+
     function changeDeploymentType(type) {
         deploymentType = type;
         $("#red-ui-header-button-deploy-icon").attr("src",deploymentTypes[type].img);
@@ -133,37 +135,38 @@ RED.deploy = (function() {
             }
         });
 
-        var activeNotifyMessage;
         RED.comms.subscribe("notification/runtime-deploy",function(topic,msg) {
-            if (!activeNotifyMessage) {
-                var currentRev = RED.nodes.version();
-                if (currentRev === null || deployInflight || currentRev === msg.revision) {
-                    return;
-                }
-                var message = $('<p>').text(RED._('deploy.confirm.backgroundUpdate'));
-                activeNotifyMessage = RED.notify(message,{
-                    modal: true,
-                    fixed: true,
-                    buttons: [
-                        {
-                            text: RED._('deploy.confirm.button.ignore'),
-                            click: function() {
-                                activeNotifyMessage.close();
-                                activeNotifyMessage = null;
-                            }
-                        },
-                        {
-                            text: RED._('deploy.confirm.button.review'),
-                            class: "primary",
-                            click: function() {
-                                activeNotifyMessage.close();
-                                var nns = RED.nodes.createCompleteNodeSet();
-                                resolveConflict(nns,false);
-                                activeNotifyMessage = null;
-                            }
+            var currentRev = RED.nodes.version();
+            if (currentRev === null || deployInflight || currentRev === msg.revision) {
+                return;
+            }
+            if (activeBackgroundDeployNotification?.hidden) {
+                activeBackgroundDeployNotification.showNotification()
+                return
+            }
+            const message = $('<p>').text(RED._('deploy.confirm.backgroundUpdate'));
+            const options = {
+                id: 'background-update',
+                type: 'compact',
+                modal: false,
+                fixed: true,
+                timeout: 10000,
+                buttons: [
+                    {
+                        text: RED._('deploy.confirm.button.review'),
+                        class: "primary",
+                        click: function() {
+                            activeBackgroundDeployNotification.hideNotification();
+                            var nns = RED.nodes.createCompleteNodeSet();
+                            resolveConflict(nns,false);
                         }
-                    ]
-                });
+                    }
+                ]
+            }
+            if (!activeBackgroundDeployNotification || activeBackgroundDeployNotification.closed) {
+                activeBackgroundDeployNotification = RED.notify(message, options)
+            } else {
+                activeBackgroundDeployNotification.update(message, options)
             }
         });
     }
@@ -220,7 +223,11 @@ RED.deploy = (function() {
                 class: "primary disabled",
                 click: function() {
                     if (!$("#red-ui-deploy-dialog-confirm-deploy-review").hasClass('disabled')) {
-                        RED.diff.showRemoteDiff();
+                        RED.diff.showRemoteDiff(null, {
+                            onmerge: function () {
+                                activeBackgroundDeployNotification.close()
+                            }
+                        });
                         conflictNotification.close();
                     }
                 }
@@ -233,6 +240,7 @@ RED.deploy = (function() {
                     if (!$("#red-ui-deploy-dialog-confirm-deploy-merge").hasClass('disabled')) {
                         RED.diff.mergeDiff(currentDiff);
                         conflictNotification.close();
+                        activeBackgroundDeployNotification.close()
                     }
                 }
             }
@@ -245,6 +253,7 @@ RED.deploy = (function() {
                 click: function() {
                     save(true,activeDeploy);
                     conflictNotification.close();
+                    activeBackgroundDeployNotification.close()
                 }
             })
         }
@@ -255,21 +264,17 @@ RED.deploy = (function() {
             buttons: buttons
         });
 
-        var now = Date.now();
         RED.diff.getRemoteDiff(function(diff) {
-            var ellapsed = Math.max(1000 - (Date.now()-now), 0);
             currentDiff = diff;
-            setTimeout(function() {
-                conflictCheck.hide();
-                var d = Object.keys(diff.conflicts);
-                if (d.length === 0) {
-                    conflictAutoMerge.show();
-                    $("#red-ui-deploy-dialog-confirm-deploy-merge").removeClass('disabled')
-                } else {
-                    conflictManualMerge.show();
-                }
-                $("#red-ui-deploy-dialog-confirm-deploy-review").removeClass('disabled')
-            },ellapsed);
+            conflictCheck.hide();
+            var d = Object.keys(diff.conflicts);
+            if (d.length === 0) {
+                conflictAutoMerge.show();
+                $("#red-ui-deploy-dialog-confirm-deploy-merge").removeClass('disabled')
+            } else {
+                conflictManualMerge.show();
+            }
+            $("#red-ui-deploy-dialog-confirm-deploy-review").removeClass('disabled')
         })
     }
     function cropList(list) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -140,7 +140,7 @@ RED.deploy = (function() {
             if (currentRev === null || deployInflight || currentRev === msg.revision) {
                 return;
             }
-            if (activeBackgroundDeployNotification?.hidden) {
+            if (activeBackgroundDeployNotification?.hidden && !activeBackgroundDeployNotification?.closed) {
                 activeBackgroundDeployNotification.showNotification()
                 return
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
@@ -1,5 +1,4 @@
 RED.diff = (function() {
-
     var currentDiff = {};
     var diffVisible = false;
     var diffList;
@@ -62,12 +61,14 @@ RED.diff = (function() {
                         addedCount:0,
                         deletedCount:0,
                         changedCount:0,
+                        movedCount:0,
                         unchangedCount: 0
                     },
                     remote: {
                         addedCount:0,
                         deletedCount:0,
                         changedCount:0,
+                        movedCount:0,
                         unchangedCount: 0
                     },
                     conflicts: 0
@@ -138,7 +139,7 @@ RED.diff = (function() {
                             $(this).parent().toggleClass('collapsed');
                         });
 
-                        createNodePropertiesTable(def,tab,localTabNode,remoteTabNode,conflicts).appendTo(div);
+                        createNodePropertiesTable(def,tab,localTabNode,remoteTabNode).appendTo(div);
                         selectState = "";
                         if (conflicts[tab.id]) {
                             flowStats.conflicts++;
@@ -208,19 +209,26 @@ RED.diff = (function() {
                         var localStats = $('<span>',{class:"red-ui-diff-list-flow-stats"}).appendTo(localCell);
                         $('<span class="red-ui-diff-status"></span>').text(RED._('diff.nodeCount',{count:localNodeCount})).appendTo(localStats);
 
-                        if (flowStats.conflicts + flowStats.local.addedCount + flowStats.local.changedCount + flowStats.local.deletedCount > 0) {
+                        if (flowStats.conflicts + flowStats.local.addedCount + flowStats.local.changedCount + flowStats.local.movedCount + flowStats.local.deletedCount > 0) {
                             $('<span class="red-ui-diff-status"> [ </span>').appendTo(localStats);
                             if (flowStats.conflicts > 0) {
                                 $('<span class="red-ui-diff-status-conflict"><span class="red-ui-diff-status"><i class="fa fa-exclamation"></i> '+flowStats.conflicts+'</span></span>').appendTo(localStats);
                             }
                             if (flowStats.local.addedCount > 0) {
-                                $('<span class="red-ui-diff-status-added"><span class="red-ui-diff-status"><i class="fa fa-plus-square"></i> '+flowStats.local.addedCount+'</span></span>').appendTo(localStats);
+                                const cell = $('<span class="red-ui-diff-status-added"><span class="red-ui-diff-status"><i class="fa fa-plus-square"></i> '+flowStats.local.addedCount+'</span></span>').appendTo(localStats);
+                                RED.popover.tooltip(cell, RED._('diff.type.added'))
                             }
                             if (flowStats.local.changedCount > 0) {
-                                $('<span class="red-ui-diff-status-changed"><span class="red-ui-diff-status"><i class="fa fa-square"></i> '+flowStats.local.changedCount+'</span></span>').appendTo(localStats);
+                                const cell = $('<span class="red-ui-diff-status-changed"><span class="red-ui-diff-status"><i class="fa fa-square"></i> '+flowStats.local.changedCount+'</span></span>').appendTo(localStats);
+                                RED.popover.tooltip(cell, RED._('diff.type.changed'))
+                            }
+                            if (flowStats.local.movedCount > 0) {
+                                const cell = $('<span class="red-ui-diff-status-moved"><span class="red-ui-diff-status"><i class="fa fa-square"></i> '+flowStats.local.movedCount+'</span></span>').appendTo(localStats);
+                                RED.popover.tooltip(cell, RED._('diff.type.moved'))
                             }
                             if (flowStats.local.deletedCount > 0) {
-                                $('<span class="red-ui-diff-status-deleted"><span class="red-ui-diff-status"><i class="fa fa-minus-square"></i> '+flowStats.local.deletedCount+'</span></span>').appendTo(localStats);
+                                const cell = $('<span class="red-ui-diff-status-deleted"><span class="red-ui-diff-status"><i class="fa fa-minus-square"></i> '+flowStats.local.deletedCount+'</span></span>').appendTo(localStats);
+                                RED.popover.tooltip(cell, RED._('diff.type.deleted'))
                             }
                             $('<span class="red-ui-diff-status"> ] </span>').appendTo(localStats);
                         }
@@ -246,19 +254,26 @@ RED.diff = (function() {
                             }
                             var remoteStats = $('<span>',{class:"red-ui-diff-list-flow-stats"}).appendTo(remoteCell);
                             $('<span class="red-ui-diff-status"></span>').text(RED._('diff.nodeCount',{count:remoteNodeCount})).appendTo(remoteStats);
-                            if (flowStats.conflicts + flowStats.remote.addedCount + flowStats.remote.changedCount + flowStats.remote.deletedCount > 0) {
+                            if (flowStats.conflicts + flowStats.remote.addedCount + flowStats.remote.changedCount + flowStats.remote.movedCount + flowStats.remote.deletedCount > 0) {
                                 $('<span class="red-ui-diff-status"> [ </span>').appendTo(remoteStats);
                                 if (flowStats.conflicts > 0) {
                                     $('<span class="red-ui-diff-status-conflict"><span class="red-ui-diff-status"><i class="fa fa-exclamation"></i> '+flowStats.conflicts+'</span></span>').appendTo(remoteStats);
                                 }
                                 if (flowStats.remote.addedCount > 0) {
-                                    $('<span class="red-ui-diff-status-added"><span class="red-ui-diff-status"><i class="fa fa-plus-square"></i> '+flowStats.remote.addedCount+'</span></span>').appendTo(remoteStats);
+                                    const cell = $('<span class="red-ui-diff-status-added"><span class="red-ui-diff-status"><i class="fa fa-plus-square"></i> '+flowStats.remote.addedCount+'</span></span>').appendTo(remoteStats);
+                                    RED.popover.tooltip(cell, RED._('diff.type.added'))
                                 }
                                 if (flowStats.remote.changedCount > 0) {
-                                    $('<span class="red-ui-diff-status-changed"><span class="red-ui-diff-status"><i class="fa fa-square"></i> '+flowStats.remote.changedCount+'</span></span>').appendTo(remoteStats);
+                                    const cell = $('<span class="red-ui-diff-status-changed"><span class="red-ui-diff-status"><i class="fa fa-square"></i> '+flowStats.remote.changedCount+'</span></span>').appendTo(remoteStats);
+                                    RED.popover.tooltip(cell, RED._('diff.type.changed'))
+                                }
+                                if (flowStats.remote.movedCount > 0) {
+                                    const cell = $('<span class="red-ui-diff-status-moved"><span class="red-ui-diff-status"><i class="fa fa-square"></i> '+flowStats.remote.movedCount+'</span></span>').appendTo(remoteStats);
+                                    RED.popover.tooltip(cell, RED._('diff.type.moved'))
                                 }
                                 if (flowStats.remote.deletedCount > 0) {
-                                    $('<span class="red-ui-diff-status-deleted"><span class="red-ui-diff-status"><i class="fa fa-minus-square"></i> '+flowStats.remote.deletedCount+'</span></span>').appendTo(remoteStats);
+                                    const cell = $('<span class="red-ui-diff-status-deleted"><span class="red-ui-diff-status"><i class="fa fa-minus-square"></i> '+flowStats.remote.deletedCount+'</span></span>').appendTo(remoteStats);
+                                    RED.popover.tooltip(cell, RED._('diff.type.deleted'))
                                 }
                                 $('<span class="red-ui-diff-status"> ] </span>').appendTo(remoteStats);
                             }
@@ -293,7 +308,7 @@ RED.diff = (function() {
         if (options.mode === "merge") {
             diffPanel.addClass("red-ui-diff-panel-merge");
         }
-        var diffList = createDiffTable(diffPanel, diff);
+        var diffList = createDiffTable(diffPanel, diff, options);
 
         var localDiff = diff.localDiff;
         var remoteDiff = diff.remoteDiff;
@@ -516,7 +531,6 @@ RED.diff = (function() {
 
         var hasChanges = false; // exists in original and local/remote but with changes
         var unChanged = true; // existing in original,local,remote unchanged
-        var localChanged = false;
 
         if (localDiff.added[node.id]) {
             stats.local.addedCount++;
@@ -535,12 +549,20 @@ RED.diff = (function() {
             unChanged = false;
         }
         if (localDiff.changed[node.id]) {
-            stats.local.changedCount++;
+            if (localDiff.positionChanged[node.id]) {
+                stats.local.movedCount++
+            } else {
+                stats.local.changedCount++;
+            }
             hasChanges = true;
             unChanged = false;
         }
         if (remoteDiff && remoteDiff.changed[node.id]) {
-            stats.remote.changedCount++;
+            if (remoteDiff.positionChanged[node.id]) {
+                stats.remote.movedCount++
+            } else {
+                stats.remote.changedCount++;
+            }
             hasChanges = true;
             unChanged = false;
         }
@@ -605,27 +627,32 @@ RED.diff = (function() {
                     localNodeDiv.addClass("red-ui-diff-status-moved");
                     var localMovedMessage = "";
                     if (node.z === localN.z) {
-                        localMovedMessage = RED._("diff.type.movedFrom",{id:(localDiff.currentConfig.all[node.id].z||'global')});
+                        const movedFromNodeTab = localDiff.currentConfig.all[localDiff.currentConfig.all[node.id].z]
+                        const movedFromLabel = `'${movedFromNodeTab ? (movedFromNodeTab.label || movedFromNodeTab.id) : 'global'}'`
+                        localMovedMessage = RED._("diff.type.movedFrom",{id: movedFromLabel});
                     } else {
-                        localMovedMessage = RED._("diff.type.movedTo",{id:(localN.z||'global')});
+                        const movedToNodeTab = localDiff.newConfig.all[localN.z]
+                        const movedToLabel = `'${movedToNodeTab ? (movedToNodeTab.label || movedToNodeTab.id) : 'global'}'`
+                        localMovedMessage = RED._("diff.type.movedTo",{id:movedToLabel});
                     }
                     $('<span class="red-ui-diff-status"><i class="fa fa-caret-square-o-right"></i> '+localMovedMessage+'</span>').appendTo(localNodeDiv);
                 }
-                localChanged = true;
             } else if (localDiff.deleted[node.z]) {
                 localNodeDiv.addClass("red-ui-diff-empty");
-                localChanged = true;
             } else if (localDiff.deleted[node.id]) {
                 localNodeDiv.addClass("red-ui-diff-status-deleted");
                 $('<span class="red-ui-diff-status"><i class="fa fa-minus-square"></i> <span data-i18n="diff.type.deleted"></span></span>').appendTo(localNodeDiv);
-                localChanged = true;
             } else if (localDiff.changed[node.id]) {
                 if (localDiff.newConfig.all[node.id].z !== node.z) {
                     localNodeDiv.addClass("red-ui-diff-empty");
                 } else {
-                    localNodeDiv.addClass("red-ui-diff-status-changed");
-                    $('<span class="red-ui-diff-status"><i class="fa fa-square"></i> <span data-i18n="diff.type.changed"></span></span>').appendTo(localNodeDiv);
-                    localChanged = true;
+                    if (localDiff.positionChanged[node.id]) {
+                        localNodeDiv.addClass("red-ui-diff-status-moved");
+                        $('<span class="red-ui-diff-status"><i class="fa fa-square"></i> <span data-i18n="diff.type.moved"></span></span>').appendTo(localNodeDiv);
+                    } else {
+                        localNodeDiv.addClass("red-ui-diff-status-changed");
+                        $('<span class="red-ui-diff-status"><i class="fa fa-square"></i> <span data-i18n="diff.type.changed"></span></span>').appendTo(localNodeDiv);
+                    }
                 }
             } else {
                 if (localDiff.newConfig.all[node.id].z !== node.z) {
@@ -646,9 +673,13 @@ RED.diff = (function() {
                         remoteNodeDiv.addClass("red-ui-diff-status-moved");
                         var remoteMovedMessage = "";
                         if (node.z === remoteN.z) {
-                            remoteMovedMessage = RED._("diff.type.movedFrom",{id:(remoteDiff.currentConfig.all[node.id].z||'global')});
+                            const movedFromNodeTab = remoteDiff.currentConfig.all[remoteDiff.currentConfig.all[node.id].z]
+                            const movedFromLabel = `'${movedFromNodeTab ? (movedFromNodeTab.label || movedFromNodeTab.id) : 'global'}'`
+                            remoteMovedMessage = RED._("diff.type.movedFrom",{id:movedFromLabel});
                         } else {
-                            remoteMovedMessage = RED._("diff.type.movedTo",{id:(remoteN.z||'global')});
+                            const movedToNodeTab = remoteDiff.newConfig.all[remoteN.z]
+                            const movedToLabel = `'${movedToNodeTab ? (movedToNodeTab.label || movedToNodeTab.id) : 'global'}'`
+                            remoteMovedMessage = RED._("diff.type.movedTo",{id:movedToLabel});
                         }
                         $('<span class="red-ui-diff-status"><i class="fa fa-caret-square-o-right"></i> '+remoteMovedMessage+'</span>').appendTo(remoteNodeDiv);
                     }
@@ -661,8 +692,13 @@ RED.diff = (function() {
                     if (remoteDiff.newConfig.all[node.id].z !== node.z) {
                         remoteNodeDiv.addClass("red-ui-diff-empty");
                     } else {
-                        remoteNodeDiv.addClass("red-ui-diff-status-changed");
-                        $('<span class="red-ui-diff-status"><i class="fa fa-square"></i> <span data-i18n="diff.type.changed"></span></span>').appendTo(remoteNodeDiv);
+                        if (remoteDiff.positionChanged[node.id]) {
+                            remoteNodeDiv.addClass("red-ui-diff-status-moved");
+                            $('<span class="red-ui-diff-status"><i class="fa fa-square"></i> <span data-i18n="diff.type.moved"></span></span>').appendTo(remoteNodeDiv);
+                        } else {
+                            remoteNodeDiv.addClass("red-ui-diff-status-changed");
+                            $('<span class="red-ui-diff-status"><i class="fa fa-square"></i> <span data-i18n="diff.type.changed"></span></span>').appendTo(remoteNodeDiv);
+                        }
                     }
                 } else {
                     if (remoteDiff.newConfig.all[node.id].z !== node.z) {
@@ -788,7 +824,7 @@ RED.diff = (function() {
             $("<td>",{class:"red-ui-diff-list-cell-label"}).text("position").appendTo(row);
             localCell = $("<td>",{class:"red-ui-diff-list-cell red-ui-diff-list-node-local"}).appendTo(row);
             if (localNode) {
-                localCell.addClass("red-ui-diff-status-"+(localChanged?"changed":"unchanged"));
+                localCell.addClass("red-ui-diff-status-"+(localChanged?"moved":"unchanged"));
                 $('<span class="red-ui-diff-status">'+(localChanged?'<i class="fa fa-square"></i>':'')+'</span>').appendTo(localCell);
                 element = $('<span class="red-ui-diff-list-element"></span>').appendTo(localCell);
                 var localPosition = {x:localNode.x,y:localNode.y};
@@ -813,7 +849,7 @@ RED.diff = (function() {
 
             if (remoteNode !== undefined) {
                 remoteCell = $("<td>",{class:"red-ui-diff-list-cell red-ui-diff-list-node-remote"}).appendTo(row);
-                remoteCell.addClass("red-ui-diff-status-"+(remoteChanged?"changed":"unchanged"));
+                remoteCell.addClass("red-ui-diff-status-"+(remoteChanged?"moved":"unchanged"));
                 if (remoteNode) {
                     $('<span class="red-ui-diff-status">'+(remoteChanged?'<i class="fa fa-square"></i>':'')+'</span>').appendTo(remoteCell);
                     element = $('<span class="red-ui-diff-list-element"></span>').appendTo(remoteCell);
@@ -1144,23 +1180,53 @@ RED.diff = (function() {
         }
     }
     function generateDiff(currentNodes,newNodes) {
-        var currentConfig = parseNodes(currentNodes);
-        var newConfig = parseNodes(newNodes);
-        var added = {};
-        var deleted = {};
-        var changed = {};
-        var moved = {};
+        const currentConfig = parseNodes(currentNodes);
+        const newConfig = parseNodes(newNodes);
+        const added = {};
+        const deleted = {};
+        const changed = {};
+        const positionChanged = {};
+        const moved = {};
 
         Object.keys(currentConfig.all).forEach(function(id) {
-            var node = RED.nodes.workspace(id)||RED.nodes.subflow(id)||RED.nodes.node(id);
+            const node = RED.nodes.workspace(id)||RED.nodes.subflow(id)||RED.nodes.node(id);
             if (!newConfig.all.hasOwnProperty(id)) {
                 deleted[id] = true;
-            } else if (JSON.stringify(currentConfig.all[id]) !== JSON.stringify(newConfig.all[id])) {
+                return
+            }
+            const currentConfigJSON = JSON.stringify(currentConfig.all[id])
+            const newConfigJSON = JSON.stringify(newConfig.all[id])
+            
+            if (currentConfigJSON !== newConfigJSON) {
                 changed[id] = true;
-
                 if (currentConfig.all[id].z !== newConfig.all[id].z) {
                     moved[id] = true;
+                } else if (
+                    currentConfig.all[id].x !== newConfig.all[id].x ||
+                    currentConfig.all[id].y !== newConfig.all[id].y ||
+                    currentConfig.all[id].w !== newConfig.all[id].w ||
+                    currentConfig.all[id].h !== newConfig.all[id].h
+                ) {
+                    // This node's position on its parent has changed. We want to
+                    // check if this is the *only* change for this given node
+                    const currentNodeClone = JSON.parse(currentConfigJSON)
+                    const newNodeClone = JSON.parse(newConfigJSON)
+
+                    delete currentNodeClone.x
+                    delete currentNodeClone.y
+                    delete currentNodeClone.w
+                    delete currentNodeClone.h
+                    delete newNodeClone.x
+                    delete newNodeClone.y
+                    delete newNodeClone.w
+                    delete newNodeClone.h
+                    
+                    if (JSON.stringify(currentNodeClone) === JSON.stringify(newNodeClone)) {
+                        // Only the position has changed - everything else is the same
+                        positionChanged[id] = true
+                    }
                 }
+
             }
         });
         Object.keys(newConfig.all).forEach(function(id) {
@@ -1169,13 +1235,14 @@ RED.diff = (function() {
             }
         });
 
-        var diff = {
-            currentConfig: currentConfig,
-            newConfig: newConfig,
-            added: added,
-            deleted: deleted,
-            changed: changed,
-            moved: moved
+        const diff = {
+            currentConfig,
+            newConfig,
+            added,
+            deleted,
+            changed,
+            positionChanged,
+            moved
         };
         return diff;
     }
@@ -1246,6 +1313,8 @@ RED.diff = (function() {
         }
         options = options || {};
         var mode = options.mode || 'merge';
+        
+        options.hidePositionChanges = true
 
         var localDiff = diff.localDiff;
         var remoteDiff = diff.remoteDiff;

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/diff.js
@@ -1099,11 +1099,11 @@ RED.diff = (function() {
     //     var diff = generateDiff(originalFlow,nns);
     //     showDiff(diff);
     // }
-    function showRemoteDiff(diff) {
-        if (diff === undefined) {
-            getRemoteDiff(showRemoteDiff);
+    function showRemoteDiff(diff, options = {}) {
+        if (!diff) {
+            getRemoteDiff((remoteDiff) => showRemoteDiff(remoteDiff, options));
         } else {
-            showDiff(diff,{mode:'merge'});
+            showDiff(diff,{...options, mode:'merge'});
         }
     }
     function parseNodes(nodeList) {
@@ -1240,7 +1240,7 @@ RED.diff = (function() {
         return diff;
     }
 
-    function showDiff(diff,options) {
+    function showDiff(diff, options) {
         if (diffVisible) {
             return;
         }
@@ -1315,6 +1315,9 @@ RED.diff = (function() {
                         if (!$("#red-ui-diff-view-diff-merge").hasClass('disabled')) {
                             refreshConflictHeader(diff);
                             mergeDiff(diff);
+                            if (options.onmerge) {
+                                options.onmerge()
+                            }
                             RED.tray.close();
                         }
                     }
@@ -1345,6 +1348,7 @@ RED.diff = (function() {
         var newConfig = [];
         var node;
         var nodeChangedStates = {};
+        var nodeMovedStates = {};
         var localChangedStates = {};
         for (id in localDiff.newConfig.all) {
             if (localDiff.newConfig.all.hasOwnProperty(id)) {
@@ -1352,12 +1356,14 @@ RED.diff = (function() {
                 if (resolutions[id] === 'local') {
                     if (node) {
                         nodeChangedStates[id] = node.changed;
+                        nodeMovedStates[id] = node.moved;
                     }
                     newConfig.push(localDiff.newConfig.all[id]);
                 } else if (resolutions[id] === 'remote') {
                     if (!remoteDiff.deleted[id] && remoteDiff.newConfig.all.hasOwnProperty(id)) {
                         if (node) {
                             nodeChangedStates[id] = node.changed;
+                            nodeMovedStates[id] = node.moved;
                         }
                         localChangedStates[id] = 1;
                         newConfig.push(remoteDiff.newConfig.all[id]);
@@ -1381,8 +1387,9 @@ RED.diff = (function() {
         }
         return {
             config: newConfig,
-            nodeChangedStates: nodeChangedStates,
-            localChangedStates: localChangedStates
+            nodeChangedStates,
+            nodeMovedStates,
+            localChangedStates
         }
     }
 
@@ -1393,6 +1400,7 @@ RED.diff = (function() {
 
         var newConfig = appliedDiff.config;
         var nodeChangedStates = appliedDiff.nodeChangedStates;
+        var nodeMovedStates = appliedDiff.nodeMovedStates;
         var localChangedStates = appliedDiff.localChangedStates;
 
         var isDirty = RED.nodes.dirty();
@@ -1401,33 +1409,56 @@ RED.diff = (function() {
             t:"replace",
             config: RED.nodes.createCompleteNodeSet(),
             changed: nodeChangedStates,
+            moved: nodeMovedStates,
+            complete: true,
             dirty: isDirty,
             rev: RED.nodes.version()
         }
 
         RED.history.push(historyEvent);
 
-        var originalFlow = RED.nodes.originalFlow();
-        // originalFlow is what the editor things it loaded
-        //  - add any newly added nodes from remote diff as they are now part of the record
-        for (var id in diff.remoteDiff.added) {
-            if (diff.remoteDiff.added.hasOwnProperty(id)) {
-                if (diff.remoteDiff.newConfig.all.hasOwnProperty(id)) {
-                    originalFlow.push(JSON.parse(JSON.stringify(diff.remoteDiff.newConfig.all[id])));
-                }
-            }
-        }
+        // var originalFlow = RED.nodes.originalFlow();
+        // // originalFlow is what the editor thinks it loaded
+        // //  - add any newly added nodes from remote diff as they are now part of the record
+        // for (var id in diff.remoteDiff.added) {
+        //     if (diff.remoteDiff.added.hasOwnProperty(id)) {
+        //         if (diff.remoteDiff.newConfig.all.hasOwnProperty(id)) {
+        //             originalFlow.push(JSON.parse(JSON.stringify(diff.remoteDiff.newConfig.all[id])));
+        //         }
+        //     }
+        // }
 
         RED.nodes.clear();
         var imported = RED.nodes.import(newConfig);
 
-        // Restore the original flow so subsequent merge resolutions can properly
-        // identify new-vs-old
-        RED.nodes.originalFlow(originalFlow);
+        // // Restore the original flow so subsequent merge resolutions can properly
+        // // identify new-vs-old
+        // RED.nodes.originalFlow(originalFlow);
+
+        // Clear all change flags from the import
+        RED.nodes.dirty(false);
+        
+        const flowsToLock = new Set()
+        function ensureUnlocked(id) {
+            const flow = id && (RED.nodes.workspace(id) || RED.nodes.subflow(id) || null);
+            const isLocked = flow ? flow.locked : false;
+            if (flow && isLocked) {
+                flow.locked = false;
+                flowsToLock.add(flow)
+            }
+        }
         imported.nodes.forEach(function(n) {
-            if (nodeChangedStates[n.id] || localChangedStates[n.id]) {
+            if (nodeChangedStates[n.id]) {
+                ensureUnlocked(n.z)
                 n.changed = true;
             }
+            if (nodeMovedStates[n.id]) {
+                ensureUnlocked(n.z)
+                n.moved = true;
+            }
+        })
+        flowsToLock.forEach(flow => {
+            flow.locked = true
         })
 
         RED.nodes.version(diff.remoteDiff.rev);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/notifications.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/notifications.js
@@ -223,7 +223,7 @@ RED.notifications = (function() {
                     }
                     newTimeout = newOptions.hasOwnProperty('timeout')?newOptions.timeout:timeout
                     if (!fixed || newOptions.fixed === false) {
-                        newTimeout === newTimeout || 5000
+                        newTimeout = newTimeout || 5000
                     }
                     if (newOptions.buttons) {
                         var buttonSet = $('<div class="ui-dialog-buttonset"></div>').appendTo(nn)

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/notifications.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/notifications.js
@@ -221,12 +221,12 @@ RED.notifications = (function() {
                     if (newType) {
                         n.className = "red-ui-notification red-ui-notification-"+newType;
                     }
-
+                    newTimeout = newOptions.hasOwnProperty('timeout')?newOptions.timeout:timeout
                     if (!fixed || newOptions.fixed === false) {
-                        newTimeout = (newOptions.hasOwnProperty('timeout')?newOptions.timeout:timeout)||5000;
+                        newTimeout === newTimeout || 5000
                     }
                     if (newOptions.buttons) {
-                        var buttonSet = $('<div style="margin-top: 20px;" class="ui-dialog-buttonset"></div>').appendTo(nn)
+                        var buttonSet = $('<div class="ui-dialog-buttonset"></div>').appendTo(nn)
                         newOptions.buttons.forEach(function(buttonDef) {
                             var b = $('<button>').text(buttonDef.text).on("click", buttonDef.click).appendTo(buttonSet);
                             if (buttonDef.id) {
@@ -272,6 +272,15 @@ RED.notifications = (function() {
                 };
             })());
             n.timeoutid = window.setTimeout(n.close,timeout||5000);
+        } else if (timeout) {
+            $(n).on("click.red-ui-notification-close", (function() {
+                var nn = n;
+                return function() {
+                    nn.hideNotification();
+                    window.clearTimeout(nn.timeoutid);
+                };
+            })());
+            n.timeoutid = window.setTimeout(n.hideNotification,timeout||5000);
         }
         currentNotifications.push(n);
         if (options.id) {


### PR DESCRIPTION
This PR is a first iteration of improving the background conflict handling within the editor.

In Node-RED today, if another user deploys changes to the runtime whilst I have the editor open, it displays a modal notification and forces you to do something about it there and then. The choices being to merge, review or ignore the update.

If the other developer is being particular productive, they could be repeatedly deploying changes - causing this modal interruption every time.

The goal here is to remove this interruption, whilst still providing a way for a user to know there are upstream changes available for them to deal with at their time of choosing.

----

This PR updates the notification so that:
    1. it is no longer modal - the user is not blocked from continuing what they were doing
    2. it is stream-lined - single line notification to be less intrusive
    3. it hides after 10s (or if clicked, as with other notifications)
    4. the warning icon is shown - clicking on it reopens the notification

As part of this, I've fixed a few issues around tracking the changed/moved status of nodes across merges, as well as the undo/redo action of merging remote changes. There is still a bug with undo history going beyond a merge - but will look at separately.

<img width="975" alt="image" src="https://github.com/node-red/node-red/assets/51083/611d9aac-96df-4be8-9413-32b5eef826aa">

Clicking the 'Review changes' button takes the user through the existing workflow - no changes in this area. This is the same dialog they see if they try deploying their changes with pending background changes.

<img width="656" alt="image" src="https://github.com/node-red/node-red/assets/51083/b8efd264-385c-4781-98ed-5b08cb048ad9">







