### PR TITLE
Let batch node terminate "early" if msg.parts set to end of sequence

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/sequence/19-batch.html
+++ b/packages/node_modules/@node-red/nodes/core/sequence/19-batch.html
@@ -36,6 +36,10 @@
             <label style="margin-left: 10px; width: 175px;" for="node-input-overlap" data-i18n="batch.count.overlap"></label>
             <input type="text" id="node-input-overlap" style="width: 50px;">
         </div>
+        <div class="form-row">
+            <input type="checkbox" id="node-input-honourParts" style="margin-left: 10px; margin-right:10px; vertical-align:top; width:auto;">
+            <label for="node-input-honourParts" style="width:auto;" data-i18n="batch.honourParts"></label>
+        </div>
     </div>
 
     <div class="node-row-msg-interval">
@@ -45,7 +49,7 @@
             <span data-i18n="batch.interval.seconds"></span>
         </div>
         <div class="form-row">
-            <input type="checkbox" id="node-input-allowEmptySequence" style="margin-left:20px; margin-right: 10px; vertical-align:top; width:auto;">
+            <input type="checkbox" id="node-input-allowEmptySequence" style="margin-left:20px; margin-right:10px; vertical-align:top; width:auto;">
             <label for="node-input-allowEmptySequence" style="width:auto;" data-i18n="batch.interval.empty"></label>
         </div>
     </div>
@@ -101,6 +105,7 @@
                 }
             },
             allowEmptySequence: {value:false},
+            honourParts: {value:false},
             topics: {value:[{topic:""}]}
         },
         inputs:1,

--- a/packages/node_modules/@node-red/nodes/core/sequence/19-batch.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/19-batch.js
@@ -181,6 +181,8 @@ module.exports = function(RED) {
         RED.nodes.createNode(this,n);
         var node = this;
         var mode = n.mode || "count";
+        var eof = false;
+        node.honourParts = n.honourParts || false;
 
         node.pending_count = 0;
         if (mode === "count") {
@@ -201,9 +203,12 @@ module.exports = function(RED) {
                     return;
                 }
                 var queue = node.pending;
+                if (node.honourParts && msg.hasOwnProperty("parts")) {
+                    if (msg.parts.index + 1 === msg.parts.count) { eof = true; }
+                }
                 queue.push({msg, send, done});
                 node.pending_count++;
-                if (queue.length === count) {
+                if (queue.length === count || eof === true) {
                     send_msgs(node, queue, is_overlap);
                     for (let i = 0; i < queue.length-overlap; i++) {
                         queue[i].done();
@@ -211,6 +216,7 @@ module.exports = function(RED) {
                     node.pending =
                         (overlap === 0) ? [] : queue.slice(-overlap);
                     node.pending_count = 0;
+                    eof = false;
                 }
                 var max_msgs = max_kept_msgs_count(node);
                 if ((max_msgs > 0) && (node.pending_count > max_msgs)) {

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -1112,6 +1112,7 @@
         "too-many": "too many pending messages in batch node",
         "unexpected": "unexpected mode",
         "no-parts": "no parts property in message",
+        "honourParts": "Allow msg.parts to also complete batch operation.",
         "error": {
             "invalid-count": "Invalid count",
             "invalid-overlap": "Invalid overlap",

--- a/test/nodes/core/sequence/19-batch_spec.js
+++ b/test/nodes/core/sequence/19-batch_spec.js
@@ -98,7 +98,7 @@ describe('BATCH node', function() {
                 var n2 = helper.getNode("n2");
                 check_data(n1, n2, results, done);
                 for(var i = 0; i < 6; i++) {
-                    n1.receive({payload: i});
+                    n1.receive({payload: i, parts: { count:6, index:i }});
                 }
             });
         }
@@ -163,6 +163,25 @@ describe('BATCH node', function() {
             var results = [
                 [0, 1],
                 [2, 3],
+                [4, 5]
+            ];
+            check_count(flow, results, done);
+        });
+
+        it('should create seq. with count (more sent than count)', function(done) {
+            var flow = [{id:"n1", type:"batch", name: "BatchNode", mode: "count", count: 4, overlap: 0, interval: 10, allowEmptySequence: false, topics: [], wires:[["n2"]]},
+                        {id:"n2", type:"helper"}];
+            var results = [
+                [0, 1, 2, 3]
+            ];
+            check_count(flow, results, done);
+        });
+
+        it('should create seq. with count and terminate early if parts honoured', function(done) {
+            var flow = [{id:"n1", type:"batch", name: "BatchNode", mode: "count", count: 4, overlap: 0, interval: 10, allowEmptySequence:false, honourParts:true, topics: [], wires:[["n2"]]},
+                        {id:"n2", type:"helper"}];
+            var results = [
+                [0, 1, 2, 3],
                 [4, 5]
             ];
             check_count(flow, results, done);
@@ -455,7 +474,7 @@ describe('BATCH node', function() {
         function mapiDoneTestHelper(done, mode, count, overlap, interval, allowEmptySequence, msgAndTimings) {
             const completeNode = require("nr-test-utils").require("@node-red/nodes/core/common/24-complete.js");
             const catchNode = require("nr-test-utils").require("@node-red/nodes/core/common/25-catch.js");
-            const flow = [{id:"batchNode1", type:"batch", name: "BatchNode", mode, count, overlap, interval, 
+            const flow = [{id:"batchNode1", type:"batch", name: "BatchNode", mode, count, overlap, interval,
                            allowEmptySequence, topics: [{topic: "TA"}], wires:[[]]},
                           {id:"completeNode1",type:"complete",scope: ["batchNode1"],uncaught:false,wires:[["helperNode1"]]},
                           {id:"catchNode1", type:"catch",scope: ["batchNode1"],uncaught:false,wires:[["helperNode1"]]},
@@ -482,13 +501,13 @@ describe('BATCH node', function() {
         }
 
         it('should call done() when message is sent (mode: count)', function(done) {
-            mapiDoneTestHelper(done, "count", 2, 0, 2, false, [ 
+            mapiDoneTestHelper(done, "count", 2, 0, 2, false, [
                 { msg: {payload: 0}, delay: 0, avr: 0, var: 100},
                 { msg: {payload: 1}, delay: 0, avr: 0, var: 100}
             ]);
         });
         it('should call done() when reset (mode: count)', function(done) {
-            mapiDoneTestHelper(done, "count", 2, 0, 2, false, [ 
+            mapiDoneTestHelper(done, "count", 2, 0, 2, false, [
                 { msg: {payload: 0}, delay: 0, avr: 200, var: 100},
                 { msg: {payload: 1, reset:true}, delay: 200, avr: 200, var: 100}
             ]);


### PR DESCRIPTION
(ie index = count -1). Useful to close at end of files etc.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This PR adds a option to the batch node to allow it to terminate/send the batch early if the msg.parts indicates the end of a sequence - ie if msg.parts.index = msg.parts.count - 1 

Useful if you want to chunk say a file into batches of lines - but also send the last few remaining lines at the end of the file... etc

See forum request here - https://discourse.nodered.org/t/feature-request-read-file-set-msg-complete-to-true-for-last-line/89225

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `npm run test` to verify the unit tests pass
- [X] I have added suitable unit tests to cover the new/changed functionality
