### PR TITLE
Add periodic update check to editor

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -583,6 +583,8 @@ RED.palette.editor = (function() {
     var updateAllowList = ['*'];
     var updateDenyList = [];
 
+    var settingsPane;
+
     function init() {
         catalogues = RED.settings.theme('palette.catalogues')||['https://catalogue.nodered.org/catalogue.json']
         if (RED.settings.get('externalModules.palette.allowInstall', true) === false) {
@@ -607,6 +609,10 @@ RED.palette.editor = (function() {
         updateDenyList = RED.utils.parseModuleList(updateDenyList);
         updateAllowed = RED.settings.get("externalModules.palette.allowUpdate",true);
 
+        if (RED.settings.get("editorTheme.palette.checkForUpdates", true) === true) {
+            // Enable checking for updates triggered every 30 minutes
+            initCheckForUpdatesInterval();
+        }
 
         createSettingsPane();
 
@@ -727,7 +733,34 @@ RED.palette.editor = (function() {
         });
     }
 
-    var settingsPane;
+    /**
+     * Initializes the check for updates triggered every 30 minutes.
+     * This interval is based on the cumulative active window time.
+     */
+    function initCheckForUpdatesInterval() {
+        let activeTime = 0, lastActiveTime = Date.now();
+        const INTERVAL = 30 * 60;   // 30min
+
+        document.addEventListener("visibilitychange", function () {
+            if (document.visibilityState === "visible") {
+                lastActiveTime = Date.now();
+            } else {
+                activeTime += (Date.now() - lastActiveTime) / 1000;
+            }
+        });
+
+        setInterval(function () {
+            if (document.visibilityState === "visible") {
+                activeTime += (Date.now() - lastActiveTime) / 1000;
+                lastActiveTime = Date.now();
+
+                if (activeTime >= INTERVAL) {
+                    activeTime = 0;
+                    getSettingsPane();
+                }
+            }
+        }, 1000 * 60);  // refresh every minute
+    }
 
     function getSettingsPane() {
         initInstallTab();

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -416,6 +416,11 @@ module.exports = {
              * If not set, the following default order is used:
              */
             //categories: ['subflows', 'common', 'function', 'network', 'sequence', 'parser', 'storage'],
+
+            /**
+             * To enable checking for updates every 30min when the editor is open and active.
+             */
+            checkForUpdates: false,
         },
 
         projects: {


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Part of #4931.

If enabled in the settings, every 30 minutes an update check will be launched.
The cumulative time is incremented every minute if the editor is open and active.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
