### PR TITLE
Safari: Fix an unexpected input selection

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/base.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/base.scss
@@ -40,6 +40,7 @@ body {
     position: absolute;
     top:40px; left:0; bottom: 0; right:0;
     overflow:hidden;
+    -webkit-user-select: none;
 }
 
 #red-ui-palette-shade, #red-ui-editor-shade, #red-ui-header-shade, #red-ui-sidebar-shade  {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Partial fix of #4463.

When double clicking on a node to open the edit box, the palette filter input is selected (blue background). Visible on the video in the linked issue.

It's the same behavior if the double clicking is done in a container (editableList), one of the inputs will be selected.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
