### PR TITLE
Add `httpStaticCors`

### DIFF
--- a/packages/node_modules/node-red/package.json
+++ b/packages/node_modules/node-red/package.json
@@ -37,6 +37,7 @@
         "@node-red/nodes": "4.0.0-beta.4",
         "basic-auth": "2.0.1",
         "bcryptjs": "2.4.3",
+        "cors": "2.8.5",
         "express": "4.19.2",
         "fs-extra": "11.2.0",
         "node-red-admin": "^3.1.3",

--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -44,6 +44,8 @@ var nopt = require("nopt");
 var path = require("path");
 const os = require("os")
 var fs = require("fs-extra");
+const cors = require('cors');
+
 var RED = require("./lib/red.js");
 
 var server;
@@ -441,10 +443,16 @@ httpsPromise.then(function(startupHttps) {
             const thisRoot = sp.root || "/";
             const options = sp.options;
             const middleware = sp.middleware;
+            const corsOptions = sp.cors || settings.httpStaticCors;
             if(appUseMem[filePath + "::" + thisRoot]) {
                 continue;// this path and root already registered!
             }
             appUseMem[filePath + "::" + thisRoot] = true;
+            if (corsOptions) {
+                const corsHandler = cors(corsOptions);
+                app.options(thisRoot, corsHandler)
+                app.use(thisRoot, corsHandler)
+            }
             if (settings.httpStaticAuth) {
                 app.use(thisRoot, basicAuthMiddleware(settings.httpStaticAuth.user, settings.httpStaticAuth.pass));
             }

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -139,6 +139,7 @@ module.exports = {
  *  - httpNodeMiddleware
  *  - httpStatic
  *  - httpStaticRoot
+ *  - httpStaticCors
  ******************************************************************************/
 
     /** the tcp port that the Node-RED web server is listening on */
@@ -233,6 +234,9 @@ module.exports = {
      *  OR multiple static sources can be created using an array of objects...
      *  Each object can also contain an options object for further configuration.
      *  See https://expressjs.com/en/api.html#express.static for available options.
+     *  They can also contain an option `cors` object to set specific Cross-Origin
+     *  Resource Sharing rules for the source. `httpStaticCors` can be used to
+     *  set a default cors policy across all static routes.
      */
     //httpStatic: [
     //    {path: '/home/nol/pics/',    root: "/img/"},
@@ -249,6 +253,16 @@ module.exports = {
      *      then "/home/nol/pics/" will be served at "/static/img/"
      */
     //httpStaticRoot: '/static/',
+
+    /** The following property can be used to configure cross-origin resource sharing
+     * in the http static routes.
+     * See https://github.com/troygoode/node-cors#configuration-options for
+     * details on its contents. The following is a basic permissive set of options:
+     */
+    //httpStaticCors: {
+    //    origin: "*",
+    //    methods: "GET,PUT,POST,DELETE"
+    //},
 
     /** The following property can be used to modify proxy options */
     // proxyOptions: {


### PR DESCRIPTION
Closes #4759 

Adds `httpStaticCors` to allow cors configuration to be applied to the `httpStatic` routes.

If `httpStatic` is provided as an array of configurations, they can each contain their own `cors` property, to allow for per-route configurations.