### PR TITLE
Truncate long messages from the Debug Sidebar

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -128,8 +128,20 @@ RED.utils = (function() {
     function formatString(str) {
         return str.replace(/\r?\n/g,"&crarr;").replace(/\t/g,"&rarr;");
     }
+
     function sanitize(m) {
         return m.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+    }
+
+    /**
+     * Truncates a string to a specified maximum length, adding ellipsis if truncated.
+     *
+     * @param {string} str - The string to be truncated.
+     * @param {number} maxLength - The maximum length of the truncated string. Default `120`.
+     * @returns {string} The truncated string with ellipsis if it exceeds the maximum length.
+     */
+    function truncateString(str, maxLength = 120) {
+        return str.length > maxLength ? str.slice(0, maxLength) + "..." : str;
     }
 
     function buildMessageSummaryValue(value) {
@@ -376,6 +388,9 @@ RED.utils = (function() {
         }
     }
 
+    // Max string length before truncating
+    const MAX_STRING_LENGTH = 80;
+
     /**
      * Create a DOM element representation of obj - as used by Debug sidebar etc
      *
@@ -469,7 +484,7 @@ RED.utils = (function() {
         } else if (typeHint === "internal" || (obj.__enc__ && obj.type === 'internal')) {
             e = $('<span class="red-ui-debug-msg-type-meta red-ui-debug-msg-object-header"></span>').text("[internal]").appendTo(entryObj);
         } else if (typeof obj === 'string') {
-            if (/[\t\n\r]/.test(obj)) {
+            if (/[\t\n\r]/.test(obj) || obj.length > MAX_STRING_LENGTH) {
                 element.addClass('collapsed');
                 $('<i class="fa fa-caret-right red-ui-debug-msg-object-handle"></i> ').prependTo(header);
                 makeExpandable(header, function() {
@@ -478,7 +493,7 @@ RED.utils = (function() {
                     $('<pre class="red-ui-debug-msg-type-string"></pre>').text(obj).appendTo(row);
                 },function(state) {if (ontoggle) { ontoggle(path,state);}}, checkExpanded(strippedKey,expandPaths));
             }
-            e = $('<span class="red-ui-debug-msg-type-string red-ui-debug-msg-object-header"></span>').html('"'+formatString(sanitize(obj))+'"').appendTo(entryObj);
+            e = $('<span class="red-ui-debug-msg-type-string red-ui-debug-msg-object-header"></span>').html('"'+formatString(sanitize(truncateString(obj, MAX_STRING_LENGTH)))+'"').appendTo(entryObj);
             if (/^#[0-9a-f]{6}$/i.test(obj)) {
                 $('<span class="red-ui-debug-msg-type-string-swatch"></span>').css('backgroundColor',obj).appendTo(e);
             }
@@ -1503,6 +1518,7 @@ RED.utils = (function() {
         parseContextKey: parseContextKey,
         createIconElement: createIconElement,
         sanitize: sanitize,
+        truncateString: truncateString,
         renderMarkdown: renderMarkdown,
         createNodeIcon: createNodeIcon,
         getDarkerColor: getDarkerColor,

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -134,11 +134,14 @@ RED.utils = (function() {
     }
 
     /**
-     * Truncates a string to a specified maximum length, adding ellipsis if truncated.
+     * Truncates a string to a specified maximum length, adding ellipsis
+     * if truncated.
      *
-     * @param {string} str - The string to be truncated.
-     * @param {number} maxLength - The maximum length of the truncated string. Default `120`.
-     * @returns {string} The truncated string with ellipsis if it exceeds the maximum length.
+     * @param {string} str The string to be truncated.
+     * @param {number} [maxLength = 120] The maximum length of the truncated
+     * string. Default `120`.
+     * @returns {string} The truncated string with ellipsis if it exceeds the
+     * maximum length.
      */
     function truncateString(str, maxLength = 120) {
         return str.length > maxLength ? str.slice(0, maxLength) + "..." : str;

--- a/packages/node_modules/@node-red/editor-client/src/sass/debug.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/debug.scss
@@ -237,10 +237,7 @@
 .red-ui-debug-msg-type-number-toggle { cursor: pointer;}
 
 .red-ui-debug-msg-type-string {
-    display: block;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    white-space: pre-wrap;
 }
 
 .red-ui-debug-msg-row {

--- a/packages/node_modules/@node-red/editor-client/src/sass/debug.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/debug.scss
@@ -131,6 +131,10 @@
 }
 .red-ui-debug-msg-topic {
     display: block;
+    max-width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
     color: var(--red-ui-debug-message-text-color-meta);
 }
 .red-ui-debug-msg-name {
@@ -233,7 +237,10 @@
 .red-ui-debug-msg-type-number-toggle { cursor: pointer;}
 
 .red-ui-debug-msg-type-string {
-    white-space: pre-wrap;
+    display: block;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 .red-ui-debug-msg-row {

--- a/packages/node_modules/@node-red/editor-client/src/sass/debug.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/debug.scss
@@ -131,10 +131,6 @@
 }
 .red-ui-debug-msg-topic {
     display: block;
-    max-width: 100%;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
     color: var(--red-ui-debug-message-text-color-meta);
 }
 .red-ui-debug-msg-name {


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

As described [here](https://discourse.nodered.org/t/visually-truncate-long-strings-in-debug-side-bar/91294), truncates long topic and string messages from the Debug Sidebar with pure CSS solution.

Preview:

<img width="468" alt="truncate-debug-msg" src="https://github.com/user-attachments/assets/d357d3fd-0c3d-4798-a135-2d0cf3582b79">


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
