### PR TITLE
Export Nodes dialog refinement

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -27,7 +27,8 @@
             "lock": "Lock",
             "unlock": "Unlock",
             "locked": "Locked",
-            "unlocked": "Unlocked"
+            "unlocked": "Unlocked",
+            "format": "Format"
         },
         "type": {
             "string": "string",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -26,6 +26,7 @@ RED.clipboard = (function() {
     var currentPopoverError;
     var activeTab;
     var libraryBrowser;
+    var clipboardTabs;
 
     var activeLibraries = {};
 
@@ -214,6 +215,13 @@ RED.clipboard = (function() {
                 ],
                 open: function( event, ui ) {
                     RED.keyboard.disable();
+                },
+                beforeClose: function(e) {
+                    if (clipboardTabs && activeTab === "red-ui-clipboard-dialog-export-tab-clipboard") {
+                        const jsonTabIndex = clipboardTabs.getTabIndex('red-ui-clipboard-dialog-export-tab-clipboard-json')
+                        const activeTabIndex = clipboardTabs.activeIndex()
+                        RED.settings.set("editor.dialog.export.json-view", activeTabIndex === jsonTabIndex )
+                    }
                 },
                 close: function(e) {
                     RED.keyboard.enable();
@@ -574,7 +582,7 @@ RED.clipboard = (function() {
 
         dialogContainer.empty();
         dialogContainer.append($(exportNodesDialog));
-
+        clipboardTabs = null
         var tabs = RED.tabs.create({
             id: "red-ui-clipboard-dialog-export-tabs",
             vertical: true,
@@ -635,7 +643,7 @@ RED.clipboard = (function() {
         $("#red-ui-clipboard-dialog-tab-library-name").on('paste',function() { setTimeout(validateExportFilename,10)});
         $("#red-ui-clipboard-dialog-export").button("enable");
 
-        var clipboardTabs = RED.tabs.create({
+        clipboardTabs = RED.tabs.create({
             id: "red-ui-clipboard-dialog-export-tab-clipboard-tabs",
             onchange: function(tab) {
                 $(".red-ui-clipboard-dialog-export-tab-clipboard-tab").hide();
@@ -652,6 +660,9 @@ RED.clipboard = (function() {
             id: "red-ui-clipboard-dialog-export-tab-clipboard-json",
             label: RED._("editor.types.json")
         });
+        if (RED.settings.get("editor.dialog.export.json-view") === true) {
+            clipboardTabs.activateTab("red-ui-clipboard-dialog-export-tab-clipboard-json");
+        }
 
         var previewList = $("#red-ui-clipboard-dialog-export-tab-clipboard-preview-list").css({position:"absolute",top:0,right:0,bottom:0,left:0}).treeList({
             data: []

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -228,12 +228,23 @@ RED.clipboard = (function() {
 
         exportNodesDialog =
             '<div class="form-row">'+
-                '<label style="width:auto;margin-right: 10px;" data-i18n="common.label.export"></label>'+
-                '<span id="red-ui-clipboard-dialog-export-rng-group" class="button-group">'+
-                    '<a id="red-ui-clipboard-dialog-export-rng-selected" class="red-ui-button toggle" href="#" data-i18n="clipboard.export.selected"></a>'+
-                    '<a id="red-ui-clipboard-dialog-export-rng-flow" class="red-ui-button toggle" href="#" data-i18n="clipboard.export.current"></a>'+
-                    '<a id="red-ui-clipboard-dialog-export-rng-full" class="red-ui-button toggle" href="#" data-i18n="clipboard.export.all"></a>'+
-                '</span>'+
+                '<div style="display: flex; justify-content: space-between;">'+
+                    '<div class="form-row">'+
+                        '<label style="width:auto;margin-right: 10px;" data-i18n="common.label.export"></label>'+
+                        '<span id="red-ui-clipboard-dialog-export-rng-group" class="button-group">'+
+                            '<a id="red-ui-clipboard-dialog-export-rng-selected" class="red-ui-button toggle" href="#" data-i18n="clipboard.export.selected"></a>'+
+                            '<a id="red-ui-clipboard-dialog-export-rng-flow" class="red-ui-button toggle" href="#" data-i18n="clipboard.export.current"></a>'+
+                            '<a id="red-ui-clipboard-dialog-export-rng-full" class="red-ui-button toggle" href="#" data-i18n="clipboard.export.all"></a>'+
+                        '</span>'+
+                    '</div>'+
+                    '<div class="form-row">'+
+                        '<label style="width:auto;margin-right: 10px;" data-i18n="common.label.format"></label>'+
+                        '<span id="red-ui-clipboard-dialog-export-fmt-group" class="button-group">'+
+                            '<a id="red-ui-clipboard-dialog-export-fmt-mini" class="red-ui-button red-ui-button toggle" href="#" data-i18n="clipboard.export.compact"></a>'+
+                            '<a id="red-ui-clipboard-dialog-export-fmt-full" class="red-ui-button red-ui-button toggle" href="#" data-i18n="clipboard.export.formatted"></a>'+
+                        '</span>'+
+                    '</div>'+
+                '</div>'+
             '</div>'+
             '<div class="red-ui-clipboard-dialog-box">'+
                 '<div class="red-ui-clipboard-dialog-tabs">'+
@@ -248,14 +259,8 @@ RED.clipboard = (function() {
                             '<div id="red-ui-clipboard-dialog-export-tab-clipboard-preview-list"></div>'+
                         '</div>'+
                         '<div class="red-ui-clipboard-dialog-export-tab-clipboard-tab" id="red-ui-clipboard-dialog-export-tab-clipboard-json">'+
-                            '<div class="form-row" style="height:calc(100% - 40px)">'+
+                            '<div class="form-row" style="height:calc(100% - 10px)">'+
                                 '<textarea readonly id="red-ui-clipboard-dialog-export-text"></textarea>'+
-                            '</div>'+
-                            '<div class="form-row" style="text-align: right;">'+
-                                '<span id="red-ui-clipboard-dialog-export-fmt-group" class="button-group">'+
-                                    '<a id="red-ui-clipboard-dialog-export-fmt-mini" class="red-ui-button red-ui-button-small toggle" href="#" data-i18n="clipboard.export.compact"></a>'+
-                                    '<a id="red-ui-clipboard-dialog-export-fmt-full" class="red-ui-button red-ui-button-small toggle" href="#" data-i18n="clipboard.export.formatted"></a>'+
-                                '</span>'+
                             '</div>'+
                         '</div>'+
                     '</div>'+


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

### About

Reposition Export Dialog fomat buttons and remember user view

### Details

1. Move the Export Format toggle off the JSON view onto the main export dialog to make it always visible regardless of tab selected
2. Remember the users selected tab on the export dialog (Export Nodes / JSON)


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
