### PR TITLE
Add tooltip for number of subflow instance on info tab

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
@@ -103,7 +103,7 @@ RED.sidebar.info.outliner = (function() {
                 evt.stopPropagation();
                 RED.search.show("type:subflow:"+n.id);
             })
-            // RED.popover.tooltip(userCountBadge,function() { return RED._('editor.nodesUse',{count:n.users.length})});
+            RED.popover.tooltip(subflowInstanceBadge,function() { return RED._('subflow.subflowInstances',{count:n.instances.length})});
         }
         if (n._def.category === "config" && n.type !== "group") {
             var userCountBadge = $('<button type="button" class="red-ui-info-outline-item-control-users red-ui-button red-ui-button-small"><i class="fa fa-toggle-right"></i></button>').text(n.users.length).appendTo(controls).on("click",function(evt) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I added tooltip for subflow instance button on info tab.

<img width="903" alt="Screenshot 2024-06-23 at 21 10 23" src="https://github.com/node-red/node-red/assets/20310935/a77e752d-3194-4f53-a72f-0a1cbee42195">


## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality