### PR TITLE
Handle the import of an incomplete Subflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1049,6 +1049,9 @@ RED.nodes = (function() {
             });
             sf.name = subflowName;
         }
+
+        sf.instances = [];
+
         subflows[sf.id] = sf;
         allNodes.addTab(sf.id);
         linkTabMap[sf.id] = [];
@@ -1101,7 +1104,7 @@ RED.nodes = (function() {
                 module: "node-red"
             }
         });
-        sf.instances = [];
+
         sf._def = RED.nodes.getType("subflow:"+sf.id);
         RED.events.emit("subflows:add",sf);
     }
@@ -1743,7 +1746,8 @@ RED.nodes = (function() {
             // Remove the old subflow definition - but leave the instances in place
             var removalResult = RED.subflow.removeSubflow(n.id, true);
             // Create the list of nodes for the new subflow def
-            var subflowNodes = [n].concat(zMap[n.id]);
+            // Need to sort the list in order to remove missing nodes
+            var subflowNodes = [n].concat(zMap[n.id]).filter((s) => !!s);
             // Import the new subflow - no clashes should occur as we've removed
             // the old version
             var result = importNodes(subflowNodes);
@@ -2170,7 +2174,7 @@ RED.nodes = (function() {
                         x:parseFloat(n.x || 0),
                         y:parseFloat(n.y || 0),
                         z:n.z,
-                        type:0,
+                        type: n.type,
                         info: n.info,
                         changed:false,
                         _config:{}
@@ -2261,6 +2265,15 @@ RED.nodes = (function() {
                                 outputs: n.outputs|| (n.wires && n.wires.length) || 0,
                                 set: registry.getNodeSet("node-red/unknown")
                             }
+                            var orig = {};
+                            for (var p in n) {
+                                if (n.hasOwnProperty(p) && p!="x" && p!="y" && p!="z" && p!="id" && p!="wires") {
+                                    orig[p] = n[p];
+                                }
+                            }
+                            node._orig = orig;
+                            node.name = n.type;
+                            node.type = "unknown";
                         } else {
                             if (subflow_denylist[parentId] || createNewIds || options.importMap[n.id] === "copy") {
                                 parentId = subflow.id;
@@ -2441,9 +2454,11 @@ RED.nodes = (function() {
             n = new_subflows[i];
             n.in.forEach(function(input) {
                 input.wires.forEach(function(wire) {
-                    var link = {source:input, sourcePort:0, target:node_map[wire.id]};
-                    addLink(link);
-                    new_links.push(link);
+                    if (node_map.hasOwnProperty(wire.id)) {
+                        var link = {source:input, sourcePort:0, target:node_map[wire.id]};
+                        addLink(link);
+                        new_links.push(link);
+                    }
                 });
                 delete input.wires;
             });
@@ -2452,11 +2467,13 @@ RED.nodes = (function() {
                     var link;
                     if (subflow_map[wire.id] && subflow_map[wire.id].id == n.id) {
                         link = {source:n.in[wire.port], sourcePort:wire.port,target:output};
-                    } else {
+                    } else if (node_map.hasOwnProperty(wire.id) || subflow_map.hasOwnProperty(wire.id)) {
                         link = {source:node_map[wire.id]||subflow_map[wire.id], sourcePort:wire.port,target:output};
                     }
-                    addLink(link);
-                    new_links.push(link);
+                    if (link) {
+                        addLink(link);
+                        new_links.push(link);
+                    }
                 });
                 delete output.wires;
             });
@@ -2465,11 +2482,13 @@ RED.nodes = (function() {
                     var link;
                     if (subflow_map[wire.id] && subflow_map[wire.id].id == n.id) {
                         link = {source:n.in[wire.port], sourcePort:wire.port,target:n.status};
-                    } else {
+                    } else if (node_map.hasOwnProperty(wire.id) || subflow_map.hasOwnProperty(wire.id)) {
                         link = {source:node_map[wire.id]||subflow_map[wire.id], sourcePort:wire.port,target:n.status};
                     }
-                    addLink(link);
-                    new_links.push(link);
+                    if (link) {
+                        addLink(link);
+                        new_links.push(link);
+                    }
                 });
                 delete n.status.wires;
             }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Handle the import of an incomplete Subflow:

- Missing def
  If I import a Subflow node without its definition, I want the node to be of unknown type which allows me to open the edit box and be able to export this node.
- Add def
  Replacing this unknown node with the new definition creates an error because `sf.instances` does not yet exist.
- Missing Node
  If I import the definition of a Subflow with one or more missing nodes, need to handle that these links are abandoned.

Related PR: #4757.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
