### PR TITLE
Fix `envVar` editable list should be sortable

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/envVarList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/envVarList.js
@@ -131,7 +131,7 @@ RED.editor.envVarList = (function() {
                         nameField.trigger('change');
                     }
                 },
-                sortable: ".red-ui-editableList-item-handle",
+                sortable: true,
                 removable: false
             });
         var parentEnv = {};


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

The `envVar` editable list should be sortable.

If the value is not `true`, the bar (`fa fa-bars`) is not added.

Resolves https://discourse.nodered.org/t/feature-request-rearrange-global-environment-variables/89502.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
