### PR TITLE
Deleting a grouped node should update the group

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -901,6 +901,11 @@ RED.editor = (function() {
                         var startDirty = RED.nodes.dirty();
                         var removedNodes = [];
                         var removedLinks = [];
+
+                        if (editing_node.g) {
+                            RED.group.removeFromGroup(RED.nodes.group(editing_node.g), [{...editing_node}]);
+                        }
+
                         var removedEntities = RED.nodes.remove(editing_node.id);
                         removedNodes.push(editing_node);
                         removedNodes = removedNodes.concat(removedEntities.nodes);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
@@ -606,7 +606,8 @@ RED.group = (function() {
         for (var i=0; i<nodes.length; i++) {
             n = nodes[i];
             n.dirty = true;
-            var index = group.nodes.indexOf(n);
+            // TODO: Why Proxy indexOf returns -1 ?
+            var index = group.nodes.findIndex(function (node) { return node.id === n.id; });
             group.nodes.splice(index,1);
             if (reparent && parentGroup) {
                 n.g = group.g


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Fixes #4712

When the user deletes a grouped node from the edit box, the group must be updated in order to remove the node from the group.

PS: I don't know why `indexOf` doesn't return the correct value.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
