### PR TITLE
Stay in quick-add mode following context menu insert

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1210,10 +1210,9 @@ RED.view = (function() {
         }
         if (d3.event.touches || d3.event.button === 0) {
             if (
-                    (mouse_mode === 0 && isControlPressed(d3.event) && !(d3.event.altKey || d3.event.shiftKey))
-                    ||
-                    mouse_mode === RED.state.QUICK_JOINING
-                ) {
+                (mouse_mode === 0 && isControlPressed(d3.event) && !(d3.event.altKey || d3.event.shiftKey)) ||
+                mouse_mode === RED.state.QUICK_JOINING
+            ) {
                 // Trigger quick add dialog
                 d3.event.stopPropagation();
                 clearSelection();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1209,7 +1209,11 @@ RED.view = (function() {
             lasso = null;
         }
         if (d3.event.touches || d3.event.button === 0) {
-            if ((mouse_mode === 0 || mouse_mode === RED.state.QUICK_JOINING) && isControlPressed(d3.event) && !(d3.event.altKey || d3.event.shiftKey)) {
+            if (
+                    (mouse_mode === 0 && isControlPressed(d3.event) && !(d3.event.altKey || d3.event.shiftKey))
+                    ||
+                    mouse_mode === RED.state.QUICK_JOINING
+                ) {
                 // Trigger quick add dialog
                 d3.event.stopPropagation();
                 clearSelection();
@@ -1285,7 +1289,6 @@ RED.view = (function() {
         }
 
         var mainPos = $("#red-ui-main-container").position();
-
         if (mouse_mode !== RED.state.QUICK_JOINING) {
             mouse_mode = RED.state.QUICK_JOINING;
             $(window).on('keyup',disableQuickJoinEventHandler);
@@ -3057,8 +3060,8 @@ RED.view = (function() {
     }
 
     function disableQuickJoinEventHandler(evt) {
-        // Check for ctrl (all browsers), "Meta" (Chrome/FF), keyCode 91 (Safari)
-        if (evt.keyCode === 17 || evt.key === "Meta" || evt.keyCode === 91) {
+        // Check for ctrl (all browsers), "Meta" (Chrome/FF), keyCode 91 (Safari), or Escape
+        if (evt.keyCode === 17 || evt.key === "Meta" || evt.keyCode === 91 || evt.keyCode === 27) {
             resetMouseVars();
             hideDragLines();
             redraw();


### PR DESCRIPTION
Fixes #4881

When triggering the quick-add dialog via the context menu, we set state to QUICK_JOINING. Part of this includes setting up a key listener for when the user releases the cmd/ctrl key to exit QUICK_JOINING mode. However, when triggered via context menu, the keyboard isn't touched, so we are left in QUICK_JOINING mode. The user doesn't know to press/release cmd/ctrl to exit this mode.

This fix adds the escape key to the list of keys that will exit QUICK_JOINING mode.

It also updates the handling of clicking in the workspace when in QJ mode. Previously it was checking for the keyboard modifiers - but it should only do this when in default mode. When in QJ mode, it should just show the dialog.