### PR TITLE
Add the vertical marker to the palette hand

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/palette.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/palette.scss
@@ -26,6 +26,26 @@
     @include disable-selection;
     @include component-border;
     transition: width 0.2s ease-in-out;
+
+    &:before {
+        content: '';
+        top: 0px;
+        bottom: 0px;
+        right: 0px;
+        width: 7px;
+        height: 100%;
+        z-index: 4;
+        position: absolute;
+        -webkit-mask-image: url(images/grip.svg);
+        mask-image: url(images/grip.svg);
+        -webkit-mask-size: auto;
+        mask-size: auto;
+        -webkit-mask-position: 50% 50%;
+        mask-position: 50% 50%;
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        background-color: var(--red-ui-grip-color);
+    }
 }
 
 .red-ui-palette-closed {


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Add the vertical marker to the palette hand.

See [preview in the Forum](https://discourse.nodered.org/t/wheres-my-sidebar-nodes/93091/5).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
