### PR TITLE
Get the env config node from the parent subflow

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -113,6 +113,10 @@ async function evaluateEnvProperties(flow, env, credentials) {
                     resolve()
                 });
             }))
+        } else if (type === "conf-type" && /^\${[^}]+}$/.test(value)) {
+            // Get the config node from the parent subflow
+            const name = value.substring(2, value.length - 1);
+            value = flow.getSetting(name);
         } else {
             try {
                 value = redUtil.evaluateNodeProperty(value, type, {_flow: flow}, null, null);


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #4942.

If the value has the form `${CONF_NODE}`, it means that the sublow node is in a subflow.
Have to check if the env config node exists in the parent subflow.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
