### PR TITLE
Add httpAdminCookieOptions

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/auth/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/index.js
@@ -160,20 +160,30 @@ function completeVerify(profile,done) {
 
 
 function genericStrategy(adminApp,strategy) {
-    var crypto = require("crypto")
-    var session = require('express-session')
-    var MemoryStore = require('memorystore')(session)
+    const crypto = require("crypto")
+    const session = require('express-session')
+    const MemoryStore = require('memorystore')(session)
 
-    adminApp.use(session({
-      // As the session is only used across the life-span of an auth
-      // hand-shake, we can use a instance specific random string
-      secret: crypto.randomBytes(20).toString('hex'),
-      resave: false,
-      saveUninitialized: false,
-      store: new MemoryStore({
-        checkPeriod: 86400000 // prune expired entries every 24h
-      })
-    }));
+    const sessionOptions = {
+        // As the session is only used across the life-span of an auth
+        // hand-shake, we can use a instance specific random string
+        secret: crypto.randomBytes(20).toString('hex'),
+        resave: false,
+        saveUninitialized: false,
+        store: new MemoryStore({
+          checkPeriod: 86400000 // prune expired entries every 24h
+        })
+    }
+    if (settings.httpAdminCookieOptions) {
+        sessionOptions.cookie = {
+            path: '/',
+            httpOnly: true,
+            secure: false,
+            maxAge: null,
+            ...settings.httpAdminCookieOptions
+        }
+    }
+    adminApp.use(session(sessionOptions));
     //TODO: all passport references ought to be in ./auth
     adminApp.use(passport.initialize());
     adminApp.use(passport.session());

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -133,6 +133,7 @@ module.exports = {
  *  - httpServerOptions
  *  - httpAdminRoot
  *  - httpAdminMiddleware
+ *  - httpAdminCookieOptions
  *  - httpNodeRoot
  *  - httpNodeCors
  *  - httpNodeMiddleware
@@ -178,6 +179,11 @@ module.exports = {
     //    next();
     // },
 
+    /** The following property can be used to set addition options on the session
+     * cookie used as part of adminAuth authentication system
+     * Available options are documented here: https://www.npmjs.com/package/express-session#cookie
+     */
+    // httpAdminCookieOptions: { },
 
     /** Some nodes, such as HTTP In, can be used to listen for incoming http requests.
      * By default, these are served relative to '/'. The following property


### PR DESCRIPTION
Closes #4717

This allows the session cookie used as part of adminAuth OAuth strategies to have its options customised.

The code applies the documented defaults, then allows `httpAdminCookieOptions` to override them.