### PR TITLE
Hide add-flow options when disabled via editorTheme

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/actionList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/actionList.js
@@ -205,7 +205,9 @@ RED.actionList = (function() {
     }
 
     function init() {
-        RED.actions.add("core:show-action-list",show);
+        if (RED.settings.theme("menu.menu-item-action-list", true)) {
+            RED.actions.add("core:show-action-list",show);
+        }
 
         RED.events.on("editor:open",function() { disabled = true; });
         RED.events.on("editor:close",function() { disabled = false; });

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
@@ -65,10 +65,11 @@ RED.contextMenu = (function () {
                 addY = gridSize * Math.floor(addY / gridSize)
             }
 
-            menuItems.push(
-                { onselect: 'core:show-action-list', label: RED._("contextMenu.showActionList"), onpostselect: function () { } }
-            )
-
+            if (RED.settings.theme("menu.menu-item-action-list", true)) {
+                menuItems.push(
+                    { onselect: 'core:show-action-list', label: RED._("contextMenu.showActionList"), onpostselect: function () { } }
+                )
+            }
             const insertOptions = []
             menuItems.push({ label: RED._("contextMenu.insert"), options: insertOptions })
             insertOptions.push(

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -479,7 +479,6 @@ RED.workspaces = (function() {
             },
             minimumActiveTabWidth: 150,
             scrollable: true,
-            addButton: "core:add-flow",
             addButton: RED.settings.theme("menu.menu-item-workspace-add", true) ? "core:add-flow" : undefined,
             addButtonCaption: RED._("workspace.addFlow"),
             menu: function() { return getMenuItems(true) },

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -183,25 +183,29 @@ RED.workspaces = (function() {
             },
             null)
         }
-        menuItems.push(
-            {
-                id:"red-ui-tabs-menu-option-add-flow",
-                label: RED._("workspace.addFlow"),
-                onselect: "core:add-flow"
-            }
-        )
-        if (isMenuButton || !!tab) {
+        if (RED.settings.theme("menu.menu-item-workspace-add", true)) {
             menuItems.push(
                 {
-                    id:"red-ui-tabs-menu-option-add-flow-right",
-                    label: RED._("workspace.addFlowToRight"),
-                    shortcut: RED.keyboard.getShortcut("core:add-flow-to-right"),
-                    onselect: function() {
-                        RED.actions.invoke("core:add-flow-to-right", tab)
-                    }
-                },
-                null
+                    id:"red-ui-tabs-menu-option-add-flow",
+                    label: RED._("workspace.addFlow"),
+                    onselect: "core:add-flow"
+                }
             )
+        }
+        if (isMenuButton || !!tab) {
+            if (RED.settings.theme("menu.menu-item-workspace-add", true)) {
+                menuItems.push(
+                    {
+                        id:"red-ui-tabs-menu-option-add-flow-right",
+                        label: RED._("workspace.addFlowToRight"),
+                        shortcut: RED.keyboard.getShortcut("core:add-flow-to-right"),
+                        onselect: function() {
+                            RED.actions.invoke("core:add-flow-to-right", tab)
+                        }
+                    },
+                    null
+                )
+            }
             if (activeWorkspace && activeWorkspace.type === 'tab') {
                 menuItems.push(
                     isFlowDisabled ? {
@@ -255,7 +259,9 @@ RED.workspaces = (function() {
                 }
             )
         }
-        menuItems.push(null)
+        if (menuItems.length > 0) {
+            menuItems.push(null)
+        }
         if (isMenuButton || !!tab) {
             menuItems.push(
                 {
@@ -299,19 +305,24 @@ RED.workspaces = (function() {
             }
         )
         if (tab) {
+            menuItems.push(null)
+
+            if (RED.settings.theme("menu.menu-item-workspace-delete", true)) {
+                menuItems.push(
+                    {
+                        label: RED._("common.label.delete"),
+                        onselect: function() {
+                            if (tab.type === 'tab') {
+                                RED.workspaces.delete(tab)
+                            } else if (tab.type === 'subflow') {
+                                RED.subflow.delete(tab.id)
+                            }
+                        },
+                        disabled: isCurrentLocked || (workspaceTabCount === 1)
+                    }
+                )
+            }
             menuItems.push(
-                null,
-                {
-                    label: RED._("common.label.delete"),
-                    onselect: function() {
-                        if (tab.type === 'tab') {
-                            RED.workspaces.delete(tab)
-                        } else if (tab.type === 'subflow') {
-                            RED.subflow.delete(tab.id)
-                        }
-                    },
-                    disabled: isCurrentLocked || (workspaceTabCount === 1)
-                },
                 {
                     label: RED._("menu.label.export"),
                     shortcut: RED.keyboard.getShortcut("core:show-export-dialog"),
@@ -469,6 +480,7 @@ RED.workspaces = (function() {
             minimumActiveTabWidth: 150,
             scrollable: true,
             addButton: "core:add-flow",
+            addButton: RED.settings.theme("menu.menu-item-workspace-add", true) ? "core:add-flow" : undefined,
             addButtonCaption: RED._("workspace.addFlow"),
             menu: function() { return getMenuItems(true) },
             contextmenu: function(tab) { return getMenuItems(false, tab) }
@@ -525,19 +537,24 @@ RED.workspaces = (function() {
         $(window).on("resize", function() {
             workspace_tabs.resize();
         });
-
-        RED.actions.add("core:add-flow",function(opts) { addWorkspace(undefined,undefined,opts?opts.index:undefined)});
-        RED.actions.add("core:add-flow-to-right",function(workspace) {
-            let index
-            if (workspace) {
-                index = workspace_tabs.getTabIndex(workspace.id)+1
-            } else {
-                index = workspace_tabs.activeIndex()+1
-            }
-            addWorkspace(undefined,undefined,index)
-        });
-        RED.actions.add("core:edit-flow",editWorkspace);
-        RED.actions.add("core:remove-flow",removeWorkspace);
+        if (RED.settings.theme("menu.menu-item-workspace-add", true)) {
+            RED.actions.add("core:add-flow",function(opts) { addWorkspace(undefined,undefined,opts?opts.index:undefined)});
+            RED.actions.add("core:add-flow-to-right",function(workspace) {
+                let index
+                if (workspace) {
+                    index = workspace_tabs.getTabIndex(workspace.id)+1
+                } else {
+                    index = workspace_tabs.activeIndex()+1
+                }
+                addWorkspace(undefined,undefined,index)
+            });
+        }
+        if (RED.settings.theme("menu.menu-item-workspace-edit", true)) {
+            RED.actions.add("core:edit-flow",editWorkspace);
+        }
+        if (RED.settings.theme("menu.menu-item-workspace-delete", true)) {
+            RED.actions.add("core:remove-flow",removeWorkspace);
+        }
         RED.actions.add("core:enable-flow",enableWorkspace);
         RED.actions.add("core:disable-flow",disableWorkspace);
         RED.actions.add("core:lock-flow",lockWorkspace);

--- a/packages/node_modules/@node-red/editor-client/src/sass/tabs.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tabs.scss
@@ -151,8 +151,9 @@
     &.red-ui-tabs-add {
         padding-right: 29px;
     }
-    &.red-ui-tabs-add.red-ui-tabs-scrollable {
-        padding-right: 53px;
+    &.red-ui-tabs-add.red-ui-tabs-scrollable,
+    &.red-ui-tabs-menu.red-ui-tabs-scrollable {
+            padding-right: 53px;
     }
     &.red-ui-tabs-add.red-ui-tabs-menu.red-ui-tabs-scrollable,
     &.red-ui-tabs-add.red-ui-tabs-search.red-ui-tabs-scrollable {
@@ -310,8 +311,9 @@
     }
 
 }
-.red-ui-tabs.red-ui-tabs-add .red-ui-tab-scroll-right {
-    right: 32px;
+.red-ui-tabs.red-ui-tabs-add .red-ui-tab-scroll-right,
+.red-ui-tabs.red-ui-tabs-menu .red-ui-tab-scroll-right {
+        right: 32px;
 }
 
 .red-ui-tabs.red-ui-tabs-add.red-ui-tabs-menu .red-ui-tab-scroll-right,


### PR DESCRIPTION
Fixes #4864, #4870

 - Ensures the context menu does not show flow-add/delete options if disabled in the editorTheme. (#4864)
 - Ensures the context menu does not show action list option if disabled in the editorTheme. (#4870)


Also hides the 'add flow' button in the workspace tab bar and skips registering the corresponding actions.