### PR TITLE
Handle subflow node as user of config nodes

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/history.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/history.js
@@ -453,10 +453,48 @@ RED.history = (function() {
                                     RED.events.emit("nodes:change",newConfigNode);
                                 }
                             });
+                        } else if (i === "env" && ev.node.type.indexOf("subflow:") === 0) {
+                            // Subflow can have config node in node.env
+                            let nodeList = ev.node.env || [];
+                            nodeList = nodeList.reduce((list, prop) => {
+                                if (prop.type === "conf-type" && prop.value) {
+                                    list.push(prop.value);
+                                }
+                                return list;
+                            }, []);
+
+                            nodeList.forEach(function(id) {
+                                const configNode = RED.nodes.node(id);
+                                if (configNode) {
+                                    if (configNode.users.indexOf(ev.node) !== -1) {
+                                        configNode.users.splice(configNode.users.indexOf(ev.node), 1);
+                                        RED.events.emit("nodes:change", configNode);
+                                    }
+                                }
+                            });
+
+                            nodeList = ev.changes.env || [];
+                            nodeList = nodeList.reduce((list, prop) => {
+                                if (prop.type === "conf-type" && prop.value) {
+                                    list.push(prop.value);
+                                }
+                                return list;
+                            }, []);
+
+                            nodeList.forEach(function(id) {
+                                const configNode = RED.nodes.node(id);
+                                if (configNode) {
+                                    if (configNode.users.indexOf(ev.node) === -1) {
+                                        configNode.users.push(ev.node);
+                                        RED.events.emit("nodes:change", configNode);
+                                    }
+                                }
+                            });
                         }
                         ev.node[i] = ev.changes[i];
                     }
                 }
+
                 ev.node.dirty = true;
                 ev.node.changed = ev.changed;
 

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -702,11 +702,11 @@ RED.nodes = (function() {
             n["_"] = RED._;
         }
         if (n._def.category == "config") {
-            configNodes[n.id] = n;
+            configNodes[n.id] = newNode;
         } else {
             if (n.wires && (n.wires.length > n.outputs)) { n.outputs = n.wires.length; }
             n.dirty = true;
-            updateConfigNodeUsers(n);
+            updateConfigNodeUsers(newNode);
             if (n._def.category == "subflows" && typeof n.i === "undefined") {
                 var nextId = 0;
                 RED.nodes.eachNode(function(node) {

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -809,6 +809,20 @@ RED.nodes = (function() {
                 if (sf) {
                     sf.instances.splice(sf.instances.indexOf(node),1);
                 }
+
+                node.env?.forEach((prop) => {
+                    if (prop.type === "conf-type" && prop.value) {
+                        // Remove the node from the config node users
+                        const configNode = getNode(prop.value);
+                        if (configNode) {
+                            if (configNode.users.indexOf(node) !== -1) {
+                                configNode.users.splice(configNode.users.indexOf(node), 1);
+                                RED.events.emit('nodes:change', configNode);
+                                updatedConfigNode = true;
+                            }
+                        }
+                    }
+                });
             }
 
             if (updatedConfigNode) {
@@ -2683,6 +2697,22 @@ RED.nodes = (function() {
                     }
                 }
             }
+        }
+
+        // Subflows can have config node env
+        if (n.type.indexOf("subflow:") === 0) {
+            n.env?.forEach((prop) => {
+                if (prop.type === "conf-type" && prop.value) {
+                    // Add the node to the config node users
+                    const configNode = getNode(prop.value);
+                    if (configNode) {
+                        if (configNode.users.indexOf(n) === -1) {
+                            configNode.users.push(n);
+                            RED.events.emit('nodes:change', configNode);
+                        }
+                    }
+                }
+            });
         }
     }
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/envVarProperties.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/envVarProperties.js
@@ -20,8 +20,29 @@
             apply: function(editState) {
                 var old_env = node.env;
                 var new_env = [];
+
                 if (/^subflow:/.test(node.type)) {
+                    // Get the list of environment variables from the node properties
                     new_env = RED.subflow.exportSubflowInstanceEnv(node);
+                }
+
+                if (old_env && old_env.length) {
+                    old_env.forEach(function (prop) {
+                        if (prop.type === "conf-type" && prop.value) {
+                            const stillInUse = new_env?.some((p) => p.type === "conf-type" && p.name === prop.name && p.value === prop.value);
+                            if (!stillInUse) {
+                                // Remove the node from the config node users
+                                // Only for empty value or modified
+                                const configNode = RED.nodes.node(prop.value);
+                                if (configNode) {
+                                    if (configNode.users.indexOf(node) !== -1) {
+                                        configNode.users.splice(configNode.users.indexOf(node), 1);
+                                        RED.events.emit('nodes:change', configNode)
+                                    }
+                                }
+                            }
+                        }
+                    });
                 }
 
                 // Get the values from the Properties table tab
@@ -41,7 +62,6 @@
                     }
                 });
 
-
                 if (new_env && new_env.length > 0) {
                     new_env.forEach(function(prop) {
                         if (prop.type === "cred") {
@@ -52,6 +72,15 @@
                                 editState.changed = true;
                             }
                             delete prop.value;
+                        } else if (prop.type === "conf-type" && prop.value) {  
+                            const configNode = RED.nodes.node(prop.value);
+                            if (configNode) {
+                                if (configNode.users.indexOf(node) === -1) {
+                                    // Add the node to the config node users
+                                    configNode.users.push(node);
+                                    RED.events.emit('nodes:change', configNode);
+                                }
+                            }
                         }
                     });
                 }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
@@ -44,6 +44,7 @@
             apply: function(editState) {
                 var newValue;
                 var d;
+                // If the node is a subflow, the node's properties (exepts name) are saved by `envProperties`
                 if (node._def.defaults) {
                     for (d in node._def.defaults) {
                         if (node._def.defaults.hasOwnProperty(d)) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -1362,7 +1362,7 @@ RED.subflow = (function() {
                         item.value = ""+input.prop("checked");
                         break;
                     case "conf-types":
-                        item.value = input.val()
+                        item.value = input.val() === "_ADD_" ? "" : input.val();
                         item.type = "conf-type"
                 }
                 if (ui.type === "cred" || item.type !== data.parent.type || item.value !== data.parent.value) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes https://github.com/FlowFuse/node-red-dashboard/issues/754.

#4587 introduced a feature that allows nodes in a subflow to choose a config node from the environment variables.

It's the subflow node that will define which "real" config node will be the environment variable. It is also this node that should be added to the users of the config node.

This PR therefore handles it:
- when adding/removing the subflow node
- when saving the subflow node config
- into the history (undo/redo subflow node changes)

This PR also fixes the node object added to the config node users, it must be the proxy object. Detected in #4807.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
