### PR TITLE
Propagate errors when testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "cors": "2.8.5",
         "cronosjs": "1.7.1",
         "denque": "2.1.0",
+        "detect-mocha": "^0.1.0",
         "express": "4.21.1",
         "express-session": "1.18.1",
         "form-data": "4.0.0",

--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -21,6 +21,7 @@ const flowUtil = require("./util");
 const context = require('../nodes/context');
 const hooks = require("@node-red/util").hooks;
 const credentials = require("../nodes/credentials");
+const detectMocha = require("detect-mocha");
 
 let Subflow;
 let Log;
@@ -804,6 +805,9 @@ function deliverMessageToDestination(sendEvent) {
         } catch(err) {
             Log.error(`Error delivering message to node:${sendEvent.destination.node._path} [${sendEvent.destination.node.type}]`)
             Log.error(err.stack)
+            if (detectMocha()) {
+                throw err;
+            }
         }
     }
 }

--- a/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
@@ -21,6 +21,7 @@ var redUtil = require("@node-red/util").util;
 var Log = require("@node-red/util").log;
 var context = require("./context");
 var flows = require("../flows");
+var detectMocha = require("detect-mocha");
 const hooks = require("@node-red/util").hooks;
 
 
@@ -218,6 +219,9 @@ Node.prototype._emitInput = function(arg) {
                     );
                 } catch(err) {
                     node.error(err,arg);
+                    if (detectMocha()) {
+                        throw err;
+                    }
                 }
             } else if (node._inputCallbacks) {
                 // Multiple callbacks registered. Call each one, tracking eventual completion


### PR DESCRIPTION
Testing with Mocha requires errors raised within flows to propagate to the test runner, not getting swallowed by Node-Red.

This commit tests whether Mocha's global functions exist and, if they do, propagates exceptions that are raised there.

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

When running under Mocha, Node-Red must propagate exceptions to the test runner so that suitable error messages can be emitted instead of a timeout.

This closes issue #4956.

Suggestions how to test for this feature, should such a test be deemed necessary, are welcome. I have to admit that I am not well-versed enough in Javascript, Mocha and/or Node-Red lore to write a test for this specific issue that's not (a) visual, or (b) would be a copy of the test that the "detect-mocha" module already does.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
