### PR TITLE
Fix subflow outbound-link filter

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2406,15 +2406,25 @@ RED.nodes = (function() {
             } else {
                 delete n.g
             }
-            // If importing a subflow, ensure an outbound-link doesn't get added
+            // If importing a link node, ensure both ends of each link are either:
+            // - not in a subflow
+            // - both in the same subflow
             if (/^link /.test(n.type) && n.links) {
-                const isSubflow = !!getSubflow(n.z);
-                if (isSubflow) {
-                    n.links = n.links.filter(function(id) {
-                        const otherNode = node_map[id] || RED.nodes.node(id);
-                        return (otherNode && otherNode.z === n.z);
-                    });
-                }
+                n.links = n.links.filter(function(id) {
+                    const otherNode = node_map[id] || RED.nodes.node(id);
+                    if (!otherNode) {
+                        // Cannot find other end - remove the link
+                        return false
+                    }
+                    if (otherNode.z === n.z) {
+                        // Both ends in the same flow/subflow
+                        return true
+                    } else if (!!getSubflow(n.z) || !!getSubflow(otherNode.z)) {
+                        // One end is in a subflow - remove the link
+                        return false                        
+                    }
+                    return true
+                });
             }
             for (var d3 in n._def.defaults) {
                 if (n._def.defaults.hasOwnProperty(d3)) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #4749, completes #4750: The purpose of the filter is to prevent adding a link to a node outside the subflow.

The previous logic only filters nodes linked to the active subflow, which removes links in a child subflow.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
