### PR TITLE
Fix save and history of credentials for panes

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
@@ -131,9 +131,13 @@
                     }
                 }
                 if (node._def.credentials) {
-                    var credDefinition = node._def.credentials;
-                    var credsChanged = updateNodeCredentials(node,credDefinition,this.inputClass);
-                    editState.changed = editState.changed || credsChanged;
+                    const credsDefinition = node._def.credentials;
+                    const credsChanged = updateNodeCredentials(node, credsDefinition, this.inputClass);
+
+                    if (credsChanged) {
+                        editState.changed = true;
+                        editState.changes.credentials = node.credentials._;
+                    }
                 }
             }
         }
@@ -178,11 +182,14 @@
                     var value = input.val();
                     if (credDefinition[cred].type == 'password') {
                         node.credentials['has_' + cred] = (value !== "");
-                        if (value == '__PWRD__') {
+
+                        // Skip if the credential has not changed
+                        if ((value === '__PWRD__' && node.credentials._['has_' + cred] === true) ||
+                        (value === "" && node.credentials._['has_' + cred] === false)) {
                             continue;
                         }
-                        changed = true;
 
+                        changed = true;
                     }
                     node.credentials[cred] = value;
                     if (value != node.credentials._[cred]) {
@@ -193,6 +200,4 @@
         }
         return changed;
     }
-
-
 })();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
@@ -131,12 +131,15 @@
                     }
                 }
                 if (node._def.credentials) {
-                    const credsDefinition = node._def.credentials;
-                    const credsChanged = updateNodeCredentials(node, credsDefinition, this.inputClass);
+                    const credDefinition = node._def.credentials;
+                    const credChanges = updateNodeCredentials(node, credDefinition, this.inputClass);
 
-                    if (credsChanged) {
+                    if (Object.keys(credChanges).length) {
                         editState.changed = true;
-                        editState.changes.credentials = node.credentials._;
+                        editState.changes.credentials = {
+                            ...(editState.changes.credentials || {}),
+                            ...credChanges
+                        };
                     }
                 }
             }
@@ -165,10 +168,11 @@
      * @param node - the node containing the credentials
      * @param credDefinition - definition of the credentials
      * @param prefix - prefix of the input fields
-     * @return {boolean} whether anything has changed
+     * @return {object} an object containing the modified properties
      */
     function updateNodeCredentials(node, credDefinition, prefix) {
-        var changed = false;
+        const changes = {};
+
         if (!node.credentials) {
             node.credentials = {_:{}};
         } else if (!node.credentials._) {
@@ -181,23 +185,32 @@
                 if (input.length > 0) {
                     var value = input.val();
                     if (credDefinition[cred].type == 'password') {
-                        node.credentials['has_' + cred] = (value !== "");
-
-                        // Skip if the credential has not changed
-                        if ((value === '__PWRD__' && node.credentials._['has_' + cred] === true) ||
-                        (value === "" && node.credentials._['has_' + cred] === false)) {
-                            continue;
+                        if (value === '__PWRD__') {
+                            // A cred value exists - no changes
+                        } else if (value === '' && node.credentials['has_' + cred] === false) {
+                            // Empty cred value exists - no changes
+                        } else if (value === node.credentials[cred]) {
+                            // A cred value exists locally in the editor - no changes
+                            // Like the user sets a value, saves the config,
+                            // reopens the config and save the config again
+                        } else {
+                            changes[cred] = node.credentials[cred];
+                            node.credentials[cred] = value;
                         }
 
-                        changed = true;
-                    }
-                    node.credentials[cred] = value;
-                    if (value != node.credentials._[cred]) {
-                        changed = true;
+                        node.credentials['has_' + cred] = (value !== '');
+                    } else {
+                        // Since these creds are loaded by the editor,
+                        // values can be directly compared
+                        if (value !== node.credentials[cred]) {
+                            changes[cred] = node.credentials[cred];
+                            node.credentials[cred] = value;
+                        }
                     }
                 }
             }
         }
-        return changed;
+
+        return changes;
     }
 })();


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

- Add credentials to the history (`editState.changes`) so that they are reversible.
- Fix the handler that determines if a credential has changed.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
