### PR TITLE
Allow nodes to return additional history entries in onEditSave

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -741,9 +741,16 @@ RED.editor = (function() {
             }
 
             try {
-                var rc = editing_node._def.oneditsave.call(editing_node);
+                const rc = editing_node._def.oneditsave.call(editing_node);
                 if (rc === true) {
                     editState.changed = true;
+                } else if (typeof rc === 'object' && rc !== null ) {
+                    if (rc.changed === true) {
+                        editState.changed = true
+                    }
+                    if (Array.isArray(rc.history) && rc.history.length > 0) {
+                        editState.history = rc.history
+                    }
                 }
             } catch(err) {
                 console.warn("oneditsave",editing_node.id,editing_node.type,err.toString());
@@ -1015,7 +1022,7 @@ RED.editor = (function() {
                                     }
                                 });
                             }
-                            var historyEvent = {
+                            let historyEvent = {
                                 t:'edit',
                                 node:editing_node,
                                 changes:editState.changes,
@@ -1031,6 +1038,15 @@ RED.editor = (function() {
                                     instances:subflowInstances
                                 }
                             }
+
+                            if (editState.history) {
+                                historyEvent = {
+                                    t: 'multi',
+                                    events: [ historyEvent, ...editState.history ],
+                                    dirty: wasDirty
+                                }
+                            }
+
                             RED.history.push(historyEvent);
                         }
                         editing_node.dirty = true;

--- a/packages/node_modules/@node-red/nodes/core/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.html
@@ -194,25 +194,44 @@
                 nodeMap[node.links[i]].new = true;
             }
         }
-        var n;
-        for (var id in nodeMap) {
+
+        let editHistories = []
+        let n;
+        for (let id in nodeMap) {
             if (nodeMap.hasOwnProperty(id)) {
                 n = RED.nodes.node(id);
                 if (n) {
+                    editHistories.push({
+                        t:'edit',
+                        node: n,
+                        changes: {
+                            links: [...n.links]
+                        },
+                        changed: n.changed
+                    })
                     if (nodeMap[id].old && !nodeMap[id].new) {
                         // Removed id
                         i = n.links.indexOf(node.id);
                         if (i > -1) {
                             n.links.splice(i,1);
+                            n.changed = true
+                            n.dirty = true
                         }
                     } else if (!nodeMap[id].old && nodeMap[id].new) {
                         // Added id
                         i = n.links.indexOf(id);
                         if (i === -1) {
                             n.links.push(node.id);
+                            n.changed = true
+                            n.dirty = true
                         }
                     }
                 }
+            }
+        }
+        if (editHistories.length > 0) {
+            return {
+                history: editHistories
             }
         }
     }
@@ -254,13 +273,14 @@
             onEditPrepare(this,"link out");
         },
         oneditsave: function() {
-            onEditSave(this);
+            const result = onEditSave(this);
             // In case the name has changed, ensure any link call nodes on this
             // tab are redrawn with the updated name
             var localCallNodes = RED.nodes.filterNodes({z:RED.workspaces.active(), type:"link call"});
             localCallNodes.forEach(function(node) {
                 node.dirty = true;
             });
+            return result
         },
         onadd: onAdd,
         oneditresize: resizeNodeList
@@ -329,7 +349,7 @@
             onEditPrepare(this,"link in");
         },
         oneditsave: function() {
-            onEditSave(this);
+            return onEditSave(this);
         },
         oneditresize: resizeNodeList
     });
@@ -373,7 +393,7 @@
 
         },
         oneditsave: function() {
-            onEditSave(this);
+            return onEditSave(this);
         },
         onadd: onAdd,
         oneditresize: resizeNodeList


### PR DESCRIPTION
Fixes #4704 


Editing link nodes can have a side-effect on the configurations of other link nodes. The existing `oneditsave` mechanism does not provide any way for those side-effects to be automatically captured in the edit history.

This was the root cause of the linked issue - editing the link in node via the edit dialog, modified the link out nodes, but those modifications didn't get recorded in edit history

This PR fixes it by allowing `onEditSave` to return an object containing a history property. This should be an array of additional edit history events that will get merged with the node's own edit event into a single `multi` history event. This allows all of the node modifications to be undone in one.