### PR TITLE
Fix typo in httprequest.html

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/de/network/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/locales/de/network/21-httprequest.html
@@ -81,7 +81,7 @@
     <p>Wenn <code>msg.payload</code> ein Objekt ist, setzt der Node automatisch den Inhaltstyp der Anforderung
        auf <code>application/json</code> und kodiert den Hauptteil als solchen.</p>
     <p>Um die Anforderung als Formulardaten zu kodieren, sollte <code>msg.headers["content-type"]</code> auf
-       <code>application/x-wwww-form-urlencoded</code> gesetzt werden.</p>
+       <code>application/x-www-form-urlencoded</code> gesetzt werden.</p>
     <h4><b>Datei-Upload</b></h4>
     <p>Um einen Datei-Upload umzusetzen, sollte <code>msg.headers["content-type"]</code> auf <code>multipart/form-data</code>
        gesetzt werden und das an den Node zu sendende <code>msg.payload</code> muss ein Objekt mit folgender Struktur sein:</p>


### PR DESCRIPTION
Fix typo in documentation of httprequest documentation.
This is a non-code fix that should have no side-effects.
This fix is below threshold of originality and I consider it to be in the public domain.
