### PR TITLE
Fix `setModulePendingUpdated` with plugins

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -73,7 +73,13 @@ RED.nodes = (function() {
 
         var exports = {
             setModulePendingUpdated: function(module,version) {
-                moduleList[module].pending_version = version;
+                if (!!RED.plugins.getModule(module)) {
+                    // The module updated is a plugin
+                    RED.plugins.getModule(module).pending_version = version;
+                } else {
+                    moduleList[module].pending_version = version;
+                }
+
                 RED.events.emit("registry:module-updated",{module:module,version:version});
             },
             getModule: function(module) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #4831.

`moduleList` does not contain the plugins, have to ask `RED.plugins`.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
