### PR TITLE
Add missing tooltips to Sidebar

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -719,6 +719,7 @@
             "nodeHelp": "Node Help",
             "showHelp": "Show help",
             "showInOutline": "Show in outline",
+            "hideTopics": "Hide topics",
             "showTopics": "Show topics",
             "noHelp": "No help topic selected",
             "changeLog": "Change Log"

--- a/packages/node_modules/@node-red/editor-client/locales/fr/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/fr/editor.json
@@ -719,6 +719,7 @@
       "nodeHelp": "Aide sur les noeuds",
       "showHelp": "Afficher l'aide",
       "showInOutline": "Afficher dans les grandes lignes",
+      "hideTopics": "Masquer les sujets",
       "showTopics": "Afficher les sujets",
       "noHelp": "Aucune rubrique d'aide sélectionnée",
       "changeLog": "Journal des modifications"

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
@@ -382,9 +382,11 @@ RED.sidebar.config = (function() {
                 refreshConfigNodeList();
             }
         });
+
         RED.popover.tooltip($('#red-ui-sidebar-config-filter-all'), RED._("sidebar.config.showAllConfigNodes"));
         RED.popover.tooltip($('#red-ui-sidebar-config-filter-unused'), RED._("sidebar.config.showAllUnusedConfigNodes"));
-
+        RED.popover.tooltip($('#red-ui-sidebar-config-collapse-all'), RED._("palette.actions.collapse-all"));
+        RED.popover.tooltip($('#red-ui-sidebar-config-expand-all'), RED._("palette.actions.expand-all"));
     }
 
     function flashConfigNode(el) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-help.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-help.js
@@ -36,7 +36,13 @@ RED.sidebar.help = (function() {
         toolbar = $("<div>", {class:"red-ui-sidebar-header red-ui-info-toolbar"}).appendTo(content);
         $('<span class="button-group"><a id="red-ui-sidebar-help-show-toc" class="red-ui-button red-ui-button-small selected" href="#"><i class="fa fa-list-ul"></i></a></span>').appendTo(toolbar)
         var showTOCButton = toolbar.find('#red-ui-sidebar-help-show-toc')
-        RED.popover.tooltip(showTOCButton,RED._("sidebar.help.showTopics"));
+        RED.popover.tooltip(showTOCButton, function () {
+            if ($(showTOCButton).hasClass('selected')) {
+                return RED._("sidebar.help.hideTopics");
+            } else {
+                return RED._("sidebar.help.showTopics");
+            }
+        });
         showTOCButton.on("click",function(e) {
             e.preventDefault();
             if ($(this).hasClass('selected')) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Add missing tooltips to Sidebar:

- `Collapse all` and `Expand all` are missing in **Config tab** (footer)
  <img width="188" alt="Capture d’écran 2024-05-21 à 13 04 56" src="https://github.com/node-red/node-red/assets/92022724/b6adcb8a-6404-4d58-a2ae-2696361cfeb1">

- `Show topics` button now displays a dynamic message (hide/show) in **Help tab**

  <img width="332" alt="Capture d’écran 2024-05-21 à 13 10 16" src="https://github.com/node-red/node-red/assets/92022724/d59125b6-c92a-4ad1-a9f9-6c7c2001c715">

@kazuhitoyokoi  I mention you so that it is easier for you to find the translations to do.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
