### PR TITLE
Guard against undefined sessions in multiplayer

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/multiplayer/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/multiplayer/index.js
@@ -23,14 +23,16 @@ module.exports = {
             if (existingSessionId) {
                 connections.delete(opts.session)
                 const session = sessions.get(existingSessionId)
-                session.active = false
-                session.idleTimeout = setTimeout(() => {
-                    sessions.delete(existingSessionId)
-                }, 30000)
-                runtime.events.emit('comms', {
-                    topic: "multiplayer/connection-removed",
-                    data: { session: existingSessionId }
-                })
+                if (session) {
+                    session.active = false
+                    session.idleTimeout = setTimeout(() => {
+                        sessions.delete(existingSessionId)
+                    }, 30000)
+                    runtime.events.emit('comms', {
+                        topic: "multiplayer/connection-removed",
+                        data: { session: existingSessionId }
+                    })
+                }
             }
         })
         runtime.events.on('comms:message:multiplayer/connect', (opts) => {

--- a/packages/node_modules/@node-red/runtime/lib/multiplayer/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/multiplayer/index.js
@@ -93,29 +93,31 @@ module.exports = {
             const sessionId = connections.get(opts.session)
             const session = sessions.get(sessionId)
 
-            if (opts.user) {
-                if (session.user.anonymous !== opts.user.anonymous) {
-                    session.user = opts.user
-                    runtime.events.emit('comms', {
-                        topic: 'multiplayer/connection-added',
-                        excludeSession: opts.session,
-                        data: session
-                    })
+            if (session) {
+                if (opts.user) {
+                    if (session.user.anonymous !== opts.user.anonymous) {
+                        session.user = opts.user
+                        runtime.events.emit('comms', {
+                            topic: 'multiplayer/connection-added',
+                            excludeSession: opts.session,
+                            data: session
+                        })
+                    }
                 }
-            }
 
-            session.location = opts.data
+                session.location = opts.data
 
-            const payload = {
-                session: sessionId,
-                workspace: opts.data.workspace,
-                node: opts.data.node
+                const payload = {
+                    session: sessionId,
+                    workspace: opts.data.workspace,
+                    node: opts.data.node
+                }
+                runtime.events.emit('comms', {
+                    topic: 'multiplayer/location',
+                    data: payload,
+                    excludeSession: opts.session
+                })
             }
-            runtime.events.emit('comms', {
-                topic: 'multiplayer/location',
-                data: payload,
-                excludeSession: opts.session
-            })
         })
     }
 }


### PR DESCRIPTION
Fixes #4814 

Having stepped through the logic in the multiplayer code, I can't quite see how `session` can be undefined to cause the exception reported in #4814. However, the evidence shows it is possible to happen.

This PR adds a suitable guard to ensure we don't get an uncaught exception when it does.

Will need to revisit this as we progress the multiplayer features.