### PR TITLE
Ensure mermaid.min.js is cached properly between loads of the editor

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/mermaid.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/mermaid.js
@@ -11,9 +11,22 @@ RED.editor.mermaid = (function () {
             
             if (!initializing) {
                 initializing = true
-                $.getScript(
-                    'vendor/mermaid/mermaid.min.js',
-                    function (data, stat, jqxhr) {
+                // Find the cache-buster:
+                let cacheBuster
+                $('script').each(function (i, el) { 
+                    if (!cacheBuster) {
+                        const src = el.getAttribute('src')
+                        const m = /\?v=(.+)$/.exec(src)
+                        if (m) {
+                            cacheBuster = m[1]
+                        }
+                    }
+                })
+                $.ajax({
+                    url: `vendor/mermaid/mermaid.min.js?v=${cacheBuster}`,
+                    dataType: "script",
+                    cache: true,
+                    success: function (data, stat, jqxhr) {
                         mermaid.initialize({
                             startOnLoad: false,
                             theme: RED.settings.get('mermaid', {}).theme
@@ -24,7 +37,7 @@ RED.editor.mermaid = (function () {
                             render(pending)
                         }
                     }
-                )
+                });
             }
         } else {
             const nodes = document.querySelectorAll(selector)


### PR DESCRIPTION
By default `$.getScript` will append a timestamp-based query param to ensure the script doesn't get cached by the browser. This is entirely not what we want it to do.

We already have a cache-buster query param we use on all asserts loaded directly from the base html. This cache-buster value only changes when a new NR version is installed - which is when we want to ensure the browser loads the new version of the assets.

This PR updates the mermaid loading code to use our cache-buster value and not the timestamp one. This will save over 3Mb of traffic on each editor load (after the initial load).