### PR TITLE
Clean up orphaned editors

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
@@ -165,7 +165,13 @@ RED.editor.codeEditor.monaco = (function() {
         //Handles orphaned models
         //ensure loaded models that are not explicitly destroyed by a call to .destroy() are disposed
         RED.events.on("editor:close",function() {
-            let models = window.monaco ? monaco.editor.getModels() : null;
+            if (!window.monaco) { return; }
+            const editors = window.monaco.editor.getEditors()
+            const orphanEditors = editors.filter(editor => editor && !document.body.contains(editor.getDomNode()))
+            orphanEditors.forEach(editor => {
+                editor.dispose();
+            });
+            let models = monaco.editor.getModels()
             if(models && models.length) {
                 console.warn("Cleaning up monaco models left behind. Any node that calls createEditor() should call .destroy().")
                 for (let index = 0; index < models.length; index++) {
@@ -1124,6 +1130,7 @@ RED.editor.codeEditor.monaco = (function() {
 
             $(el).remove();
             $(toolbarRow).remove();
+            ed.dispose();
         }
 
         ed.resize = function resize() {


### PR DESCRIPTION
closes #4820

## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

1. call editor.dispose at end of destroy call
2. iterate any editors not in DOM and call dispose 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
