### PR TITLE
Fix the user list of nested config node

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -707,12 +707,15 @@ RED.nodes = (function() {
             }
             n["_"] = RED._;
         }
+
+        // Both node and config node can use a config node
+        updateConfigNodeUsers(newNode, { action: "add" });
+
         if (n._def.category == "config") {
             configNodes[n.id] = newNode;
         } else {
             if (n.wires && (n.wires.length > n.outputs)) { n.outputs = n.wires.length; }
             n.dirty = true;
-            updateConfigNodeUsers(newNode, { action: "add" });
             if (n._def.category == "subflows" && typeof n.i === "undefined") {
                 var nextId = 0;
                 RED.nodes.eachNode(function(node) {
@@ -774,9 +777,11 @@ RED.nodes = (function() {
         var removedLinks = [];
         var removedNodes = [];
         var node;
+
         if (id in configNodes) {
             node = configNodes[id];
             delete configNodes[id];
+            updateConfigNodeUsers(node, { action: "remove" });
             RED.events.emit('nodes:remove',node);
             RED.workspaces.refresh();
         } else if (allNodes.hasNode(id)) {
@@ -786,6 +791,8 @@ RED.nodes = (function() {
             removedLinks = links.filter(function(l) { return (l.source === node) || (l.target === node); });
             removedLinks.forEach(removeLink);
             updateConfigNodeUsers(node, { action: "remove" });
+
+            // TODO: Legacy code for exclusive config node
             var updatedConfigNode = false;
             for (var d in node._def.defaults) {
                 if (node._def.defaults.hasOwnProperty(d)) {
@@ -2187,6 +2194,21 @@ RED.nodes = (function() {
             }
         }
 
+        // Config node can use another config node, must ensure that this other
+        // config node is added before to exists when updating the user list
+        const configNodeFilter = function (node) {
+            let count = 0;
+            if (node._def?.defaults) {
+                for (const def of Object.values(node._def.defaults)) {
+                    if (def.type) {
+                        count++;
+                    }
+                }
+            }
+            return count;
+        };
+        new_nodes.sort((a, b) => configNodeFilter(a) - configNodeFilter(b));
+
         // Find regular flow nodes and subflow instances
         for (i=0;i<newNodes.length;i++) {
             n = newNodes[i];
@@ -2724,6 +2746,7 @@ RED.nodes = (function() {
                 var property = node._def.defaults[d];
                 if (property.type) {
                     var type = registry.getNodeType(property.type);
+                    // Need to ensure the type is a config node to not treat links nodes
                     if (type && type.category == "config") {
                         var configNode = configNodes[node[d]];
                         if (configNode) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #4994.

#4807 removed some duplicate code that handles the user list. Unfortunately it was forgotten that config nodes can also use another config node.

During the import, the list of config nodes is sorted to ensure that nested nodes are created before updating the user list.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
