### PR TITLE
Do not include Junction type in quick-add for virtual links

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js
@@ -335,13 +335,25 @@ RED.typeSearch = (function() {
         }
     }
     function applyFilter(filter,type,def) {
-        return !def || !filter ||
-            (
-                (!filter.spliceMultiple) &&
-                (!filter.type || type === filter.type) &&
-                (!filter.input || type === 'junction' || def.inputs > 0) &&
-                (!filter.output || type === 'junction' || def.outputs > 0)
-            )
+        if (!filter) {
+            // No filter; allow everything
+            return true
+        }
+        if (type === 'junction') {
+            // Only allow Junction is there's no specific type filter
+            return !filter.type
+        }
+        if (filter.type) {
+            // Handle explicit type filter
+            return filter.type === type
+        }
+        if (!def) {
+            // No node definition available - allow it
+            return true
+        }
+        // Check if the filter is for input/outputs and apply
+        return (!filter.input || def.inputs > 0) &&
+                (!filter.output || def.outputs > 0)
     }
     function refreshTypeList(opts) {
         var i;


### PR DESCRIPTION
I noticed the quick-add dialog when adding a virtual link between link nodes was offering Junction as a valid option; we don't support junctions on virtual links.

This fixes how we apply the filter of the quick-add dialog to ensure Junction isn't included. The existing if statement had gotten a bit too complex; broken out into easier-to-understand checks.