### PR TITLE
Fix menu to enable/disable selection when it's a group

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
@@ -32,24 +32,28 @@ RED.contextMenu = (function () {
             const canRemoveFromGroup = hasSelection && !!selection.nodes[0].g
             let hasGroup, isAllGroups = true, hasDisabledNode, hasEnabledNode, hasLabeledNode, hasUnlabeledNode;
             if (hasSelection) {
-                selection.nodes.forEach(n => {
+                const nodes = selection.nodes.slice();
+                while (nodes.length) {
+                    const n = nodes.shift();
                     if (n.type === 'group') {
                         hasGroup = true;
+                        nodes.push(...n.nodes);
                     } else {
                         isAllGroups = false;
-                    }
-                    if (n.d) {
-                        hasDisabledNode = true;
-                    } else {
-                        hasEnabledNode = true;
+                        if (n.d) {
+                            hasDisabledNode = true;
+                        } else {
+                            hasEnabledNode = true;
+                        }
                     }
                     if (n.l === undefined || n.l) {
                         hasLabeledNode = true;
                     } else {
                         hasUnlabeledNode = true;
                     }
-                });
+                }
             }
+
             const offset = $("#red-ui-workspace-chart").offset()
 
             let addX = options.x - offset.left + $("#red-ui-workspace-chart").scrollLeft()


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #4827.

If the node in the selection is a group, must retrieve the nodes of that group.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
