### PR TITLE
Use a more subtle border on the header

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
@@ -259,7 +259,7 @@ $deploy-button-background-disabled-hover: #555;
 
 $header-background: #000;
 $header-button-background-active: #121212;
-$header-accent: #d41313;
+$header-accent: #8c101c;
 $header-menu-color: #eee;
 $header-menu-color-disabled: #666;
 $header-menu-heading-color: #fff;

--- a/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
@@ -259,7 +259,7 @@ $deploy-button-background-disabled-hover: #555;
 
 $header-background: #000;
 $header-button-background-active: #121212;
-$header-accent: #8c101c;
+$header-accent: #C02020;
 $header-menu-color: #eee;
 $header-menu-color-disabled: #666;
 $header-menu-heading-color: #fff;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

As discussed [on the forum](https://discourse.nodered.org/t/can-we-have-a-more-subtle-border-on-the-header/89043), I'm proposing to use a color that makes the header border more subtle. I used the same red from the Deploy button.

Now:

<img width="960" alt="SCR-20240628-jads" src="https://github.com/node-red/node-red/assets/29807944/2b852940-af98-430a-be6a-3b32bb6705eb"><br>

Then:

<img width="960" alt="SCR-20240628-jaif" src="https://github.com/node-red/node-red/assets/29807944/1d0921c8-1cb8-446d-8fde-e958d01b402f"><br>

It also works well with themes. Here's an example using the 'dark' theme.

Now:

<img width="960" alt="SCR-20240628-jbra" src="https://github.com/node-red/node-red/assets/29807944/1aabd1b8-25ec-4795-bffe-c4049e50d751"><br>

Then:

<img width="960" alt="SCR-20240628-jbtn" src="https://github.com/node-red/node-red/assets/29807944/67fc3e22-7346-42f4-8f57-74a7fe95db9c"><br>

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
