### PR TITLE
let multiplayer name be set in browser storage rather than fully anonymous

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/multiplayer.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/multiplayer.js
@@ -164,7 +164,7 @@ RED.multiplayer = (function () {
                         $(this).show()
                     }
                 })
-                if (users.length < maxShown + 1) { 
+                if (users.length < maxShown + 1) {
                     userCountIcon.hide()
                 } else {
                     userCountSpan.text('+'+(users.length - maxShown))
@@ -365,12 +365,12 @@ RED.multiplayer = (function () {
                 border.setAttribute("r",radius/2);
                 border.setAttribute("class", "red-ui-multiplayer-annotation-border")
                 group.appendChild(border)
-          
+
 
 
                 return group
             }
-            
+
             RED.view.annotations.register("red-ui-multiplayer",{
                 type: 'badge',
                 align: 'left',
@@ -411,7 +411,7 @@ RED.multiplayer = (function () {
             // } else {
                 log('Session ID', activeSessionId)
             // }
-            
+
             headerWidget = $('<li><ul id="red-ui-multiplayer-user-list"></ul></li>').prependTo('.red-ui-header-toolbar')
 
             RED.comms.on('connect', () => {
@@ -421,6 +421,9 @@ RED.multiplayer = (function () {
                 }
                 if (location.workspace !== 0) {
                     connectInfo.location = location
+                }
+                if (localStorage.getItem("multiplayer-name") !== undefined && localStorage.getItem("multiplayer-name").length >0) {
+                    connectInfo.name = localStorage.getItem("multiplayer-name");
                 }
                 RED.comms.send('multiplayer/connect', connectInfo)
             })

--- a/packages/node_modules/@node-red/runtime/lib/multiplayer/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/multiplayer/index.js
@@ -42,7 +42,7 @@ module.exports = {
                 let user = opts.user
                 if (!user || user.anonymous) {
                     user = user || { anonymous: true }
-                    user.username = `Anon ${Math.floor(Math.random()*100)}`
+                    user.username = opts?.data?.name || `Anon ${Math.floor(Math.random()*100)}`
                 }
                 session = {
                     session: opts.data.session,


### PR DESCRIPTION

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

When using multiplayer option when not logged in you get assigned a random Anon-XYZ id - which then changes every time you refresh the browser connection. It would be nice to be able to set this to a fixed / useful value in someway so that you can make use of this multiplayer capability in situations where you may not have or need authenticated users. 

This PR lets the name be set by using a value stored in the browser localstorage area.
So far this PR does not provide a UI to set this value but it can easily be tested by using the developer javascript console and using the command ` localStorage.setItem("multiplayer-name", "Fred") ` etc

Even without a UI I think the plumbing for this is useful to explore the concept.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
