### PR TITLE
Fix losing links when importing a copy of links into a subflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2406,8 +2406,9 @@ RED.nodes = (function() {
             // get added
             if (activeSubflow && /^link /.test(n.type) && n.links) {
                 n.links = n.links.filter(function(id) {
-                    const otherNode = node_map[id] || RED.nodes.node(id);
-                    return (otherNode && otherNode.z === activeWorkspace)
+                    const otherNodeInMap = Object.values(node_map).filter(function(n) { return n.id === id; });
+                    const otherNode = (otherNodeInMap.length ? otherNodeInMap[0] : null) || RED.nodes.node(id);
+                    return (otherNode && otherNode.z === activeWorkspace);
                 });
             }
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2406,8 +2406,8 @@ RED.nodes = (function() {
             // get added
             if (activeSubflow && /^link /.test(n.type) && n.links) {
                 n.links = n.links.filter(function(id) {
-                    const otherNodeInMap = Object.values(node_map).filter(function(n) { return n.id === id; });
-                    const otherNode = (otherNodeInMap.length ? otherNodeInMap[0] : null) || RED.nodes.node(id);
+                    const nodeImported = new_nodes.filter(function(n) { return n.id === id; });
+                    const otherNode = (nodeImported.length ? nodeImported[0] : null) || RED.nodes.node(id);
                     return (otherNode && otherNode.z === activeWorkspace);
                 });
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2379,6 +2379,13 @@ RED.nodes = (function() {
             } else {
                 delete n.g
             }
+            // If importing into a subflow, ensure an outbound-link doesn't get added
+            if (activeSubflow && /^link /.test(n.type) && n.links) {
+                n.links = n.links.filter(function(id) {
+                    const otherNode = node_map[id] || RED.nodes.node(id);
+                    return (otherNode && otherNode.z === activeWorkspace);
+                });
+            }
             for (var d3 in n._def.defaults) {
                 if (n._def.defaults.hasOwnProperty(d3)) {
                     if (n._def.defaults[d3].type) {
@@ -2401,15 +2408,6 @@ RED.nodes = (function() {
                         n[d3] = Array.isArray(n[d3])?nodeList:nodeList[0];
                     }
                 }
-            }
-            // If importing into a subflow, ensure an outbound-link doesn't
-            // get added
-            if (activeSubflow && /^link /.test(n.type) && n.links) {
-                n.links = n.links.filter(function(id) {
-                    const nodeImported = new_nodes.filter(function(n) { return n.id === id; });
-                    const otherNode = (nodeImported.length ? nodeImported[0] : null) || RED.nodes.node(id);
-                    return (otherNode && otherNode.z === activeWorkspace);
-                });
             }
         }
         for (i=0;i<new_subflows.length;i++) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #4749.

Fixes `node_map` does not contain as key the new id of a copied node.

It's `new_nodes` which contains the new ids.
At the end of updating the new nodes, they are added to `node_map` which explains why they are in the image.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
