### PR TITLE
Improve the node name auto-generated with the first available number

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
@@ -1102,18 +1102,27 @@ RED.view.tools = (function() {
                     const paletteLabel = RED.utils.getPaletteLabel(n.type, nodeDef)
                     const defaultNodeNameRE = new RegExp('^'+paletteLabel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')+' (\\d+)$')
                     if (!typeIndex.hasOwnProperty(n.type)) {
-                        const existingNodes = RED.nodes.filterNodes({type: n.type})
-                        let maxNameNumber = 0;
-                        existingNodes.forEach(n => {
-                            let match = defaultNodeNameRE.exec(n.name)
+                        const existingNodes = RED.nodes.filterNodes({ type: n.type });
+                        const existingIds = existingNodes.reduce((ids, node) => {
+                            let match = defaultNodeNameRE.exec(node.name);
                             if (match) {
-                                let nodeNumber = parseInt(match[1])
-                                if (nodeNumber > maxNameNumber) {
-                                    maxNameNumber = nodeNumber
+                                const nodeNumber = parseInt(match[1], 10);
+                                if (!ids.includes(nodeNumber)) {
+                                    ids.push(nodeNumber);
                                 }
                             }
-                        })
-                        typeIndex[n.type] = maxNameNumber + 1
+                            return ids;
+                        }, []).sort((a, b) => a - b);
+
+                        let availableNameNumber = 1;
+                        for (let i = 0; i < existingIds.length; i++) {
+                            if (existingIds[i] !== availableNameNumber) {
+                                break;
+                            }
+                            availableNameNumber++;
+                        }
+
+                        typeIndex[n.type] = availableNameNumber;
                     }
                     if ((options.renameBlank && n.name === '') || (options.renameClash && defaultNodeNameRE.test(n.name))) {
                         if (generateHistory) {


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

As discussed in the [forum](https://discourse.nodered.org/t/resetting-the-default-debug-node-name/92285), this PR improves the auto-generation of the node name to take the first available number.

So if existing numbers are 1,3 and 4. The new number is 2 instead of 5.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
