### PR TITLE
Rename variable to avoid confusion in view.js

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -2689,22 +2689,21 @@ RED.view = (function() {
                 addToRemovedLinks(reconnectResult.removedLinks)
             }
 
-            var startDirty = RED.nodes.dirty();
-            var startChanged = false;
-            var selectedGroups = [];
+            const startDirty = RED.nodes.dirty();
+            let movingSelectedGroups = [];
             if (movingSet.length() > 0) {
 
                 for (var i=0;i<movingSet.length();i++) {
                     node = movingSet.get(i).n;
                     if (node.type === "group") {
-                        selectedGroups.push(node);
+                        movingSelectedGroups.push(node);
                     }
                 }
                 // Make sure we have identified all groups about to be deleted
-                for (i=0;i<selectedGroups.length;i++) {
-                    selectedGroups[i].nodes.forEach(function(n) {
-                        if (n.type === "group" && selectedGroups.indexOf(n) === -1) {
-                            selectedGroups.push(n);
+                for (i=0;i<movingSelectedGroups.length;i++) {
+                    movingSelectedGroups[i].nodes.forEach(function(n) {
+                        if (n.type === "group" && movingSelectedGroups.indexOf(n) === -1) {
+                            movingSelectedGroups.push(n);
                         }
                     })
                 }
@@ -2721,7 +2720,7 @@ RED.view = (function() {
                         addToRemovedLinks(removedEntities.links);
                         if (node.g) {
                             var group = RED.nodes.group(node.g);
-                            if (selectedGroups.indexOf(group) === -1) {
+                            if (movingSelectedGroups.indexOf(group) === -1) {
                                 // Don't use RED.group.removeFromGroup as that emits
                                 // a change event on the node - but we're deleting it
                                 var index = group.nodes.indexOf(node);
@@ -2735,7 +2734,7 @@ RED.view = (function() {
                         removedLinks = removedLinks.concat(result.links);
                         if (node.g) {
                             var group = RED.nodes.group(node.g);
-                            if (selectedGroups.indexOf(group) === -1) {
+                            if (movingSelectedGroups.indexOf(group) === -1) {
                                 // Don't use RED.group.removeFromGroup as that emits
                                 // a change event on the node - but we're deleting it
                                 var index = group.nodes.indexOf(node);
@@ -2757,8 +2756,8 @@ RED.view = (function() {
 
                 // Groups must be removed in the right order - from inner-most
                 // to outermost.
-                for (i = selectedGroups.length-1; i>=0; i--) {
-                    var g = selectedGroups[i];
+                for (i = movingSelectedGroups.length-1; i>=0; i--) {
+                    var g = movingSelectedGroups[i];
                     removedGroups.push(g);
                     RED.nodes.removeGroup(g);
                 }


### PR DESCRIPTION
Whilst reviewing #4959 spotted we had a variable name reused in view.js that would have been caught if we applied linting... that's a topic for another day... so for now, just fixing the clash to avoid future confusion.