### PR TITLE
Fix local icon in library

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/library/local.js
+++ b/packages/node_modules/@node-red/runtime/lib/library/local.js
@@ -32,7 +32,7 @@ function saveEntry(type,path,meta,body) {
 module.exports = {
     id: "local",
     label: "editor:library.types.local",
-    icon: "font-awesome/fa-hdd-o",
+    icon: "fa fa-hdd-o",
     init: init,
     getEntry: getEntry,
     saveEntry: saveEntry

--- a/test/unit/@node-red/runtime/lib/library/index_spec.js
+++ b/test/unit/@node-red/runtime/lib/library/index_spec.js
@@ -84,7 +84,7 @@ describe("runtime/library", function() {
             libs[0].should.have.property('id', 'local');
             libs[0].should.have.property('label','editor:library.types.local');
             libs[0].should.have.property("user", false);
-            libs[0].should.have.property('icon', 'font-awesome/fa-hdd-o');
+            libs[0].should.have.property('icon', 'fa fa-hdd-o');
 
             libs[1].should.have.property('id', 'examples');
             libs[1].should.have.property('label','editor:library.types.examples');


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Local item on the function node library has no icon as follows. So, I fixed the font awesome path in this pull request.

<img width="1440" alt="before" src="https://github.com/user-attachments/assets/b63d83f7-efb5-4571-ab66-a8540f0b9167" />

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
