### PR TITLE
Fix a checkbox that should return a boolean value and not the string `on`

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -248,6 +248,8 @@ RED.editor = (function() {
             var value = input.val();
             if (defaults[property].hasOwnProperty("format") && defaults[property].format !== "" && input[0].nodeName === "DIV") {
                 value = input.text();
+            } else if (input.attr("type") === "checkbox") {
+                value = input.prop("checked");
             }
             var valid = validateNodeProperty(node, defaults, property,value);
             if (((typeof valid) === "string") || !valid) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

A node validates these inputs when:
1. the user edits an input
2. the user validates the changes (clicks on `Done`)

For point 2, a checkbox returns a Boolean value (line 1404) before `validateNode` is called.
But for point 1, a checkbox returns the string `on` before `validateNodeProperty` is called.

The checkbox should return a boolean value for point 1.

Validation when all nodes are loaded does not pose a problem because the value (from runtime) is a Boolean.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
