### PR TITLE
Ensure generated mqtt clientId uses only valid chars

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -675,7 +675,7 @@ module.exports = function(RED) {
             node.options.password = node.password;
             node.options.keepalive = node.keepalive;
             node.options.clean = node.cleansession;
-            node.options.clientId = node.clientid || 'nodered_' + RED.util.generateId();
+            node.options.clientId = node.clientid || 'nodered' + RED.util.generateId();
             node.options.reconnectPeriod = RED.settings.mqttReconnectTime||5000;
             delete node.options.protocolId; //V4+ default
             delete node.options.protocolVersion; //V4 default


### PR DESCRIPTION


- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
MQTT clientid:
If automatically generating a clientid for user it should be =< 23 Right now it generates length of 24.

See mqtt specifications --> http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc385349242 "The Server MUST allow ClientIds which are between 1 and 23 UTF-8 encoded bytes in length,..."

As 23 is the max acceptable; we should shoot for this specification.

I noticed this when connecting to a mqtt server that was set to minimum spec. it would not connect! Sure I can generate my own ID or fill it in with less than 23 but it did confuse me for 15min.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [X] I have added suitable unit tests to cover the new/changed functionality
