### PR TITLE
Add --version cli args

### DIFF
--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -42,6 +42,7 @@ try { bcrypt = require('bcrypt'); }
 catch(e) { bcrypt = require('bcryptjs'); }
 var nopt = require("nopt");
 var path = require("path");
+const os = require("os")
 var fs = require("fs-extra");
 var RED = require("./lib/red.js");
 
@@ -104,6 +105,7 @@ if (parsedArgs.help) {
 if (parsedArgs.version) {
     console.log("Node-RED v"+RED.version())
     console.log("Node.js "+process.version)
+    console.log(os.type()+" "+os.release()+" "+os.arch()+" "+os.endianness())
     process.exit()
 }
 

--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -103,6 +103,7 @@ if (parsedArgs.help) {
 
 if (parsedArgs.version) {
     console.log("Node-RED v"+RED.version())
+    console.log("Node.js "+process.version)
     process.exit()
 }
 

--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -59,6 +59,7 @@ var knownOpts = {
     "userDir": [path],
     "verbose": Boolean,
     "safe": Boolean,
+    "version": Boolean,
     "define": [String, Array]
 };
 var shortHands = {
@@ -92,11 +93,17 @@ if (parsedArgs.help) {
     console.log("  -v, --verbose        enable verbose output");
     console.log("      --safe           enable safe mode");
     console.log("  -D, --define   X=Y   overwrite value in settings file");
+    console.log("      --version        show version information");
     console.log("  -?, --help           show this help");
     console.log("  admin <command>      run an admin command");
     console.log("");
     console.log("Documentation can be found at https://nodered.org");
     process.exit();
+}
+
+if (parsedArgs.version) {
+    console.log("Node-RED v"+RED.version())
+    process.exit()
 }
 
 if (parsedArgs.argv.remain.length > 0) {


### PR DESCRIPTION
Closes #4569 

Adds `--version` cli arg that returns the node-red, node.js versions and OS info in one go:

```
$ node-red --version
Node-RED v4.0.0-beta.3-1
Node.js v18.18.2
Darwin 20.6.0 x64 LE
```

This is the same info we log on startup.

I know the original feature request wanted npm version as well, but that we can't get so easily without using child_process etc - and to be honest, npm version issues are much much rarer these days.

