### PR TITLE
Allow auth cookie name to be customised

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/auth/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/index.js
@@ -182,6 +182,10 @@ function genericStrategy(adminApp,strategy) {
             maxAge: null,
             ...settings.httpAdminCookieOptions
         }
+        if (sessionOptions.cookie.name){
+            sessionOptions.name = sessionOptions.cookie.name
+            delete sessionOptions.cookie.name
+        }
     }
     adminApp.use(session(sessionOptions));
     //TODO: all passport references ought to be in ./auth
@@ -217,10 +221,10 @@ function genericStrategy(adminApp,strategy) {
     adminApp.get('/auth/strategy',
         passport.authenticate(strategy.name, {
             session:false,
-            failureMessage: true,
-            failureRedirect: settings.httpAdminRoot + '?session_message=Login Failed'
+            failWithError: true,
+            failureMessage: true
         }),
-        completeGenerateStrategyAuth,
+        completeGenericStrategyAuth,
         handleStrategyError
     );
 
@@ -232,14 +236,14 @@ function genericStrategy(adminApp,strategy) {
         passport.authenticate(strategy.name, {
             session:false,
             failureMessage: true,
-            failureRedirect: settings.httpAdminRoot + '?session_message=Login Failed'
+            failWithError: true
         }),
-        completeGenerateStrategyAuth,
+        completeGenericStrategyAuth,
         handleStrategyError
     );
 
 }
-function completeGenerateStrategyAuth(req,res) {
+function completeGenericStrategyAuth(req,res) {
     var tokens = req.user.tokens;
     delete req.user.tokens;
     // Successful authentication, redirect home.
@@ -249,6 +253,8 @@ function handleStrategyError(err, req, res, next) {
     if (res.headersSent) {
         return next(err)
     }
+    // Remove the header that passport auto-adds as we don't need it
+    res.removeHeader('WWW-Authenticate')
     log.audit({event: "auth.login.fail.oauth",error:err.toString()});
     res.redirect(settings.httpAdminRoot + '?session_message='+err.toString());
 }


### PR DESCRIPTION
In 4.0 we added support for customising the auth session cookie via `httpAdminCookieOptions`.

The session cookie still uses the default `connect.sid` name however. For reasons, we have a need to customise this cookie name - to avoid potential clashes.

I considered proposing hardcoding the cookie name to something different, but it feels much safer to make this customisable - hence this PR.

Whilst technically the cookie name isn't part of the cookie options object the underlying library uses, I don't see a good reason not to include it in the `httpAdminCookieOptions` object - we just have to extract it and pass it through to the right place.

---

Whilst investigating the original issue that has led to this PR, I also spotted our error handling around oauth authentication wasn't ideal.

We currently use `failureRedirect` to tell Passport to redirect on auth failure. That's fine, but it means we don't audit log the failure. We already had the middleware in place to capture the error and log it before redirecting - it just wasn't being reached because passport was taking care of it.

This PR includes a small change to tell passport *not* to redirect on failure and to pass the error on to our middleware. It uses the `failWithError` flag which I can't find in the passport docs, but was discovered whilst stepping through the code.

There is no external change in behaviour, other than having an audit log entry for oauth failure.