### PR TITLE
GitHub: Add citation file to enable "Cite this repository" feature

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,7 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "Node-RED"
+authors:
+  - family-names: "OpenJS Foundation"
+  - family-names: "Contributors"
+url: "https://nodered.org"


### PR DESCRIPTION

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Recently I wanted to cite Node-RED for an academic work. Online search led me to https://discourse.nodered.org/t/citing-node-red-in-a-scientific-publication/52412/5 and https://nodered.org/about/#citing-node-red which I will use for my citation.

GitHub is able to show a "Cite this repository" if a citation file is added to the root of the repository as described in https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files. Even though there is information about citation in the node-red website, having a dedicated button in the GitHub repository is nice too (personally, it's the first place I look).

I made this PR to add the citation file required to enable this functionality in case you find this feature useful.

Cheers!

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
