### PR TITLE
Add globalFunctionTimeout

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  **/
 
-const { log } = require("console");
-
 module.exports = function(RED) {
     "use strict";
 

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  **/
 
+const { log } = require("console");
+
 module.exports = function(RED) {
     "use strict";
 
@@ -399,6 +401,8 @@ module.exports = function(RED) {
                     if(node.timeout>0){
                         finOpt.timeout = node.timeout;
                         finOpt.breakOnSigint = true;
+                    } else if(RED.settings.defaultFunctionTimeout > 0){
+                        finOpt.timeout = RED.settings.defaultFunctionTimeout * 1000
                     }
                 }
                 var promise = Promise.resolve();
@@ -415,8 +419,15 @@ module.exports = function(RED) {
                     var opts = {};
                     if (node.timeout>0){
                         opts = node.timeoutOptions;
+                    } else if(RED.settings.defaultFunctionTimeout > 0){
+                        opts.timeout = RED.settings.defaultFunctionTimeout * 1000
                     }
-                    node.script.runInContext(context,opts);
+                    try {
+                        node.script.runInContext(context,opts);
+                    } catch (err) {
+                        node.error(err);
+                        return done(err);
+                    }
                     context.results.then(function(results) {
                         sendResults(node,send,msg._msgid,results,false);
                         if (handleNodeDoneCall) {

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -399,8 +399,8 @@ module.exports = function(RED) {
                     if(node.timeout>0){
                         finOpt.timeout = node.timeout;
                         finOpt.breakOnSigint = true;
-                    } else if(RED.settings.defaultFunctionTimeout > 0){
-                        finOpt.timeout = RED.settings.defaultFunctionTimeout * 1000
+                    } else if (RED.settings.globalFunctionTimeout > 0){
+                        finOpt.timeout = RED.settings.globalFunctionTimeout * 1000
                     }
                 }
                 var promise = Promise.resolve();
@@ -417,13 +417,12 @@ module.exports = function(RED) {
                     var opts = {};
                     if (node.timeout>0){
                         opts = node.timeoutOptions;
-                    } else if(RED.settings.defaultFunctionTimeout > 0){
-                        opts.timeout = RED.settings.defaultFunctionTimeout * 1000
+                    } else if (RED.settings. globalFunctionTimeout > 0){
+                        opts.timeout = RED.settings. globalFunctionTimeout * 1000
                     }
                     try {
                         node.script.runInContext(context,opts);
                     } catch (err) {
-                        node.error(err);
                         return done(err);
                     }
                     context.results.then(function(results) {

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -473,6 +473,7 @@ module.exports = {
  *  - fileWorkingDirectory
  *  - functionGlobalContext
  *  - functionExternalModules
+ *  - defaultFunctionTimeout
  *  - functionTimeout
  *  - nodeMessageBufferMaxLength
  *  - ui (for use with Node-RED Dashboard)
@@ -499,8 +500,30 @@ module.exports = {
     /** Allow the Function node to load additional npm modules directly */
     functionExternalModules: true,
 
+
+    /**
+     * Default function timeout (in seconds) for the Function node. 
+     * A value of 0 indicates no timeout is applied, meaning the function can run indefinitely.
+     * 
+     * The default function timeout is designed to prevent blocking code in function nodes, 
+     * which could otherwise lead to a stalled or unresponsive main thread. For example, 
+     * the following code would block the event loop indefinitely:
+     * 
+     *     `while(1) {}` 
+     * 
+     * By specifying a `defaultFunctionTimeout`, such scenarios can be mitigated, 
+     * ensuring that long-running or infinite loops are terminated automatically after 
+     * the specified timeout duration.
+     * 
+     * Note: If both `defaultFunctionTimeout` and `functionTimeout` are defined in the 
+     * settings file, `functionTimeout` takes precedence, providing a more granular 
+     * control for individual function nodes.
+     */
+
+    defaultFunctionTimeout: 5,
+
     /** Default timeout, in seconds, for the Function node. 0 means no timeout is applied */
-    functionTimeout: 0,
+    functionTimeout: 2,
 
     /** The following property can be used to set predefined values in Global Context.
      * This allows extra node modules to be made available with in Function node.

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -523,7 +523,7 @@ module.exports = {
     defaultFunctionTimeout: 0,
 
     /** Default timeout, in seconds, for the Function node. 0 means no timeout is applied */
-    functionTimeout: 2,
+    functionTimeout: 0,
 
     /** The following property can be used to set predefined values in Global Context.
      * This allows extra node modules to be made available with in Function node.

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -473,7 +473,7 @@ module.exports = {
  *  - fileWorkingDirectory
  *  - functionGlobalContext
  *  - functionExternalModules
- *  - defaultFunctionTimeout
+ *  - globalFunctionTimeout
  *  - functionTimeout
  *  - nodeMessageBufferMaxLength
  *  - ui (for use with Node-RED Dashboard)
@@ -502,27 +502,17 @@ module.exports = {
 
 
     /**
-     * Default function timeout (in seconds) for the Function node. 
-     * A value of 0 indicates no timeout is applied, meaning the function can run indefinitely.
-     * 
-     * The default function timeout is designed to prevent blocking code in function nodes, 
-     * which could otherwise lead to a stalled or unresponsive main thread. For example, 
-     * the following code would block the event loop indefinitely:
-     * 
-     *     `while(1) {}` 
-     * 
-     * By specifying a `defaultFunctionTimeout`, such scenarios can be mitigated, 
-     * ensuring that long-running or infinite loops are terminated automatically after 
-     * the specified timeout duration.
-     * 
-     * Note: If both `defaultFunctionTimeout` and `functionTimeout` are defined in the 
-     * settings file, `functionTimeout` takes precedence, providing a more granular 
-     * control for individual function nodes.
+     * The default timeout (in seconds) for all Function nodes.
+     * Individual nodes can set their own timeout value within their configuration.
      */
+    globalFunctionTimeout: 0,
 
-    defaultFunctionTimeout: 0,
-
-    /** Default timeout, in seconds, for the Function node. 0 means no timeout is applied */
+    /**
+      * Default timeout, in seconds, for the Function node. 0 means no timeout is applied
+      * This value is applied when the node is first added to the workspace - any changes
+      * must then be made with the individual node configurations.
+      * To set a global timeout value, use `globalFunctionTimeout`
+     */
     functionTimeout: 0,
 
     /** The following property can be used to set predefined values in Global Context.

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -520,7 +520,7 @@ module.exports = {
      * control for individual function nodes.
      */
 
-    defaultFunctionTimeout: 5,
+    defaultFunctionTimeout: 0,
 
     /** Default timeout, in seconds, for the Function node. 0 means no timeout is applied */
     functionTimeout: 2,

--- a/test/nodes/core/function/10-function_spec.js
+++ b/test/nodes/core/function/10-function_spec.js
@@ -1437,7 +1437,7 @@ describe('function node', function() {
                     var logEvents = helper.log().args.filter(function(evt) {
                         return evt[0].type == "function";
                     });
-                    logEvents.should.have.length(1);
+                    logEvents.should.have.length(2);
                     var msg = logEvents[0][0];
                     msg.should.have.property('level', helper.log().ERROR);
                     msg.should.have.property('id', 'n1');
@@ -1451,7 +1451,7 @@ describe('function node', function() {
         });
     });
 
-    it('check if default function timeout settings are recognized', function (done) {
+    it('check if function timeout settings are recognized', function (done) {
         RED.settings.functionTimeout = 0.01;
         var flow = [{id: "n1",type: "function",timeout: RED.settings.functionTimeout,wires: [["n2"]],func: "while(1==1){};\nreturn msg;"}];
         helper.load(functionNode, flow, function () {
@@ -1463,7 +1463,7 @@ describe('function node', function() {
                     var logEvents = helper.log().args.filter(function (evt) {
                         return evt[0].type == "function";
                     });
-                    logEvents.should.have.length(1);
+                    logEvents.should.have.length(2);
                     var msg = logEvents[0][0];
                     msg.should.have.property('level', helper.log().ERROR);
                     msg.should.have.property('id', 'n1');
@@ -1471,6 +1471,65 @@ describe('function node', function() {
                     should.equal(RED.settings.functionTimeout, 0.01);
                     should.equal(msg.msg.message, 'Script execution timed out after 10ms');
                     delete RED.settings.functionTimeout;
+                    done();
+                } catch (err) {
+                    done(err);
+                }
+            }, 500);
+        });
+    });
+
+    it('check if default function timeout settings are recognized', function (done) {
+        RED.settings.defaultFunctionTimeout = 0.01;
+        var flow = [{id: "n1",type: "function",wires: [["n2"]],func: "while(1==1){};\nreturn msg;"}];
+        helper.load(functionNode, flow, function () {
+            var n1 = helper.getNode("n1");
+            n1.receive({ payload: "foo", topic: "bar" });
+            setTimeout(function () {
+                try {
+                    helper.log().called.should.be.true();
+                    var logEvents = helper.log().args.filter(function (evt) {
+                        return evt[0].type == "function";
+                    });
+                    logEvents.should.have.length(2);
+                    var msg = logEvents[0][0];
+                    msg.should.have.property('level', helper.log().ERROR);
+                    msg.should.have.property('id', 'n1');
+                    msg.should.have.property('type', 'function');
+                    should.equal(RED.settings.defaultFunctionTimeout, 0.01);
+                    should.equal(msg.msg.message, 'Script execution timed out after 10ms');
+                    delete RED.settings.defaultFunctionTimeout;
+                    done();
+                } catch (err) {
+                    done(err);
+                }
+            }, 500);
+        });
+    });
+
+    it('check if functionTimeout has higher precedence over default function timeout setting', function (done) {
+        RED.settings.defaultFunctionTimeout = 0.02;
+        RED.settings.functionTimeout = 0.01;
+        var flow = [{id: "n1",type: "function",timeout: RED.settings.functionTimeout,wires: [["n2"]],func: "while(1==1){};\nreturn msg;"}];
+        helper.load(functionNode, flow, function () {
+            var n1 = helper.getNode("n1");
+            n1.receive({ payload: "foo", topic: "bar" });
+            setTimeout(function () {
+                try {
+                    helper.log().called.should.be.true();
+                    var logEvents = helper.log().args.filter(function (evt) {
+                        return evt[0].type == "function";
+                    });
+                    logEvents.should.have.length(2);
+                    var msg = logEvents[0][0];
+                    msg.should.have.property('level', helper.log().ERROR);
+                    msg.should.have.property('id', 'n1');
+                    msg.should.have.property('type', 'function');
+                    should.equal(RED.settings.functionTimeout, 0.01);
+                    should.equal(RED.settings.defaultFunctionTimeout, 0.02);
+                    should.equal(msg.msg.message, 'Script execution timed out after 10ms');
+                    delete RED.settings.functionTimeout;
+                    delete RED.settings.defaultFunctionTimeout;
                     done();
                 } catch (err) {
                     done(err);

--- a/test/nodes/core/function/10-function_spec.js
+++ b/test/nodes/core/function/10-function_spec.js
@@ -1437,7 +1437,7 @@ describe('function node', function() {
                     var logEvents = helper.log().args.filter(function(evt) {
                         return evt[0].type == "function";
                     });
-                    logEvents.should.have.length(2);
+                    logEvents.should.have.length(1);
                     var msg = logEvents[0][0];
                     msg.should.have.property('level', helper.log().ERROR);
                     msg.should.have.property('id', 'n1');
@@ -1463,7 +1463,7 @@ describe('function node', function() {
                     var logEvents = helper.log().args.filter(function (evt) {
                         return evt[0].type == "function";
                     });
-                    logEvents.should.have.length(2);
+                    logEvents.should.have.length(1);
                     var msg = logEvents[0][0];
                     msg.should.have.property('level', helper.log().ERROR);
                     msg.should.have.property('id', 'n1');
@@ -1480,7 +1480,7 @@ describe('function node', function() {
     });
 
     it('check if default function timeout settings are recognized', function (done) {
-        RED.settings.defaultFunctionTimeout = 0.01;
+        RED.settings.globalFunctionTimeout = 0.01;
         var flow = [{id: "n1",type: "function",wires: [["n2"]],func: "while(1==1){};\nreturn msg;"}];
         helper.load(functionNode, flow, function () {
             var n1 = helper.getNode("n1");
@@ -1491,14 +1491,14 @@ describe('function node', function() {
                     var logEvents = helper.log().args.filter(function (evt) {
                         return evt[0].type == "function";
                     });
-                    logEvents.should.have.length(2);
+                    logEvents.should.have.length(1);
                     var msg = logEvents[0][0];
                     msg.should.have.property('level', helper.log().ERROR);
                     msg.should.have.property('id', 'n1');
                     msg.should.have.property('type', 'function');
-                    should.equal(RED.settings.defaultFunctionTimeout, 0.01);
+                    should.equal(RED.settings.globalFunctionTimeout, 0.01);
                     should.equal(msg.msg.message, 'Script execution timed out after 10ms');
-                    delete RED.settings.defaultFunctionTimeout;
+                    delete RED.settings.globalFunctionTimeout;
                     done();
                 } catch (err) {
                     done(err);
@@ -1508,7 +1508,7 @@ describe('function node', function() {
     });
 
     it('check if functionTimeout has higher precedence over default function timeout setting', function (done) {
-        RED.settings.defaultFunctionTimeout = 0.02;
+        RED.settings.globalFunctionTimeout = 0.02;
         RED.settings.functionTimeout = 0.01;
         var flow = [{id: "n1",type: "function",timeout: RED.settings.functionTimeout,wires: [["n2"]],func: "while(1==1){};\nreturn msg;"}];
         helper.load(functionNode, flow, function () {
@@ -1520,16 +1520,16 @@ describe('function node', function() {
                     var logEvents = helper.log().args.filter(function (evt) {
                         return evt[0].type == "function";
                     });
-                    logEvents.should.have.length(2);
+                    logEvents.should.have.length(1);
                     var msg = logEvents[0][0];
                     msg.should.have.property('level', helper.log().ERROR);
                     msg.should.have.property('id', 'n1');
                     msg.should.have.property('type', 'function');
                     should.equal(RED.settings.functionTimeout, 0.01);
-                    should.equal(RED.settings.defaultFunctionTimeout, 0.02);
+                    should.equal(RED.settings.globalFunctionTimeout, 0.02);
                     should.equal(msg.msg.message, 'Script execution timed out after 10ms');
                     delete RED.settings.functionTimeout;
-                    delete RED.settings.defaultFunctionTimeout;
+                    delete RED.settings.globalFunctionTimeout;
                     done();
                 } catch (err) {
                     done(err);


### PR DESCRIPTION
* added default timeout to function node

* added unit test to support defaultFunctionTimeout

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

---

Issue -> https://github.com/node-red/node-red/issues/4976

This PR introduces the `defaultFunctionTimeout` parameter for the Function node, defined in seconds. The primary purpose of this setting is to prevent blocking code within function blocks from indefinitely halting execution.  

**Key Details:**  
- **Default Value**: `0` (indicating no timeout).  
- **Functionality**:  
  - Serves as a default safeguard against blocking operations, such as an infinite loop (`while(1){}`), which can block the main thread.  
  - Ensures system stability by unblocking such scenarios after the specified timeout duration.  
- **Precedence**: If `functionTimeout` is specified in the settings file, it overrides `defaultFunctionTimeout`.  

This enhancement aims to improve the resilience of the system by mitigating the risk of blocking code. Please review and share feedback if further clarity or adjustments are needed.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
