### PR TITLE
Ensure will payload is a string

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -673,6 +673,8 @@ module.exports = function(RED) {
             delete node.options.protocolId; //V4+ default
             delete node.options.protocolVersion; //V4 default
             delete node.options.properties;//V5 only
+
+
             if (node.compatmode == "true" || node.compatmode === true || node.protocolVersion == 3) {
                 node.options.protocolId = 'MQIsdp';//V3 compat only
                 node.options.protocolVersion = 3;
@@ -691,6 +693,21 @@ module.exports = function(RED) {
                     setIntProp(node,node.options.properties,"sessionExpiryInterval");
                 }
             }
+            // Ensure will payload, if set, is a string
+            if (node.options.will && Object.hasOwn(node.options.will, 'payload')) {
+                let payload = node.options.will.payload
+                if (payload === null || payload === undefined) {
+                    payload = "";
+                } else if (!Buffer.isBuffer(payload)) {
+                    if (typeof payload === "object") {
+                        payload = JSON.stringify(payload);
+                    } else if (typeof payload !== "string") {
+                        payload = "" + payload;
+                    }
+                }
+                node.options.will.payload = payload
+            }
+
             if (node.usetls && n.tls) {
                 var tlsNode = RED.nodes.getNode(n.tls);
                 if (tlsNode) {

--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -696,7 +696,7 @@ module.exports = function(RED) {
             // Ensure will payload, if set, is a string
             if (node.options.will && Object.hasOwn(node.options.will, 'payload')) {
                 let payload = node.options.will.payload
-                if (payload === null || payload === undefined) {
+                if (payload === null || typeof payload === 'undefined') {
                     payload = "";
                 } else if (!Buffer.isBuffer(payload)) {
                     if (typeof payload === "object") {


### PR DESCRIPTION
Fixes #4858

With MQTT, will payload must be a string. In my testing, this is the case for both v3.1.1 and v5.

This PR ensures that if it is set, then it is formatted as a string.
