### PR TITLE
Fix wrong unlock state when event is triggered after deployment

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -591,6 +591,7 @@ RED.deploy = (function() {
             const flowsToLock = new Set()
             // Node's properties cannot be modified if its workspace is locked.
             function ensureUnlocked(id) {
+                // TODO: `RED.nodes.subflow` is useless
                 const flow = id && (RED.nodes.workspace(id) || RED.nodes.subflow(id) || null);
                 const isLocked = flow ? flow.locked : false;
                 if (flow && isLocked) {
@@ -643,27 +644,27 @@ RED.deploy = (function() {
                     delete confNode.credentials;
                 }
             });
+            // Subflow cannot be locked
             RED.nodes.eachSubflow(function (subflow) {
                 if (subflow.changed) {
                     subflow.changed = false;
-                    if (flowsToLock.has(subflow)) {
-                        subflow.locked = true;
-                    }
                     RED.events.emit("subflows:change", subflow);
                 }
             });
             RED.nodes.eachWorkspace(function (ws) {
                 if (ws.changed || ws.added) {
-                    ensureUnlocked(ws.z)
+                    // Ensure the Workspace is unlocked to modify its properties.
+                    ensureUnlocked(ws.id);
                     ws.changed = false;
                     delete ws.added
                     if (flowsToLock.has(ws)) {
                         ws.locked = true;
+                        flowsToLock.delete(ws);
                     }
                     RED.events.emit("flows:change", ws)
                 }
             });
-            // Ensures all workspaces/subflows to be locked have been locked.
+            // Ensures all workspaces to be locked have been locked.
             flowsToLock.forEach(flow => {
                 flow.locked = true
             })

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -589,6 +589,7 @@ RED.deploy = (function() {
                 RED.notify('<p>' + RED._("deploy.successfulDeploy") + '</p>', "success");
             }
             const flowsToLock = new Set()
+            // Node's properties cannot be modified if its workspace is locked.
             function ensureUnlocked(id) {
                 const flow = id && (RED.nodes.workspace(id) || RED.nodes.subflow(id) || null);
                 const isLocked = flow ? flow.locked : false;
@@ -645,6 +646,9 @@ RED.deploy = (function() {
             RED.nodes.eachSubflow(function (subflow) {
                 if (subflow.changed) {
                     subflow.changed = false;
+                    if (flowsToLock.has(subflow)) {
+                        subflow.locked = true;
+                    }
                     RED.events.emit("subflows:change", subflow);
                 }
             });
@@ -653,9 +657,13 @@ RED.deploy = (function() {
                     ensureUnlocked(ws.z)
                     ws.changed = false;
                     delete ws.added
+                    if (flowsToLock.has(ws)) {
+                        ws.locked = true;
+                    }
                     RED.events.emit("flows:change", ws)
                 }
             });
+            // Ensures all workspaces/subflows to be locked have been locked.
             flowsToLock.forEach(flow => {
                 flow.locked = true
             })


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #4888.

In order to modify nodes, subflows/workspaces are temporarily unlocked.

An event is triggered for any subflow/workspace that has changed. This event will always contain an **unlocked** workspace because the re-locking only happens after all events have been triggered.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
