### PR TITLE
Trigger button action of the selected nodes with new Hotkey

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/keymap.json
+++ b/packages/node_modules/@node-red/editor-client/src/js/keymap.json
@@ -91,8 +91,7 @@
         "alt-shift-w": "core:show-last-hidden-flow",
         "ctrl-+": "core:zoom-in",
         "ctrl--": "core:zoom-out",
-        "ctrl-0": "core:zoom-reset",
-        "ctrl-shift-t": "core:click-selected-nodes-button"
+        "ctrl-0": "core:zoom-reset"
      },
      "red-ui-editor-stack": {
         "ctrl-enter": "core:confirm-edit-tray",

--- a/packages/node_modules/@node-red/editor-client/src/js/keymap.json
+++ b/packages/node_modules/@node-red/editor-client/src/js/keymap.json
@@ -91,8 +91,8 @@
         "alt-shift-w": "core:show-last-hidden-flow",
         "ctrl-+": "core:zoom-in",
         "ctrl--": "core:zoom-out",
-        "ctrl-0": "core:zoom-reset"
-
+        "ctrl-0": "core:zoom-reset",
+        "ctrl-shift-t": "core:click-selected-nodes-button"
      },
      "red-ui-editor-stack": {
         "ctrl-enter": "core:confirm-edit-tray",

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -3014,7 +3014,7 @@ RED.nodes = (function() {
             RED.events.on('deploy', function () {
                 allNodes.clearState()
             });
-            RED.actions.add("core:click-selected-nodes-button", function () {
+            RED.actions.add("core:trigger-selected-nodes-action", function () {
                 const selectedNodes = RED.view.selection().nodes || [];
                 // Triggers the button action of the selected nodes
                 selectedNodes.forEach((node) => RED.view.clickNodeButton(node));

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -3013,7 +3013,12 @@ RED.nodes = (function() {
             });
             RED.events.on('deploy', function () {
                 allNodes.clearState()
-            })
+            });
+            RED.actions.add("core:click-selected-nodes-button", function () {
+                const selectedNodes = RED.view.selection().nodes || [];
+                // Triggers the button action of the selected nodes
+                selectedNodes.forEach((node) => RED.view.clickNodeButton(node));
+            });
         },
         registry:registry,
         setNodeList: registry.setNodeList,


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

[Forum](https://discourse.nodered.org/t/inject-node-trigger-via-hotkey/92154) request.

Triggers button action for selected nodes via a Hotkey (`ctrl-shift-t`).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
