### PR TITLE
Add qoutes when installing local tgz to fix spacing in the file path

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/installer.js
+++ b/packages/node_modules/@node-red/registry/lib/installer.js
@@ -144,7 +144,7 @@ async function installModule(module,version,url) {
         if (url) {
             if (pkgurlRe.test(url) || localtgzRe.test(url)) {
                 // Git remote url or Tarball url - check the valid package url
-                installName = url;
+                installName = localtgzRe.test(url) && slashRe.test(url) ? `"${url}"` : url;
                 isRegistryPackage = false;
             } else {
                 log.warn(log._("server.install.install-failed-url",{name:module,url:url}));

--- a/test/unit/@node-red/registry/lib/installer_spec.js
+++ b/test/unit/@node-red/registry/lib/installer_spec.js
@@ -258,6 +258,29 @@ describe('nodes/registry/installer', function() {
             }).catch(done);
         });
 
+        it("succeeds when file path is valid node-red module", function(done) {
+            var nodeInfo = {nodes:{module:"foo",types:["a"]}};
+
+            var res = {
+                code: 0,
+                stdout:"",
+                stderr:""
+            }
+            var p = Promise.resolve(res);
+            p.catch((err)=>{});
+            execResponse = p;
+
+            var addModule = sinon.stub(registry,"addModule").callsFake(function(md) {
+                return Promise.resolve(nodeInfo);
+            });
+
+            installer.installModule("foo",null,"/example path/foo-0.1.1.tgz").then(function(info) {
+                exec.run.lastCall.args[1].should.eql([ 'install', '--no-audit', '--no-update-notifier', '--no-fund', '--save', '--save-prefix=~', '--omit=dev', '--engine-strict', '"/example path/foo-0.1.1.tgz"' ]);
+                info.should.eql(nodeInfo);
+                done();
+            }).catch(done);
+        });
+
         it("triggers preInstall and postInstall hooks", function(done) {
             let receivedPreEvent,receivedPostEvent;
             hooks.add("preInstall", function(event) { event.args = ["a"]; receivedPreEvent = event; })


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
The pull request is to fix an issue with installing local Tarball files that have spaces in the file path. When attempting to install a package with a file path containing spaces, such as "C:\ProgramData\Node-Red Installer\nodes\objectif-lune-node-red-contrib-package.tgz", the installation would fail with an error message indicating the path was trimmed, like this:

"ERR! path C:\ProgramData\Node-Red/package.json"

The root cause is that the npm install command was not properly handling the file path with spaces, and as a result, the path was being truncated. also in the logs it have this npm install command 

npm.cmd install --no-audit --no-update-notifier --no-fund --save --save-prefix=~ --production --engine-strict C:\ProgramData\Node-Red Installer\nodes\objectif-lune-node-red-contrib-package.tgz

The fix is to include double quotes around the file path in the npm install command, like this:

npm.cmd install --no-audit --no-update-notifier --no-fund --save --save-prefix=~ --production --engine-strict "C:\ProgramData\Node-Red Installer\nodes\objectif-lune-node-red-contrib-package.tgz"

By wrapping the file path in double quotes, the npm install command can properly handle the spaces in the path and successfully install the local Tarball file.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
