### PR TITLE
Back off node 22.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22.4.x]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Node 22.5 has a regression causing npm install to hang. This PR pins our Node 22 version to 22.4.x for the time being.

We'll revert this once the issue has been resolved.