### PR TITLE
Refresh page title after changing tab name

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -904,6 +904,13 @@ RED.workspaces = (function() {
             }
         },
         refresh: function() {
+            var workspace = RED.nodes.workspace(RED.workspaces.active());
+            if (workspace) {
+                document.title = `${documentTitle} : ${workspace.label}`;
+            } else {
+                var subflow = RED.nodes.subflow(RED.workspaces.active());
+                document.title = `${documentTitle} : ${subflow.name}`;
+            }
             RED.nodes.eachWorkspace(function(ws) {
                 workspace_tabs.renameTab(ws.id,ws.label);
                 $("#red-ui-tab-"+(ws.id.replace(".","-"))).attr("flowname",ws.label)

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -909,7 +909,11 @@ RED.workspaces = (function() {
                 document.title = `${documentTitle} : ${workspace.label}`;
             } else {
                 var subflow = RED.nodes.subflow(RED.workspaces.active());
-                document.title = `${documentTitle} : ${subflow.name}`;
+                if (subflow) {
+                    document.title = `${documentTitle} : ${subflow.name}`;
+                } else {
+                    document.title = documentTitle
+                }
             }
             RED.nodes.eachWorkspace(function(ws) {
                 workspace_tabs.renameTab(ws.id,ws.label);


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
The page title should always be the name of the active workspace, but the name is not updated after changing tab and subflow name. To solve this problem, I added handling to update the page title.

<img width="737" alt="Screenshot 2024-08-12 at 13 43 53" src="https://github.com/user-attachments/assets/4e632657-b0e1-4536-a877-fd560ef648a6">

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
