### PR TITLE
Refix link call node can call out of a subflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2419,10 +2419,10 @@ RED.nodes = (function() {
                     if (otherNode.z === n.z) {
                         // Both ends in the same flow/subflow
                         return true
-                    } else if (n.type === "link call" && !!getSubflow(otherNode.z)) {
+                    } else if (n.type === "link call" && !getSubflow(otherNode.z)) {
                         // Link call node can call out of a subflow as long as otherNode is
                         // not in a subflow
-                        return false
+                        return true
                     } else if (!!getSubflow(n.z) || !!getSubflow(otherNode.z)) {
                         // One end is in a subflow - remove the link
                         return false


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #4891 again.

With #4892, if `otherNode` is not in a Subflow, the following check will deny the link because the `link call` node is in Subflow 🤦‍♂️ 🙄

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
