### PR TITLE
Bump generate-publish-script with latest

### DIFF
--- a/scripts/generate-publish-script.js
+++ b/scripts/generate-publish-script.js
@@ -4,7 +4,7 @@ const path = require("path");
 const fs = require("fs-extra");
 const should = require("should");
 
-const LATEST = "3";
+const LATEST = "4";
 
 function generateScript() {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
The generate-publish-script needs to know what `latest` major version is so it generates the right tags. I always forget to bump this and end up doing it manually. Finally getting this update into the script.