### PR TITLE
fix: modulesInUse might be undefined

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/projects/projectSettings.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/projects/projectSettings.js
@@ -308,7 +308,7 @@ RED.projects.settings = (function() {
         if (activeProject.dependencies) {
             for (var m in activeProject.dependencies) {
                 if (activeProject.dependencies.hasOwnProperty(m)) {
-                    var installed = !!RED.nodes.registry.getModule(m) && activeProject.dependencies[m] === modulesInUse[m].version;
+                    var installed = !!RED.nodes.registry.getModule(m) && activeProject.dependencies[m] === modulesInUse[m]?.version;
                     depsList.editableList('addItem',{
                         id: m,
                         version: activeProject.dependencies[m], //RED.nodes.registry.getModule(module).version,


### PR DESCRIPTION


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
This fixes an runtime error when `modulesInUse` is undefined. Trying to access `version` will prevent the project settings dialog from opening.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
