### PR TITLE
Refactoring the `RED.nodes.import()` function

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1764,6 +1764,16 @@ RED.nodes = (function() {
 
     }
 
+    /**
+     * Analyzes the array of nodes passed as an argument to find unknown node types.
+     *
+     * Options:
+     * - `emitNotification` (boolean) - Emit an notification with unknown types.
+     *
+     * @param {Array<object>} nodes An array of nodes to analyse
+     * @param {object} options An options object
+     * @returns {Array<string>} An array with unknown types
+     */
     function identifyUnknowType(nodes, options = {}) {
         const unknownTypes = [];
         for (let node of nodes) {
@@ -1791,6 +1801,191 @@ RED.nodes = (function() {
         return unknownTypes;
     }
 
+    function copyConfigNode(configNode, def, options = {}) {
+        const newNode = {
+            id: configNode.id,
+            z: configNode.z,
+            type: configNode.type,
+            icon: configNode.icon,
+            info: configNode.info,
+            label: def.label,
+            users: [],
+            _config: {},
+            _def: def
+        };
+
+        if (!configNode.z) {
+            delete newNode.z;
+        }
+
+        if (options.markChanged) {
+            newNode.changed = true;
+        }
+
+        if (configNode.hasOwnProperty("d")) {
+            newNode.d = configNode.d;
+        }
+
+        // Copy node user properties
+        for (const d in def.defaults) {
+            if (def.defaults.hasOwnProperty(d)) {
+                newNode._config[d] = JSON.stringify(configNode[d]);
+                newNode[d] = configNode[d];
+            }
+        }
+
+        // Copy credentials - ONLY if the node contains it to avoid erase it
+        if (def.hasOwnProperty("credentials") && configNode.hasOwnProperty("credentials")) {
+            newNode.credentials = {};
+            for (const c in def.credentials) {
+                if (def.credentials.hasOwnProperty(c) && configNode.credentials.hasOwnProperty(c)) {
+                    newNode.credentials[c] = configNode.credentials[c];
+                }
+            }
+        }
+    
+        return newNode;
+    }
+
+    function copyNode(node, def, options = {}) {
+        const newNode = {
+            id: node.id,
+            x: parseFloat(node.x || 0),
+            y: parseFloat(node.y || 0),
+            z: node.z,
+            type: node.type,
+            info: node.info,
+            changed: false,
+            _config: {},
+            _def: def
+        };
+
+        if (node.type !== "group" && node.type !== "junction") {
+            newNode.wires = node.wires || [];
+            newNode.inputLabels = node.inputLabels;
+            newNode.outputLabels = node.outputLabels;
+            newNode.icon = node.icon;
+        }
+        if (node.type === "junction") {
+            newNode.wires = node.wires || [];
+        }
+        if (node.hasOwnProperty("l")) {
+            newNode.l = node.l;
+        }
+        if (node.hasOwnProperty("d")) {
+            newNode.d = node.d;
+        }
+        if (node.hasOwnProperty("g")) { // Group
+            newNode.g = node.g;
+        }
+        if (options.markChanged) {
+            newNode.changed = true
+        }
+
+        if (node.type === "group") {
+            newNode._def = RED.group.def;
+            for (const d in newNode._def.defaults) {
+                if (newNode._def.defaults.hasOwnProperty(d) && d !== "inputs" && d !== "outputs") {
+                    newNode[d] = node[d];
+                    newNode._config[d] = JSON.stringify(node[d]);
+                }
+            }
+            newNode._config.x = node.x;
+            newNode._config.y = node.y;
+            if (node.hasOwnProperty("w")) { // Weight
+                newNode.w = node.w
+            }
+            if (node.hasOwnProperty("h")) { // Height
+                newNode.h = node.h
+            }
+        } else if (node.type === "junction") {
+            newNode._def = { defaults: {} };
+            newNode._config.x = node.x
+            newNode._config.y = node.y
+            newNode.inputs = 1
+            newNode.outputs = 1
+            newNode.w = 0;
+            newNode.h = 0;
+        } else if (node.type.substring(0, 7) === "subflow") {
+            const parentId = node.type.split(":")[1];
+            /*
+            const subflow = subflow_denylist[parentId]||subflow_map[parentId]||getSubflow(parentId);
+            // TODO: Pourquoi ne pas l'avoir mis dans les tabs ?
+            if (!subflow){
+                node._def = {
+                    color:"#fee",
+                    defaults: {},
+                    label: "unknown: "+n.type,
+                    labelStyle: "red-ui-flow-node-label-italic",
+                    outputs: n.outputs|| (n.wires && n.wires.length) || 0,
+                    set: registry.getNodeSet("node-red/unknown")
+                }
+            } else {
+                // TODO: Normal que la copie utilise le Subflow parent ?
+                if (subflow_denylist[parentId] || createNewIds || options.importMap[n.id] === "copy") {
+                    parentId = subflow.id;
+                    node.type = "subflow:"+parentId;
+                    node._def = registry.getNodeType(node.type);
+                    delete node.i;
+                }
+                node.name = n.name;
+                node.outputs = subflow.out.length;
+                node.inputs = subflow.in.length;
+                node.env = n.env;
+            }*/
+        } else {
+            newNode._config.x = node.x;
+            newNode._config.y = node.y;
+
+            if (node.hasOwnProperty("inputs")) {
+                newNode._config.inputs = JSON.stringify(node.inputs);
+                newNode.inputs = node.inputs;
+            } else {
+                newNode.inputs = def.inputs;
+            }
+
+            if (node.hasOwnProperty("outputs")) {
+                newNode._config.outputs = JSON.stringify(node.outputs);
+                newNode.outputs = node.outputs;
+            } else {
+                newNode.outputs = def.outputs;
+            }
+
+            if (newNode.wires.length > newNode.outputs) {
+                if (!def.defaults.hasOwnProperty("outputs") || !isNaN(parseInt(newNode.outputs))) {
+                    // The node declares outputs in its defaults, but has not got a valid value
+                    // Defer to the length of the wires array
+                    newNode.outputs = newNode.wires.length;
+                } else {
+                    // If 'wires' is longer than outputs, clip wires
+                    console.log("Warning: node.wires longer than node.outputs - trimming wires:", node.id, " wires:", node.wires.length, " outputs:", node.outputs);
+                    // TODO: Pas dans l'autre sens ?
+                    newNode.wires = newNode.wires.slice(0, newNode.outputs);
+                }
+            }
+
+            // Copy node user properties
+            for (const d in def.defaults) {
+                if (newNode._def.defaults.hasOwnProperty(d) && d !== "inputs" && d !== "outputs") {
+                    newNode._config[d] = JSON.stringify(node[d]);
+                    newNode[d] = node[d];
+                }
+            }
+
+            // Copy credentials - ONLY if the node contains it to avoid erase it
+            if (def.hasOwnProperty("credentials") && node.hasOwnProperty("credentials")) {
+                newNode.credentials = {};
+                for (const c in def.credentials) {
+                    if (newNode._def.credentials.hasOwnProperty(c) && node.credentials.hasOwnProperty(c)) {
+                        newNode.credentials[c] = node.credentials[c];
+                    }
+                }
+            }
+        }
+
+        return newNode;
+    }
+
     /**
      * Options:
      *  - generateIds - whether to replace all node ids
@@ -1803,7 +1998,7 @@ RED.nodes = (function() {
      *       - id:copy - import with new id
      *       - id:replace - import over the top of existing
      */
-    function importNodes(newNodes, options) {
+    function importNodes(originalNodes, options) {
         const defaultOptions = { generateIds: false, addFlow: false, markChanged: false, reimport: false, importMap: {} };
         options = Object.assign({}, defaultOptions, options);
 
@@ -1811,11 +2006,11 @@ RED.nodes = (function() {
         const createMissingWorkspace = options.addFlow;
         const reimport = (!createNewIds && !!options.reimport);
 
-        // Checks and converts the flow into an Array if necessary
-        if (typeof newNodes === "string") {
-            if (newNodes === "") { return; }
+        // Checks and converts nodes into an Array if necessary
+        if (typeof originalNodes === "string") {
+            if (originalNodes === "") { return; }
             try {
-                newNodes = JSON.parse(newNodes);
+                originalNodes = JSON.parse(originalNodes);
             } catch(err) {
                 const error = new Error(RED._("clipboard.invalidFlow", { message: err.message }));
                 error.code = "NODE_RED";
@@ -1823,15 +2018,15 @@ RED.nodes = (function() {
             }
         }
 
-        if (!Array.isArray(newNodes)) {
-            newNodes = [newNodes];
+        if (!Array.isArray(originalNodes)) {
+            originalNodes = [originalNodes];
         }
 
         const seenIds = new Set();
         const existingNodes = [];
         const nodesToReplace = [];
-        // Checks if the imported flow contains duplicates or existing nodes.
-        newNodes = newNodes.filter(function(node) {
+        // Checks if the imported nodes contains duplicates or existing nodes.
+        originalNodes = originalNodes.filter(function(node) {
             const id = node.id;
 
             // This is a temporary fix to help resolve corrupted flows caused by 0.20.0 where multiple
@@ -1840,10 +2035,11 @@ RED.nodes = (function() {
             if (seenIds.has(id)) { return false; }
             seenIds.add(id);
 
-            // Checks if the node already exists - the user will choose between copying the node or replacing it
+            // Checks if the node already exists - the user will choose between copying the node, replacing it or not import it
             if (!createNewIds) {
                 if (!options.importMap[id]) {
                     // No conflict resolution for this node
+                    // TODO: Sure?
                     const existingNode = allNodes.getNode(id) || configNodes[id] || workspaces[id] || subflows[id] || groups[id] || junctions[id];
                     if (existingNode) {
                         existingNodes.push({ existing: existingNode, imported: node });
@@ -1857,9 +2053,10 @@ RED.nodes = (function() {
             return true;
         });
 
-        // If some nodes already exists, ask the user for each node to choose between copying it or replacing it
+        // If some nodes already exists, ask the user for each node to choose
+        // between copying it, replacing it or not importing it.
         if (existingNodes.length) {
-            const errorMessage = RED._("clipboard.importDuplicate",{ count: existingNodes.length });
+            const errorMessage = RED._("clipboard.importDuplicate", { count: existingNodes.length });
             const maxItemCount = 5; // Max 5 items in the list
             const nodeList = $("<ul>");
 
@@ -1872,13 +2069,13 @@ RED.nodes = (function() {
             }
 
             if (existingNodes.length > maxItemCount) {
-                $("<li>").text(RED._("deploy.confirm.plusNMore", {count: (existingNodes.length - maxItemCount) })).appendTo(nodeList);
+                $("<li>").text(RED._("deploy.confirm.plusNMore", { count: (existingNodes.length - maxItemCount) })).appendTo(nodeList);
             }
 
             const wrapper = $("<p>").append(nodeList);
             const existingNodesError = new Error(errorMessage + wrapper.html());
             existingNodesError.code = "import_conflict";
-            existingNodesError.importConfig = identifyImportConflicts(newNodes);
+            existingNodesError.importConfig = identifyImportConflicts(originalNodes);
             throw existingNodesError;
         }
 
@@ -1886,7 +2083,7 @@ RED.nodes = (function() {
         // TODO: Handled activeWorkspace = 0
         let activeWorkspace = RED.workspaces.active();
         const activeSubflow = getSubflow(activeWorkspace);
-        for (let node of newNodes) {
+        for (const node of originalNodes) {
             const group = /^subflow:(.+)$/.exec(node.type);
             if (group) {
                 const subflowId = group[1];
@@ -1916,18 +2113,19 @@ RED.nodes = (function() {
         let isInitialLoad = false;
         if (!initialLoad) {
             isInitialLoad = true;
-            initialLoad = JSON.parse(JSON.stringify(newNodes));
+            initialLoad = JSON.parse(JSON.stringify(originalNodes));
         }
-       
-        const unknownTypes = identifyUnknowType(newNodes, { emitNotification: isInitialLoad });
+
+        const unknownTypes = identifyUnknowType(originalNodes, { emitNotification: isInitialLoad });
 
         const nodeZmap = {};
-        let recoveryWorkspace;
-        for (let node of newNodes) {
+        let recoveryWorkspace = null;
+        let missingWorkspace = null;
+        for (const node of originalNodes) {
             if (node.z) {
                 nodeZmap[node.z] = nodeZmap[node.z] || [];
                 nodeZmap[node.z].push(node);
-            } else if (isInitialLoad && node.hasOwnProperty('x') && node.hasOwnProperty('y') && !node.z) {
+            } else if (isInitialLoad && node.hasOwnProperty('x') && node.hasOwnProperty('y')) {
                 // Hit the rare issue where node z values get set to 0.
                 // Repair the flow - but we really need to track that down.
                 if (!recoveryWorkspace) {
@@ -1948,265 +2146,127 @@ RED.nodes = (function() {
             }
         }
 
-    
-        var i;
-        var n;
+        // TODO
+        const subflow_denylist = {};
 
-
-        var new_workspaces = [];
-        var workspace_map = {};
-        var new_subflows = [];
-        var subflow_map = {};
-        var subflow_denylist = {};
-        var node_map = {};
-        var new_nodes = [];
-        var new_links = [];
-        var new_groups = [];
-        var new_junctions = [];
-        var new_group_set = new Set();
-        var nid;
-        var def;
-        var configNode;
-        var missingWorkspace = null;
-        var d;
-
+        const newWorkspaces = [];
         if (recoveryWorkspace) {
-            new_workspaces.push(recoveryWorkspace);
+            newWorkspaces.push(recoveryWorkspace);
+            const notification = RED.notify(RED._("clipboard.recoveredNodesNotification", { flowName: RED._("clipboard.recoveredNodes") }), {
+                type: "warning",
+                fixed: true,
+                buttons: [
+                    { text: RED._("common.label.close"), click: function() { notification.close(); } }
+                ]
+            });
         }
 
-        // Find all tabs and subflow templates
-        for (i=0;i<newNodes.length;i++) {
-            n = newNodes[i];
+        const subflowMap = {};
+        const workspaceMap = {};
+        const newSubflows = [];
+        // Find all tabs and subflow tabs and add it to workspace
+        // NOTE: Subflow tab not the instance
+        for (const node of originalNodes) {
+            const oldId = node.id;
+
             // TODO: remove workspace in next release+1
-            if (n.type === "workspace" || n.type === "tab") {
-                if (n.type === "workspace") {
-                    n.type = "tab";
+            if (node.type === "workspace" || node.type === "tab") {
+                // Legacy type
+                if (node.type === "workspace") {
+                    node.type = "tab";
                 }
+                // The flow being sorted, the first workspace is supposed to be the default
                 if (defaultWorkspace == null) {
-                    defaultWorkspace = n;
+                    defaultWorkspace = node;
                 }
-                if (activeWorkspace === 0) {
-                    activeWorkspace = n.id;
+                if (activeWorkspace === 0) {    // TODO: Why?
+                    activeWorkspace = node.id;
                 }
-                if (createNewIds || options.importMap[n.id] === "copy") {
-                    nid = getID();
-                    workspace_map[n.id] = nid;
-                    n.id = nid;
-                } else {
-                    workspace_map[n.id] = n.id;
+                if (createNewIds || options.importMap[node.id] === "copy") {
+                    node.id = getID();
                 }
-                addWorkspace(n);
-                RED.workspaces.add(n);
-                new_workspaces.push(n);
-            } else if (n.type === "subflow") {
-                var matchingSubflow;
-                if (!options.importMap[n.id]) {
-                    matchingSubflow = checkForMatchingSubflow(n,nodeZmap[n.id]);
+                addWorkspace(node);
+                workspaceMap[oldId] = node.id;
+                newWorkspaces.push(node);
+                RED.workspaces.add(node);
+            } else if (node.type === "subflow") {
+                let matchingSubflow;
+
+                // TODO: Toujours lié à node.z ?
+                if (!options.importMap[node.id]) {
+                    matchingSubflow = checkForMatchingSubflow(node, nodeZmap[node.id]);
                 }
                 if (matchingSubflow) {
-                    subflow_denylist[n.id] = matchingSubflow;
+                    subflow_denylist[node.id] = matchingSubflow;
                 } else {
-                    subflow_map[n.id] = n;
-                    if (createNewIds || options.importMap[n.id] === "copy") {
-                        nid = getID();
-                        n.id = nid;
-                    }
-                    // TODO: handle createNewIds - map old to new subflow ids
-                    n.in.forEach(function(input,i) {
+                    node.in.forEach(function(input, i) {
                         input.type = "subflow";
                         input.direction = "in";
-                        input.z = n.id;
+                        input.z = node.id;
                         input.i = i;
                         input.id = getID();
                     });
-                    n.out.forEach(function(output,i) {
+                    node.out.forEach(function(output, i) {
                         output.type = "subflow";
                         output.direction = "out";
-                        output.z = n.id;
+                        output.z = node.id;
                         output.i = i;
                         output.id = getID();
                     });
-                    if (n.status) {
-                        n.status.type = "subflow";
-                        n.status.direction = "status";
-                        n.status.z = n.id;
-                        n.status.id = getID();
+                    if (node.status) {
+                        node.status.type = "subflow";
+                        node.status.direction = "status";
+                        node.status.z = node.id;
+                        node.status.id = getID();
                     }
-                    new_subflows.push(n);
-                    addSubflow(n,createNewIds || options.importMap[n.id] === "copy");
+                    if (createNewIds || options.importMap[node.id] === "copy") {
+                        node.id = getID();
+                    }
+                    subflowMap[oldId] = node;
+                    newSubflows.push(node);
+                    addSubflow(node, (createNewIds || options.importMap[node.id] === "copy"));
                 }
             }
         }
 
-        // Add a tab if there isn't one there already
-        if (defaultWorkspace == null) {
-            defaultWorkspace = { type:"tab", id:getID(), disabled: false, info:"",  label:RED._('workspace.defaultName',{number:1}), env:[]};
+        // Add a tab if there isn't one there already - Like first install
+        if (!defaultWorkspace) {
+            defaultWorkspace = { type: "tab", id: getID(), disabled: false, info: "",  label: RED._("workspace.defaultName", { number: 1 }), env: [] };
             addWorkspace(defaultWorkspace);
             RED.workspaces.add(defaultWorkspace);
-            new_workspaces.push(defaultWorkspace);
+            newWorkspaces.push(defaultWorkspace);
             activeWorkspace = RED.workspaces.active();
         }
 
-        // Find all config nodes and add them
-        for (i=0;i<newNodes.length;i++) {
-            n = newNodes[i];
-            def = registry.getNodeType(n.type);
-            if (def && def.category == "config") {
-                var existingConfigNode = null;
-                if (createNewIds || options.importMap[n.id] === "copy") {
-                    if (n.z) {
-                        if (subflow_denylist[n.z]) {
-                            continue;
-                        } else if (subflow_map[n.z]) {
-                            n.z = subflow_map[n.z].id;
-                        } else {
-                            n.z = workspace_map[n.z];
-                            if (!workspaces[n.z]) {
-                                if (createMissingWorkspace) {
-                                    if (missingWorkspace === null) {
-                                        missingWorkspace = RED.workspaces.add(null,true);
-                                        new_workspaces.push(missingWorkspace);
-                                    }
-                                    n.z = missingWorkspace.id;
-                                } else {
-                                    n.z = activeWorkspace;
-                                }
-                            }
-                        }
-                    }
-                    if (options.importMap[n.id] !== "copy") {
-                        existingConfigNode = RED.nodes.node(n.id);
-                        if (existingConfigNode) {
-                            if (n.z && existingConfigNode.z !== n.z) {
-                                existingConfigNode = null;
-                                // Check the config nodes on n.z
-                                for (var cn in configNodes) {
-                                    if (configNodes.hasOwnProperty(cn)) {
-                                        if (configNodes[cn].z === n.z && compareNodes(configNodes[cn],n,false)) {
-                                            existingConfigNode = configNodes[cn];
-                                            node_map[n.id] = configNodes[cn];
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    const keepNodesCurrentZ = reimport && n.z && (RED.workspaces.contains(n.z) || RED.nodes.subflow(n.z))
-                    if (!keepNodesCurrentZ && n.z && !workspace_map[n.z] && !subflow_map[n.z]) {
-                        n.z = activeWorkspace;
-                    }
-                }
+        const nodeMap = {};
+        const newNodes = [];
+        const newGroups = [];
+        const newJunctions = [];
+        // Find all Config Nodes, Groups, Junctions, Nodes and Subflow instances and add them
+        // NOTE: Replaced Config Nodes and Subflow instances no longer appear below
+        for (const node of originalNodes) {
+            const def = registry.getNodeType(node.type);
+            const isConfigNode = def?.category === "config";
+            const oldId = node.id;
 
-                if (!existingConfigNode || existingConfigNode._def.exclusive) { //} || !compareNodes(existingConfigNode,n,true) || existingConfigNode.z !== n.z) {
-                    configNode = {
-                        id:n.id,
-                        z:n.z,
-                        type:n.type,
-                        info: n.info,
-                        users:[],
-                        _config:{}
-                    };
-                    if (!n.z) {
-                        delete configNode.z;
-                    }
-                    if (options.markChanged) {
-                        configNode.changed = true
-                    }
-                    if (n.hasOwnProperty('d')) {
-                        configNode.d = n.d;
-                    }
-                    for (d in def.defaults) {
-                        if (def.defaults.hasOwnProperty(d)) {
-                            configNode[d] = n[d];
-                            configNode._config[d] = JSON.stringify(n[d]);
-                        }
-                    }
-                    if (def.hasOwnProperty('credentials') && n.hasOwnProperty('credentials')) {
-                        configNode.credentials = {};
-                        for (d in def.credentials) {
-                            if (def.credentials.hasOwnProperty(d) && n.credentials.hasOwnProperty(d)) {
-                                configNode.credentials[d] = n.credentials[d];
-                            }
-                        }
-                    }
-                    configNode.label = def.label;
-                    configNode._def = def;
-                    if (createNewIds || options.importMap[n.id] === "copy") {
-                        configNode.id = getID();
-                    }
-                    node_map[n.id] = configNode;
-                    new_nodes.push(configNode);
-                }
-            }
-        }
-
-        // Find regular flow nodes and subflow instances
-        for (i=0;i<newNodes.length;i++) {
-            n = newNodes[i];
             // TODO: remove workspace in next release+1
-            if (n.type !== "workspace" && n.type !== "tab" && n.type !== "subflow") {
-                def = registry.getNodeType(n.type);
-                if (!def || def.category != "config") {
-                    var node = {
-                        x:parseFloat(n.x || 0),
-                        y:parseFloat(n.y || 0),
-                        z:n.z,
-                        type:0,
-                        info: n.info,
-                        changed:false,
-                        _config:{}
-                    }
-                    if (n.type !== "group" && n.type !== 'junction') {
-                        node.wires = n.wires||[];
-                        node.inputLabels = n.inputLabels;
-                        node.outputLabels = n.outputLabels;
-                        node.icon = n.icon;
-                    }
-                    if (n.type === 'junction') {
-                        node.wires = n.wires||[];
-                    }
-                    if (n.hasOwnProperty('l')) {
-                        node.l = n.l;
-                    }
-                    if (n.hasOwnProperty('d')) {
-                        node.d = n.d;
-                    }
-                    if (n.hasOwnProperty('g')) {
-                        node.g = n.g;
-                    }
-                    if (options.markChanged) {
-                        node.changed = true
-                    }
-                    if (createNewIds || options.importMap[n.id] === "copy") {
-                        if (subflow_denylist[n.z]) {
-                            continue;
-                        } else if (subflow_map[node.z]) {
-                            node.z = subflow_map[node.z].id;
-                        } else {
-                            node.z = workspace_map[node.z];
-                            if (!workspaces[node.z]) {
-                                if (createMissingWorkspace) {
-                                    if (missingWorkspace === null) {
-                                        missingWorkspace = RED.workspaces.add(null,true);
-                                        new_workspaces.push(missingWorkspace);
-                                    }
-                                    node.z = missingWorkspace.id;
-                                } else {
-                                    node.z = activeWorkspace;
-                                }
-                            }
-                        }
-                        node.id = getID();
+            if (node.type === "workspace" || node.type === "tab" || node.type === "subflow") { continue; }
+
+            // TODO: Fixes weird thing with `node.z`
+            if (createNewIds || options.importMap[oldId] === "copy") {
+                // Config Node can have an undefined `node.z`
+                if (!isConfigNode || (isConfigNode && node.z)) {
+                    if (subflow_denylist[node.z]) {
+                        continue;
+                    } else if (subflowMap[node.z]) {
+                        node.z = subflowMap[node.z].id;
                     } else {
-                        node.id = n.id;
-                        const keepNodesCurrentZ = reimport && node.z && (RED.workspaces.contains(node.z) || RED.nodes.subflow(node.z))
-                        if (!keepNodesCurrentZ && (node.z == null || (!workspace_map[node.z] && !subflow_map[node.z]))) {
+                        node.z = workspaceMap[node.z];
+                        if (!workspaces[node.z]) {
                             if (createMissingWorkspace) {
                                 if (missingWorkspace === null) {
-                                    missingWorkspace = RED.workspaces.add(null,true);
-                                    new_workspaces.push(missingWorkspace);
+                                    missingWorkspace = RED.workspaces.add(null, true);
+                                    newWorkspaces.push(missingWorkspace);
                                 }
                                 node.z = missingWorkspace.id;
                             } else {
@@ -2214,267 +2274,237 @@ RED.nodes = (function() {
                             }
                         }
                     }
-                    node.type = n.type;
-                    node._def = def;
-                    if (node.type === "group") {
-                        node._def = RED.group.def;
-                        for (d in node._def.defaults) {
-                            if (node._def.defaults.hasOwnProperty(d) && d !== 'inputs' && d !== 'outputs') {
-                                node[d] = n[d];
-                                node._config[d] = JSON.stringify(n[d]);
-                            }
-                        }
-                        node._config.x = node.x;
-                        node._config.y = node.y;
-                        if (n.hasOwnProperty('w')) {
-                            node.w = n.w
-                        }
-                        if (n.hasOwnProperty('h')) {
-                            node.h = n.h
-                        }
-                    } else if (n.type.substring(0,7) === "subflow") {
-                        var parentId = n.type.split(":")[1];
-                        var subflow = subflow_denylist[parentId]||subflow_map[parentId]||getSubflow(parentId);
-                        if (!subflow){
-                            node._def = {
-                                color:"#fee",
-                                defaults: {},
-                                label: "unknown: "+n.type,
-                                labelStyle: "red-ui-flow-node-label-italic",
-                                outputs: n.outputs|| (n.wires && n.wires.length) || 0,
-                                set: registry.getNodeSet("node-red/unknown")
-                            }
-                        } else {
-                            if (subflow_denylist[parentId] || createNewIds || options.importMap[n.id] === "copy") {
-                                parentId = subflow.id;
-                                node.type = "subflow:"+parentId;
-                                node._def = registry.getNodeType(node.type);
-                                delete node.i;
-                            }
-                            node.name = n.name;
-                            node.outputs = subflow.out.length;
-                            node.inputs = subflow.in.length;
-                            node.env = n.env;
-                        }
-                    } else if (n.type === 'junction') {
-                         node._def = {defaults:{}}
-                         node._config.x = node.x
-                         node._config.y = node.y
-                         node.inputs = 1
-                         node.outputs = 1
-                         node.w = 0;
-                         node.h = 0;
+                }
+            } else {
+                const keepNodesCurrentZ = reimport && node.z && (RED.workspaces.contains(node.z) || RED.nodes.subflow(node.z));
 
-                    } else {
-                        if (!node._def) {
-                            if (node.x && node.y) {
-                                node._def = {
-                                    color:"#fee",
-                                    defaults: {},
-                                    label: "unknown: "+n.type,
-                                    labelStyle: "red-ui-flow-node-label-italic",
-                                    outputs: n.outputs|| (n.wires && n.wires.length) || 0,
-                                    set: registry.getNodeSet("node-red/unknown")
-                                }
-                            } else {
-                                node._def = {
-                                    category:"config",
-                                    set: registry.getNodeSet("node-red/unknown")
-                                };
-                                node.users = [];
-                                // This is a config node, so delete the default
-                                // non-config node properties
-                                delete node.x;
-                                delete node.y;
-                                delete node.wires;
-                                delete node.inputLabels;
-                                delete node.outputLabels;
-                                if (!n.z) {
-                                    delete node.z;
-                                }
-                            }
-                            var orig = {};
-                            for (var p in n) {
-                                if (n.hasOwnProperty(p) && p!="x" && p!="y" && p!="z" && p!="id" && p!="wires") {
-                                    orig[p] = n[p];
-                                }
-                            }
-                            node._orig = orig;
-                            node.name = n.type;
-                            node.type = "unknown";
+                if (isConfigNode && !keepNodesCurrentZ && node.z && !workspaceMap[node.z] && !subflowMap[node.z]) {
+                    node.z = activeWorkspace;
+                } else if (!isConfigNode && !keepNodesCurrentZ && (node.z == null || (!workspaceMap[node.z] && !subflowMap[node.z]))) {
+                    // TODO: Encore ?
+                    if (createMissingWorkspace) {
+                        if (missingWorkspace === null) {
+                            missingWorkspace = RED.workspaces.add(null,true);
+                            newWorkspaces.push(missingWorkspace);
                         }
-                        if (node._def.category != "config") {
-                            if (n.hasOwnProperty('inputs')) {
-                                node.inputs = n.inputs;
-                                node._config.inputs = JSON.stringify(n.inputs);
-                            } else {
-                                node.inputs = node._def.inputs;
-                            }
-                            if (n.hasOwnProperty('outputs')) {
-                                node.outputs = n.outputs;
-                                node._config.outputs = JSON.stringify(n.outputs);
-                            } else {
-                                node.outputs = node._def.outputs;
-                            }
-                            if (node.hasOwnProperty('wires') && node.wires.length > node.outputs) {
-                                if (!node._def.defaults.hasOwnProperty("outputs") || !isNaN(parseInt(n.outputs))) {
-                                    // If 'wires' is longer than outputs, clip wires
-                                    console.log("Warning: node.wires longer than node.outputs - trimming wires:",node.id," wires:",node.wires.length," outputs:",node.outputs);
-                                    node.wires = node.wires.slice(0,node.outputs);
-                                } else {
-                                    // The node declares outputs in its defaults, but has not got a valid value
-                                    // Defer to the length of the wires array
-                                    node.outputs = node.wires.length;
-                                }
-                            }
-                            for (d in node._def.defaults) {
-                                if (node._def.defaults.hasOwnProperty(d) && d !== 'inputs' && d !== 'outputs') {
-                                    node[d] = n[d];
-                                    node._config[d] = JSON.stringify(n[d]);
-                                }
-                            }
-                            node._config.x = node.x;
-                            node._config.y = node.y;
-                            if (node._def.hasOwnProperty('credentials') && n.hasOwnProperty('credentials')) {
-                                node.credentials = {};
-                                for (d in node._def.credentials) {
-                                    if (node._def.credentials.hasOwnProperty(d) && n.credentials.hasOwnProperty(d)) {
-                                        node.credentials[d] = n.credentials[d];
+                        node.z = missingWorkspace.id;
+                    } else {
+                        node.z = activeWorkspace;
+                    }
+                }
+            }
+
+            // Config Node
+            if (isConfigNode) {
+                // TODO: A quoi sert ce bloc ? Replace?
+                let existingConfigNode;
+                if (createNewIds || options.importMap[oldId] === "copy") {
+                    if (options.importMap[oldId] !== "copy") {
+                        existingConfigNode = RED.nodes.node(oldId);
+                        if (existingConfigNode) {
+                            if (node.z && existingConfigNode.z !== node.z) {
+                                existingConfigNode = null;
+                                // Check the config nodes on n.z
+                                // TODO: pourquoi utiliser z au lieu de l'id ?
+                                for (var cn in configNodes) {
+                                    if (configNodes.hasOwnProperty(cn)) {
+                                        if (configNodes[cn].z === node.z && compareNodes(configNodes[cn], node, false)) {
+                                            existingConfigNode = configNodes[cn];
+                                            nodeMap[oldId] = configNodes[cn];
+                                            break;
+                                        }
                                     }
                                 }
                             }
                         }
                     }
-                    node_map[n.id] = node;
-                    // If an 'unknown' config node, it will not have been caught by the
-                    // proper config node handling, so needs adding to new_nodes here
-                    if (node.type === 'junction') {
-                        new_junctions.push(node)
-                    } else if (node.type === "unknown" || node._def.category !== "config") {
-                        new_nodes.push(node);
-                    } else if (node.type === "group") {
-                        new_groups.push(node);
-                        new_group_set.add(node.id);
-                    }
                 }
+                if (!existingConfigNode || existingConfigNode._def.exclusive) { //} || !compareNodes(existingConfigNode,n,true) || existingConfigNode.z !== n.z) {
+                    nodeMap[oldId] = copyConfigNode(node, def, options);
+                }
+                //nodeMap[oldId] = copyConfigNode(node, def, options);
+            // Node, Group, Junction or Subflow
+            } else if (def || node.type === "group") {
+                nodeMap[oldId] = copyNode(node, def, options);
+            // Unknown Node
+            } else {
+                // Config Node
+                if (!node.x && !node.y) {
+                    node._def = {
+                        category: "config",
+                        set: registry.getNodeSet("node-red/unknown")
+                    };
+                } else {
+                    node._def = {
+                        color: "#fee",
+                        defaults: {},
+                        label: "unknown: " + node.type,
+                        labelStyle: "red-ui-flow-node-label-italic",
+                        outputs: node.outputs ?? node.wires?.length ?? 0,
+                        set: registry.getNodeSet("node-red/unknown")
+                    };
+                }
+                const propertiesNotCopyable = ["x", "y", "z", "id", "wires"];
+                node._orig = Object.entries(node).reduce(function (orig, [prop, value]) {
+                    if (node.hasOwnProperty(prop) && !propertiesNotCopyable.includes(prop)) {
+                        orig[prop] = value;
+                    }
+                    return orig;
+                }, {});
+                node.name = node.type;
+                node.type = "unknown";
+                nodeMap[oldId] = node;
+            }
+
+            // Now the properties have been copied, change the `id` if it's a copy
+            if (createNewIds || options.importMap[oldId] === "copy") {
+                nodeMap[oldId].id = getID();
+            }
+
+            if (node.type === "junction") {
+                newJunctions.push(nodeMap[oldId])
+            } else if (node.type === "group") {
+                newGroups.push(nodeMap[oldId]);
+            } else {
+                newNodes.push(nodeMap[oldId]);
             }
         }
 
-        // Remap all wires and config node references
-        for (i=0;i<new_nodes.length+new_junctions.length;i++) {
-            if (i<new_nodes.length) {
-                n = new_nodes[i];
-            } else {
-                n = new_junctions[i - new_nodes.length]
+        // Update Users Count
+        // NOTE: the only reliable way to get the right number is to scan all the nodes
+        // Replacing a Config Node overwrites the list giving a wrong number
+        allNodes.eachNode(function (node) {
+            const def = registry.getNodeType(node.type);
+            if (def?.category === "config") {
+                node.users = [];
             }
-            if (n.wires) {
-                for (var w1=0;w1<n.wires.length;w1++) {
-                    var wires = (Array.isArray(n.wires[w1]))?n.wires[w1]:[n.wires[w1]];
-                    for (var w2=0;w2<wires.length;w2++) {
-                        if (node_map.hasOwnProperty(wires[w2])) {
-                            if (n.z === node_map[wires[w2]].z) {
-                                var link = {source:n,sourcePort:w1,target:node_map[wires[w2]]};
-                                addLink(link);
-                                new_links.push(link);
-                            } else {
-                                console.log("Warning: dropping link that crosses tabs:",n.id,"->",node_map[wires[w2]].id);
-                            }
+        });
+        allNodes.eachNode(function (node) {
+            // The event will be triggered after the import
+            updateConfigNodeUsers(node, { emitEvent: false });
+        });
+
+        const newLinks = [];
+        // Remap all wires and (Config) Node references
+        for (const node of [...newNodes, ...newGroups]) {
+            if (node.wires) {
+                for (const wiresGroup of node.wires) {
+                    const wires = Array.isArray(wiresGroup) ? wiresGroup : [wiresGroup];
+                    wires.forEach(function (wire) {
+                        // Skip if the wire is clinked to a non-existent node
+                        // TODO: Add warning message? Add RED.nodes.node() for same workspace?
+                        if (!nodeMap.hasOwnProperty(wire)) { return; }
+                        if (node.z === nodeMap[wire].z) {
+                            const link = { source: node, sourcePort: node.wires.indexOf(wiresGroup), target: nodeMap[wire] };
+                            addLink(link);
+                            newLinks.push(link);
+                        } else {
+                            console.log("Warning: dropping link that crosses tabs:", node.id, "->", nodeMap[wire].id);
                         }
-                    }
+                    });
                 }
-                delete n.wires;
+                delete node.wires;
             }
-            if (n.g && node_map[n.g]) {
-                n.g = node_map[n.g].id;
+
+            if (node.g && nodeMap[node.g]) {
+                node.g = nodeMap[node.g].id;
             } else {
-                delete n.g
+                delete node.g;
             }
-            for (var d3 in n._def.defaults) {
-                if (n._def.defaults.hasOwnProperty(d3)) {
-                    if (n._def.defaults[d3].type) {
-                        var nodeList = n[d3];
-                        if (!Array.isArray(nodeList)) {
-                            nodeList = [nodeList];
-                        }
-                        nodeList = nodeList.map(function(id) {
-                            var node = node_map[id];
-                            if (node) {
-                                if (node._def.category === 'config') {
-                                    if (node.users.indexOf(n) === -1) {
-                                        node.users.push(n);
-                                    }
-                                }
-                                return node.id;
-                            }
-                            return id;
-                        })
-                        n[d3] = Array.isArray(n[d3])?nodeList:nodeList[0];
-                    }
-                }
-            }
-            // If importing into a subflow, ensure an outbound-link doesn't
-            // get added
-            if (activeSubflow && /^link /.test(n.type) && n.links) {
-                n.links = n.links.filter(function(id) {
-                    const otherNode = node_map[id] || RED.nodes.node(id);
-                    return (otherNode && otherNode.z === activeWorkspace)
+
+            // If importing into a subflow, ensure an outbound-link doesn't get added
+            if (activeSubflow && /^link /.test(node.type) && node.links) {
+                node.links = node.links.filter(function (id) {
+                    const otherNode = nodeMap[id] || RED.nodes.node(id);
+                    return (otherNode?.z === activeWorkspace);
                 });
             }
+
+            // Update the old Node Id with the new one
+            for (const d in node._def.defaults) {
+                // Config Node, Node or Links (not sure)
+                if (node._def.defaults.hasOwnProperty(d) && node._def.defaults[d].type) {
+                    let nodeList = node[d];
+
+                    if (!Array.isArray(nodeList)) {
+                        nodeList = [nodeList];
+                    }
+                    nodeList = nodeList.map(function(id) {
+                        const n = nodeMap[id];
+                        if (n) {
+                            if (n._def.category === "config") {
+                                if (n.users.indexOf(node) === -1) {
+                                    n.users.push(node);
+                                }
+                            }
+                            return n.id;
+                        }
+                        return id;
+                    });
+
+                    node[d] = Array.isArray(node[d]) ? nodeList : nodeList[0];
+                }
+            }
         }
-        for (i=0;i<new_subflows.length;i++) {
-            n = new_subflows[i];
-            n.in.forEach(function(input) {
-                input.wires.forEach(function(wire) {
-                    var link = {source:input, sourcePort:0, target:node_map[wire.id]};
+
+        for (const subflow of newSubflows) {
+            subflow.in.forEach(function (input) {
+                input.wires.forEach(function (wire) {
+                    const link = { source: input, sourcePort: 0, target: nodeMap[wire.id] };
                     addLink(link);
-                    new_links.push(link);
+                    newLinks.push(link);
                 });
                 delete input.wires;
             });
-            n.out.forEach(function(output) {
-                output.wires.forEach(function(wire) {
-                    var link;
-                    if (subflow_map[wire.id] && subflow_map[wire.id].id == n.id) {
-                        link = {source:n.in[wire.port], sourcePort:wire.port,target:output};
+
+            subflow.out.forEach(function (output) {
+                output.wires.forEach(function (wire) {
+                    let link;
+                    if (subflowMap[wire.id] && subflowMap[wire.id].id === subflow.id) {
+                        link = { source: subflow.in[wire.port], sourcePort: wire.port, target: output };
                     } else {
-                        link = {source:node_map[wire.id]||subflow_map[wire.id], sourcePort:wire.port,target:output};
+                        link = { source: nodeMap[wire.id] || subflowMap[wire.id], sourcePort: wire.port, target: output };
                     }
                     addLink(link);
-                    new_links.push(link);
+                    newLinks.push(link);
                 });
                 delete output.wires;
             });
-            if (n.status) {
-                n.status.wires.forEach(function(wire) {
-                    var link;
-                    if (subflow_map[wire.id] && subflow_map[wire.id].id == n.id) {
-                        link = {source:n.in[wire.port], sourcePort:wire.port,target:n.status};
-                    } else {
-                        link = {source:node_map[wire.id]||subflow_map[wire.id], sourcePort:wire.port,target:n.status};
-                    }
-                    addLink(link);
-                    new_links.push(link);
-                });
-                delete n.status.wires;
+
+            subflow.status?.wires.forEach(function (wire) {
+                let link;
+                if (subflowMap[wire.id] && subflowMap[wire.id].id === subflow.id) {
+                    link = { source: subflow.in[wire.port], sourcePort: wire.port, target: subflow.status };
+                } else {
+                    link = { source: subflowMap[wire.id] || subflowMap[wire.id], sourcePort: wire.port, target: subflow.status };
+                }
+                addLink(link);
+                newLinks.push(link);
+            });
+
+            if (subflow.status) {
+                delete subflow.status.wires;
             }
         }
+
         // Order the groups to ensure they are outer-most to inner-most
         var groupDepthMap = {};
-        for (i=0;i<new_groups.length;i++) {
-            n = new_groups[i];
-
-            if (n.g && !new_group_set.has(n.g)) {
-                delete n.g;
+        const groupsId = newGroups.map(function (group) { return group.id; });
+        for (const group of newGroups) {
+            if (group.g && !groupsId.includes(group.g)) {
+                delete group.g;
             }
-            if (!n.g) {
-                groupDepthMap[n.id] = 0;
+            if (!group.g) {
+                groupDepthMap[group.id] = 0;
             }
         }
+
+        // TODO: C'est quoi ce brol ?
         var changedDepth;
         do {
             changedDepth = false;
-            for (i=0;i<new_groups.length;i++) {
-                n = new_groups[i];
+            for (let i=0;i<newGroups.length;i++) {
+                const n = newGroups[i];
                 if (n.g) {
                     if (groupDepthMap[n.id] !== groupDepthMap[n.g] + 1) {
                         groupDepthMap[n.id] = groupDepthMap[n.g] + 1;
@@ -2484,90 +2514,86 @@ RED.nodes = (function() {
             }
         } while(changedDepth);
 
-        new_groups.sort(function(A,B) {
-            return groupDepthMap[A.id] - groupDepthMap[B.id];
+        console.log("GROUP", groupDepthMap);
+
+        newGroups.sort(function(a, b) {
+            return (groupDepthMap[a.id] - groupDepthMap[b.id]);
         });
-        for (i=0;i<new_groups.length;i++) {
-            new_groups[i] = addGroup(new_groups[i]);
-            node_map[new_groups[i].id] = new_groups[i]
+
+        for (const index in newGroups) {
+            if (newGroups.hasOwnProperty(newGroups[index])) {
+                newGroups[index] = addGroup(newGroups[index]);
+                nodeMap[newGroups[index].id] = newGroups[index];
+            }
         }
 
-        for (i=0;i<new_junctions.length;i++) {
-            new_junctions[i] = addJunction(new_junctions[i]);
-            node_map[new_junctions[i].id] = new_junctions[i]
+        for (const index in newJunctions) {
+            if (newJunctions.hasOwnProperty(newJunctions[index])) {
+                newJunctions[index] = addJunction(newJunctions[index]);
+                nodeMap[newJunctions[index].id] = newJunctions[index];
+            }
         }
 
-
-        // Now the nodes have been fully updated, add them.
-        for (i=0;i<new_nodes.length;i++) {
-            new_nodes[i] = addNode(new_nodes[i])
-            node_map[new_nodes[i].id] = new_nodes[i]
+        // Now the nodes have been fully updated, add them as Proxy.
+        for (const index in newNodes) {
+            if (newNodes.hasOwnProperty(newNodes[index])) {
+                newNodes[index] = addNode(newNodes[index]);
+                nodeMap[newNodes[index].id] = newNodes[index];
+            }
         }
 
-        // Finally validate them all.
-        // This has to be done after everything is added so that any checks for
-        // dependent config nodes will pass
-        for (i=0;i<new_nodes.length;i++) {
-            var node = new_nodes[i];
+        // Finally validate all Nodes.
+        for (const node of newNodes) {
             RED.editor.validateNode(node);
         }
+
         const lookupNode = (id) => {
-            const mappedNode = node_map[id]
+            const mappedNode = nodeMap[id];
             if (!mappedNode) {
-                return null
+                return null;
             }
             if (mappedNode.__isProxy__) {
-                return mappedNode
+                return mappedNode;
             } else {
-                return node_map[mappedNode.id]
+                return nodeMap[mappedNode.id];
             }
-        }
+        };
+
         // Update groups to reference proxy node objects
-        for (i=0;i<new_groups.length;i++) {
-            n = new_groups[i];
+        for (const group of newGroups) {
             // bypass the proxy in case the flow is locked
-            n.__node__.nodes = n.nodes.map(lookupNode)
+            group.__node__.nodes = group.nodes.map(lookupNode);
             // Just in case the group references a node that doesn't exist for some reason
-            n.__node__.nodes = n.nodes.filter(function(v) {
-                if (v) {
+            group.__node__.nodes = group.nodes.filter(function (n) {
+                if (n) {
                     // Repair any nodes that have forgotten they are in this group
-                    if (v.g !== n.id) {
-                        v.g = n.id;
+                    if (n.g !== group.id) {
+                        n.g = group.id;
                     }
                 }
-                return !!v
+                return !!n;
             });
         }
 
         // Update links to use proxy node objects
-        for (i=0;i<new_links.length;i++) {
-            new_links[i].source = lookupNode(new_links[i].source.id) || new_links[i].source
-            new_links[i].target = lookupNode(new_links[i].target.id) || new_links[i].target
+        for (const link of newLinks) {
+            link.source = lookupNode(link.source.id) || link.source;
+            link.target = lookupNode(link.target.id) || link.target;
         }
 
+        // TODO: Right place?
         RED.workspaces.refresh();
 
-
-        if (recoveryWorkspace) {
-            var notification = RED.notify(RED._("clipboard.recoveredNodesNotification",{flowName:RED._("clipboard.recoveredNodes")}),{
-                type:"warning",
-                fixed:true,
-                buttons: [
-                    {text: RED._("common.label.close"), click: function() { notification.close() }}
-                ]
-            });
-        }
-
         return {
-            nodes:new_nodes,
-            links:new_links,
-            groups:new_groups,
-            junctions: new_junctions,
-            workspaces:new_workspaces,
-            subflows:new_subflows,
+            nodes: newNodes,
+            links: newLinks,
+            groups: newGroups,
+            junctions: newJunctions,
+            workspaces: newWorkspaces,
+            subflows: newSubflows,
             missingWorkspace: missingWorkspace,
             removedNodes: removedNodes
-        }
+        };
     }
 
     // TODO: supports filter.z|type
@@ -2633,7 +2659,10 @@ RED.nodes = (function() {
     }
 
     // Update any config nodes referenced by the provided node to ensure their 'users' list is correct
-    function updateConfigNodeUsers(n) {
+    function updateConfigNodeUsers(n, options) {
+        const defaultOptions = { emitEvent: true };
+        options = Object.assign({}, defaultOptions, options);
+
         for (var d in n._def.defaults) {
             if (n._def.defaults.hasOwnProperty(d)) {
                 var property = n._def.defaults[d];
@@ -2644,7 +2673,9 @@ RED.nodes = (function() {
                         if (configNode) {
                             if (configNode.users.indexOf(n) === -1) {
                                 configNode.users.push(n);
-                                RED.events.emit('nodes:change',configNode)
+                                if (options.emitEvent) {
+                                    RED.events.emit('nodes:change', configNode);
+                                }
                             }
                         }
                     }

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -681,6 +681,7 @@ RED.nodes = (function() {
             n.dirty = true;
             // TODO: The event should be triggered?
             updateConfigNodeUsers(n, { action: "add", emitEvent: false });
+            // TODO: What is this property used for?
             if (n._def.category == "subflows" && typeof n.i === "undefined") {
                 var nextId = 0;
                 RED.nodes.eachNode(function(node) {
@@ -1034,6 +1035,8 @@ RED.nodes = (function() {
             sf.name = subflowName;
         }
 
+        sf.instances = [];
+
         subflows[sf.id] = sf;
         allNodes.addTab(sf.id);
         linkTabMap[sf.id] = [];
@@ -1086,7 +1089,7 @@ RED.nodes = (function() {
                 module: "node-red"
             }
         });
-        sf.instances = [];
+
         sf._def = RED.nodes.getType("subflow:"+sf.id);
         RED.events.emit("subflows:add",sf);
     }
@@ -2195,7 +2198,7 @@ RED.nodes = (function() {
         let recoveryWorkspace = null;
         // Correct or update the z property of each node
         for (const node of originalNodes) {
-            const isConfigNode = !node.x && !node.y;
+            const isConfigNode = !node.hasOwnProperty("x") && !node.hasOwnProperty("y");
 
             // If it's the initial load, create a recovery workspace if any nodes don't have `node.z` and assign to it.
             if (!node.z && isInitialLoad && node.hasOwnProperty("x") && node.hasOwnProperty("y")) {
@@ -2283,20 +2286,40 @@ RED.nodes = (function() {
             // TODO: remove workspace in next release+1
             if (node.type === "workspace" || node.type === "tab" || node.type === "subflow") { continue; }
 
-            // Try to fix the node definition
+            // Get the Node definition
             let def = registry.getNodeType(node.type);
+
+            // Update the Node definition for Subflow instance
+            // TODO: A thing with `node.i`
+            if (node.type.substring(0, 7) === "subflow") {
+                const parentId = node.type.split(":")[1];
+                const subflow = subflowMap[parentId] || getSubflow(parentId);
+
+                // If the parent Subflow is not found, this Subflow will be marked as unknown
+                if (subflow) {
+                    if (createNewIds || options.importMap[node.id] === "copy") {
+                        node.type = "subflow:" + subflow.id;
+                        def = registry.getNodeType(node.type);
+                    }
+
+                    node.inputs = subflow.in.length;
+                    node.outputs = subflow.out.length;
+                }
+            }
+
             let isUnknownNode = false;
+            // Try to fix the node definition
             if (!def) {
                 // Group Node
                 if (node.type === "group") {
                     def = RED.group.def;
                 }
                 // Unknown Config Node
-                else if (!node.x && !node.y) {
+                else if (!node.hasOwnProperty("x") && !node.hasOwnProperty("y")) {
                     isUnknownNode = true;
                     def = {
                         category: "config",
-                        //defaults: {},
+                        defaults: {},
                         set: registry.getNodeSet("node-red/unknown")
                     };
                 // Unknown Node
@@ -2307,6 +2330,7 @@ RED.nodes = (function() {
                         defaults: {},
                         label: "unknown: " + node.type,
                         labelStyle: "red-ui-flow-node-label-italic",
+                        inputs: node.inputs ?? 0,   // TODO: Find if the node has an input
                         outputs: node.outputs ?? node.wires?.length ?? 0,
                         set: registry.getNodeSet("node-red/unknown")
                     };
@@ -2315,33 +2339,17 @@ RED.nodes = (function() {
 
             const isConfigNode = def?.category === "config";
 
-            // Update the node definition for subflow instance
-            // TODO: A thing with `node.i`
-            if (!isUnknownNode && node.type.substring(0, 7) === "subflow") {
-                const parentId = node.type.split(":")[1];
-                const subflow = subflowMap[parentId] || getSubflow(parentId);
-
-                if (createNewIds || options.importMap[node.id] === "copy") {
-                    node.type = "subflow:" + subflow.id;
-                    def = registry.getNodeType(node.type);
-                }
-
-                node.inputs = subflow.in.length;
-                node.outputs = subflow.out.length;
-            }
-
             // Now the properties have been fixed, copy the node properties:
-            // Config Node
+            // NOTE: If the Node def is unknown, user properties will not be copied
             if (isConfigNode) {
                 nodeMap[oldId] = copyConfigNode(node, def, options);
-            // Node, Group, Junction or Subflow
             } else {
+                // Node, Group, Junction or Subflow
                 nodeMap[oldId] = copyNode(node, def, options);
             }
 
-            // Unknown Node
-            // TODO: Error: Cannot find subflow defintion 148a957f98ce9770 used by subflow instance 6d7f8e702e60f976
-            if (isUnknownNode && !node.type.startsWith("subflow")) {
+            // Unknown Node - Copy user properties so that the node is always exportable
+            if (isUnknownNode) {
                 const propertiesNotCopyable = ["x", "y", "z", "id", "wires"];
                 nodeMap[oldId]._orig = Object.entries(node).reduce(function (orig, [prop, value]) {
                     if (node.hasOwnProperty(prop) && !propertiesNotCopyable.includes(prop)) {
@@ -2349,6 +2357,7 @@ RED.nodes = (function() {
                     }
                     return orig;
                 }, {});
+
                 nodeMap[oldId].name = node.type;
                 nodeMap[oldId].type = "unknown";
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -564,6 +564,11 @@ RED.nodes = (function() {
         return api;
     })()
 
+    /**
+     * Generates a random ID consisting of 8 bytes.
+     * 
+     * @returns {string} The generated ID.
+     */
     function generateId() {
         var bytes = [];
         for (var i=0;i<8;i++) {
@@ -1693,7 +1698,6 @@ RED.nodes = (function() {
         var newConfigNodes = {};
         var removedNodes = [];
         // Figure out what we're being asked to replace - subflows/configNodes
-        // TODO: config nodes
         newNodes.forEach(function(n) {
             if (n.type === "subflow") {
                 newSubflows[n.id] = n;
@@ -1795,10 +1799,11 @@ RED.nodes = (function() {
      * Analyzes the array of nodes passed as an argument to find unknown node types.
      *
      * Options:
-     * - `emitNotification` (boolean) - Emit an notification with unknown types.
+     * - `emitNotification` - Emit an notification with unknown types. Default false.
      *
+     * @remarks Throws an error to be handled.
      * @param {Array<object>} nodes An array of nodes to analyse
-     * @param {object} options An options object
+     * @param {{ emitNotification?: boolean; }} options An options object
      * @returns {Array<string>} An array with unknown types
      */
     function identifyUnknowType(nodes, options = {}) {
@@ -1828,6 +1833,13 @@ RED.nodes = (function() {
         return unknownTypes;
     }
 
+    /**
+     * Warns the user that the import contains existing nodes that the user need to resolve.
+     *
+     * @remarks Throws an error to be handled.
+     * @param {Array<object>} existingNodes An array containing conflicting nodes.
+     * @param {Array<object>} importedNodes An array containing all imported nodes.
+     */
     function emitExistingNodesNotification(existingNodes, importedNodes) {
         const errorMessage = RED._("clipboard.importDuplicate", { count: existingNodes.length });
         const maxItemCount = 5; // Max 5 items in the list
@@ -1852,6 +1864,15 @@ RED.nodes = (function() {
         throw existingNodesError;
     }
 
+    /**
+     * Makes a copy of the Config Node received as a parameter.
+     *
+     * @remarks Don't change the ID.
+     * @param {object} configNode The Config Node to copy.
+     * @param {object} def The Config Node definition.
+     * @param {object} options Same options as import
+     * @returns The new Config Node copied.
+     */
     function copyConfigNode(configNode, def, options = {}) {
         const newNode = {
             id: configNode.id,
@@ -1899,6 +1920,15 @@ RED.nodes = (function() {
         return newNode;
     }
 
+    /**
+     * Makes a copy of the Node received as a parameter.
+     *
+     * @remarks Don't change the ID.
+     * @param {object} node The Node to copy.
+     * @param {object} def The Node definition.
+     * @param {object} options Same options as import
+     * @returns The new Node copied.
+     */
     function copyNode(node, def, options = {}) {
         const newNode = {
             id: node.id,
@@ -2012,18 +2042,30 @@ RED.nodes = (function() {
     }
 
     /**
+     * Handles the import of nodes - these nodes can be copied, replaced or just imported.
+     *
      * Options:
-     *  - generateIds - whether to replace all node ids
-     *  - addFlow - whether to import nodes to a new tab
-     *  - markChanged - whether to set changed=true on all newly imported objects
-     *  - reimport - if node has a .z property, dont overwrite it
-     *               Only applicible when `generateIds` is false
-     *  - importMap - how to resolve any conflicts.
-     *       - id:import - import as-is
-     *       - id:copy - import with new id
-     *       - id:replace - import over the top of existing
+     *  - `addFlow` - whether to import nodes to a new tab. Default false.
+     *  - `generateIds` - whether to replace all node ids. Default false.
+     *  - `markChanged` - whether to set `changed` = true on all newly imported nodes.
+     *  - `reimport` - if node has a `z` property, dont overwrite it
+     *               Only applicible when `generateIds` is false. Default false.
+     *  - `importMap` - how to resolve any conflicts.
+     *       - nodeId: `import` - import as-is
+     *       - nodeId: `copy` - import with new id
+     *       - nodeId: `replace` - repace the existing
+     *
+     * @remarks Only Subflow definition (tab) and Config Node are replaceable!
+     *
+     * @typedef {string} NodeId
+     * @typedef {Record<NodeId, "copy" | "import" | "replace" | "skip">} ImportMap
+     *
+     * @param {string | object | Array<object>} originalNodes A node or array of nodes to import
+     * @param {{ addFlow?: boolean; generateIds?: boolean; importMap?: ImportMap; markChanged?: boolean;
+     * reimport?: boolean; }} options Options to involve on import.
+     * @returns An object containing all the elements created.
      */
-    function importNodes(originalNodes, options) {
+    function importNodes(originalNodes, options = {}) {
         const defaultOptions = { generateIds: false, addFlow: false, markChanged: false, reimport: false, importMap: {} };
         options = Object.assign({}, defaultOptions, options);
 
@@ -2073,6 +2115,11 @@ RED.nodes = (function() {
                     nodesToReplace.push(node);
                     return false;
                 }
+            }
+
+            // Ensure ignored nodes are not imported
+            if (options.importMap[id] === "skip") {
+                return false;
             }
 
             return true;
@@ -2653,30 +2700,40 @@ RED.nodes = (function() {
         return result;
     }
 
-    // Update any config nodes referenced by the provided node to ensure their 'users' list is correct
-    function updateConfigNodeUsers(n, options) {
+    /**
+     * Update any config nodes referenced by the provided node to ensure
+     * their 'users' list is correct.
+     *
+     * Options:
+     * - `action` - Add or remove the node from the Config Node users list. Default `add`.
+     * - `emitEvent` - Emit the `nodes:changes` event. Default true.
+     *
+     * @param {object} node The node in which to check if it contains references
+     * @param {{ action?: "add" | "remove"; emitEvent?: boolean; }} options Options to apply.
+     */
+    function updateConfigNodeUsers(node, options = {}) {
         const defaultOptions = { action: "add", emitEvent: true };
         options = Object.assign({}, defaultOptions, options);
 
-        for (var d in n._def.defaults) {
-            if (n._def.defaults.hasOwnProperty(d)) {
-                var property = n._def.defaults[d];
+        for (var d in node._def.defaults) {
+            if (node._def.defaults.hasOwnProperty(d)) {
+                var property = node._def.defaults[d];
                 if (property.type) {
                     var type = registry.getNodeType(property.type);
                     if (type && type.category == "config") {
-                        var configNode = configNodes[n[d]];
+                        var configNode = configNodes[node[d]];
                         if (configNode) {
                             if (options.action === "add") {
-                                if (configNode.users.indexOf(n) === -1) {
-                                    configNode.users.push(n);
+                                if (configNode.users.indexOf(node) === -1) {
+                                    configNode.users.push(node);
                                     if (options.emitEvent) {
                                         RED.events.emit('nodes:change', configNode);
                                     }
                                 }
                             } else if (options.action === "remove") {
-                                if (configNode.users.indexOf(n) !== -1) {
+                                if (configNode.users.indexOf(node) !== -1) {
                                     const users = configNode.users;
-                                    users.splice(users.indexOf(n), 1);
+                                    users.splice(users.indexOf(node), 1);
                                     if (options.emitEvent) {
                                         RED.events.emit('nodes:change', configNode);
                                     }
@@ -2952,88 +3009,110 @@ RED.nodes = (function() {
         }
     }
 
-    return {
-        init: function() {
-            RED.events.on("registry:node-type-added",function(type) {
-                var def = registry.getNodeType(type);
-                var replaced = false;
-                var replaceNodes = {};
-                RED.nodes.eachNode(function(n) {
-                    if (n.type === "unknown" && n.name === type) {
-                        replaceNodes[n.id] = n;
+    /**
+     * Finds unknown nodes of the same type and replaces them to update their
+     * definition.
+     *
+     * An imported node that has no definition is marked as unknown.
+     * When adding a new node type, this function searches for existing nodes
+     * of that type to update their definition.
+     *
+     * @param {string} type The type of the Node added
+     */
+    function onNodeTypeAdded(type) {
+        const nodesToReplace = [];
+        RED.nodes.eachConfig(function (node) {
+            if (node.type === "unknown" && node.name === type) {
+                nodesToReplace.push(node);
+            }
+        });
+
+        RED.nodes.eachNode(function (node) {
+            if (node.type === "unknown" && node.name === type) {
+                nodesToReplace.push(node);
+            }
+        });
+
+        // Skip if there is nothing to replace
+        if (!nodesToReplace.length) {
+            return;
+        }
+
+        const nodeGroupMap = {};
+        const removedNodes = [];
+        nodesToReplace.forEach(function (node) {
+            // Create a snapshot of the Node
+            removedNodes.push(convertNode(node));
+
+            // Remove the Node
+            removeNode(node);
+
+            // Reimporting a node *without* including its group object will cause
+            // the g property to be cleared. Cache it here so we can restore it.
+            if (node.g) {
+                nodeGroupMap[node.id] = node.g
+            }
+        });
+
+        const removedLinks = [];
+        const nodeMap = nodesToReplace.reduce(function (map, node) {
+            map[node.id] = node;
+            return map;
+        }, {});
+        // Remove any links between nodes that are going to be reimported.
+        // This prevents a duplicate link from being added.
+        RED.nodes.eachLink(function (link) {
+            if (nodeMap.hasOwnProperty(link.source.id) && nodeMap.hasOwnProperty(link.target.id)) {
+                removedLinks.push(link);
+            }
+        });
+
+        removedLinks.forEach(removeLink);
+
+        // Force the redraw to be synchronous so the view updates
+        // *now* and removes the unknown node
+        RED.view.redraw(true, true);
+
+        // Re-import removed nodes - now nodes have their definition
+        const result = importNodes(removedNodes, { generateIds: false, reimport: true });
+
+        const newNodeMap = {};
+        // Rattach the nodes to their group
+        result?.nodes.forEach(function (node) {
+            newNodeMap[node.id] = node;
+            if (nodeGroupMap[node.id]) {
+                // This node is in a group - need to substitute the
+                // node reference inside the group
+                node.g = nodeGroupMap[node.id];
+                const group = RED.nodes.group(node.g);
+                if (group) {
+                    const index = group.nodes.findIndex((g) => g.id === node.id);
+                    if (index > -1) {
+                        group.nodes[index] = node;
                     }
-                });
-                RED.nodes.eachConfig(function(n) {
-                    if (n.type === "unknown" && n.name === type) {
-                        replaceNodes[n.id] = n;
-                    }
-                });
-
-                const nodeGroupMap = {}
-                var replaceNodeIds = Object.keys(replaceNodes);
-                if (replaceNodeIds.length > 0) {
-                    var reimportList = [];
-                    replaceNodeIds.forEach(function(id) {
-                        var n = replaceNodes[id];
-                        if (configNodes.hasOwnProperty(n.id)) {
-                            delete configNodes[n.id];
-                        } else {
-                            allNodes.removeNode(n);
-                        }
-                        if (n.g) {
-                            // reimporting a node *without* including its group object
-                            // will cause the g property to be cleared. Cache it
-                            // here so we can restore it
-                            nodeGroupMap[n.id] = n.g
-                        }
-                        reimportList.push(convertNode(n));
-                        RED.events.emit('nodes:remove',n);
-                    });
-
-                    // Remove any links between nodes that are going to be reimported.
-                    // This prevents a duplicate link from being added.
-                    var removeLinks = [];
-                    RED.nodes.eachLink(function(l) {
-                        if (replaceNodes.hasOwnProperty(l.source.id) && replaceNodes.hasOwnProperty(l.target.id)) {
-                            removeLinks.push(l);
-                        }
-                    });
-                    removeLinks.forEach(removeLink);
-
-                    // Force the redraw to be synchronous so the view updates
-                    // *now* and removes the unknown node
-                    RED.view.redraw(true, true);
-                    var result = importNodes(reimportList,{generateIds:false, reimport: true});
-                    var newNodeMap = {};
-                    result.nodes.forEach(function(n) {
-                        newNodeMap[n.id] = n;
-                        if (nodeGroupMap[n.id]) {
-                            // This node is in a group - need to substitute the
-                            // node reference inside the group
-                            n.g = nodeGroupMap[n.id]
-                            const group = RED.nodes.group(n.g)
-                            if (group) {
-                                var index = group.nodes.findIndex(gn => gn.id === n.id)
-                                if (index > -1) {
-                                    group.nodes[index] = n
-                                }
-                            }
-                        }
-                    });
-                    RED.nodes.eachLink(function(l) {
-                        if (newNodeMap.hasOwnProperty(l.source.id)) {
-                            l.source = newNodeMap[l.source.id];
-                        }
-                        if (newNodeMap.hasOwnProperty(l.target.id)) {
-                            l.target = newNodeMap[l.target.id];
-                        }
-                    });
-                    RED.view.redraw(true);
                 }
+            }
+        });
+
+        // Relink nodes
+        RED.nodes.eachLink(function (link) {
+            if (newNodeMap.hasOwnProperty(link.source.id)) {
+                link.source = newNodeMap[link.source.id];
+            }
+            if (newNodeMap.hasOwnProperty(link.target.id)) {
+                link.target = newNodeMap[link.target.id];
+            }
+        });
+
+        RED.view.redraw(true);
+    }
+
+    return {
+        init: function () {
+            RED.events.on("registry:node-type-added", onNodeTypeAdded);
+            RED.events.on("deploy", function () {
+                allNodes.clearState();
             });
-            RED.events.on('deploy', function () {
-                allNodes.clearState()
-            })
         },
         registry:registry,
         setNodeList: registry.setNodeList,

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1806,6 +1806,7 @@ RED.nodes = (function() {
             id: configNode.id,
             z: configNode.z,
             type: configNode.type,
+            changed: false,
             icon: configNode.icon,
             info: configNode.info,
             label: def.label,
@@ -1854,8 +1855,8 @@ RED.nodes = (function() {
             y: parseFloat(node.y || 0),
             z: node.z,
             type: node.type,
-            info: node.info,
             changed: false,
+            info: node.info,
             _config: {},
             _def: def
         };
@@ -1865,9 +1866,6 @@ RED.nodes = (function() {
             newNode.inputLabels = node.inputLabels;
             newNode.outputLabels = node.outputLabels;
             newNode.icon = node.icon;
-        }
-        if (node.type === "junction") {
-            newNode.wires = node.wires || [];
         }
         if (node.hasOwnProperty("l")) {
             newNode.l = node.l;
@@ -1879,11 +1877,10 @@ RED.nodes = (function() {
             newNode.g = node.g;
         }
         if (options.markChanged) {
-            newNode.changed = true
+            newNode.changed = true;
         }
 
         if (node.type === "group") {
-            newNode._def = RED.group.def;
             for (const d in newNode._def.defaults) {
                 if (newNode._def.defaults.hasOwnProperty(d) && d !== "inputs" && d !== "outputs") {
                     newNode[d] = node[d];
@@ -1893,46 +1890,25 @@ RED.nodes = (function() {
             newNode._config.x = node.x;
             newNode._config.y = node.y;
             if (node.hasOwnProperty("w")) { // Weight
-                newNode.w = node.w
+                newNode.w = node.w;
             }
             if (node.hasOwnProperty("h")) { // Height
-                newNode.h = node.h
+                newNode.h = node.h;
             }
         } else if (node.type === "junction") {
             newNode._def = { defaults: {} };
-            newNode._config.x = node.x
-            newNode._config.y = node.y
-            newNode.inputs = 1
-            newNode.outputs = 1
+            newNode._config.x = node.x;
+            newNode._config.y = node.y;
+            newNode.wires = node.wires || [];
+            newNode.inputs = 1;
+            newNode.outputs = 1;
             newNode.w = 0;
             newNode.h = 0;
         } else if (node.type.substring(0, 7) === "subflow") {
-            const parentId = node.type.split(":")[1];
-            /*
-            const subflow = subflow_denylist[parentId]||subflow_map[parentId]||getSubflow(parentId);
-            // TODO: Pourquoi ne pas l'avoir mis dans les tabs ?
-            if (!subflow){
-                node._def = {
-                    color:"#fee",
-                    defaults: {},
-                    label: "unknown: "+n.type,
-                    labelStyle: "red-ui-flow-node-label-italic",
-                    outputs: n.outputs|| (n.wires && n.wires.length) || 0,
-                    set: registry.getNodeSet("node-red/unknown")
-                }
-            } else {
-                // TODO: Normal que la copie utilise le Subflow parent ?
-                if (subflow_denylist[parentId] || createNewIds || options.importMap[n.id] === "copy") {
-                    parentId = subflow.id;
-                    node.type = "subflow:"+parentId;
-                    node._def = registry.getNodeType(node.type);
-                    delete node.i;
-                }
-                node.name = n.name;
-                node.outputs = subflow.out.length;
-                node.inputs = subflow.in.length;
-                node.env = n.env;
-            }*/
+            newNode.name = node.name;
+            newNode.inputs = node.inputs;
+            newNode.outputs = node.outputs;
+            newNode.env = node.env;
         } else {
             newNode._config.x = node.x;
             newNode._config.y = node.y;
@@ -2001,7 +1977,7 @@ RED.nodes = (function() {
         options = Object.assign({}, defaultOptions, options);
 
         const createNewIds = options.generateIds;
-        const createMissingWorkspace = options.addFlow;
+        const createNewWorkspace = options.addFlow;
         const reimport = (!createNewIds && !!options.reimport);
 
         // Checks and converts nodes into an Array if necessary
@@ -2024,7 +2000,7 @@ RED.nodes = (function() {
         const existingNodes = [];
         const nodesToReplace = [];
         // Checks if the imported nodes contains duplicates or existing nodes.
-        originalNodes = originalNodes.filter(function(node) {
+        originalNodes = originalNodes.filter(function (node) {
             const id = node.id;
 
             // This is a temporary fix to help resolve corrupted flows caused by 0.20.0 where multiple
@@ -2077,14 +2053,13 @@ RED.nodes = (function() {
             throw existingNodesError;
         }
 
-        // TODO: check the z of the subflow instance and check _that_ if it exists
-        // TODO: Handled activeWorkspace = 0
         let activeWorkspace = RED.workspaces.active();
         const activeSubflow = getSubflow(activeWorkspace);
         for (const node of originalNodes) {
             const group = /^subflow:(.+)$/.exec(node.type);
             if (group) {
                 const subflowId = group[1];
+                // NOTE: activeWorkspace can be equal to 0 if it's the initial load
                 if (activeSubflow) {
                     let error;
                     if (subflowId === activeSubflow.id) {
@@ -2114,27 +2089,28 @@ RED.nodes = (function() {
             initialLoad = JSON.parse(JSON.stringify(originalNodes));
         }
 
-        const unknownTypes = identifyUnknowType(originalNodes, { emitNotification: isInitialLoad });
+        const unknownTypes = identifyUnknowType(originalNodes, { emitNotification: !isInitialLoad });
 
         const nodeZmap = {};
         let recoveryWorkspace = null;
-        let missingWorkspace = null;
+        // If it's the initial load, create a recovery workspace if any nodes don't have `node.z` and assign to it.
         for (const node of originalNodes) {
             if (node.z) {
                 nodeZmap[node.z] = nodeZmap[node.z] || [];
                 nodeZmap[node.z].push(node);
-            } else if (isInitialLoad && node.hasOwnProperty('x') && node.hasOwnProperty('y')) {
+            } else if (isInitialLoad && node.hasOwnProperty("x") && node.hasOwnProperty("y")) {
                 // Hit the rare issue where node z values get set to 0.
                 // Repair the flow - but we really need to track that down.
                 if (!recoveryWorkspace) {
                     recoveryWorkspace = {
-                        id: RED.nodes.id(),
+                        id: getID(),
                         type: "tab",
                         disabled: false,
                         label: RED._("clipboard.recoveredNodes"),
                         info: RED._("clipboard.recoveredNodesInfo"),
                         env: []
                     };
+
                     addWorkspace(recoveryWorkspace);
                     RED.workspaces.add(recoveryWorkspace);
                     nodeZmap[recoveryWorkspace.id] = [];
@@ -2144,9 +2120,6 @@ RED.nodes = (function() {
             }
         }
 
-        // TODO
-        const subflow_denylist = {};
-
         const newWorkspaces = [];
         if (recoveryWorkspace) {
             newWorkspaces.push(recoveryWorkspace);
@@ -2154,7 +2127,7 @@ RED.nodes = (function() {
                 type: "warning",
                 fixed: true,
                 buttons: [
-                    { text: RED._("common.label.close"), click: function() { notification.close(); } }
+                    { text: RED._("common.label.close"), click: function () { notification.close(); } }
                 ]
             });
         }
@@ -2162,6 +2135,7 @@ RED.nodes = (function() {
         const subflowMap = {};
         const workspaceMap = {};
         const newSubflows = [];
+        const subflowDenyList = {};
         // Find all tabs and subflow tabs and add it to workspace
         // NOTE: Subflow tab not the instance
         for (const node of originalNodes) {
@@ -2177,8 +2151,9 @@ RED.nodes = (function() {
                 if (defaultWorkspace == null) {
                     defaultWorkspace = node;
                 }
-                if (activeWorkspace === 0) {    // TODO: Why?
-                    activeWorkspace = node.id;
+                // If it is the initial load, the value is equal to 0
+                if (activeWorkspace === 0) {
+                    activeWorkspace = defaultWorkspace.id;
                 }
                 if (createNewIds || options.importMap[node.id] === "copy") {
                     node.id = getID();
@@ -2190,12 +2165,13 @@ RED.nodes = (function() {
             } else if (node.type === "subflow") {
                 let matchingSubflow;
 
-                // TODO: Toujours lié à node.z ?
+                // TODO: Si l'id est différent on devrait l'importer
                 if (!options.importMap[node.id]) {
                     matchingSubflow = checkForMatchingSubflow(node, nodeZmap[node.id]);
+                    console.log("SUBFLOW", matchingSubflow)
                 }
                 if (matchingSubflow) {
-                    subflow_denylist[node.id] = matchingSubflow;
+                    subflowDenyList[node.id] = matchingSubflow;
                 } else {
                     node.in.forEach(function(input, i) {
                         input.type = "subflow";
@@ -2233,40 +2209,71 @@ RED.nodes = (function() {
             addWorkspace(defaultWorkspace);
             RED.workspaces.add(defaultWorkspace);
             newWorkspaces.push(defaultWorkspace);
-            activeWorkspace = RED.workspaces.active();
+            activeWorkspace = defaultWorkspace.id;
         }
 
         const nodeMap = {};
         const newNodes = [];
         const newGroups = [];
         const newJunctions = [];
+        let newWorkspace = null;
         // Find all Config Nodes, Groups, Junctions, Nodes and Subflow instances and add them
         // NOTE: Replaced Config Nodes and Subflow instances no longer appear below
         for (const node of originalNodes) {
-            const def = registry.getNodeType(node.type);
-            const isConfigNode = def?.category === "config";
             const oldId = node.id;
 
             // TODO: remove workspace in next release+1
             if (node.type === "workspace" || node.type === "tab" || node.type === "subflow") { continue; }
 
-            // TODO: Fixes weird thing with `node.z`
+            // Try to fix the node definition
+            let def = registry.getNodeType(node.type);
+            let isUnknownNode = false;
+            if (!def) {
+                // Group Node
+                if (node.type === "group") {
+                    def = RED.group.def;
+                }
+                // Unknown Config Node
+                else if (!node.x && !node.y) {
+                    isUnknownNode = true;
+                    def = {
+                        category: "config",
+                        //defaults: {},
+                        set: registry.getNodeSet("node-red/unknown")
+                    };
+                // Unknown Node
+                } else {
+                    isUnknownNode = true;
+                    def = {
+                        color: "#fee",
+                        defaults: {},
+                        label: "unknown: " + node.type,
+                        labelStyle: "red-ui-flow-node-label-italic",
+                        outputs: node.outputs ?? node.wires?.length ?? 0,
+                        set: registry.getNodeSet("node-red/unknown")
+                    };
+                }
+            }
+
+            const isConfigNode = def?.category === "config";
+
+            // Fix `node.z` for undefined/not found/new one case
             if (createNewIds || options.importMap[oldId] === "copy") {
                 // Config Node can have an undefined `node.z`
                 if (!isConfigNode || (isConfigNode && node.z)) {
-                    if (subflow_denylist[node.z]) {
+                    if (subflowDenyList[node.z]) {
                         continue;
                     } else if (subflowMap[node.z]) {
                         node.z = subflowMap[node.z].id;
                     } else {
                         node.z = workspaceMap[node.z];
                         if (!workspaces[node.z]) {
-                            if (createMissingWorkspace) {
-                                if (missingWorkspace === null) {
-                                    missingWorkspace = RED.workspaces.add(null, true);
-                                    newWorkspaces.push(missingWorkspace);
+                            if (createNewWorkspace) {
+                                if (newWorkspace === null) {
+                                    newWorkspace = RED.workspaces.add(null, true);
+                                    newWorkspaces.push(newWorkspace);
                                 }
-                                node.z = missingWorkspace.id;
+                                node.z = newWorkspace.id;
                             } else {
                                 node.z = activeWorkspace;
                             }
@@ -2279,18 +2286,33 @@ RED.nodes = (function() {
                 if (isConfigNode && !keepNodesCurrentZ && node.z && !workspaceMap[node.z] && !subflowMap[node.z]) {
                     node.z = activeWorkspace;
                 } else if (!isConfigNode && !keepNodesCurrentZ && (node.z == null || (!workspaceMap[node.z] && !subflowMap[node.z]))) {
-                    // TODO: Encore ?
-                    if (createMissingWorkspace) {
-                        if (missingWorkspace === null) {
-                            missingWorkspace = RED.workspaces.add(null,true);
-                            newWorkspaces.push(missingWorkspace);
+                    if (createNewWorkspace) {
+                        if (newWorkspace === null) {
+                            newWorkspace = RED.workspaces.add(null,true);
+                            newWorkspaces.push(newWorkspace);
                         }
-                        node.z = missingWorkspace.id;
+                        node.z = newWorkspace.id;
                     } else {
                         node.z = activeWorkspace;
                     }
                 }
             }
+
+            // Update the node definition for subflow instance
+            if (!isUnknownNode && node.type.substring(0, 7) === "subflow") {
+                const parentId = node.type.split(":")[1];
+                const subflow = subflowDenyList[parentId] || subflowMap[parentId] || getSubflow(parentId);
+
+                if (subflowDenyList[parentId] || createNewIds || options.importMap[node.id] === "copy") {
+                    node.type = "subflow:" + subflow.id;
+                    def = registry.getNodeType(node.type);
+                }
+
+                node.inputs = subflow.in.length;
+                node.outputs = subflow.out.length;
+            }
+
+            // Now the properties have been corrected, copy the node properties:
 
             // Config Node
             if (isConfigNode) {
@@ -2320,41 +2342,26 @@ RED.nodes = (function() {
                 if (!existingConfigNode || existingConfigNode._def.exclusive) { //} || !compareNodes(existingConfigNode,n,true) || existingConfigNode.z !== n.z) {
                     nodeMap[oldId] = copyConfigNode(node, def, options);
                 }
-                //nodeMap[oldId] = copyConfigNode(node, def, options);
             // Node, Group, Junction or Subflow
-            } else if (def || node.type === "group") {
-                nodeMap[oldId] = copyNode(node, def, options);
-            // Unknown Node
             } else {
-                // Config Node
-                if (!node.x && !node.y) {
-                    node._def = {
-                        category: "config",
-                        set: registry.getNodeSet("node-red/unknown")
-                    };
-                } else {
-                    node._def = {
-                        color: "#fee",
-                        defaults: {},
-                        label: "unknown: " + node.type,
-                        labelStyle: "red-ui-flow-node-label-italic",
-                        outputs: node.outputs ?? node.wires?.length ?? 0,
-                        set: registry.getNodeSet("node-red/unknown")
-                    };
-                }
+                nodeMap[oldId] = copyNode(node, def, options);
+            }
+
+            // Unknown Node
+            // TODO: Error: Cannot find subflow defintion 148a957f98ce9770 used by subflow instance 6d7f8e702e60f976
+            if (isUnknownNode && !node.type.startsWith("subflow")) {
                 const propertiesNotCopyable = ["x", "y", "z", "id", "wires"];
-                node._orig = Object.entries(node).reduce(function (orig, [prop, value]) {
+                nodeMap[oldId]._orig = Object.entries(node).reduce(function (orig, [prop, value]) {
                     if (node.hasOwnProperty(prop) && !propertiesNotCopyable.includes(prop)) {
                         orig[prop] = value;
                     }
                     return orig;
                 }, {});
-                node.name = node.type;
-                node.type = "unknown";
-                nodeMap[oldId] = node;
+                nodeMap[oldId].name = node.type;
+                nodeMap[oldId].type = "unknown";
             }
 
-            // Now the properties have been copied, change the `id` if it's a copy
+            // Now the node has been copied, change the `id` if it's a copy
             if (createNewIds || options.importMap[oldId] === "copy") {
                 nodeMap[oldId].id = getID();
             }
@@ -2445,6 +2452,7 @@ RED.nodes = (function() {
             }
         }
 
+        // Add Links to Workspace
         for (const subflow of newSubflows) {
             subflow.in.forEach(function (input) {
                 input.wires.forEach(function (wire) {
@@ -2486,38 +2494,38 @@ RED.nodes = (function() {
         }
 
         // Order the groups to ensure they are outer-most to inner-most
-        var groupDepthMap = {};
+
+        const groupDepthMap = {};
         const groupsId = newGroups.map(function (group) { return group.id; });
         for (const group of newGroups) {
+            // Delete the group if it is not part of the import
             if (group.g && !groupsId.includes(group.g)) {
                 delete group.g;
             }
+            // If the group does not contain a group, it's the outer-most
             if (!group.g) {
                 groupDepthMap[group.id] = 0;
             }
         }
 
-        // TODO: C'est quoi ce brol ?
-        var changedDepth;
+        let changedDepth;
         do {
             changedDepth = false;
-            for (let i=0;i<newGroups.length;i++) {
-                const n = newGroups[i];
-                if (n.g) {
-                    if (groupDepthMap[n.id] !== groupDepthMap[n.g] + 1) {
-                        groupDepthMap[n.id] = groupDepthMap[n.g] + 1;
+            for (const group of newGroups) {
+                if (group.g) {
+                    if (groupDepthMap[group.id] !== groupDepthMap[group.g] + 1) {
+                        groupDepthMap[group.id] = groupDepthMap[group.g] + 1;
                         changedDepth = true;
                     }
                 }
             }
         } while(changedDepth);
 
-        console.log("GROUP", groupDepthMap);
-
-        newGroups.sort(function(a, b) {
+        newGroups.sort(function (a, b) {
             return (groupDepthMap[a.id] - groupDepthMap[b.id]);
         });
 
+        // Add Groups to Workspace
         for (const index in newGroups) {
             if (newGroups.indexOf(newGroups[index]) !== -1) {
                 newGroups[index] = addGroup(newGroups[index]);
@@ -2525,6 +2533,7 @@ RED.nodes = (function() {
             }
         }
 
+        // Add Junctions to Workspace
         for (const index in newJunctions) {
             if (newJunctions.indexOf(newJunctions[index]) !== -1) {
                 newJunctions[index] = addJunction(newJunctions[index]);
@@ -2589,7 +2598,7 @@ RED.nodes = (function() {
             junctions: newJunctions,
             workspaces: newWorkspaces,
             subflows: newSubflows,
-            missingWorkspace: missingWorkspace,
+            missingWorkspace: newWorkspace,
             removedNodes: removedNodes
         };
     }

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2142,7 +2142,7 @@ RED.nodes = (function() {
                     nodeZmap[recoveryWorkspace.id] = [];
                 }
                 node.z = recoveryWorkspace.id;
-                nodeZmap[recoveryWorkspace.id].push(node);
+                nodeZmap[node.z].push(node);
             }
         }
 
@@ -2385,14 +2385,14 @@ RED.nodes = (function() {
         });
 
         const newLinks = [];
-        // Remap all wires and (Config) Node references
+        // Remap all Wires and (Config) Node references
         for (const node of [...newNodes, ...newGroups]) {
             if (node.wires) {
                 for (const wiresGroup of node.wires) {
                     const wires = Array.isArray(wiresGroup) ? wiresGroup : [wiresGroup];
                     wires.forEach(function (wire) {
                         // Skip if the wire is clinked to a non-existent node
-                        // TODO: Add warning message? Add RED.nodes.node() for same workspace?
+                        // TODO: Add warning message?
                         if (!nodeMap.hasOwnProperty(wire)) { return; }
                         if (node.z === nodeMap[wire].z) {
                             const link = { source: node, sourcePort: node.wires.indexOf(wiresGroup), target: nodeMap[wire] };
@@ -2521,14 +2521,14 @@ RED.nodes = (function() {
         });
 
         for (const index in newGroups) {
-            if (newGroups.hasOwnProperty(newGroups[index])) {
+            if (newGroups.indexOf(newGroups[index]) !== -1) {
                 newGroups[index] = addGroup(newGroups[index]);
                 nodeMap[newGroups[index].id] = newGroups[index];
             }
         }
 
         for (const index in newJunctions) {
-            if (newJunctions.hasOwnProperty(newJunctions[index])) {
+            if (newJunctions.indexOf(newJunctions[index]) !== -1) {
                 newJunctions[index] = addJunction(newJunctions[index]);
                 nodeMap[newJunctions[index].id] = newJunctions[index];
             }
@@ -2536,7 +2536,7 @@ RED.nodes = (function() {
 
         // Now the nodes have been fully updated, add them as Proxy.
         for (const index in newNodes) {
-            if (newNodes.hasOwnProperty(newNodes[index])) {
+            if (newNodes.indexOf(newNodes[index]) !== -1) {
                 newNodes[index] = addNode(newNodes[index]);
                 nodeMap[newNodes[index].id] = newNodes[index];
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1728,6 +1728,7 @@ RED.nodes = (function() {
             // Remove the old subflow definition - but leave the instances in place
             var removalResult = RED.subflow.removeSubflow(n.id, true);
             // Create the list of nodes for the new subflow def
+            // Need to sort the list in order to remove missing nodes
             var subflowNodes = [n].concat(zMap[n.id]).filter((s) => !!s);
             // Import the new subflow - no clashes should occur as we've removed
             // the old version
@@ -1765,9 +1766,20 @@ RED.nodes = (function() {
         // Replace config nodes
         //
         configNodeIds.forEach(function(id) {
-            removedNodes = removedNodes.concat(convertNode(getNode(id)));
+            const configNode = getNode(id);
+            const currentUserCount = configNode.users;
+
+            // Add a snapshot of the Config Node
+            removedNodes = removedNodes.concat(convertNode(configNode));
+
+            // Remove the Config Node instance
             removeNode(id);
-            importNodes([newConfigNodes[id]])
+
+            // Import the new one
+            importNodes([newConfigNodes[id]]);
+
+            // Re-attributes the user count
+            getNode(id).users = currentUserCount;
         });
 
         return {

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1895,7 +1895,7 @@ RED.nodes = (function() {
             newNode.changed = true;
         }
 
-        if (configNode.hasOwnProperty("d")) {
+        if (configNode.hasOwnProperty("d")) {   // Disabled
             newNode.d = configNode.d;
         }
 
@@ -1948,10 +1948,10 @@ RED.nodes = (function() {
             newNode.outputLabels = node.outputLabels;
             newNode.icon = node.icon;
         }
-        if (node.hasOwnProperty("l")) {
+        if (node.hasOwnProperty("l")) { // Label (show/hide)
             newNode.l = node.l;
         }
-        if (node.hasOwnProperty("d")) {
+        if (node.hasOwnProperty("d")) { // Disabled
             newNode.d = node.d;
         }
         if (node.hasOwnProperty("g")) { // Group
@@ -3045,7 +3045,13 @@ RED.nodes = (function() {
             removedNodes.push(convertNode(node));
 
             // Remove the Node
-            removeNode(node);
+            // NOTE: DON'T use removeNode - no need for everything that is done there.
+            // Just delete the node because we re-import it as is afterwards.
+            if (configNodes.hasOwnProperty(node.id)) {
+                delete configNodes[node.id];
+            } else {
+                allNodes.removeNode(node);
+            }
 
             // Reimporting a node *without* including its group object will cause
             // the g property to be cleared. Cache it here so we can restore it.

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1386,7 +1386,7 @@ RED.nodes = (function() {
             var wires = links.filter(function(d) { return d.source === p });
             for (var i=0;i<wires.length;i++) {
                 var w = wires[i];
-                if (w?.target && w.target.type != "subflow") {
+                if (w.target.type != "subflow") {
                     nIn.wires.push({id:w.target.id})
                 }
             }
@@ -2422,12 +2422,13 @@ RED.nodes = (function() {
 
         // Add Links to Workspace
         for (const subflow of newSubflows) {
-            // TODO: Handled missing node
             subflow.in.forEach(function (input) {
                 input.wires.forEach(function (wire) {
-                    const link = { source: input, sourcePort: 0, target: nodeMap[wire.id] };
-                    addLink(link);
-                    newLinks.push(link);
+                    if (nodeMap.hasOwnProperty(wire.id)) {
+                        const link = { source: input, sourcePort: 0, target: nodeMap[wire.id] };
+                        addLink(link);
+                        newLinks.push(link);
+                    }
                 });
                 delete input.wires;
             });
@@ -2437,11 +2438,14 @@ RED.nodes = (function() {
                     let link;
                     if (subflowMap[wire.id] && subflowMap[wire.id].id === subflow.id) {
                         link = { source: subflow.in[wire.port], sourcePort: wire.port, target: output };
-                    } else {
+                    } else if (nodeMap.hasOwnProperty(wire.id) || subflowMap.hasOwnProperty(wire.id)) {
                         link = { source: nodeMap[wire.id] || subflowMap[wire.id], sourcePort: wire.port, target: output };
                     }
-                    addLink(link);
-                    newLinks.push(link);
+
+                    if (link) {
+                        addLink(link);
+                        newLinks.push(link);
+                    }
                 });
                 delete output.wires;
             });
@@ -2450,11 +2454,14 @@ RED.nodes = (function() {
                 let link;
                 if (subflowMap[wire.id] && subflowMap[wire.id].id === subflow.id) {
                     link = { source: subflow.in[wire.port], sourcePort: wire.port, target: subflow.status };
-                } else {
-                    link = { source: subflowMap[wire.id] || subflowMap[wire.id], sourcePort: wire.port, target: subflow.status };
+                } else if (nodeMap.hasOwnProperty(wire.id) || subflowMap.hasOwnProperty(wire.id)) {
+                    link = { source: nodeMap[wire.id] || subflowMap[wire.id], sourcePort: wire.port, target: subflow.status };
                 }
-                addLink(link);
-                newLinks.push(link);
+
+                if (link) {
+                    addLink(link);
+                    newLinks.push(link);
+                }
             });
 
             if (subflow.status) {

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1764,6 +1764,33 @@ RED.nodes = (function() {
 
     }
 
+    function identifyUnknowType(nodes, options = {}) {
+        const unknownTypes = [];
+        for (let node of nodes) {
+            // TODO: remove workspace in next release+1
+            const knowTypes = ["workspace", "tab", "subflow", "group", "junction"];
+
+            if (!knowTypes.includes(node.type) &&
+                node.type.substring(0, 8) != "subflow:" &&
+                !registry.getNodeType(node.type) &&
+                !unknownTypes.includes(node.type)) {
+                    unknownTypes.push(node.type);
+            }
+        }
+
+        if (options.emitNotification && unknownTypes.length) {
+            const typeList = $("<ul>");
+            unknownTypes.forEach(function(type) {
+                $("<li>").text(type).appendTo(typeList);
+            });
+
+            RED.notify(
+                "<p>" + RED._("clipboard.importUnrecognised", {count: unknownTypes.length }) + "</p>" + typeList[0].outerHTML,
+                "error", false, 10000);
+        }
+        return unknownTypes;
+    }
+
     /**
      * Options:
      *  - generateIds - whether to replace all node ids
@@ -1776,119 +1803,131 @@ RED.nodes = (function() {
      *       - id:copy - import with new id
      *       - id:replace - import over the top of existing
      */
-    function importNodes(newNodesObj,options) { // createNewIds,createMissingWorkspace) {
-        const defOpts = { generateIds: false, addFlow: false, markChanged: false, reimport: false, importMap: {} }
-        options = Object.assign({}, defOpts, options)
-        options.importMap = options.importMap || {}
+    function importNodes(newNodes, options) {
+        const defaultOptions = { generateIds: false, addFlow: false, markChanged: false, reimport: false, importMap: {} };
+        options = Object.assign({}, defaultOptions, options);
+
         const createNewIds = options.generateIds;
-        const reimport = (!createNewIds && !!options.reimport)
         const createMissingWorkspace = options.addFlow;
-        var i;
-        var n;
-        var newNodes;
-        var nodeZmap = {};
-        var recoveryWorkspace;
-        if (typeof newNodesObj === "string") {
-            if (newNodesObj === "") {
-                return;
-            }
+        const reimport = (!createNewIds && !!options.reimport);
+
+        // Checks and converts the flow into an Array if necessary
+        if (typeof newNodes === "string") {
+            if (newNodes === "") { return; }
             try {
-                newNodes = JSON.parse(newNodesObj);
+                newNodes = JSON.parse(newNodes);
             } catch(err) {
-                var e = new Error(RED._("clipboard.invalidFlow",{message:err.message}));
-                e.code = "NODE_RED";
-                throw e;
+                const error = new Error(RED._("clipboard.invalidFlow", { message: err.message }));
+                error.code = "NODE_RED";
+                throw error;
             }
-        } else {
-            newNodes = newNodesObj;
         }
 
         if (!Array.isArray(newNodes)) {
             newNodes = [newNodes];
         }
 
-        // Scan for any duplicate nodes and remove them. This is a temporary
-        // fix to help resolve corrupted flows caused by 0.20.0 where multiple
-        // copies of the flow would get loaded at the same time.
-        // If the user hit deploy they would have saved those duplicates.
-        var seenIds = {};
-        var existingNodes = [];
-        var nodesToReplace = [];
+        const seenIds = new Set();
+        const existingNodes = [];
+        const nodesToReplace = [];
+        // Checks if the imported flow contains duplicates or existing nodes.
+        newNodes = newNodes.filter(function(node) {
+            const id = node.id;
 
-        newNodes = newNodes.filter(function(n) {
-            var id = n.id;
-            if (seenIds[n.id]) {
-                return false;
-            }
-            seenIds[n.id] = true;
+            // This is a temporary fix to help resolve corrupted flows caused by 0.20.0 where multiple
+            // copies of the flow would get loaded at the same time.
+            // NOTE: Generally it is the last occurrence which is kept but not here.
+            if (seenIds.has(id)) { return false; }
+            seenIds.add(id);
 
-            if (!options.generateIds) {
+            // Checks if the node already exists - the user will choose between copying the node or replacing it
+            if (!createNewIds) {
                 if (!options.importMap[id]) {
                     // No conflict resolution for this node
-                    var existing = allNodes.getNode(id) || configNodes[id] || workspaces[id] || subflows[id] || groups[id] || junctions[id];
-                    if (existing) {
-                        existingNodes.push({existing:existing, imported:n});
+                    const existingNode = allNodes.getNode(id) || configNodes[id] || workspaces[id] || subflows[id] || groups[id] || junctions[id];
+                    if (existingNode) {
+                        existingNodes.push({ existing: existingNode, imported: node });
                     }
                 } else if (options.importMap[id] === "replace") {
-                    nodesToReplace.push(n);
+                    nodesToReplace.push(node);
                     return false;
                 }
             }
 
             return true;
-        })
+        });
 
-        if (existingNodes.length > 0) {
-            var errorMessage = RED._("clipboard.importDuplicate",{count:existingNodes.length});
-            var nodeList = $("<ul>");
-            var existingNodesCount = Math.min(5,existingNodes.length);
-            for (var i=0;i<existingNodesCount;i++) {
-                var conflict = existingNodes[i];
-                $("<li>").text(
-                    conflict.existing.id+
-                    " [ "+conflict.existing.type+ ((conflict.imported.type !== conflict.existing.type)?" | "+conflict.imported.type:"")+" ]").appendTo(nodeList)
-            }
-            if (existingNodesCount !== existingNodes.length) {
-                $("<li>").text(RED._("deploy.confirm.plusNMore",{count:existingNodes.length-existingNodesCount})).appendTo(nodeList)
-            }
-            var wrapper = $("<p>").append(nodeList);
+        // If some nodes already exists, ask the user for each node to choose between copying it or replacing it
+        if (existingNodes.length) {
+            const errorMessage = RED._("clipboard.importDuplicate",{ count: existingNodes.length });
+            const maxItemCount = 5; // Max 5 items in the list
+            const nodeList = $("<ul>");
 
-            var existingNodesError = new Error(errorMessage+wrapper.html());
+            let itemCount = 0;
+            for (let { existing, imported } of existingNodes) {
+                if (itemCount >= maxItemCount) { break; }
+                const conflictType = (imported.type !== existing.type) ? " | " + imported.type : "";
+                $("<li>").text(existing.id + " [ " + existing.type + conflictType + " ]").appendTo(nodeList);
+                itemCount++;
+            }
+
+            if (existingNodes.length > maxItemCount) {
+                $("<li>").text(RED._("deploy.confirm.plusNMore", {count: (existingNodes.length - maxItemCount) })).appendTo(nodeList);
+            }
+
+            const wrapper = $("<p>").append(nodeList);
+            const existingNodesError = new Error(errorMessage + wrapper.html());
             existingNodesError.code = "import_conflict";
             existingNodesError.importConfig = identifyImportConflicts(newNodes);
             throw existingNodesError;
         }
-        var removedNodes;
-        if (nodesToReplace.length > 0) {
-            var replaceResult = replaceNodes(nodesToReplace);
-            removedNodes = replaceResult.removedNodes;
+
+        // TODO: check the z of the subflow instance and check _that_ if it exists
+        // TODO: Handled activeWorkspace = 0
+        let activeWorkspace = RED.workspaces.active();
+        const activeSubflow = getSubflow(activeWorkspace);
+        for (let node of newNodes) {
+            const group = /^subflow:(.+)$/.exec(node.type);
+            if (group) {
+                const subflowId = group[1];
+                if (activeSubflow) {
+                    let error;
+                    if (subflowId === activeSubflow.id) {
+                        error = new Error(RED._("notification.errors.cannotAddSubflowToItself"));
+                    } else if (subflowContains(subflowId, activeSubflow.id)) {
+                        error = new Error(RED._("notification.errors.cannotAddCircularReference"));
+                    }
+                    if (error) {
+                        // TODO: standardise error codes
+                        error.code = "NODE_RED";
+                        throw error;
+                    }
+                }
+            }
         }
 
+        const removedNodes = [];
+        // Now that the user has made his choice, replace the nodes that need to be replaced.
+        if (nodesToReplace.length > 0) {
+            const result = replaceNodes(nodesToReplace);
+            removedNodes.concat(result.removedNodes);
+        }
 
-        var isInitialLoad = false;
+        let isInitialLoad = false;
         if (!initialLoad) {
             isInitialLoad = true;
             initialLoad = JSON.parse(JSON.stringify(newNodes));
         }
-        var unknownTypes = [];
-        for (i=0;i<newNodes.length;i++) {
-            n = newNodes[i];
-            var id = n.id;
-            // TODO: remove workspace in next release+1
-            if (n.type != "workspace" &&
-                n.type != "tab" &&
-                n.type != "subflow" &&
-                n.type != "group" &&
-                n.type != 'junction' &&
-                !registry.getNodeType(n.type) &&
-                n.type.substring(0,8) != "subflow:" &&
-                unknownTypes.indexOf(n.type)==-1) {
-                    unknownTypes.push(n.type);
-            }
-            if (n.z) {
-                nodeZmap[n.z] = nodeZmap[n.z] || [];
-                nodeZmap[n.z].push(n);
-            } else if (isInitialLoad && n.hasOwnProperty('x') && n.hasOwnProperty('y') && !n.z) {
+       
+        const unknownTypes = identifyUnknowType(newNodes, { emitNotification: isInitialLoad });
+
+        const nodeZmap = {};
+        let recoveryWorkspace;
+        for (let node of newNodes) {
+            if (node.z) {
+                nodeZmap[node.z] = nodeZmap[node.z] || [];
+                nodeZmap[node.z].push(node);
+            } else if (isInitialLoad && node.hasOwnProperty('x') && node.hasOwnProperty('y') && !node.z) {
                 // Hit the rare issue where node z values get set to 0.
                 // Repair the flow - but we really need to track that down.
                 if (!recoveryWorkspace) {
@@ -1899,49 +1938,20 @@ RED.nodes = (function() {
                         label: RED._("clipboard.recoveredNodes"),
                         info: RED._("clipboard.recoveredNodesInfo"),
                         env: []
-                    }
+                    };
                     addWorkspace(recoveryWorkspace);
                     RED.workspaces.add(recoveryWorkspace);
                     nodeZmap[recoveryWorkspace.id] = [];
                 }
-                n.z = recoveryWorkspace.id;
-                nodeZmap[recoveryWorkspace.id].push(n);
-            }
-
-        }
-        if (!isInitialLoad && unknownTypes.length > 0) {
-            var typeList = $("<ul>");
-            unknownTypes.forEach(function(t) {
-                $("<li>").text(t).appendTo(typeList);
-            })
-            typeList = typeList[0].outerHTML;
-            RED.notify("<p>"+RED._("clipboard.importUnrecognised",{count:unknownTypes.length})+"</p>"+typeList,"error",false,10000);
-        }
-
-        var activeWorkspace = RED.workspaces.active();
-        //TODO: check the z of the subflow instance and check _that_ if it exists
-        var activeSubflow = getSubflow(activeWorkspace);
-        for (i=0;i<newNodes.length;i++) {
-            var m = /^subflow:(.+)$/.exec(newNodes[i].type);
-            if (m) {
-                var subflowId = m[1];
-                var parent = getSubflow(activeWorkspace);
-                if (parent) {
-                    var err;
-                    if (subflowId === parent.id) {
-                        err = new Error(RED._("notification.errors.cannotAddSubflowToItself"));
-                    }
-                    if (subflowContains(subflowId,parent.id)) {
-                        err = new Error(RED._("notification.errors.cannotAddCircularReference"));
-                    }
-                    if (err) {
-                        // TODO: standardise error codes
-                        err.code = "NODE_RED";
-                        throw err;
-                    }
-                }
+                node.z = recoveryWorkspace.id;
+                nodeZmap[recoveryWorkspace.id].push(node);
             }
         }
+
+    
+        var i;
+        var n;
+
 
         var new_workspaces = [];
         var workspace_map = {};

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -564,7 +564,7 @@ RED.nodes = (function() {
         return api;
     })()
 
-    function getID() {
+    function generateId() {
         var bytes = [];
         for (var i=0;i<8;i++) {
             bytes.push(Math.round(0xff*Math.random()).toString(16).padStart(2,'0'));
@@ -2124,7 +2124,7 @@ RED.nodes = (function() {
                     activeWorkspace = defaultWorkspace.id;
                 }
                 if (createNewIds || options.importMap[node.id] === "copy") {
-                    node.id = getID();
+                    node.id = generateId();
                 }
                 addWorkspace(node);
                 workspaceMap[oldId] = node.id;
@@ -2136,23 +2136,23 @@ RED.nodes = (function() {
                     input.direction = "in";
                     input.z = node.id;
                     input.i = i;
-                    input.id = getID();
+                    input.id = generateId();
                 });
                 node.out.forEach(function(output, i) {
                     output.type = "subflow";
                     output.direction = "out";
                     output.z = node.id;
                     output.i = i;
-                    output.id = getID();
+                    output.id = generateId();
                 });
                 if (node.status) {
                     node.status.type = "subflow";
                     node.status.direction = "status";
                     node.status.z = node.id;
-                    node.status.id = getID();
+                    node.status.id = generateId();
                 }
                 if (createNewIds || options.importMap[node.id] === "copy") {
-                    node.id = getID();
+                    node.id = generateId();
                 }
                 subflowMap[oldId] = node;
                 newSubflows.push(node);
@@ -2162,7 +2162,7 @@ RED.nodes = (function() {
 
         // Add a tab if there isn't one there already - Like first install
         if (!defaultWorkspace) {
-            defaultWorkspace = { type: "tab", id: getID(), disabled: false, info: "",  label: RED._("workspace.defaultName", { number: 1 }), env: [] };
+            defaultWorkspace = { type: "tab", id: generateId(), disabled: false, info: "",  label: RED._("workspace.defaultName", { number: 1 }), env: [] };
             addWorkspace(defaultWorkspace);
             RED.workspaces.add(defaultWorkspace);
             newWorkspaces.push(defaultWorkspace);
@@ -2181,7 +2181,7 @@ RED.nodes = (function() {
                 // Repair the flow - but we really need to track that down.
                 if (!recoveryWorkspace) {
                     recoveryWorkspace = {
-                        id: getID(),
+                        id: generateId(),
                         type: "tab",
                         disabled: false,
                         label: RED._("clipboard.recoveredNodes"),
@@ -2333,7 +2333,7 @@ RED.nodes = (function() {
 
             // Now the node has been copied, change the `id` if it's a copy
             if (createNewIds || options.importMap[oldId] === "copy") {
-                nodeMap[oldId].id = getID();
+                nodeMap[oldId].id = generateId();
             }
 
             if (node.type === "junction") {
@@ -3145,7 +3145,7 @@ RED.nodes = (function() {
         createExportableNodeSet: createExportableNodeSet,
         createCompleteNodeSet: createCompleteNodeSet,
         updateConfigNodeUsers: updateConfigNodeUsers,
-        id: getID,
+        id: generateId,
         dirty: function(d) {
             if (d == null) {
                 return dirty;

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -680,7 +680,7 @@ RED.nodes = (function() {
             if (n.wires && (n.wires.length > n.outputs)) { n.outputs = n.wires.length; }
             n.dirty = true;
             // TODO: The event should be triggered?
-            updateConfigNodeUsers(n, { action: "add", emitEvent: false });
+            updateConfigNodeUsers(newNode, { action: "add" });
             // TODO: What is this property used for?
             if (n._def.category == "subflows" && typeof n.i === "undefined") {
                 var nextId = 0;
@@ -754,6 +754,9 @@ RED.nodes = (function() {
             delete nodeLinks[id];
             removedLinks = links.filter(function(l) { return (l.source === node) || (l.target === node); });
             removedLinks.forEach(removeLink);
+            // TODO: The event should not be triggered?
+            updateConfigNodeUsers(node, { action: "remove" });
+
             var updatedConfigNode = false;
             for (var d in node._def.defaults) {
                 if (node._def.defaults.hasOwnProperty(d)) {
@@ -764,13 +767,10 @@ RED.nodes = (function() {
                             var configNode = configNodes[node[d]];
                             if (configNode) {
                                 updatedConfigNode = true;
+                                // TODO: Not sure if still exists
                                 if (configNode._def.exclusive) {
                                     removeNode(node[d]);
                                     removedNodes.push(configNode);
-                                } else {
-                                    var users = configNode.users;
-                                    users.splice(users.indexOf(node),1);
-                                    RED.events.emit('nodes:change',configNode)
                                 }
                             }
                         }
@@ -2337,7 +2337,8 @@ RED.nodes = (function() {
                 }
             }
 
-            const isConfigNode = def?.category === "config";
+            // TODO: Group Node has config as category - why?
+            const isConfigNode = def?.category === "config" && node.type !== "group";
 
             // Now the properties have been fixed, copy the node properties:
             // NOTE: If the Node def is unknown, user properties will not be copied

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1386,7 +1386,7 @@ RED.nodes = (function() {
             var wires = links.filter(function(d) { return d.source === p });
             for (var i=0;i<wires.length;i++) {
                 var w = wires[i];
-                if (w.target.type != "subflow") {
+                if (w?.target && w.target.type != "subflow") {
                     nIn.wires.push({id:w.target.id})
                 }
             }
@@ -1716,7 +1716,7 @@ RED.nodes = (function() {
             // Remove the old subflow definition - but leave the instances in place
             var removalResult = RED.subflow.removeSubflow(n.id, true);
             // Create the list of nodes for the new subflow def
-            var subflowNodes = [n].concat(zMap[n.id]);
+            var subflowNodes = [n].concat(zMap[n.id]).filter((s) => !!s);
             // Import the new subflow - no clashes should occur as we've removed
             // the old version
             var result = importNodes(subflowNodes);
@@ -1799,6 +1799,30 @@ RED.nodes = (function() {
                 "error", false, 10000);
         }
         return unknownTypes;
+    }
+
+    function emitExistingNodesNotification(existingNodes, importedNodes) {
+        const errorMessage = RED._("clipboard.importDuplicate", { count: existingNodes.length });
+        const maxItemCount = 5; // Max 5 items in the list
+        const nodeList = $("<ul>");
+
+        let itemCount = 0;
+        for (const { existing, imported } of existingNodes) {
+            if (itemCount >= maxItemCount) { break; }
+            const conflictType = (imported.type !== existing.type) ? " | " + imported.type : "";
+            $("<li>").text(existing.id + " [ " + existing.type + conflictType + " ]").appendTo(nodeList);
+            itemCount++;
+        }
+
+        if (existingNodes.length > maxItemCount) {
+            $("<li>").text(RED._("deploy.confirm.plusNMore", { count: (existingNodes.length - maxItemCount) })).appendTo(nodeList);
+        }
+
+        const wrapper = $("<p>").append(nodeList);
+        const existingNodesError = new Error(errorMessage + wrapper.html());
+        existingNodesError.code = "import_conflict";
+        existingNodesError.importConfig = identifyImportConflicts(importedNodes);
+        throw existingNodesError;
     }
 
     function copyConfigNode(configNode, def, options = {}) {
@@ -1906,8 +1930,8 @@ RED.nodes = (function() {
             newNode.h = 0;
         } else if (node.type.substring(0, 7) === "subflow") {
             newNode.name = node.name;
-            newNode.inputs = node.inputs;
-            newNode.outputs = node.outputs;
+            newNode.inputs = node.inputs ?? 0;
+            newNode.outputs = node.outputs ?? 0;
             newNode.env = node.env;
         } else {
             newNode._config.x = node.x;
@@ -2029,44 +2053,27 @@ RED.nodes = (function() {
 
         // If some nodes already exists, ask the user for each node to choose
         // between copying it, replacing it or not importing it.
+        // NOTE: Stops the import here - throws an error.
         if (existingNodes.length) {
-            const errorMessage = RED._("clipboard.importDuplicate", { count: existingNodes.length });
-            const maxItemCount = 5; // Max 5 items in the list
-            const nodeList = $("<ul>");
-
-            let itemCount = 0;
-            for (let { existing, imported } of existingNodes) {
-                if (itemCount >= maxItemCount) { break; }
-                const conflictType = (imported.type !== existing.type) ? " | " + imported.type : "";
-                $("<li>").text(existing.id + " [ " + existing.type + conflictType + " ]").appendTo(nodeList);
-                itemCount++;
-            }
-
-            if (existingNodes.length > maxItemCount) {
-                $("<li>").text(RED._("deploy.confirm.plusNMore", { count: (existingNodes.length - maxItemCount) })).appendTo(nodeList);
-            }
-
-            const wrapper = $("<p>").append(nodeList);
-            const existingNodesError = new Error(errorMessage + wrapper.html());
-            existingNodesError.code = "import_conflict";
-            existingNodesError.importConfig = identifyImportConflicts(originalNodes);
-            throw existingNodesError;
+            emitExistingNodesNotification(existingNodes, originalNodes);
         }
 
+        // NOTE: activeWorkspace can be equal to 0 if it's the initial load
         let activeWorkspace = RED.workspaces.active();
         const activeSubflow = getSubflow(activeWorkspace);
-        for (const node of originalNodes) {
-            const group = /^subflow:(.+)$/.exec(node.type);
-            if (group) {
-                const subflowId = group[1];
-                // NOTE: activeWorkspace can be equal to 0 if it's the initial load
-                if (activeSubflow) {
+        if (activeSubflow) {
+            for (const node of originalNodes) {
+                const group = /^subflow:(.+)$/.exec(node.type);
+                if (group) {
+                    const subflowId = group[1];
                     let error;
+
                     if (subflowId === activeSubflow.id) {
                         error = new Error(RED._("notification.errors.cannotAddSubflowToItself"));
                     } else if (subflowContains(subflowId, activeSubflow.id)) {
                         error = new Error(RED._("notification.errors.cannotAddCircularReference"));
                     }
+
                     if (error) {
                         // TODO: standardise error codes
                         error.code = "NODE_RED";
@@ -2089,53 +2096,13 @@ RED.nodes = (function() {
             initialLoad = JSON.parse(JSON.stringify(originalNodes));
         }
 
+        // Identifies unknown nodes and can emit a notification to warn the user.
         const unknownTypes = identifyUnknowType(originalNodes, { emitNotification: !isInitialLoad });
-
-        const nodeZmap = {};
-        let recoveryWorkspace = null;
-        // If it's the initial load, create a recovery workspace if any nodes don't have `node.z` and assign to it.
-        for (const node of originalNodes) {
-            if (node.z) {
-                nodeZmap[node.z] = nodeZmap[node.z] || [];
-                nodeZmap[node.z].push(node);
-            } else if (isInitialLoad && node.hasOwnProperty("x") && node.hasOwnProperty("y")) {
-                // Hit the rare issue where node z values get set to 0.
-                // Repair the flow - but we really need to track that down.
-                if (!recoveryWorkspace) {
-                    recoveryWorkspace = {
-                        id: getID(),
-                        type: "tab",
-                        disabled: false,
-                        label: RED._("clipboard.recoveredNodes"),
-                        info: RED._("clipboard.recoveredNodesInfo"),
-                        env: []
-                    };
-
-                    addWorkspace(recoveryWorkspace);
-                    RED.workspaces.add(recoveryWorkspace);
-                    nodeZmap[recoveryWorkspace.id] = [];
-                }
-                node.z = recoveryWorkspace.id;
-                nodeZmap[node.z].push(node);
-            }
-        }
-
-        const newWorkspaces = [];
-        if (recoveryWorkspace) {
-            newWorkspaces.push(recoveryWorkspace);
-            const notification = RED.notify(RED._("clipboard.recoveredNodesNotification", { flowName: RED._("clipboard.recoveredNodes") }), {
-                type: "warning",
-                fixed: true,
-                buttons: [
-                    { text: RED._("common.label.close"), click: function () { notification.close(); } }
-                ]
-            });
-        }
 
         const subflowMap = {};
         const workspaceMap = {};
         const newSubflows = [];
-        const subflowDenyList = {};
+        const newWorkspaces = [];
         // Find all tabs and subflow tabs and add it to workspace
         // NOTE: Subflow tab not the instance
         for (const node of originalNodes) {
@@ -2163,43 +2130,32 @@ RED.nodes = (function() {
                 newWorkspaces.push(node);
                 RED.workspaces.add(node);
             } else if (node.type === "subflow") {
-                let matchingSubflow;
-
-                // TODO: Si l'id est différent on devrait l'importer
-                if (!options.importMap[node.id]) {
-                    matchingSubflow = checkForMatchingSubflow(node, nodeZmap[node.id]);
-                    console.log("SUBFLOW", matchingSubflow)
+                node.in.forEach(function(input, i) {
+                    input.type = "subflow";
+                    input.direction = "in";
+                    input.z = node.id;
+                    input.i = i;
+                    input.id = getID();
+                });
+                node.out.forEach(function(output, i) {
+                    output.type = "subflow";
+                    output.direction = "out";
+                    output.z = node.id;
+                    output.i = i;
+                    output.id = getID();
+                });
+                if (node.status) {
+                    node.status.type = "subflow";
+                    node.status.direction = "status";
+                    node.status.z = node.id;
+                    node.status.id = getID();
                 }
-                if (matchingSubflow) {
-                    subflowDenyList[node.id] = matchingSubflow;
-                } else {
-                    node.in.forEach(function(input, i) {
-                        input.type = "subflow";
-                        input.direction = "in";
-                        input.z = node.id;
-                        input.i = i;
-                        input.id = getID();
-                    });
-                    node.out.forEach(function(output, i) {
-                        output.type = "subflow";
-                        output.direction = "out";
-                        output.z = node.id;
-                        output.i = i;
-                        output.id = getID();
-                    });
-                    if (node.status) {
-                        node.status.type = "subflow";
-                        node.status.direction = "status";
-                        node.status.z = node.id;
-                        node.status.id = getID();
-                    }
-                    if (createNewIds || options.importMap[node.id] === "copy") {
-                        node.id = getID();
-                    }
-                    subflowMap[oldId] = node;
-                    newSubflows.push(node);
-                    addSubflow(node, (createNewIds || options.importMap[node.id] === "copy"));
+                if (createNewIds || options.importMap[node.id] === "copy") {
+                    node.id = getID();
                 }
+                subflowMap[oldId] = node;
+                newSubflows.push(node);
+                addSubflow(node, (createNewIds || options.importMap[node.id] === "copy"));
             }
         }
 
@@ -2212,11 +2168,90 @@ RED.nodes = (function() {
             activeWorkspace = defaultWorkspace.id;
         }
 
+        let newWorkspace = null;
+        let recoveryWorkspace = null;
+        // Correct or update the z property of each node
+        for (const node of originalNodes) {
+            const isConfigNode = !node.x && !node.y;
+
+            // If it's the initial load, create a recovery workspace if any nodes don't have `node.z` and assign to it.
+            if (!node.z && isInitialLoad && node.hasOwnProperty("x") && node.hasOwnProperty("y")) {
+                // Hit the rare issue where node z values get set to 0.
+                // Repair the flow - but we really need to track that down.
+                if (!recoveryWorkspace) {
+                    recoveryWorkspace = {
+                        id: getID(),
+                        type: "tab",
+                        disabled: false,
+                        label: RED._("clipboard.recoveredNodes"),
+                        info: RED._("clipboard.recoveredNodesInfo"),
+                        env: []
+                    };
+                }
+                node.z = recoveryWorkspace.id;
+                continue;
+            }
+
+            // TODO: remove workspace in next release+1
+            if (node.type === "workspace" || node.type === "tab" || node.type === "subflow") { continue; }
+
+            // Fix `node.z` for not found/new one case
+            if (createNewIds || options.importMap[node.id] === "copy") {
+                // Config Node can have an undefined `node.z`
+                if (!isConfigNode || (isConfigNode && node.z)) {
+                    if (subflowMap[node.z]) {
+                        node.z = subflowMap[node.z].id;
+                    } else {
+                        node.z = workspaceMap[node.z];
+                        if (!workspaces[node.z]) {
+                            node.z = activeWorkspace;
+                            if (createNewWorkspace) {
+                                if (newWorkspace === null) {
+                                    newWorkspace = RED.workspaces.add(null, true);
+                                    newWorkspaces.push(newWorkspace);
+                                }
+                                node.z = newWorkspace.id;
+                            }
+                        }
+                    }
+                }
+            } else {
+                const keepNodesCurrentZ = reimport && node.z && (RED.workspaces.contains(node.z) || RED.nodes.subflow(node.z));
+
+                if (isConfigNode && !keepNodesCurrentZ && node.z && !workspaceMap[node.z] && !subflowMap[node.z]) {
+                    node.z = activeWorkspace;
+                } else if (!isConfigNode && !keepNodesCurrentZ && (node.z == null || (!workspaceMap[node.z] && !subflowMap[node.z]))) {
+                    node.z = activeWorkspace;
+                    if (createNewWorkspace) {
+                        if (!newWorkspace) {
+                            newWorkspace = RED.workspaces.add(null,true);
+                            newWorkspaces.push(newWorkspace);
+                        }
+                        node.z = newWorkspace.id;
+                    }
+                }
+            }
+        }
+
+        // Add the recovery tab if used and warn the user
+        if (recoveryWorkspace) {
+            addWorkspace(recoveryWorkspace);
+            RED.workspaces.add(recoveryWorkspace);
+            // Put the recovery workspace at the first position
+            newWorkspaces.splice(0, 1, recoveryWorkspace, newWorkspaces[0]);
+            const notification = RED.notify(RED._("clipboard.recoveredNodesNotification", { flowName: RED._("clipboard.recoveredNodes") }), {
+                type: "warning",
+                fixed: true,
+                buttons: [
+                    { text: RED._("common.label.close"), click: function () { notification.close(); } }
+                ]
+            });
+        }
+
         const nodeMap = {};
         const newNodes = [];
         const newGroups = [];
         const newJunctions = [];
-        let newWorkspace = null;
         // Find all Config Nodes, Groups, Junctions, Nodes and Subflow instances and add them
         // NOTE: Replaced Config Nodes and Subflow instances no longer appear below
         for (const node of originalNodes) {
@@ -2257,53 +2292,12 @@ RED.nodes = (function() {
 
             const isConfigNode = def?.category === "config";
 
-            // Fix `node.z` for undefined/not found/new one case
-            if (createNewIds || options.importMap[oldId] === "copy") {
-                // Config Node can have an undefined `node.z`
-                if (!isConfigNode || (isConfigNode && node.z)) {
-                    if (subflowDenyList[node.z]) {
-                        continue;
-                    } else if (subflowMap[node.z]) {
-                        node.z = subflowMap[node.z].id;
-                    } else {
-                        node.z = workspaceMap[node.z];
-                        if (!workspaces[node.z]) {
-                            if (createNewWorkspace) {
-                                if (newWorkspace === null) {
-                                    newWorkspace = RED.workspaces.add(null, true);
-                                    newWorkspaces.push(newWorkspace);
-                                }
-                                node.z = newWorkspace.id;
-                            } else {
-                                node.z = activeWorkspace;
-                            }
-                        }
-                    }
-                }
-            } else {
-                const keepNodesCurrentZ = reimport && node.z && (RED.workspaces.contains(node.z) || RED.nodes.subflow(node.z));
-
-                if (isConfigNode && !keepNodesCurrentZ && node.z && !workspaceMap[node.z] && !subflowMap[node.z]) {
-                    node.z = activeWorkspace;
-                } else if (!isConfigNode && !keepNodesCurrentZ && (node.z == null || (!workspaceMap[node.z] && !subflowMap[node.z]))) {
-                    if (createNewWorkspace) {
-                        if (newWorkspace === null) {
-                            newWorkspace = RED.workspaces.add(null,true);
-                            newWorkspaces.push(newWorkspace);
-                        }
-                        node.z = newWorkspace.id;
-                    } else {
-                        node.z = activeWorkspace;
-                    }
-                }
-            }
-
             // Update the node definition for subflow instance
             if (!isUnknownNode && node.type.substring(0, 7) === "subflow") {
                 const parentId = node.type.split(":")[1];
-                const subflow = subflowDenyList[parentId] || subflowMap[parentId] || getSubflow(parentId);
+                const subflow = subflowMap[parentId] || getSubflow(parentId);
 
-                if (subflowDenyList[parentId] || createNewIds || options.importMap[node.id] === "copy") {
+                if (createNewIds || options.importMap[node.id] === "copy") {
                     node.type = "subflow:" + subflow.id;
                     def = registry.getNodeType(node.type);
                 }
@@ -2312,36 +2306,10 @@ RED.nodes = (function() {
                 node.outputs = subflow.out.length;
             }
 
-            // Now the properties have been corrected, copy the node properties:
-
+            // Now the properties have been fixed, copy the node properties:
             // Config Node
             if (isConfigNode) {
-                // TODO: A quoi sert ce bloc ? Replace?
-                let existingConfigNode;
-                if (createNewIds || options.importMap[oldId] === "copy") {
-                    if (options.importMap[oldId] !== "copy") {
-                        existingConfigNode = RED.nodes.node(oldId);
-                        if (existingConfigNode) {
-                            if (node.z && existingConfigNode.z !== node.z) {
-                                existingConfigNode = null;
-                                // Check the config nodes on n.z
-                                // TODO: pourquoi utiliser z au lieu de l'id ?
-                                for (var cn in configNodes) {
-                                    if (configNodes.hasOwnProperty(cn)) {
-                                        if (configNodes[cn].z === node.z && compareNodes(configNodes[cn], node, false)) {
-                                            existingConfigNode = configNodes[cn];
-                                            nodeMap[oldId] = configNodes[cn];
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                if (!existingConfigNode || existingConfigNode._def.exclusive) { //} || !compareNodes(existingConfigNode,n,true) || existingConfigNode.z !== n.z) {
-                    nodeMap[oldId] = copyConfigNode(node, def, options);
-                }
+                nodeMap[oldId] = copyConfigNode(node, def, options);
             // Node, Group, Junction or Subflow
             } else {
                 nodeMap[oldId] = copyNode(node, def, options);
@@ -2385,7 +2353,7 @@ RED.nodes = (function() {
             }
         });
         allNodes.eachNode(function (node) {
-            // The event will be triggered after the import
+            // TODO: The event will be triggered after the import - Quid?
             updateConfigNodeUsers(node, { emitEvent: false });
         });
 
@@ -2397,7 +2365,6 @@ RED.nodes = (function() {
                     const wires = Array.isArray(wiresGroup) ? wiresGroup : [wiresGroup];
                     wires.forEach(function (wire) {
                         // Skip if the wire is clinked to a non-existent node
-                        // TODO: Add warning message?
                         if (!nodeMap.hasOwnProperty(wire)) { return; }
                         if (node.z === nodeMap[wire].z) {
                             const link = { source: node, sourcePort: node.wires.indexOf(wiresGroup), target: nodeMap[wire] };
@@ -2438,6 +2405,7 @@ RED.nodes = (function() {
                         const n = nodeMap[id];
                         if (n) {
                             if (n._def.category === "config") {
+                                // TODO: addNode calls updateConfigNodeUsers so remove here
                                 if (n.users.indexOf(node) === -1) {
                                     n.users.push(node);
                                 }
@@ -2454,6 +2422,7 @@ RED.nodes = (function() {
 
         // Add Links to Workspace
         for (const subflow of newSubflows) {
+            // TODO: Handled missing node
             subflow.in.forEach(function (input) {
                 input.wires.forEach(function (wire) {
                     const link = { source: input, sourcePort: 0, target: nodeMap[wire.id] };

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -679,7 +679,8 @@ RED.nodes = (function() {
         } else {
             if (n.wires && (n.wires.length > n.outputs)) { n.outputs = n.wires.length; }
             n.dirty = true;
-            updateConfigNodeUsers(n);
+            // TODO: The event should be triggered?
+            updateConfigNodeUsers(n, { action: "add", emitEvent: false });
             if (n._def.category == "subflows" && typeof n.i === "undefined") {
                 var nextId = 0;
                 RED.nodes.eachNode(function(node) {
@@ -2293,6 +2294,7 @@ RED.nodes = (function() {
             const isConfigNode = def?.category === "config";
 
             // Update the node definition for subflow instance
+            // TODO: A thing with `node.i`
             if (!isUnknownNode && node.type.substring(0, 7) === "subflow") {
                 const parentId = node.type.split(":")[1];
                 const subflow = subflowMap[parentId] || getSubflow(parentId);
@@ -2343,20 +2345,6 @@ RED.nodes = (function() {
             }
         }
 
-        // Update Users Count
-        // NOTE: the only reliable way to get the right number is to scan all the nodes
-        // Replacing a Config Node overwrites the list giving a wrong number
-        allNodes.eachNode(function (node) {
-            const def = registry.getNodeType(node.type);
-            if (def?.category === "config") {
-                node.users = [];
-            }
-        });
-        allNodes.eachNode(function (node) {
-            // TODO: The event will be triggered after the import - Quid?
-            updateConfigNodeUsers(node, { emitEvent: false });
-        });
-
         const newLinks = [];
         // Remap all Wires and (Config) Node references
         for (const node of [...newNodes, ...newGroups]) {
@@ -2378,6 +2366,7 @@ RED.nodes = (function() {
                 delete node.wires;
             }
 
+            // Update the Group id
             if (node.g && nodeMap[node.g]) {
                 node.g = nodeMap[node.g].id;
             } else {
@@ -2392,27 +2381,18 @@ RED.nodes = (function() {
                 });
             }
 
-            // Update the old Node Id with the new one
+            // Update the node id for select inputs and Links nodes
             for (const d in node._def.defaults) {
-                // Config Node, Node or Links (not sure)
                 if (node._def.defaults.hasOwnProperty(d) && node._def.defaults[d].type) {
                     let nodeList = node[d];
 
                     if (!Array.isArray(nodeList)) {
                         nodeList = [nodeList];
                     }
-                    nodeList = nodeList.map(function(id) {
+
+                    nodeList = nodeList.map(function (id) {
                         const n = nodeMap[id];
-                        if (n) {
-                            if (n._def.category === "config") {
-                                // TODO: addNode calls updateConfigNodeUsers so remove here
-                                if (n.users.indexOf(node) === -1) {
-                                    n.users.push(node);
-                                }
-                            }
-                            return n.id;
-                        }
-                        return id;
+                        return n ? n.id : id;
                     });
 
                     node[d] = Array.isArray(node[d]) ? nodeList : nodeList[0];
@@ -2643,7 +2623,7 @@ RED.nodes = (function() {
 
     // Update any config nodes referenced by the provided node to ensure their 'users' list is correct
     function updateConfigNodeUsers(n, options) {
-        const defaultOptions = { emitEvent: true };
+        const defaultOptions = { action: "add", emitEvent: true };
         options = Object.assign({}, defaultOptions, options);
 
         for (var d in n._def.defaults) {
@@ -2654,10 +2634,20 @@ RED.nodes = (function() {
                     if (type && type.category == "config") {
                         var configNode = configNodes[n[d]];
                         if (configNode) {
-                            if (configNode.users.indexOf(n) === -1) {
-                                configNode.users.push(n);
-                                if (options.emitEvent) {
-                                    RED.events.emit('nodes:change', configNode);
+                            if (options.action === "add") {
+                                if (configNode.users.indexOf(n) === -1) {
+                                    configNode.users.push(n);
+                                    if (options.emitEvent) {
+                                        RED.events.emit('nodes:change', configNode);
+                                    }
+                                }
+                            } else if (options.action === "remove") {
+                                if (configNode.users.indexOf(n) !== -1) {
+                                    const users = configNode.users;
+                                    users.splice(users.indexOf(n), 1);
+                                    if (options.emitEvent) {
+                                        RED.events.emit('nodes:change', configNode);
+                                    }
                                 }
                             }
                         }

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1006,23 +1006,34 @@ RED.nodes = (function() {
         return {nodes:removedNodes,links:removedLinks, groups: removedGroups, junctions: removedJunctions};
     }
 
+    /**
+     * Add a Subflow to the Workspace
+     *
+     * @param {object} sf The Subflow to add.
+     * @param {boolean|undefined} createNewIds Whether to create a new ID and update the name.
+     */
     function addSubflow(sf, createNewIds) {
         if (createNewIds) {
-            var subflowNames = Object.keys(subflows).map(function(sfid) {
-                return subflows[sfid].name;
-            });
+            // Update the Subflow Id
+            sf.id = generateId();
 
-            subflowNames.sort();
-            var copyNumber = 1;
-            var subflowName = sf.name;
+            // Update the Subflow name to highlight that this is a copy
+            const subflowNames = Object.keys(subflows).map(function (sfid) {
+                return subflows[sfid].name || "";
+            }).sort();
+
+            let copyNumber = 1;
+            let subflowName = sf.name;
             subflowNames.forEach(function(name) {
                 if (subflowName == name) {
+                    subflowName = sf.name + " (" + copyNumber + ")";
                     copyNumber++;
-                    subflowName = sf.name+" ("+copyNumber+")";
                 }
             });
+
             sf.name = subflowName;
         }
+
         subflows[sf.id] = sf;
         allNodes.addTab(sf.id);
         linkTabMap[sf.id] = [];
@@ -2151,11 +2162,10 @@ RED.nodes = (function() {
                     node.status.z = node.id;
                     node.status.id = generateId();
                 }
-                if (createNewIds || options.importMap[node.id] === "copy") {
-                    node.id = generateId();
-                }
+
                 subflowMap[oldId] = node;
                 newSubflows.push(node);
+                // NOTE: Update the id in the `addSubflow` function
                 addSubflow(node, (createNewIds || options.importMap[node.id] === "copy"));
             }
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1937,31 +1937,29 @@ RED.nodes = (function() {
             newNode._config.x = node.x;
             newNode._config.y = node.y;
 
-            if (node.hasOwnProperty("inputs")) {
+            if (node.hasOwnProperty("inputs") && def.defaults.hasOwnProperty("inputs")) {
                 newNode._config.inputs = JSON.stringify(node.inputs);
-                newNode.inputs = node.inputs;
+                newNode.inputs = parseInt(node.inputs, 10);
             } else {
                 newNode.inputs = def.inputs;
             }
 
-            if (node.hasOwnProperty("outputs")) {
+            if (node.hasOwnProperty("outputs") && def.defaults.hasOwnProperty("outputs")) {
                 newNode._config.outputs = JSON.stringify(node.outputs);
-                newNode.outputs = node.outputs;
+                newNode.outputs = parseInt(node.outputs, 10);
             } else {
                 newNode.outputs = def.outputs;
             }
 
-            if (newNode.wires.length > newNode.outputs) {
-                if (!def.defaults.hasOwnProperty("outputs") || !isNaN(parseInt(newNode.outputs))) {
-                    // The node declares outputs in its defaults, but has not got a valid value
-                    // Defer to the length of the wires array
-                    newNode.outputs = newNode.wires.length;
-                } else {
-                    // If 'wires' is longer than outputs, clip wires
-                    console.log("Warning: node.wires longer than node.outputs - trimming wires:", node.id, " wires:", node.wires.length, " outputs:", node.outputs);
-                    // TODO: Pas dans l'autre sens ?
-                    newNode.wires = newNode.wires.slice(0, newNode.outputs);
-                }
+            // The node declares outputs in its defaults, but has not got a valid value
+            // Defer to the length of the wires array
+            if (isNaN(newNode.outputs)) {
+                newNode.outputs = newNode.wires.length;
+            } else if (newNode.wires.length > newNode.outputs) {
+                // If 'wires' is longer than outputs, clip wires
+                console.log("Warning: node.wires longer than node.outputs - trimming wires:", node.id, " wires:", node.wires.length, " outputs:", node.outputs);
+                // TODO: Pas dans l'autre sens ?
+                newNode.wires = newNode.wires.slice(0, newNode.outputs);
             }
 
             // Copy node user properties

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -508,10 +508,8 @@ RED.subflow = (function() {
         var activeSubflow = RED.nodes.subflow(id);
 
         RED.nodes.eachNode(function(n) {
-            if (!keepInstanceNodes && n.type == "subflow:"+id) {
-                removedNodes.push(n);
-            }
-            if (n.z == id) {
+            if (n.z === id || !keepInstanceNodes && n.type === "subflow:" + id) {
+                RED.nodes.updateConfigNodeUsers(n, { emitEvent: false, action: "remove" });
                 removedNodes.push(n);
             }
         });

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -5618,12 +5618,9 @@ RED.view = (function() {
      *                           default names
      */
     function importNodes(newNodesObj,options) {
-        options = options || {
-            addFlow: false,
-            touchImport: false,
-            generateIds: false,
-            generateDefaultNames: false
-        }
+        const defaultOptions = { generateIds: false, addFlow: false, touchImport: false, generateDefaultNames: false, importMap: {} };
+        options = Object.assign({}, defaultOptions, options);
+
         var addNewFlow = options.addFlow
         var touchImport = options.touchImport;
 


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Refactoring the `importNodes` function.

Resolves also:

- Bad number of `node.users` for Config Node:
  - Deleting a Node inside a Subflow does not update the number of users.
  - Replacing a Config Node overwrites the user list to empty.

- A Node that has an invalid number of inputs/outputs (dynamic number) is not correctly handled.

- When copying a Subflow (tab), the name is not updated (addition of the copy count)

- When importing a Subflow:
  - If the definition is missing, the Node will be marked as unknown - which allows to double click and have dialog box and be able to export this Node.
  - When adding the definition, existing instances into the workspace are updated.
  - A Node missing into the Subflow import is now handled (to avoid create link)

- Ensure `activeWorkspace` can no longer be equal to 0.

Other functions modified:

- `updateConfigNodeUsers` - for either add or remove and either trigger the event
- `RED.view.importNodes()` - overwrite importMap to undefined

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
