### PR TITLE
Set status of mqtt nodes to "disconnected" when deregistered from broker

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -742,6 +742,7 @@ module.exports = function(RED) {
         };
 
         node.deregister = function(mqttNode, done, autoDisconnect) {
+            setStatusDisconnected(mqttNode, false);
             delete node.users[mqttNode.id];
             if (autoDisconnect && !node.closing && node.connected && Object.keys(node.users).length === 0) {
                 node.disconnect(done);


### PR DESCRIPTION
closes #4876

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)



## Proposed changes

Call `setStatusDisconnected` whenever an mqtt nodes' 'close' handler is called.

NOTE: Any users depending on status events from the MQTT nodes should notice no _real_ difference since the change only acts upon deploying changes and shutting down Node-RED (i.e. when a nodes deconstructor is called via the `close` event) (and all bets are off)

NOTE2: I did consider "clearing" the status however it felt more sane to say "disconnected" when "no broker" was set.

### Demo
![chrome_0qLjb33pDU](https://github.com/user-attachments/assets/0f170fff-e09a-44e6-90fb-11b9bec4cc0f)


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
