### PR TITLE
Add a node annotation if the info property is set

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -111,6 +111,7 @@
             "userSettings": "User Settings",
             "nodes": "Nodes",
             "displayStatus": "Show node status",
+            "displayInfoIcon": "Show node information icon",
             "displayConfig": "Configuration nodes",
             "import": "Import",
             "importExample": "Import example flow",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
@@ -140,6 +140,7 @@ RED.userSettings = (function() {
             title: "menu.label.nodes",
             options: [
                 {setting:"view-node-status",oldSetting:"menu-menu-item-status",label:"menu.label.displayStatus",default: true, toggle:true,onchange:"core:toggle-status"},
+                {setting:"view-node-info-icon", label:"menu.label.displayInfoIcon", default: true, toggle:true,onchange:"core:toggle-node-info-icon"},
                 {setting:"view-node-show-label",label:"menu.label.showNodeLabelDefault",default: true, toggle:true}
             ]
         },

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -865,6 +865,39 @@ RED.view = (function() {
         RED.view.navigator.init();
         RED.view.tools.init();
 
+        RED.view.annotations.register("red-ui-flow-node-docs",{
+            type: "badge",
+            class: "red-ui-flow-node-docs",
+            element: function(node) {
+
+                const docsBadge = document.createElementNS("http://www.w3.org/2000/svg","g")
+
+                const pageOutline = document.createElementNS("http://www.w3.org/2000/svg","rect");
+                pageOutline.setAttribute("x",0);
+                pageOutline.setAttribute("y",0);
+                pageOutline.setAttribute("rx",2);
+                pageOutline.setAttribute("width",7);
+                pageOutline.setAttribute("height",10);
+                docsBadge.appendChild(pageOutline)
+
+                const pageLines = document.createElementNS("http://www.w3.org/2000/svg","path");
+                pageLines.setAttribute("d", "M 7 3 h -3 v -3 M 2 8 h 3 M 2 6 h 3 M 2 4 h 2")
+                docsBadge.appendChild(pageLines)
+
+                $(docsBadge).on('click', function (evt) {
+                    if (node.type === "subflow") {
+                        RED.editor.editSubflow(activeSubflow, 'editor-tab-description');
+                    } else if (node.type === "group") {
+                        RED.editor.editGroup(node, 'editor-tab-description');
+                    } else {
+                        RED.editor.edit(node, 'editor-tab-description');
+                    }
+                })
+
+                return docsBadge;
+            },
+            show: function(n) { return !!n.info }
+        })
 
         RED.view.annotations.register("red-ui-flow-node-changed",{
             type: "badge",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -82,6 +82,7 @@ RED.view = (function() {
     var slicePathLast = null;
     var ghostNode = null;
     var showStatus = false;
+    let showNodeInfo = true;
     var lastClickNode = null;
     var dblClickPrimed = null;
     var clickTime = 0;
@@ -860,6 +861,13 @@ RED.view = (function() {
                 toggleStatus(state);
             }
         });
+        RED.actions.add("core:toggle-node-info-icon", function (state) {
+            if (state === undefined) {
+                RED.userSettings.toggle("view-node-info-icon");
+            } else {
+                toggleNodeInfo(state)
+            }
+        })
 
         RED.view.annotations.init();
         RED.view.navigator.init();
@@ -896,7 +904,7 @@ RED.view = (function() {
 
                 return docsBadge;
             },
-            show: function(n) { return !!n.info }
+            show: function(n) { return showNodeInfo && !!n.info }
         })
 
         RED.view.annotations.register("red-ui-flow-node-changed",{
@@ -6038,6 +6046,11 @@ RED.view = (function() {
         showStatus = s;
         RED.nodes.eachNode(function(n) { n.dirtyStatus = true; n.dirty = true;});
         //TODO: subscribe/unsubscribe here
+        redraw();
+    }
+    function toggleNodeInfo(s) {
+        showNodeInfo = s
+        RED.nodes.eachNode(function(n) { n.dirty = true;});
         redraw();
     }
     function setSelectedNodeState(isDisabled) {

--- a/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
@@ -242,6 +242,18 @@ svg:not(.red-ui-workspace-lasso-active) {
     stroke-linecap: round;
 }
 
+.red-ui-flow-node-docs {
+    stroke-width: 1px;
+    stroke-linejoin: round;
+    stroke-linecap: round;
+    stroke: var(--red-ui-node-border);
+    fill: none;
+    cursor: pointer;
+    rect {
+        fill: white;
+    }
+}
+
 g.red-ui-flow-node-selected {
     .red-ui-workspace-select-mode & {
         opacity: 1;


### PR DESCRIPTION
Closes #4375 

Adds an annotation to any nodes that have a non-blank `info` property - ie the 'description' field.

Clicking on the annotation opens the edit dialog for the node with the description tab shown.

Not 100% about this, but wanted to get the code shared. 

Have also added a user option to toggle whether the setting is shown or not (consistent with the option we provide to show/hide status).

<img width="147" alt="image" src="https://github.com/user-attachments/assets/3e4882ba-2350-4547-8384-594a32b5ab16">

<img width="368" alt="image" src="https://github.com/user-attachments/assets/c0376260-bdf8-4a1d-a891-ca5c1d7a140d" />
