### PR TITLE
Fix junction insert position via context menu

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
@@ -54,15 +54,15 @@ RED.contextMenu = (function () {
                 }
             }
 
+            const scale = RED.view.scale()
             const offset = $("#red-ui-workspace-chart").offset()
-
-            let addX = options.x - offset.left + $("#red-ui-workspace-chart").scrollLeft()
-            let addY = options.y - offset.top + $("#red-ui-workspace-chart").scrollTop()
+            let addX = (options.x - offset.left + $("#red-ui-workspace-chart").scrollLeft()) / scale
+            let addY = (options.y - offset.top + $("#red-ui-workspace-chart").scrollTop()) / scale
 
             if (RED.view.snapGrid) {
                 const gridSize = RED.view.gridSize()
-                addX = gridSize * Math.floor(addX / gridSize)
-                addY = gridSize * Math.floor(addY / gridSize)
+                addX = gridSize * Math.round(addX / gridSize)
+                addY = gridSize * Math.round(addY / gridSize)
             }
 
             if (RED.settings.theme("menu.menu-item-action-list", true)) {
@@ -87,7 +87,9 @@ RED.contextMenu = (function () {
                 },
                 (hasLinks) ? { // has least 1 wire selected
                     label: RED._("contextMenu.junction"),
-                    onselect: 'core:split-wires-with-junctions',
+                    onselect: function () {
+                        RED.actions.invoke('core:split-wires-with-junctions', { x: addX, y: addY })
+                    },
                     disabled: !canEdit || !hasLinks
                 } : {
                     label: RED._("contextMenu.junction"),

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
@@ -1154,11 +1154,11 @@ RED.view.tools = (function() {
         }
     }
 
-    function addJunctionsToWires(wires) {
+    function addJunctionsToWires(options = {}) {
         if (RED.workspaces.isLocked()) {
             return
         }
-        let wiresToSplit = wires || (RED.view.selection().links && RED.view.selection().links.filter(e => !e.link));
+        let wiresToSplit = options.wires || (RED.view.selection().links && RED.view.selection().links.filter(e => !e.link));
         if (!wiresToSplit) {
             return
         }
@@ -1206,21 +1206,26 @@ RED.view.tools = (function() {
             if (links.length === 0) {
                 return
             }
-            let pointCount = 0
-            links.forEach(function(l) {
-                if (l._sliceLocation) {
-                    junction.x += l._sliceLocation.x
-                    junction.y += l._sliceLocation.y
-                    delete l._sliceLocation
-                    pointCount++
-                } else {
-                    junction.x += l.source.x + l.source.w/2 + l.target.x - l.target.w/2
-                    junction.y += l.source.y + l.target.y
-                    pointCount += 2
-                }
-            })
-            junction.x = Math.round(junction.x/pointCount)
-            junction.y = Math.round(junction.y/pointCount)
+            if (addedJunctions.length === 0 && Object.hasOwn(options, 'x') && Object.hasOwn(options, 'y')) {
+                junction.x = options.x
+                junction.y = options.y
+            } else {
+                let pointCount = 0
+                links.forEach(function(l) {
+                    if (l._sliceLocation) {
+                        junction.x += l._sliceLocation.x
+                        junction.y += l._sliceLocation.y
+                        delete l._sliceLocation
+                        pointCount++
+                    } else {
+                        junction.x += l.source.x + l.source.w/2 + l.target.x - l.target.w/2
+                        junction.y += l.source.y + l.target.y
+                        pointCount += 2
+                    }
+                })
+                junction.x = Math.round(junction.x/pointCount)
+                junction.y = Math.round(junction.y/pointCount)
+            }
             if (RED.view.snapGrid) {
                 let gridSize = RED.view.gridSize()
                 junction.x = (gridSize*Math.round(junction.x/gridSize));
@@ -1410,7 +1415,7 @@ RED.view.tools = (function() {
             RED.actions.add("core:wire-multiple-to-node", function() { wireMultipleToNode() })
 
             RED.actions.add("core:split-wire-with-link-nodes", function () { splitWiresWithLinkNodes() });
-            RED.actions.add("core:split-wires-with-junctions", function () { addJunctionsToWires() });
+            RED.actions.add("core:split-wires-with-junctions", function (options) { addJunctionsToWires(options) });
 
             RED.actions.add("core:generate-node-names", generateNodeNames )
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -321,8 +321,8 @@ RED.view = (function() {
             evt.stopPropagation()
             RED.contextMenu.show({
                 type: 'workspace',
-                x:evt.clientX-5,
-                y:evt.clientY-5
+                x: evt.clientX,
+                y: evt.clientY
             })
             return false
         })

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -5174,8 +5174,8 @@ RED.view = (function() {
                                 var delta = Infinity;
                                 for (var i = 0; i < lineLength; i++) {
                                     var linePos = pathLine.getPointAtLength(i);
-                                    var posDeltaX = Math.abs(linePos.x-d3.event.offsetX)
-                                    var posDeltaY = Math.abs(linePos.y-d3.event.offsetY)
+                                    var posDeltaX = Math.abs(linePos.x-(d3.event.offsetX / scaleFactor))
+                                    var posDeltaY = Math.abs(linePos.y-(d3.event.offsetY / scaleFactor))
                                     var posDelta = posDeltaX*posDeltaX + posDeltaY*posDeltaY
                                     if (posDelta < delta) {
                                         pos = linePos


### PR DESCRIPTION
Fixes #4969 

When triggered via the context menu...

 - Accounts for view zoom level when calculating junction/node insert position via context menu
 - Inserts junction in a wire where the mouse was clicked
 - Accounts for view zoom level when calculating junction insert position via slide action
