### PR TITLE
Fix def can be undefined if the type is missing

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2357,13 +2357,13 @@ RED.nodes = (function() {
                             node.type = "unknown";
                         }
                         if (node._def.category != "config") {
-                            if (n.hasOwnProperty('inputs') && def.defaults.hasOwnProperty("inputs")) {
+                            if (n.hasOwnProperty('inputs') && node._def.defaults.hasOwnProperty("inputs")) {
                                 node.inputs = parseInt(n.inputs, 10);
                                 node._config.inputs = JSON.stringify(n.inputs);
                             } else {
                                 node.inputs = node._def.inputs;
                             }
-                            if (n.hasOwnProperty('outputs') && def.defaults.hasOwnProperty("outputs")) {
+                            if (n.hasOwnProperty('outputs') && node._def.defaults.hasOwnProperty("outputs")) {
                                 node.outputs = parseInt(n.outputs, 10);
                                 node._config.outputs = JSON.stringify(n.outputs);
                             } else {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes https://discourse.nodered.org/t/to-import-a-flow-without-dashboard-installed/93963.
Introduced by #4808.

`def` can be undefined. The default definition is added directly to the node, so `node._def` must be used instead.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
