### PR TITLE
Rework saving of credentials to undo history

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/history.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/history.js
@@ -495,11 +495,12 @@ RED.history = (function() {
                             // Reset - Only want to keep the changes
                             inverseEv.changes[i] = {};
                             for (const [key, value] of Object.entries(ev.changes[i])) {
-                                inverseEv.changes[i][key] = ev.node.credentials[key];
-                                ev.node.credentials[key] = value;
-                                if (ev.node._def.credentials[key]?.type === 'password') {
-                                    ev.node.credentials['has_' + key] = !!value;
+                                // Edge case: node.credentials is cleared after a deploy, so we can't
+                                // capture values for the inverse event when undoing past a deploy
+                                if (ev.node.credentials) {
+                                    inverseEv.changes[i][key] = ev.node.credentials[key];
                                 }
+                                ev.node.credentials[key] = value;
                             }
                         } else {
                             ev.node[i] = ev.changes[i];

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -808,17 +808,6 @@ RED.editor = (function() {
                 }
             }
 
-            const oldCreds = {};
-            if (editing_node._def.credentials) {
-                for (const prop in editing_node._def.credentials) {
-                    if (Object.prototype.hasOwnProperty.call(editing_node._def.credentials, prop)) {
-                        if (prop in editing_node.credentials) {
-                            oldCreds[prop] = editing_node.credentials[prop];
-                        }
-                    }
-                }
-            }
-
             try {
                 const rc = editing_node._def.oneditsave.call(editing_node);
                 if (rc === true) {
@@ -845,24 +834,6 @@ RED.editor = (function() {
                     } else if (editing_node.type !== 'group' || d !== "nodes") {
                         if (JSON.stringify(oldValues[d]) !== JSON.stringify(editing_node[d])) {
                             editState.changes[d] = oldValues[d];
-                            editState.changed = true;
-                        }
-                    }
-                }
-            }
-
-            if (editing_node._def.credentials) {
-                for (const prop in editing_node._def.credentials) {
-                    if (Object.prototype.hasOwnProperty.call(editing_node._def.credentials, prop)) {
-                        if (oldCreds[prop] !== editing_node.credentials[prop]) {
-                            if (editing_node.credentials[prop] === '__PWRD__') {
-                                // The password may not exist in oldCreds
-                                // The value '__PWRD__' means the password exists,
-                                // so ignore this change
-                                continue;
-                            }
-                            editState.changes.credentials = editState.changes.credentials || {};
-                            editState.changes.credentials[prop] = oldCreds[prop];
                             editState.changed = true;
                         }
                     }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -853,6 +853,25 @@ RED.editor = (function() {
                     }
                 }
             }
+
+            if (editing_node._def.credentials) {
+                for (const prop in editing_node._def.credentials) {
+                    if (Object.prototype.hasOwnProperty.call(editing_node._def.credentials, prop)) {
+                        if (oldCreds[prop] !== editing_node.credentials[prop]) {
+                            if (editing_node.credentials[prop] === '__PWRD__') {
+                                // The password may not exist in oldCreds
+                                // The value '__PWRD__' means the password exists,
+                                // so ignore this change
+                                continue;
+                            }
+                            editState.changes.credentials = editState.changes.credentials || {};
+                            editState.changes.credentials['has_' + prop] = oldCreds['has_' + prop];
+                            editState.changes.credentials[prop] = oldCreds[prop];
+                            editState.changed = true;
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -808,6 +808,20 @@ RED.editor = (function() {
                 }
             }
 
+            const oldCreds = {};
+            if (editing_node._def.credentials) {
+                for (const prop in editing_node._def.credentials) {
+                    if (Object.prototype.hasOwnProperty.call(editing_node._def.credentials, prop)) {
+                        if (editing_node._def.credentials[prop].type === 'password') {
+                            oldCreds['has_' + prop] = editing_node.credentials['has_' + prop];
+                        }
+                        if (prop in editing_node.credentials) {
+                            oldCreds[prop] = editing_node.credentials[prop];
+                        }
+                    }
+                }
+            }
+
             try {
                 const rc = editing_node._def.oneditsave.call(editing_node);
                 if (rc === true) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
@@ -195,6 +195,7 @@
                             // Like the user sets a value, saves the config,
                             // reopens the config and save the config again
                         } else {
+                            changes['has_' + cred] = node.credentials['has_' + cred];
                             changes[cred] = node.credentials[cred];
                             node.credentials[cred] = value;
                         }


### PR DESCRIPTION
Fixes undo history for credentials.

A lot of the code added in editor.js wasn't needed; the work to track changes in creds was already done in `packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js` - however it wasn't tracking the `has_XYZ` meta property needed to handle the full set of password change lifecycles.