### PR TITLE
Ensure subflow instance credential property values are extracted

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -1100,7 +1100,7 @@ RED.subflow = (function() {
                 input.val(val.value);
                 break;
             case "cred":
-                input = $('<input type="password">').css('width','70%').appendTo(row);
+                input = $('<input type="password">').css('width','70%').attr('id', elId).appendTo(row);
                 if (node.credentials) {
                     if (node.credentials[tenv.name]) {
                         input.val(node.credentials[tenv.name]);
@@ -1346,7 +1346,7 @@ RED.subflow = (function() {
                         }
                         break;
                     case "cred":
-                        item.value = input.val();
+                        item.value = input.typedInput('value');
                         item.type = 'cred';
                         break;
                     case "spinner":


### PR DESCRIPTION
The subflow instance form wasn't setting a proper `id` on the credentials typedInput. This would lead to the value not being captured properly.

I'm slightly nervous of this fix as it's touching lines of code that haven't been touched for a long time - whic implies this has been broken for a long time. But I'm certain I've used this feature. I've tried all the usual scenarios and it appears to work okay.