### PR TITLE
feat(forms): form input labels are always above the input field

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -370,7 +370,7 @@ RED.editor = (function() {
         if ((m = /(^|\s|;)width\s*:\s*([^;]+)/i.exec(attrStyle)) !== null) {
             newWidth = m[2].trim();
         } else {
-            newWidth = "70%";
+            newWidth = "100%";
         }
         const outerWrap = $("<div></div>").css({
             width: newWidth,

--- a/packages/node_modules/@node-red/editor-client/src/sass/editor.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/editor.scss
@@ -215,14 +215,14 @@ button.red-ui-tray-resize-button {
     .form-row {
         clear: both;
         color: var(--red-ui-form-text-color);
-        margin-bottom:12px;
+        margin-bottom: 10px;
     }
     .form-row label {
-        display: inline-block;
-        width: 100px;
+        width: 100%;
+        margin-bottom: 5px;
     }
     .form-row input, .form-row div[contenteditable="true"] {
-        width:70%;
+        width: 100%;
     }
     .form-tips {
         background: var(--red-ui-form-tips-background);

--- a/packages/node_modules/@node-red/editor-client/src/sass/forms.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/forms.scss
@@ -130,7 +130,6 @@
 
     label {
         display: block;
-        margin-bottom: 5px;
     }
 
     select,
@@ -244,7 +243,7 @@
     }
 
     select {
-        width: 220px;
+        width: 100%;
         background-color: var(--red-ui-form-input-background);
         border: 1px solid var(--red-ui-form-input-border-color);
     }

--- a/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
@@ -15,6 +15,8 @@
  **/
 
 .red-ui-typedInput-container {
+    // NOTE: container should take the whole horizontal space for forms. Nodes that are overriding it are wrong. This should not be calculated at runtime
+    width: 100% !important;
     border: 1px solid var(--red-ui-form-input-border-color);
     border-radius: 5px;
     height: 34px;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Forms have limited horizontal space, making it challenging to fit both labels and inputs side by side. When labels exceed around 13 characters, they wrap onto the next line, creating a cluttered and unattractive layout.

To address this, labels and inputs should each occupy the full width of the available horizontal space. Labels will be positioned above the corresponding input fields, aligned to the left for better readability and consistency.



### BEFORE

<img width="726" alt="image" src="https://github.com/user-attachments/assets/c6fe67fa-0067-4f87-bdc1-4ec15ff077ca">


<img width="475" alt="image" src="https://github.com/user-attachments/assets/a785ea21-d926-4ec4-bafd-80a1a8d618c7">

<img width="682" alt="image" src="https://github.com/user-attachments/assets/f7584890-16c3-463c-87a7-f96dfc310c04">



### AFTER

<img width="617" alt="image" src="https://github.com/user-attachments/assets/d5bcd62b-b830-4318-b81c-a2d9e6ff1c65">

<img width="546" alt="image" src="https://github.com/user-attachments/assets/bccfc465-4beb-4a35-9f1b-c9622c6d6b7b">

<img width="490" alt="image" src="https://github.com/user-attachments/assets/72cd8986-b91c-4b8d-b6ac-887398698545">


> [!IMPORTANT]
> A lot of nodes are overriding form styles. There is nothing we can do for them, unfortunately. They shouldn't have done that anyway. The pictures I took above are all showing inputs that were added without custom styles. They all use "built in" classes or styles.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
