### PR TITLE
Validate json dropped into editor to avoid unhelpful error messages

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -334,6 +334,30 @@ RED.clipboard = (function() {
         },100);
     }
 
+    /**
+     * Validates if the provided string looks like valid flow json
+     * @param {string} flowString the string to validate
+     * @returns If valid, returns the node array
+     */
+    function validateFlowString(flowString) {
+        const res = JSON.parse(flowString)
+        if (!Array.isArray(res)) {
+            throw new Error(RED._("clipboard.import.errors.notArray"));
+        }
+        for (let i = 0; i < res.length; i++) {
+            if (typeof res[i] !== "object") {
+                throw new Error(RED._("clipboard.import.errors.itemNotObject",{index:i}));
+            }
+            if (!Object.hasOwn(res[i], 'id')) {
+                throw new Error(RED._("clipboard.import.errors.missingId",{index:i}));
+            }
+            if (!Object.hasOwn(res[i], 'type')) {
+                throw new Error(RED._("clipboard.import.errors.missingType",{index:i}));
+            }
+        }
+        return res
+    }
+
     var validateImportTimeout;
     function validateImport() {
         if (activeTab === "red-ui-clipboard-dialog-import-tab-clipboard") {
@@ -351,21 +375,7 @@ RED.clipboard = (function() {
                     return;
                 }
                 try {
-                    if (!/^\[[\s\S]*\]$/m.test(v)) {
-                        throw new Error(RED._("clipboard.import.errors.notArray"));
-                    }
-                    var res = JSON.parse(v);
-                    for (var i=0;i<res.length;i++) {
-                        if (typeof res[i] !== "object") {
-                            throw new Error(RED._("clipboard.import.errors.itemNotObject",{index:i}));
-                        }
-                        if (!res[i].hasOwnProperty('id')) {
-                            throw new Error(RED._("clipboard.import.errors.missingId",{index:i}));
-                        }
-                        if (!res[i].hasOwnProperty('type')) {
-                            throw new Error(RED._("clipboard.import.errors.missingType",{index:i}));
-                        }
-                    }
+                    validateFlowString(v)
                     currentPopoverError = null;
                     popover.close(true);
                     importInput.removeClass("input-error");
@@ -998,16 +1008,16 @@ RED.clipboard = (function() {
     }
 
     function importNodes(nodesStr,addFlow) {
-        var newNodes = nodesStr;
+        let newNodes = nodesStr;
         if (typeof nodesStr === 'string') {
             try {
                 nodesStr = nodesStr.trim();
                 if (nodesStr.length === 0) {
                     return;
                 }
-                newNodes = JSON.parse(nodesStr);
+                newNodes = validateFlowString(nodesStr)
             } catch(err) {
-                var e = new Error(RED._("clipboard.invalidFlow",{message:err.message}));
+                const e = new Error(RED._("clipboard.invalidFlow",{message:err.message}));
                 e.code = "NODE_RED";
                 throw e;
             }
@@ -1342,6 +1352,7 @@ RED.clipboard = (function() {
                             }
                         }
                     } catch(err) {
+                        console.warn('Import failed: ', err)
                         // Ensure any errors throw above doesn't stop the drop target from
                         // being hidden.
                     }


### PR DESCRIPTION
Fixes #4962

The import dialog already did some better validation of JSON pasted into the dialog before we tried to import it. This PR pulls out that logic into a reusable function, and applies it to the validation of JSON dropped into the workspace.

For the DND case, and errors are logged to the console, but not shown to the user as a notification.

The validation checks for:

1. An array
2. each array element is an object, with properties 'id' and 'type'
