### PR TITLE
Include rewired nodes when calculating Modified Flows stop list

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/index.js
@@ -462,9 +462,8 @@ function stop(type,diff,muteLog,isDeploy) {
     if (type === 'nodes') {
         stopList = diff.changed.concat(diff.removed);
     } else if (type === 'flows') {
-        stopList = diff.changed.concat(diff.removed).concat(diff.linked);
+        stopList = diff.changed.concat(diff.removed).concat(diff.linked).concat(diff.rewired);
     }
-
     events.emit("flows:stopping",{config: activeConfig, type: type, diff: diff})
 
     // Stop the global flow object last


### PR DESCRIPTION
Fixes #4752 

This adds 'rewired' nodes to the list that get stopped on Modified Flows type deploys.

When testing locally, I found some other odd behaviours caused by not including this list of nodes. For example:

Starting with:
```
[A] -> [B] -> [C]
```
then deleting the wire between B/C:
```
[A] -> [B]    [C]
```

Caused the runtime to restart nodes A and C, but *not* B (as B was considered 'rewired' whereas A and C were considered 'linked'). That's just wrong.

Makes sense to restart anything and everything that has been touched by a modification.