### PR TITLE
Fix a node with an invalid number of outputs

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2321,29 +2321,29 @@ RED.nodes = (function() {
                             node.type = "unknown";
                         }
                         if (node._def.category != "config") {
-                            if (n.hasOwnProperty('inputs')) {
-                                node.inputs = n.inputs;
+                            if (n.hasOwnProperty('inputs') && def.defaults.hasOwnProperty("inputs")) {
+                                node.inputs = parseInt(n.inputs, 10);
                                 node._config.inputs = JSON.stringify(n.inputs);
                             } else {
                                 node.inputs = node._def.inputs;
                             }
-                            if (n.hasOwnProperty('outputs')) {
-                                node.outputs = n.outputs;
+                            if (n.hasOwnProperty('outputs') && def.defaults.hasOwnProperty("outputs")) {
+                                node.outputs = parseInt(n.outputs, 10);
                                 node._config.outputs = JSON.stringify(n.outputs);
                             } else {
                                 node.outputs = node._def.outputs;
                             }
-                            if (node.hasOwnProperty('wires') && node.wires.length > node.outputs) {
-                                if (!node._def.defaults.hasOwnProperty("outputs") || !isNaN(parseInt(n.outputs))) {
-                                    // If 'wires' is longer than outputs, clip wires
-                                    console.log("Warning: node.wires longer than node.outputs - trimming wires:",node.id," wires:",node.wires.length," outputs:",node.outputs);
-                                    node.wires = node.wires.slice(0,node.outputs);
-                                } else {
-                                    // The node declares outputs in its defaults, but has not got a valid value
-                                    // Defer to the length of the wires array
-                                    node.outputs = node.wires.length;
-                                }
+
+                            // The node declares outputs in its defaults, but has not got a valid value
+                            // Defer to the length of the wires array
+                            if (isNaN(node.outputs)) {
+                                node.outputs = node.wires.length;
+                            } else if (node.wires.length > node.outputs) {
+                                // If 'wires' is longer than outputs, clip wires
+                                console.log("Warning: node.wires longer than node.outputs - trimming wires:", node.id, " wires:", node.wires.length, " outputs:", node.outputs);
+                                node.wires = node.wires.slice(0, node.outputs);
                             }
+
                             for (d in node._def.defaults) {
                                 if (node._def.defaults.hasOwnProperty(d) && d !== 'inputs' && d !== 'outputs') {
                                     node[d] = n[d];

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2336,7 +2336,7 @@ RED.nodes = (function() {
 
                             // The node declares outputs in its defaults, but has not got a valid value
                             // Defer to the length of the wires array
-                            if (node.hasOwnProperty('wires'))
+                            if (node.hasOwnProperty('wires')) {
                                 if (isNaN(node.outputs)) {
                                     node.outputs = node.wires.length;
                                 } else if (node.wires.length > node.outputs) {

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2336,12 +2336,14 @@ RED.nodes = (function() {
 
                             // The node declares outputs in its defaults, but has not got a valid value
                             // Defer to the length of the wires array
-                            if (isNaN(node.outputs)) {
-                                node.outputs = node.wires.length;
-                            } else if (node.wires.length > node.outputs) {
-                                // If 'wires' is longer than outputs, clip wires
-                                console.log("Warning: node.wires longer than node.outputs - trimming wires:", node.id, " wires:", node.wires.length, " outputs:", node.outputs);
-                                node.wires = node.wires.slice(0, node.outputs);
+                            if (node.hasOwnProperty('wires'))
+                                if (isNaN(node.outputs)) {
+                                    node.outputs = node.wires.length;
+                                } else if (node.wires.length > node.outputs) {
+                                    // If 'wires' is longer than outputs, clip wires
+                                    console.log("Warning: node.wires longer than node.outputs - trimming wires:", node.id, " wires:", node.wires.length, " outputs:", node.outputs);
+                                    node.wires = node.wires.slice(0, node.outputs);
+                                }
                             }
 
                             for (d in node._def.defaults) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fix a node with an invalid number of outputs - isNaN check should be at the top.

Retrieve `nodeImported.outputs` only if the node definition allows it.

Related PR: #4757.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
