### PR TITLE
Add a new `update available` widget to statusBar

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -620,6 +620,8 @@
             "pluginCount_plural": "__count__ plugins",
             "moduleCount": "__count__ module available",
             "moduleCount_plural": "__count__ modules available",
+            "updateCount": "__count__ update available",
+            "updateCount_plural": "__count__ updates available",
             "inuse": "in use",
             "enableall": "enable all",
             "disableall": "disable all",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -649,6 +649,7 @@ RED.palette.editor = (function() {
             if (!/^subflow:/.test(nodeType)) {
                 var ns = RED.nodes.registry.getNodeSetForType(nodeType);
                 refreshNodeModule(ns.module);
+                refreshUpdateStatus();
             }
         });
         RED.events.on('registry:node-type-removed', function(nodeType) {
@@ -724,6 +725,7 @@ RED.palette.editor = (function() {
                 _refreshNodeModule(module);
             }
 
+            refreshUpdateStatus();
             for (var i=0;i<filteredList.length;i++) {
                 if (filteredList[i].info.id === module) {
                     var installButton = filteredList[i].elements.installButton;
@@ -1331,6 +1333,7 @@ RED.palette.editor = (function() {
                                     if (e) {
                                         nodeList.editableList('removeItem', e);
                                         delete nodeEntries[entry.name];
+                                        refreshUpdateStatus();
                                     }
 
                                     // We assume that a plugin that implements onremove
@@ -1521,7 +1524,7 @@ RED.palette.editor = (function() {
         if (opts.count) {
             RED.statusBar.show("update");
             updateStatusWidget.empty();
-            $('<span><i class="fa fa-cogs"></i> ' + opts.count + '</span>').appendTo(updateStatusWidget);
+            $('<span><i class="fa fa-cube"></i> ' + opts.count + '</span>').appendTo(updateStatusWidget);
         } else {
             RED.statusBar.hide("update");
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -389,9 +389,39 @@ RED.palette.editor = (function() {
 
     var activeSort = sortModulesRelevance;
 
+    function refreshCatalogues (done) {
+        catalogueLoadStatus = [];
+        catalogueLoadErrors = false;
+        catalogueCount = catalogues.length;
+        loadedList = []
+        loadedIndex = {}
+        loadedCatalogs.length = 0
+        let handled = 0
+        for (let index = 0; index < catalogues.length; index++) {
+            const url = catalogues[index];
+            $.getJSON(url, {_: new Date().getTime()},function(v) {
+                loadedCatalogs.push({ index: index, url: url, name: v.name, updated_at: v.updated_at, modules_count: (v.modules || []).length })
+                handleCatalogResponse(null,{ url: url, name: v.name},index,v);
+            }).fail(function(jqxhr, textStatus, error) {
+                console.warn("Error loading catalog",url,":",error);
+                handleCatalogResponse(jqxhr,url,index);
+            }).always(function() {
+                handled++;
+                if (handled === catalogueCount) {
+                    //sort loadedCatalogs by e.index ascending
+                    loadedCatalogs.sort((a, b) => a.index - b.index)
+                    refreshUpdateStatus();
+                    if (done) {
+                        done()
+                    }
+                }
+            })
+        }
+    }
+
     function handleCatalogResponse(err,catalog,index,v) {
         const url = catalog.url
-        catalogueLoadStatus.push(err||v);
+        catalogueLoadStatus.push(err);
         if (!err) {
             if (v.modules) {
                 v.modules = v.modules.filter(function(m) {
@@ -421,9 +451,6 @@ RED.palette.editor = (function() {
         } else {
             catalogueLoadErrors = true;
         }
-        if (catalogueCount > 1) {
-            $(".red-ui-palette-module-shade-status").html(RED._('palette.editor.loading')+"<br>"+catalogueLoadStatus.length+"/"+catalogueCount);
-        }
         if (catalogueLoadStatus.length === catalogueCount) {
             if (catalogueLoadErrors) {
                 RED.notify(RED._('palette.editor.errors.catalogLoadFailed',{url: url}),"error",false,8000);
@@ -444,37 +471,18 @@ RED.palette.editor = (function() {
             packageList.editableList('empty');
 
             $(".red-ui-palette-module-shade-status").text(RED._('palette.editor.loading'));
-
-            catalogueLoadStatus = [];
-            catalogueLoadErrors = false;
-            catalogueCount = catalogues.length;
-            if (catalogues.length > 1) {
-                $(".red-ui-palette-module-shade-status").html(RED._('palette.editor.loading')+"<br>0/"+catalogues.length);
-            }
             $("#red-ui-palette-module-install-shade").show();
-            catalogueLoadStart = Date.now();
-            var handled = 0;
-            loadedCatalogs.length = 0; // clear the loadedCatalogs array
-            for (let index = 0; index < catalogues.length; index++) {
-                const url = catalogues[index];
-                $.getJSON(url, {_: new Date().getTime()},function(v) {
-                    loadedCatalogs.push({ index: index, url: url, name: v.name, updated_at: v.updated_at, modules_count: (v.modules || []).length })
-                    handleCatalogResponse(null,{ url: url, name: v.name},index,v);
-                    refreshNodeModuleList();
-                }).fail(function(jqxhr, textStatus, error) {
-                    console.warn("Error loading catalog",url,":",error);
-                    handleCatalogResponse(jqxhr,url,index);
-                }).always(function() {
-                    handled++;
-                    if (handled === catalogueCount) {
-                        //sort loadedCatalogs by e.index ascending
-                        loadedCatalogs.sort((a, b) => a.index - b.index)
-                        updateCatalogFilter(loadedCatalogs)
-                    }
-                })
-            }
-            // Now all catalogs have been loaded, refresh the update status
-            refreshUpdateStatus();
+            refreshCatalogues(function () {
+                refreshNodeModuleList();
+                updateCatalogFilter(loadedCatalogs)
+                const delta = 250-(Date.now() - catalogueLoadStart);
+                setTimeout(function() {
+                    $("#red-ui-palette-module-install-shade").hide();
+                },Math.max(delta,0));
+            })
+        } else {
+            refreshNodeModuleList();
+            updateCatalogFilter(loadedCatalogs)
         }
     }
 
@@ -488,7 +496,6 @@ RED.palette.editor = (function() {
         if (catalogSelection.length === 0) {
             // sidebar not yet loaded (red-catalogue-filter-select is not in dom)
             if (maxRetry > 0) {
-               // console.log("updateCatalogFilter: sidebar not yet loaded, retrying in 100ms")
                 // try again in 100ms
                 setTimeout(() => {
                     updateCatalogFilter(catalogEntries, maxRetry - 1)
@@ -629,8 +636,8 @@ RED.palette.editor = (function() {
 
         // Add the update status to the status bar
         addUpdateInfoToStatusBar();
-        // Load the catalogue and check for updates
-        getSettingsPane();
+
+        refreshCatalogues()
 
         RED.actions.add("core:manage-palette",function() {
                 RED.userSettings.show('palette');
@@ -1499,26 +1506,29 @@ RED.palette.editor = (function() {
         updateStatus({ count: 0 });
     }
 
+    let pendingRefreshTimeout
     function refreshUpdateStatus() {
-        updateAvailable = [];
-
-        for (const module of Object.keys(nodeEntries)) {
-            if (loadedIndex.hasOwnProperty(module)) {
-                const moduleInfo = nodeEntries[module].info;
-                if (moduleInfo.pending_version) {
-                    // Module updated
-                    continue;
-                }
-                if (updateAllowed &&
-                    semVerCompare(loadedIndex[module].version, moduleInfo.version) > 0 &&
-                    RED.utils.checkModuleAllowed(module, null, updateAllowList, updateDenyList)
-                ) {
-                    updateAvailable.push(module);
+        clearTimeout(pendingRefreshTimeout)
+        pendingRefreshTimeout = setTimeout(() => {
+            updateAvailable = [];
+            for (const module of Object.keys(nodeEntries)) {
+                if (loadedIndex.hasOwnProperty(module)) {
+                    const moduleInfo = nodeEntries[module].info;
+                    if (moduleInfo.pending_version) {
+                        // Module updated
+                        continue;
+                    }
+                    if (updateAllowed &&
+                        semVerCompare(loadedIndex[module].version, moduleInfo.version) > 0 &&
+                        RED.utils.checkModuleAllowed(module, null, updateAllowList, updateDenyList)
+                    ) {
+                        updateAvailable.push(module);
+                    }
                 }
             }
-        }
 
-        updateStatus({ count: updateAvailable.length });
+            updateStatus({ count: updateAvailable.length });
+        }, 200)
     }
 
     function updateStatus(opts) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -1501,6 +1501,10 @@ RED.palette.editor = (function() {
         for (const module of Object.keys(nodeEntries)) {
             if (loadedIndex.hasOwnProperty(module)) {
                 const moduleInfo = nodeEntries[module].info;
+                if (moduleInfo.pending_version) {
+                    // Module updated
+                    continue;
+                }
                 if (updateAllowed &&
                     semVerCompare(loadedIndex[module].version, moduleInfo.version) > 0 &&
                     RED.utils.checkModuleAllowed(module, null, updateAllowList, updateDenyList)

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -461,6 +461,7 @@ RED.palette.editor = (function() {
                     loadedCatalogs.push({ index: index, url: url, name: v.name, updated_at: v.updated_at, modules_count: (v.modules || []).length })
                     handleCatalogResponse(null,{ url: url, name: v.name},index,v);
                     refreshNodeModuleList();
+                    refreshUpdateStatus();
                 }).fail(function(jqxhr, textStatus, error) {
                     console.warn("Error loading catalog",url,":",error);
                     handleCatalogResponse(jqxhr,url,index);
@@ -624,6 +625,10 @@ RED.palette.editor = (function() {
                 },200);
             }
         })
+
+        addUpdateInfoToStatusBar();
+        // TODO: Periodically check
+        setTimeout(getSettingsPane, 1000);
 
         RED.actions.add("core:manage-palette",function() {
                 RED.userSettings.show('palette');
@@ -1460,6 +1465,59 @@ RED.palette.editor = (function() {
             fixed: true,
             buttons: buttons
         })
+    }
+
+    const updateStatusWidget = $('<button type="button" class="red-ui-footer-button red-ui-update-status"></button>');
+    let updateAvailable = [];
+
+    function addUpdateInfoToStatusBar() {
+        updateStatusWidget.on("click", function (evt) {
+            RED.actions.invoke("core:manage-palette", {
+                view: "install",
+                filter: '"' + updateAvailable.join('", "') + '"'
+            });
+        });
+
+        RED.popover.tooltip(updateStatusWidget, function () {
+            const count = updateAvailable.length || 0;
+            return RED._("palette.editor.updateCount", { count: count });
+        });
+
+        RED.statusBar.add({
+            id: "update",
+            align: "right",
+            element: updateStatusWidget
+        });
+
+        updateStatus({ count: 0 });
+    }
+
+    function refreshUpdateStatus() {
+        updateAvailable = [];
+
+        for (const module of Object.keys(nodeEntries)) {
+            if (loadedIndex.hasOwnProperty(module)) {
+                const moduleInfo = nodeEntries[module].info;
+                if (updateAllowed &&
+                    semVerCompare(loadedIndex[module].version, moduleInfo.version) > 0 &&
+                    RED.utils.checkModuleAllowed(module, null, updateAllowList, updateDenyList)
+                ) {
+                    updateAvailable.push(module);
+                }
+            }
+        }
+
+        updateStatus({ count: updateAvailable.length });
+    }
+
+    function updateStatus(opts) {
+        if (opts.count) {
+            RED.statusBar.show("update");
+            updateStatusWidget.empty();
+            $('<span><i class="fa fa-cogs"></i> ' + opts.count + '</span>').appendTo(updateStatusWidget);
+        } else {
+            RED.statusBar.hide("update");
+        }
     }
 
     return {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -1476,7 +1476,7 @@ RED.palette.editor = (function() {
     function addUpdateInfoToStatusBar() {
         updateStatusWidget.on("click", function (evt) {
             RED.actions.invoke("core:manage-palette", {
-                view: "install",
+                view: "nodes",
                 filter: '"' + updateAvailable.join('", "') + '"'
             });
         });

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -461,7 +461,6 @@ RED.palette.editor = (function() {
                     loadedCatalogs.push({ index: index, url: url, name: v.name, updated_at: v.updated_at, modules_count: (v.modules || []).length })
                     handleCatalogResponse(null,{ url: url, name: v.name},index,v);
                     refreshNodeModuleList();
-                    refreshUpdateStatus();
                 }).fail(function(jqxhr, textStatus, error) {
                     console.warn("Error loading catalog",url,":",error);
                     handleCatalogResponse(jqxhr,url,index);
@@ -474,6 +473,8 @@ RED.palette.editor = (function() {
                     }
                 })
             }
+            // Now all catalogs have been loaded, refresh the update status
+            refreshUpdateStatus();
         }
     }
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -385,13 +385,11 @@ RED.palette.editor = (function() {
     var catalogueCount;
     var catalogueLoadStatus = [];
     var catalogueLoadStart;
-    var catalogueLoadErrors = false;
 
     var activeSort = sortModulesRelevance;
 
     function refreshCatalogues (done) {
         catalogueLoadStatus = [];
-        catalogueLoadErrors = false;
         catalogueCount = catalogues.length;
         loadedList = []
         loadedIndex = {}
@@ -401,10 +399,9 @@ RED.palette.editor = (function() {
             const url = catalogues[index];
             $.getJSON(url, {_: new Date().getTime()},function(v) {
                 loadedCatalogs.push({ index: index, url: url, name: v.name, updated_at: v.updated_at, modules_count: (v.modules || []).length })
-                handleCatalogResponse(null,{ url: url, name: v.name},index,v);
+                handleCatalogResponse({ url: url, name: v.name},index,v);
             }).fail(function(jqxhr, textStatus, error) {
                 console.warn("Error loading catalog",url,":",error);
-                handleCatalogResponse(jqxhr,url,index);
             }).always(function() {
                 handled++;
                 if (handled === catalogueCount) {
@@ -419,47 +416,31 @@ RED.palette.editor = (function() {
         }
     }
 
-    function handleCatalogResponse(err,catalog,index,v) {
-        const url = catalog.url
-        catalogueLoadStatus.push(err);
-        if (!err) {
-            if (v.modules) {
-                v.modules = v.modules.filter(function(m) {
-                    if (RED.utils.checkModuleAllowed(m.id,m.version,installAllowList,installDenyList)) {
-                        loadedIndex[m.id] = m;
-                        m.index = [m.id];
-                        if (m.keywords) {
-                            m.index = m.index.concat(m.keywords);
-                        }
-                        if (m.types) {
-                            m.index = m.index.concat(m.types);
-                        }
-                        if (m.updated_at) {
-                            m.timestamp = new Date(m.updated_at).getTime();
-                        } else {
-                            m.timestamp = 0;
-                        }
-                        m.index = m.index.join(",").toLowerCase();
-                        m.catalog = catalog;
-                        m.catalogIndex = index;
-                        return true;
+    function handleCatalogResponse(catalog,index,v) {
+        if (v.modules) {
+            v.modules = v.modules.filter(function(m) {
+                if (RED.utils.checkModuleAllowed(m.id,m.version,installAllowList,installDenyList)) {
+                    loadedIndex[m.id] = m;
+                    m.index = [m.id];
+                    if (m.keywords) {
+                        m.index = m.index.concat(m.keywords);
                     }
-                    return false;
-                })
-                loadedList = loadedList.concat(v.modules);
-            }
-        } else {
-            catalogueLoadErrors = true;
-        }
-        if (catalogueLoadStatus.length === catalogueCount) {
-            if (catalogueLoadErrors) {
-                RED.notify(RED._('palette.editor.errors.catalogLoadFailed',{url: url}),"error",false,8000);
-            }
-            var delta = 250-(Date.now() - catalogueLoadStart);
-            setTimeout(function() {
-                $("#red-ui-palette-module-install-shade").hide();
-            },Math.max(delta,0));
-
+                    if (m.types) {
+                        m.index = m.index.concat(m.types);
+                    }
+                    if (m.updated_at) {
+                        m.timestamp = new Date(m.updated_at).getTime();
+                    } else {
+                        m.timestamp = 0;
+                    }
+                    m.index = m.index.join(",").toLowerCase();
+                    m.catalog = catalog;
+                    m.catalogIndex = index;
+                    return true;
+                }
+                return false;
+            })
+            loadedList = loadedList.concat(v.modules);
         }
     }
 
@@ -472,6 +453,7 @@ RED.palette.editor = (function() {
 
             $(".red-ui-palette-module-shade-status").text(RED._('palette.editor.loading'));
             $("#red-ui-palette-module-install-shade").show();
+            catalogueLoadStart = Date.now()
             refreshCatalogues(function () {
                 refreshNodeModuleList();
                 updateCatalogFilter(loadedCatalogs)

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -626,9 +626,10 @@ RED.palette.editor = (function() {
             }
         })
 
+        // Add the update status to the status bar
         addUpdateInfoToStatusBar();
-        // TODO: Periodically check
-        setTimeout(getSettingsPane, 1000);
+        // Load the catalogue and check for updates
+        getSettingsPane();
 
         RED.actions.add("core:manage-palette",function() {
                 RED.userSettings.show('palette');
@@ -636,6 +637,7 @@ RED.palette.editor = (function() {
 
         RED.events.on('registry:module-updated', function(ns) {
             refreshNodeModule(ns.module);
+            refreshUpdateStatus();
         });
         RED.events.on('registry:node-set-enabled', function(ns) {
             refreshNodeModule(ns.module);
@@ -653,6 +655,7 @@ RED.palette.editor = (function() {
             if (!/^subflow:/.test(nodeType)) {
                 var ns = RED.nodes.registry.getNodeSetForType(nodeType);
                 refreshNodeModule(ns.module);
+                refreshUpdateStatus();
             }
         });
         RED.events.on('registry:node-set-added', function(ns) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/statusBar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/statusBar.js
@@ -33,10 +33,27 @@ RED.statusBar = (function() {
         var el = $('<span class="red-ui-statusbar-widget"></span>');
         el.prop('id', options.id);
         options.element.appendTo(el);
+        options.elementDiv = el;
         if (options.align === 'left') {
             leftBucket.append(el);
         } else if (options.align === 'right') {
             rightBucket.prepend(el);
+        }
+    }
+
+    function hideWidget(id) {
+        const widget = widgets[id];
+
+        if (widget && widget.elementDiv) {
+            widget.elementDiv.hide();
+        }
+    }
+
+    function showWidget(id) {
+        const widget = widgets[id];
+
+        if (widget && widget.elementDiv) {
+            widget.elementDiv.show();
         }
     }
 
@@ -45,7 +62,9 @@ RED.statusBar = (function() {
             leftBucket = $('<span class="red-ui-statusbar-bucket red-ui-statusbar-bucket-left">').appendTo("#red-ui-workspace-footer");
             rightBucket = $('<span class="red-ui-statusbar-bucket red-ui-statusbar-bucket-right">').appendTo("#red-ui-workspace-footer");
         },
-        add: addWidget
+        add: addWidget,
+        hide: hideWidget,
+        show: showWidget
     }
 
 })();

--- a/packages/node_modules/@node-red/editor-client/src/sass/palette-editor.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/palette-editor.scss
@@ -309,7 +309,4 @@ button.red-ui-palette-editor-upload-button {
 button.red-ui-update-status {
     width: auto;
     padding: 0 3px;
-    span {
-        color: var(--red-ui-text-color-warning);
-    }
 }

--- a/packages/node_modules/@node-red/editor-client/src/sass/palette-editor.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/palette-editor.scss
@@ -305,3 +305,11 @@ button.red-ui-palette-editor-upload-button {
         margin-left: 10px;
     }
 }
+
+button.red-ui-update-status {
+    width: auto;
+    padding: 0 3px;
+    span {
+        color: var(--red-ui-text-color-warning);
+    }
+}


### PR DESCRIPTION
This is a continuation of #4935 that replaces that PR.

It refactors the palette manager code to allow us to reload the catalogues *without* generating the whole palette manager UI. This makes it more efficient to do background checks of updates so we can keep the status widget up to date.