### PR TITLE
Move location of new creds files to be next to flows (if they don't exist already in userdir)

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/index.js
@@ -85,8 +85,8 @@ function init(_settings, _runtime) {
     var ffBase = fspath.basename(flowsFullPath,ffExt);
 
     flowsFileBackup = getBackupFilename(flowsFullPath);
-    credentialsFile = fspath.join(settings.userDir,ffBase+"_cred"+ffExt); // if creds file exists in "old" location use
-    if (!fs.existsSync(credentialsFile)) { // if not then locate it next to flows file in user dir
+    credentialsFile = fspath.join(settings.userDir,ffBase+"_cred"+ffExt); // if creds file exists in "old" location userdir then use it
+    if (!fs.existsSync(credentialsFile)) { // if not then locate it next to flows file in flows dir
         credentialsFile = fspath.join(fspath.dirname(flowsFullPath), ffBase+"_cred"+ffExt);
     }
     credentialsFileBackup = getBackupFilename(credentialsFile)

--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/index.js
@@ -85,7 +85,10 @@ function init(_settings, _runtime) {
     var ffBase = fspath.basename(flowsFullPath,ffExt);
 
     flowsFileBackup = getBackupFilename(flowsFullPath);
-    credentialsFile = fspath.join(settings.userDir,ffBase+"_cred"+ffExt);
+    credentialsFile = fspath.join(settings.userDir,ffBase+"_cred"+ffExt); // if creds file exists in "old" location use
+    if (!fs.existsSync(credentialsFile)) { // if not then locate it next to flows file in user dir
+        credentialsFile = fspath.join(fspath.dirname(flowsFullPath), ffBase+"_cred"+ffExt);
+    }
     credentialsFileBackup = getBackupFilename(credentialsFile)
 
     var setupProjectsPromise;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

If you specify the location of the flows file to be somewhere else then currently the flows_cred.json file remains located in the userdir. This PR checks to see if the file already exists in the userdir (so as not to break existing uses) - but if not - then it creates the cred file in the same directory as the flows so that copying them manually is simplified.
It also means that when using docker and setting the flows to be mounted outside the container for persistence then the creds are also persisted alongside them.
Hopefully this doesn't break existing users - but as it is a change of behaviour it may need a serious version bump.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
