### PR TITLE
Make delay node rate limit reset consistent - not send on reset.

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.js
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.js
@@ -253,9 +253,11 @@ module.exports = function(RED) {
                             if (node.allowrate && m.hasOwnProperty("rate") && !isNaN(parseFloat(m.rate))) {
                                 node.rate = m.rate;
                             }
-                            send(m);
-                            node.reportDepth();
-                            node.intervalID = setInterval(sendMsgFromBuffer, node.rate);
+                            if (!msg.hasOwnProperty("reset")) {
+                                send(m);
+                                node.reportDepth();
+                                node.intervalID = setInterval(sendMsgFromBuffer, node.rate);
+                            }
                             done();
                         }
                     }
@@ -303,7 +305,8 @@ module.exports = function(RED) {
                                 node.droppedMsgs++;
                             }
                         }
-                    } else {
+                    }
+                    else {
                         if (node.allowrate && msg.hasOwnProperty("rate") && !isNaN(parseFloat(msg.rate))) {
                             node.rate = msg.rate;
                         }

--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.js
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.js
@@ -253,11 +253,15 @@ module.exports = function(RED) {
                             if (node.allowrate && m.hasOwnProperty("rate") && !isNaN(parseFloat(m.rate))) {
                                 node.rate = m.rate;
                             }
-                            if (!msg.hasOwnProperty("reset")) {
-                                send(m);
-                                node.reportDepth();
-                                node.intervalID = setInterval(sendMsgFromBuffer, node.rate);
+                            if (msg.hasOwnProperty("reset")) {
+                                if (msg.hasOwnProperty("flush")) {
+                                    node.buffer.push({msg: m, send: send, done: done});
+                                }
                             }
+                            else { send(m); }
+
+                            node.reportDepth();
+                            node.intervalID = setInterval(sendMsgFromBuffer, node.rate);
                             done();
                         }
                     }

--- a/test/nodes/core/function/89-delay_spec.js
+++ b/test/nodes/core/function/89-delay_spec.js
@@ -1009,6 +1009,29 @@ describe('delay Node', function() {
         });
     });
 
+    it('sending a msg with reset to empty queue doesnt send anything', function(done) {
+        this.timeout(2000);
+        var flow = [{"id":"delayNode1","type":"delay","name":"delayNode","pauseType":"rate","timeout":1,"timeoutUnits":"seconds","rate":2,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[["helperNode1"]]},
+                    {id:"helperNode1", type:"helper", wires:[]}];
+        helper.load(delayNode, flow, function() {
+            var delayNode1 = helper.getNode("delayNode1");
+            var helperNode1 = helper.getNode("helperNode1");
+            var t = Date.now();
+            var c = 0;
+            helperNode1.on("input", function(msg) {
+                console.log("Shold not get here")
+                done(e);
+            });
+
+            setTimeout( function() {
+                if (c === 0) { done(); }
+            }, 250);
+
+            // send test messages
+            delayNode1.receive({payload:1,topic:"foo",reset:true});            // send something with blank topic
+        });
+    });
+
     /* Messaging API support */
     function mapiDoneTestHelper(done, pauseType, drop, msgAndTimings) {
         const completeNode = require("nr-test-utils").require("@node-red/nodes/core/common/24-complete.js");


### PR DESCRIPTION
to fix #4830

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This fix if for #4830 - it makes sending in a payload to the delay node in rate-limit mode, that has msg.reset set, not send any associated payload if the queue is empty.  (If the queue had anything in then nothing is sent.)

Note you can set msg.flush AND msg.reset - and if the queue does have contents it will flush that many - and if the msg has a payload that is added to the queue and then maybe flushed if appropriate. IE flush happens before reset.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
