### PR TITLE
Fix `link call` node can call out of a subflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2408,7 +2408,7 @@ RED.nodes = (function() {
             }
             // If importing a link node, ensure both ends of each link are either:
             // - not in a subflow
-            // - both in the same subflow
+            // - both in the same subflow (not for link call node)
             if (/^link /.test(n.type) && n.links) {
                 n.links = n.links.filter(function(id) {
                     const otherNode = node_map[id] || RED.nodes.node(id);
@@ -2418,6 +2418,9 @@ RED.nodes = (function() {
                     }
                     if (otherNode.z === n.z) {
                         // Both ends in the same flow/subflow
+                        return true
+                    } else if (n.type === "link call") {
+                        // Link call node can call out of a subflow
                         return true
                     } else if (!!getSubflow(n.z) || !!getSubflow(otherNode.z)) {
                         // One end is in a subflow - remove the link

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2419,12 +2419,13 @@ RED.nodes = (function() {
                     if (otherNode.z === n.z) {
                         // Both ends in the same flow/subflow
                         return true
-                    } else if (n.type === "link call") {
-                        // Link call node can call out of a subflow
-                        return true
+                    } else if (n.type === "link call" && !!getSubflow(otherNode.z)) {
+                        // Link call node can call out of a subflow as long as otherNode is
+                        // not in a subflow
+                        return false
                     } else if (!!getSubflow(n.z) || !!getSubflow(otherNode.z)) {
                         // One end is in a subflow - remove the link
-                        return false                        
+                        return false
                     }
                     return true
                 });


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #4891.

#4857 ignores that `link call` node can call out of a subflow.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
