### PR TITLE
Missing getSubscriptions in the docs while its implemented

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/en-US/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/network/10-mqtt.html
@@ -48,7 +48,8 @@
     <dl class="message-properties">
        <dt>action <span class="property-type">string</span></dt>
        <dd>the name of the action the node should perform. Available actions are: <code>"connect"</code>,
-       <code>"disconnect"</code>, <code>"subscribe"</code> and <code>"unsubscribe"</code>.</dd>
+       <code>"disconnect"</code>, <code>"getSubscriptions"</code>, <code>"subscribe"</code> and 
+       <code>"unsubscribe"</code>.</dd>
        <dt class="optional">topic <span class="property-type">string|object|array</span></dt>
        <dd>For the <code>"subscribe"</code> and <code>"unsubscribe"</code> actions, this property
            provides the topic. It can be set as either:<ul>


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Docs update

## Proposed changes

The mqtt node supports getSubscriptions and this is already implemented (See:
https://github.com/node-red/node-red/blob/master/packages/node_modules/%40node-red/nodes/core/network/10-mqtt.js#L1288), but it's missing in the docs. I was looking for this functionality, but I ended up discovering it accidentally in the code.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `npm run test` to verify the unit tests pass
- [X] I have added suitable unit tests to cover the new/changed functionality
