### PR TITLE
Ensure group nodes are properly exported in /flow api

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/index.js
@@ -645,16 +645,27 @@ function getFlow(id) {
     if (id !== 'global') {
         result.nodes = [];
     }
+
+    if (flow.groups) {
+        var nodeIds = Object.keys(flow.groups);
+        if (nodeIds.length > 0) {
+            nodeIds.forEach(function(nodeId) {
+                var node = jsonClone(flow.groups[nodeId]);
+                delete node.credentials;
+                result.nodes.push(node)
+            })
+        }
+    }
     if (flow.nodes) {
         var nodeIds = Object.keys(flow.nodes);
         if (nodeIds.length > 0) {
-            result.nodes = nodeIds.map(function(nodeId) {
+            nodeIds.forEach(function(nodeId) {
                 var node = jsonClone(flow.nodes[nodeId]);
                 if (node.type === 'link out') {
                     delete node.wires;
                 }
                 delete node.credentials;
-                return node;
+                result.nodes.push(node)
             })
         }
     }
@@ -680,6 +691,17 @@ function getFlow(id) {
                 delete node.credentials
                 return node
             });
+            if (subflow.groups) {
+                var nodeIds = Object.keys(subflow.groups);
+                if (nodeIds.length > 0) {
+                    nodeIds.forEach(function(nodeId) {
+                        var node = jsonClone(subflow.groups[nodeId]);
+                        delete node.credentials;
+                        subflow.nodes.push(node)
+                    })
+                }
+                delete subflow.groups
+            }
             if (subflow.configs) {
                 var configIds = Object.keys(subflow.configs);
                 subflow.configs = configIds.map(function(id) {


### PR DESCRIPTION
Fixes #4798 
The group nodes were not being included in the `/flow` response - as the runtime keeps them listed separately.

This ensures the groups nodes are included in the `nodes` property of the flow/subflow export.