### PR TITLE
Show lock on deploy if user is read-only

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -63,7 +63,7 @@ RED.deploy = (function() {
                  '<img src="red/images/spin.svg"/>'+
                 '</span>'+
               '</a>'+
-              '<a id="red-ui-header-button-deploy-options" class="red-ui-deploy-button" href="#"><i class="fa fa-caret-down"></i></a>'+
+              '<a id="red-ui-header-button-deploy-options" class="red-ui-deploy-button" href="#"><i class="fa fa-caret-down"></i><i class="fa fa-lock"></i></a>'+
               '</span></li>').prependTo(".red-ui-header-toolbar");
             const mainMenuItems = [
                     {id:"deploymenu-item-full",toggle:"deploy-type",icon:"red/images/deploy-full.svg",label:RED._("deploy.full"),sublabel:RED._("deploy.fullDesc"),selected: true, onselect:function(s) { if(s){changeDeploymentType("full")}}},
@@ -124,6 +124,9 @@ RED.deploy = (function() {
         })
 
         RED.events.on('workspace:dirty',function(state) {
+            if (RED.settings.user?.permissions === 'read') {
+                return
+            }
             if (state.dirty) {
                 // window.onbeforeunload = function() {
                 //     return 
@@ -169,6 +172,22 @@ RED.deploy = (function() {
                 activeBackgroundDeployNotification.update(message, options)
             }
         });
+
+
+        updateLockedState()
+        RED.events.on('login', updateLockedState)
+    }
+
+    function updateLockedState() {
+        if (RED.settings.user?.permissions === 'read') {
+            $(".red-ui-deploy-button-group").addClass("readOnly");
+            $("#red-ui-header-button-deploy").addClass("disabled");
+        } else {
+            $(".red-ui-deploy-button-group").removeClass("readOnly");
+            if (RED.nodes.dirty()) {
+                $("#red-ui-header-button-deploy").removeClass("disabled");
+            }
+        }
     }
 
     function getNodeInfo(node) {

--- a/packages/node_modules/@node-red/editor-client/src/sass/header.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/header.scss
@@ -186,6 +186,20 @@
         }
     }
 
+    .red-ui-deploy-button-group.readOnly {
+        .fa-caret-down { display: none; }
+        .fa-lock { display: inline-block; }
+    }
+    .red-ui-deploy-button-group:not(.readOnly) {
+        .fa-caret-down { display: inline-block; }
+        .fa-lock { display: none; }
+    }
+    .red-ui-deploy-button-group.readOnly {
+        a {
+            pointer-events: none;
+        }
+    }
+
     li.open .button {
         background: var(--red-ui-header-button-background-active);
         border-color: var(--red-ui-header-button-background-active);


### PR DESCRIPTION
To improve feedback when in the editor as a read-only user, with this PR, the deploy button now shows a lock icon and never becomes enabled. This is a clear indication that changes cannot be deployed.

<img width="186" alt="image" src="https://github.com/node-red/node-red/assets/51083/52da0567-ab73-44da-bb98-b9f4d961a239">

If a user logs in, the lock icon is removed and the button restored to its expected state (depending if they had made changes or not).