### PR TITLE
Performance : make reading single buffer / string file faster by not re-allocating and handling huge buffers

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.js
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.js
@@ -339,7 +339,7 @@ module.exports = function(RED) {
             }
             else {
                 msg.filename = filename;
-                var lines = Buffer.from([]);
+                const bufferArray = [];
                 var spare = "";
                 var count = 0;
                 var type = "buffer";
@@ -397,7 +397,7 @@ module.exports = function(RED) {
                                 }
                             }
                             else {
-                                lines = Buffer.concat([lines,chunk]);
+                                bufferArray.push(chunk);
                             }
                         }
                     })
@@ -413,10 +413,11 @@ module.exports = function(RED) {
                     })
                     .on('end', function() {
                         if (node.chunk === false) {
+                            const buffer = Buffer.concat(bufferArray);
                             if (node.format === "utf8") {
-                                msg.payload = decode(lines, node.encoding);
+                                msg.payload = decode(buffer, node.encoding);
                             }
-                            else { msg.payload = lines; }
+                            else { msg.payload = buffer; }
                             nodeSend(msg);
                         }
                         else if (node.format === "lines") {


### PR DESCRIPTION
In the same spirit as the previous [performance enhancement of the CSV node](https://github.com/node-red/node-red/pull/4349)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

By using a simple array of buffer and using a Buffer.concat call, we skip alot of memory allocation - copy overhead that heavily reduce memory allocation and garbage collection on fairly "big" file sizes.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `grunt test-nodes` to verify the unit tests pass (some other failed seemingly)
- [ ] I have added suitable unit tests to cover the new/changed functionality

## Performance number

Those tests were run on a Linux machine with alot of memory and SSD storage, meaning the file can easily sits in the memory and this does not actually benchmark the disk itself, i've accessed the files multiple times to make sure they were cached.

Much like for the CSV nodes, the change is mostly to make "bigger files" works properly, starting with around 10MB files the time taken to read file as a unique Buffer starts skyrocketing.

Once more we're looking at time taken to read the Buffer (X axis in MB), versus the time taken to read it (Y axis in MS).
Both axis are set to logarithmic scale to allow us to view the scaling.

The measurement are not scientific but precise enough to give a good view as to what's happening

![image](https://github.com/user-attachments/assets/2c0217aa-22ef-4406-8428-3f4f92e6383a)

The biggest change is obviously then on the bigger file (426MB) where the time to read was around 5 minutes and dropped to half a second.

As a side-note, the 5 minute computation time is on the main thread, but it actually takes around 10 minutes of CPU usage with some work shared on nodejs worker threads.