### PR TITLE
Optionally add msg.complete to split node output

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
@@ -17,8 +17,16 @@
 <script type="text/html" data-template-name="split">
     <!-- <div class="form-row"><span data-i18n="[html]split.intro"></span></div> -->
     <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
+    </div>
+    <div class="form-row">
         <label for="node-input-property"><i class="fa fa-forward"></i> <span data-i18n="split.split"></span></label>
         <input type="text" id="node-input-property" style="width:70%;"/>
+    </div>
+    <div class="form-row">
+        <input type="checkbox" id="node-input-addcomplete" style="margin-left:10px; vertical-align:baseline; width:auto;">
+        <label for="node-input-addcomplete" style="width:auto;" data-i18n="split.addcomplete"></label>
     </div>
     <div class="form-row"><span data-i18n="[html]split.strBuff"></span></div>
     <div class="form-row">
@@ -43,10 +51,6 @@
         <label for="node-input-addname-cb" style="width:auto;" data-i18n="split.addname"></label>
         <input type="text" id="node-input-addname" style="width:70%">
     </div>
-    <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
-    </div>
 </script>
 
 <script type="text/javascript">
@@ -61,6 +65,7 @@
             arraySpltType: {value:"len"},
             stream: {value:false},
             addname: {value:"", validate: RED.validators.typedInput({ type: 'msg', allowBlank: true })},
+            addcomplete: {value:false},
             property: {value:"payload",required:true}
         },
         inputs:1,

--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -21,13 +21,17 @@ module.exports = function(RED) {
         for (var i = 0; i < array.length-1; i++) {
             RED.util.setMessageProperty(msg,node.property,array[i]);
             msg.parts.index = node.c++;
-            if (node.stream !== true) { msg.parts.count = array.length; }
+            if (node.stream !== true) {
+                msg.parts.count = array.length;
+                if (node.addcomplete === true) { msg.complete = true; }
+            }
             send(RED.util.cloneMessage(msg));
         }
         if (node.stream !== true) {
             RED.util.setMessageProperty(msg,node.property,array[i]);
             msg.parts.index = node.c++;
             msg.parts.count = array.length;
+            if (node.addcomplete === true) { msg.complete = true; }
             send(RED.util.cloneMessage(msg));
             node.c = 0;
         }
@@ -40,6 +44,7 @@ module.exports = function(RED) {
         node.stream = n.stream;
         node.spltType = n.spltType || "str";
         node.addname = n.addname || "";
+        node.addcomplete = n.addcomplete || false;
         node.property = n.property||"payload";
         try {
             if (node.spltType === "str") {
@@ -111,6 +116,7 @@ module.exports = function(RED) {
                         if ((node.stream !== true) || (node.remainder.length === node.splt)) {
                             RED.util.setMessageProperty(msg,node.property,node.remainder);
                             msg.parts.index = node.c++;
+                            if (node.addcomplete === true) { msg.complete = true; }
                             send(RED.util.cloneMessage(msg));
                             node.pendingDones.forEach(d => d());
                             node.pendingDones = [];
@@ -153,6 +159,7 @@ module.exports = function(RED) {
                         }
                         RED.util.setMessageProperty(msg,node.property,m);
                         msg.parts.index = i;
+                        if (i === count-1 && node.addcomplete === true) { msg.complete = true; }
                         pos += node.arraySplt;
                         send(RED.util.cloneMessage(msg));
                     }
@@ -172,6 +179,7 @@ module.exports = function(RED) {
                             msg.parts.key = p;
                             msg.parts.index = j;
                             msg.parts.count = l;
+                            if (j == l-1 && node.addcomplete === true) { msg.complete = true; }
                             send(RED.util.cloneMessage(msg));
                             j += 1;
                         }
@@ -207,6 +215,7 @@ module.exports = function(RED) {
                         if ((node.stream !== true) || (node.buffer.length === node.splt)) {
                             RED.util.setMessageProperty(msg,node.property,node.buffer);
                             msg.parts.index = node.c++;
+                            if (node.addcomplete === true) { msg.complete = true; }
                             send(RED.util.cloneMessage(msg));
                             node.pendingDones.forEach(d => d());
                             node.pendingDones = [];
@@ -253,6 +262,7 @@ module.exports = function(RED) {
                             RED.util.setMessageProperty(msg,node.property,buff.slice(p,buff.length));
                             msg.parts.index = node.c++;
                             msg.parts.count = node.c++;
+                            if (node.addcomplete === true) { msg.complete = true; }
                             send(RED.util.cloneMessage(msg));
                             node.pendingDones.forEach(d => d());
                             node.pendingDones = [];

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -1020,7 +1020,8 @@
         "splitUsing": "Split using",
         "splitLength": "Fixed length of",
         "stream": "Handle as a stream of messages",
-        "addname": " Copy key to "
+        "addname": " Copy key to ",
+        "addcomplete": " Add msg.complete to last element of split."
     },
     "join": {
         "join": "join",


### PR DESCRIPTION
so can trigger join even when in manual mode.
to address #4781

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This fix adds a checkbox to the split node to optionally add the msg.complete (true) flag to the last msg of the sequence sent from the split.
<img width="358" alt="image" src="https://github.com/node-red/node-red/assets/5375409/00001973-d955-4e35-8579-705afbc9a9fe">

This is to address #4781, which flags a breaking change introduced by #4408 - which was an issue caused by the join node forcibly completing a join when in manual mode even when it wasn't wanted (as the parts property flagged that it was the last in the sequence) - But some users relied on this manual mode (mis-)behaviour and the change to make manual mean manual in #4408 has broken them.  

By adding this option to add msg.complete - will force the join to complete - when the last item has been processed even in manual mode.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
