### PR TITLE
chore: migrate deprecated `util.isArray`

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/auth/permissions.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/permissions.js
@@ -25,7 +25,7 @@ function hasPermission(userScope,permission) {
     }
     var i;
 
-    if (util.isArray(permission)) {
+    if (Array.isArray(permission)) {
         // Multiple permissions requested - check each one
         for (i=0;i<permission.length;i++) {
             if (!hasPermission(userScope,permission[i])) {
@@ -36,7 +36,7 @@ function hasPermission(userScope,permission) {
         return true;
     }
 
-    if (util.isArray(userScope)) {
+    if (Array.isArray(userScope)) {
         if (userScope.length === 0) {
             return false;
         }

--- a/packages/node_modules/@node-red/editor-api/lib/auth/users.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/users.js
@@ -74,7 +74,7 @@ function init(config) {
             } else {
                 var us = config.users;
                 /* istanbul ignore else */
-                if (!util.isArray(us)) {
+                if (!Array.isArray(us)) {
                     us = [us];
                 }
                 for (var i=0;i<us.length;i++) {

--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -70,7 +70,7 @@ function serveFilesFromTheme(themeValue, themeApp, directory, baseDirectory) {
     var result = [];
     if (themeValue) {
         var array = themeValue;
-        if (!util.isArray(array)) {
+        if (!Array.isArray(array)) {
             array = [array];
         }
 

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -25,19 +25,19 @@ module.exports = function(RED) {
     function sendResults(node,send,_msgid,msgs,cloneFirstMessage) {
         if (msgs == null) {
             return;
-        } else if (!util.isArray(msgs)) {
+        } else if (!Array.isArray(msgs)) {
             msgs = [msgs];
         }
         var msgCount = 0;
         for (var m=0; m<msgs.length; m++) {
             if (msgs[m]) {
-                if (!util.isArray(msgs[m])) {
+                if (!Array.isArray(msgs[m])) {
                     msgs[m] = [msgs[m]];
                 }
                 for (var n=0; n < msgs[m].length; n++) {
                     var msg = msgs[m][n];
                     if (msg !== null && msg !== undefined) {
-                        if (typeof msg === 'object' && !Buffer.isBuffer(msg) && !util.isArray(msg)) {
+                        if (typeof msg === 'object' && !Buffer.isBuffer(msg) && !Array.isArray(msg)) {
                             if (msgCount === 0 && cloneFirstMessage !== false) {
                                 msgs[m][n] = RED.util.cloneMessage(msgs[m][n]);
                                 msg = msgs[m][n];
@@ -47,7 +47,7 @@ module.exports = function(RED) {
                         } else {
                             var type = typeof msg;
                             if (type === 'object') {
-                                type = Buffer.isBuffer(msg)?'Buffer':(util.isArray(msg)?'Array':'Date');
+                                type = Buffer.isBuffer(msg)?'Buffer':(Array.isArray(msg)?'Array':'Date');
                             }
                             node.error(RED._("function.error.non-message-returned",{ type: type }));
                         }

--- a/packages/node_modules/@node-red/runtime/lib/api/settings.js
+++ b/packages/node_modules/@node-red/runtime/lib/api/settings.js
@@ -104,7 +104,7 @@ var api = module.exports = {
                 }
             }
             safeSettings.libraries = runtime.library.getLibraries();
-            if (util.isArray(runtime.settings.paletteCategories)) {
+            if (Array.isArray(runtime.settings.paletteCategories)) {
                 safeSettings.paletteCategories = runtime.settings.paletteCategories;
             }
 

--- a/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
@@ -377,7 +377,7 @@ Node.prototype.send = function(msg) {
 
     if (msg === null || typeof msg === "undefined") {
         return;
-    } else if (!util.isArray(msg)) {
+    } else if (!Array.isArray(msg)) {
         // A single message has been passed in
         if (typeof msg !== 'object') {
             this.error(Log._("nodes.flow.non-message-returned", { type: typeof msg }));
@@ -425,7 +425,7 @@ Node.prototype.send = function(msg) {
         if (i < msg.length) {
             var msgs = msg[i]; // msgs going to output i
             if (msgs !== null && typeof msgs !== "undefined") {
-                if (!util.isArray(msgs)) {
+                if (!Array.isArray(msgs)) {
                     msgs = [msgs];
                 }
                 var k = 0;

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -862,7 +862,7 @@ function encodeObject(msg,opts) {
                     message: msg.msg.message
                 });
             } else {
-                var isArray = util.isArray(msg.msg);
+                var isArray = Array.isArray(msg.msg);
                 var needsStringify = isArray;
                 if (isArray) {
                     msg.format = "array["+msg.msg.length+"]";
@@ -906,7 +906,7 @@ function encodeObject(msg,opts) {
                             }
                         } else if (value instanceof Error) {
                             value = value.toString()
-                        } else if (util.isArray(value) && value.length > debuglength) {
+                        } else if (Array.isArray(value) && value.length > debuglength) {
                             value = {
                                 __enc__: true,
                                 type: "array",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Deprecated: Use Array.isArray() instead.

Source: https://nodejs.org/docs/latest-v18.x/api/util.html#utilisarrayobject

## Reference

#4723

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
