### PR TITLE
Fix env-var config select when multiple defined

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -899,7 +899,7 @@ RED.editor = (function() {
                             const labelText = RED.editor.envVarList.lookupLabel(labels, labels["en-US"] || tenv.name, locale)
                             const config = {
                                 env: tenv,
-                                id: '${' + parentEnv[0].name + '}',
+                                id: '${' + tenv.name + '}',
                                 type: type,
                                 label: labelText,
                                 __label__: `[env] ${labelText}`


### PR DESCRIPTION
The config node select box was reusing the id of the first env-defined config option - so that one would always be selected regardless of which actual env-defined option was picked.