### PR TITLE
Avoid exceeding call stack when draining message group in Switch

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.js
@@ -352,7 +352,9 @@ module.exports = function(RED) {
                     if (msgs.length === 0) {
                         done()
                     } else {
-                        drainMessageGroup(msgs,count,done);
+                        setImmediate(() => {
+                            drainMessageGroup(msgs,count,done);
+                        })
                     }
                 }
             })
@@ -505,7 +507,9 @@ module.exports = function(RED) {
                 if (err) {
                     node.error(err,nextMsg);
                 }
-                processMessageQueue()
+                setImmediate(() => {
+                    processMessageQueue()
+                })
             });
         }
 


### PR DESCRIPTION
Fixes #5013

When a switch node is configured to repair a message sequence, it can get into a recursive call stack when eventually sending the messages onwards.

This fixes by throwing a `setImmediate` in to break up the call stack.