### PR TITLE
make using msg.parts optional in join node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
@@ -17,6 +17,10 @@
 <script type="text/html" data-template-name="split">
     <!-- <div class="form-row"><span data-i18n="[html]split.intro"></span></div> -->
     <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
+    </div>
+    <div class="form-row">
         <label for="node-input-property"><i class="fa fa-forward"></i> <span data-i18n="split.split"></span></label>
         <input type="text" id="node-input-property" style="width:70%;"/>
     </div>
@@ -42,10 +46,6 @@
         <input type="checkbox" id="node-input-addname-cb" style="margin-left:10px; vertical-align:baseline; width:auto;">
         <label for="node-input-addname-cb" style="width:auto;" data-i18n="split.addname"></label>
         <input type="text" id="node-input-addname" style="width:70%">
-    </div>
-    <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
 </script>
 
@@ -123,6 +123,10 @@
 
 <script type="text/html" data-template-name="join">
     <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
+    </div>
+    <div class="form-row">
         <label data-i18n="join.mode.mode"></label>
         <select id="node-input-mode" style="width:200px;">
             <option value="auto" data-i18n="join.mode.auto"></option>
@@ -157,6 +161,12 @@
             <input type="text" id="node-input-joiner" style="width:70%">
             <input type="hidden" id="node-input-joinerType">
         </div>
+
+        <div class="form-row">
+            <input type="checkbox" id="node-input-useparts" style="margin-left:8px; margin-right:8px; vertical-align:baseline; width:auto;">
+            <label for="node-input-useparts" style="width:auto;" data-i18n="join.useparts"></label>
+        </div>
+
         <div class="form-row node-row-trigger" id="trigger-row">
             <label style="width:auto;" data-i18n="join.send"></label>
             <ul>
@@ -195,10 +205,6 @@
             <label for="node-input-reduceRight" style="width:70%;" data-i18n="join.reduce.right" style="margin-left:10px;"/>
         </div>
     </div>
-    <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
-    </div>
     <div class="form-tips form-tips-auto hide" data-i18n="[html]join.tip"></div>
 </script>
 
@@ -234,6 +240,7 @@
             },
             joiner: { value:"\\n"},
             joinerType: { value:"str"},
+            useparts: { value:false },
             accumulate: { value:"false" },
             timeout: {value:""},
             count: {value:""},

--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.html
@@ -266,6 +266,12 @@
         },
         oneditprepare: function() {
             var node = this;
+            $("#node-input-useparts").on("change", function(e) {
+                if (node.useparts === undefined) {
+                    node.useparts = true;
+                    $("#node-input-useparts").attr('checked', true);
+                }
+            });
 
             $("#node-input-mode").on("change", function(e) {
                 var val = $(this).val();

--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -444,6 +444,7 @@ module.exports = function(RED) {
         this.count = Number(n.count || 0);
         this.joiner = n.joiner||"";
         this.joinerType = n.joinerType||"str";
+        this.useparts = n.useparts || false;
 
         this.reduce = (this.mode === "reduce");
         if (this.reduce) {
@@ -611,7 +612,7 @@ module.exports = function(RED) {
                     return;
                 }
 
-                if (node.mode === 'custom' && msg.hasOwnProperty('parts')) {
+                if (node.mode === 'custom' && msg.hasOwnProperty('parts') && node.useparts === false ) {
                     if (msg.parts.hasOwnProperty('parts')) {
                         msg.parts = { parts: msg.parts.parts };
                     }

--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -444,7 +444,8 @@ module.exports = function(RED) {
         this.count = Number(n.count || 0);
         this.joiner = n.joiner||"";
         this.joinerType = n.joinerType||"str";
-        this.useparts = n.useparts || false;
+        if (n.useparts === undefined) { this.useparts = true; }
+        else { this.useparts = n.useparts || false; }
 
         this.reduce = (this.mode === "reduce");
         if (this.reduce) {

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -1046,6 +1046,7 @@
         "joinedUsing": "joined using",
         "send": "Send the message:",
         "afterCount": "After a number of message parts",
+        "useparts": "Use existing msg.parts property",
         "count": "count",
         "subsequent": "and every subsequent message.",
         "afterTimeout": "After a timeout following the first message",


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
This is an alternative fix for #4781. Instead of PR #4795.
Instead of adding msg.complete on the join node - this optionally allows use of msg.parts in the join node when in manual mode. Default is not to use msg.parts. So is still breaking compared to Node-RED 3.x but is a cleaner fix in that it should also work with other nodes that create msg.parts.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
