### PR TITLE
Support custom login message and button

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/auth/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/index.js
@@ -126,6 +126,14 @@ async function login(req,res) {
         if (themeContext.login && themeContext.login.image) {
             response.image = themeContext.login.image;
         }
+        if (themeContext.login?.message) {
+            response.loginMessage = themeContext.login?.message
+        }
+        if (themeContext.login?.button) {
+            response.prompts = [
+                { type: "button", ...themeContext.login.button }
+            ]
+        }
     }
     res.json(response);
 }

--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -211,9 +211,7 @@ module.exports = {
             if (theme.login.image) {
                 url = serveFile(themeApp,"/login/",theme.login.image);
                 if (url) {
-                    themeContextLogin.login = {
-                        image: url
-                    }
+                    themeContextLogin.image = url
                     hasLoginTheme = true
                 }
             }

--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -206,13 +206,27 @@ module.exports = {
         }
 
         if (theme.login) {
+            let themeContextLogin = {}
+            let hasLoginTheme = false
             if (theme.login.image) {
                 url = serveFile(themeApp,"/login/",theme.login.image);
                 if (url) {
-                    themeContext.login = {
+                    themeContextLogin.login = {
                         image: url
                     }
+                    hasLoginTheme = true
                 }
+            }
+            if (theme.login.message) {
+                themeContextLogin.message = theme.login.message
+                hasLoginTheme = true
+            }
+            if (theme.login.button) {
+                themeContextLogin.button = theme.login.button
+                hasLoginTheme = true
+            }
+            if (hasLoginTheme) {
+                themeContext.login = themeContextLogin
             }
         }
         themeApp.get("/", async function(req,res) {

--- a/packages/node_modules/@node-red/editor-client/src/js/user.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/user.js
@@ -168,6 +168,37 @@ RED.user = (function() {
                     }
 
 
+                } else {
+                    if (data.prompts) {
+                        if (data.loginMessage) {
+                            const sessionMessages = $("<div/>",{class:"form-row",style:"text-align: center"}).appendTo("#node-dialog-login-fields");
+                            $('<div>').text(data.loginMessage).appendTo(sessionMessages);
+                        }
+
+                        i = 0;
+                        for (;i<data.prompts.length;i++) {
+                            var field = data.prompts[i];
+                            var row = $("<div/>",{class:"form-row",style:"text-align: center"}).appendTo("#node-dialog-login-fields");
+                            var loginButton = $('<a href="#" class="red-ui-button"></a>',{style: "padding: 10px"}).appendTo(row).on("click", function() {
+                                document.location = field.url;
+                            });
+                            if (field.image) {
+                                $("<img>",{src:field.image}).appendTo(loginButton);
+                            } else if (field.label) {
+                                var label = $('<span></span>').text(field.label);
+                                if (field.icon) {
+                                    $('<i></i>',{class: "fa fa-2x "+field.icon, style:"vertical-align: middle"}).appendTo(loginButton);
+                                    label.css({
+                                        "verticalAlign":"middle",
+                                        "marginLeft":"8px"
+                                    });
+
+                                }
+                                label.appendTo(loginButton);
+                            }
+                            loginButton.button();
+                        }
+                    }
                 }
                 if (opts.cancelable) {
                     $("#node-dialog-login-cancel").button().on("click", function( event ) {


### PR DESCRIPTION
If `adminAuth` is configured without a `type` (normally `credentials` or `strategy`) the login dialog is blank.

When `adminAuth` is also configured with `tokens` etc to support token based authentication, it would be useful to be able to provide a custom message and login prompt in the dialog.

This PR adds support for doing just that. The following properties can be added to the `editorTheme.login` property:

```
editorTheme: {
   login: {
      message: "Hi there Twitchers",
      button: { url: "https://nodered.org", label: "Login via FlowFuse" }
   }
}
```

<img width="655" alt="image" src="https://github.com/user-attachments/assets/b02ec0f1-362d-4c2d-b617-c2b6964b7f44" />
