### PR TITLE
Fix the Sidebar Config is not refreshed after a deploy

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -631,6 +631,7 @@ RED.deploy = (function() {
             // Once deployed, cannot undo back to a clean state
             RED.history.markAllDirty();
             RED.view.redraw();
+            RED.sidebar.config.refresh();
             RED.events.emit("deploy");
         }).fail(function (xhr, textStatus, err) {
             RED.nodes.dirty(true);


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fix the Sidebar Config is not refreshed after a deploy.

Issue described in the [Forum](https://discourse.nodered.org/t/should-the-double-exclamation-mark-for-imported-configuration-disapper-after-deploy/88348).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
