### PR TITLE
Fix node validation if the property is not required

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -148,12 +148,23 @@ RED.editor = (function() {
             ((typeof definition[property].label) == "string")) {
             label = definition[property].label;
         }
-        if ("required" in definition[property] && definition[property].required) {
-            valid = value !== "";
-            if (!valid && label) {
-                return RED._("validator.errors.missing-required-prop", {
-                    prop: label
-                });
+        if ("required" in definition[property]) {
+            if (definition[property].required) {
+                valid = value !== "";
+                if (!valid && label) {
+                    return RED._("validator.errors.missing-required-prop", {
+                        prop: label
+                    });
+                }
+            } else {
+                if (value === "") {
+                    return true;
+                }
+            }
+            
+        } else {
+            if (value === "") {
+                return true;
             }
         }
         if (valid && "validate" in definition[property]) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -148,26 +148,21 @@ RED.editor = (function() {
             ((typeof definition[property].label) == "string")) {
             label = definition[property].label;
         }
-        if ("required" in definition[property]) {
-            if (definition[property].required) {
-                valid = value !== "";
-                if (!valid && label) {
-                    return RED._("validator.errors.missing-required-prop", {
-                        prop: label
-                    });
-                }
-            } else {
+        if ("required" in definition[property] && definition[property].required) {
+            valid = value !== "";
+            if (!valid && label) {
+                return RED._("validator.errors.missing-required-prop", {
+                    prop: label
+                });
+            }
+        }
+        if (valid && "validate" in definition[property]) {
+            if (definition[property].hasOwnProperty("required") &&
+                definition[property].required === false) {
                 if (value === "") {
                     return true;
                 }
             }
-            
-        } else {
-            if (value === "") {
-                return true;
-            }
-        }
-        if (valid && "validate" in definition[property]) {
             try {
                 var opt = {};
                 if (label) {
@@ -194,6 +189,11 @@ RED.editor = (function() {
                 });
             }
         } else if (valid) {
+            if (definition[property].hasOwnProperty("required") && definition[property].required === false) {
+                if (value === "") {
+                    return true;
+                }
+            }
             // If the validator is not provided in node property => Check if the input has a validator
             if ("category" in node._def) {
                 const isConfig = node._def.category === "config";


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fix node validation if the property is not required.

Issue described on the [Forum](https://discourse.nodered.org/t/node-edit-dialogue-json-input-complaining-about-being-null-version-4-0-0-18/88997).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
