### PR TITLE
Fix updating the Subflow name during a copy

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1043,7 +1043,8 @@ RED.nodes = (function() {
             // Update the Subflow name to highlight that this is a copy
             const subflowNames = Object.keys(subflows).map(function (sfid) {
                 return subflows[sfid].name || "";
-            }).sort();
+            })
+            subflowNames.sort()
 
             let copyNumber = 1;
             let subflowName = sf.name;

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1032,23 +1032,31 @@ RED.nodes = (function() {
         return {nodes:removedNodes,links:removedLinks, groups: removedGroups, junctions: removedJunctions};
     }
 
+    /**
+      * Add a Subflow to the Workspace
+      *
+      * @param {object} sf The Subflow to add.
+      * @param {boolean|undefined} createNewIds Whether to update the name.
+      */
     function addSubflow(sf, createNewIds) {
         if (createNewIds) {
-            var subflowNames = Object.keys(subflows).map(function(sfid) {
-                return subflows[sfid].name;
-            });
+            // Update the Subflow name to highlight that this is a copy
+            const subflowNames = Object.keys(subflows).map(function (sfid) {
+                return subflows[sfid].name || "";
+            }).sort();
 
-            subflowNames.sort();
-            var copyNumber = 1;
-            var subflowName = sf.name;
+            let copyNumber = 1;
+            let subflowName = sf.name;
             subflowNames.forEach(function(name) {
                 if (subflowName == name) {
+                    subflowName = sf.name + " (" + copyNumber + ")";
                     copyNumber++;
-                    subflowName = sf.name+" ("+copyNumber+")";
                 }
             });
+
             sf.name = subflowName;
         }
+
         subflows[sf.id] = sf;
         allNodes.addTab(sf.id);
         linkTabMap[sf.id] = [];
@@ -2023,6 +2031,8 @@ RED.nodes = (function() {
                 if (matchingSubflow) {
                     subflow_denylist[n.id] = matchingSubflow;
                 } else {
+                    const oldId = n.id;
+
                     subflow_map[n.id] = n;
                     if (createNewIds || options.importMap[n.id] === "copy") {
                         nid = getID();
@@ -2050,7 +2060,7 @@ RED.nodes = (function() {
                         n.status.id = getID();
                     }
                     new_subflows.push(n);
-                    addSubflow(n,createNewIds || options.importMap[n.id] === "copy");
+                    addSubflow(n,createNewIds || options.importMap[oldId] === "copy");
                 }
             }
         }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fix updating the Subflow name during a copy:

- If the Subflow is copied, updating the id before calling `addSubflow` causes `createNewIds` is false.
- Name update starts at 2 (instead of 1)

Related PR: #4757.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality