### PR TITLE
Fix moving link wires

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -3189,27 +3189,59 @@ RED.view = (function() {
 
             for (i=0;i<drag_lines.length;i++) {
                 if (portType != drag_lines[i].portType && mouseup_node !== drag_lines[i].node) {
-                    var drag_line = drag_lines[i];
-                    var src,dst,src_port;
+                    let drag_line = drag_lines[i];
+                    let src,dst,src_port;
+                    let oldDst;
+                    let oldSrc;
                     if (drag_line.portType === PORT_TYPE_OUTPUT) {
                         src = drag_line.node;
                         src_port = drag_line.port;
                         dst = mouseup_node;
+                        oldSrc = src;
+                        if (drag_line.link) {
+                            oldDst = drag_line.link.target;
+                        }
                     } else if (drag_line.portType === PORT_TYPE_INPUT) {
                         src = mouseup_node;
                         dst = drag_line.node;
                         src_port = portIndex || 0;
+                        oldSrc = dst;
+                        if (drag_line.link) {
+                            oldDst = drag_line.link.source
+                        }
                     }
                     var link = {source: src, sourcePort:src_port, target: dst};
                     if (drag_line.virtualLink) {
                         if (/^link (in|out)$/.test(src.type) && /^link (in|out)$/.test(dst.type) && src.type !== dst.type) {
                             if (src.links.indexOf(dst.id) === -1 && dst.links.indexOf(src.id) === -1) {
-                                var oldSrcLinks = $.extend(true,{},{v:src.links}).v
-                                var oldDstLinks = $.extend(true,{},{v:dst.links}).v
+                                var oldSrcLinks = [...src.links]
+                                var oldDstLinks = [...dst.links]
+
                                 src.links.push(dst.id);
                                 dst.links.push(src.id);
+
+                                if (oldDst) {
+                                    src.links = src.links.filter(id => id !== oldDst.id)
+                                    dst.links = dst.links.filter(id => id !== oldDst.id)
+                                    var oldOldDstLinks = [...oldDst.links]
+                                    oldDst.links = oldDst.links.filter(id => id !== oldSrc.id)
+                                    oldDst.dirty = true;
+                                    modifiedNodes.push(oldDst);
+                                    linkEditEvents.push({
+                                        t:'edit',
+                                        node: oldDst,
+                                        dirty: RED.nodes.dirty(),
+                                        changed: oldDst.changed,
+                                        changes: {
+                                            links:oldOldDstLinks
+                                        }
+                                    });
+                                    oldDst.changed = true;
+                                }
+
                                 src.dirty = true;
                                 dst.dirty = true;
+
                                 modifiedNodes.push(src);
                                 modifiedNodes.push(dst);
 
@@ -3237,6 +3269,7 @@ RED.view = (function() {
                                         links:oldDstLinks
                                     }
                                 });
+                               
                                 src.changed = true;
                                 dst.changed = true;
                             }


### PR DESCRIPTION
When shift-moving link node wires, the old wire wasn't been removed.

This fixes that, and ensures the undo history replaces the wire.