### PR TITLE
Fix grunt dev via better ndoemon ignore rules

### DIFF
--- a/.nodemonignore
+++ b/.nodemonignore
@@ -1,4 +1,0 @@
-/Gruntfile.js
-/.git/*
-*.backup
-/public/*

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,16 @@
+{
+    "ignoreRoot": [
+        ".git",
+        ".nyc_output",
+        ".sass-cache",
+        "bower-components",
+        "coverage"
+    ],
+    "ignore": [
+        "/Gruntfile.js",
+        "/.git/*",
+        "*.backup",
+        "/public/*"
+    ]
+}
+


### PR DESCRIPTION
For reasons I cannot explain, the `grunt dev` task has stopped working for me this week. It no longer restarts Node-RED when I save changes to the files in the `packages/node_modules/**` tree.

Enabling debug for nodemon shows it is watching `0` files.

This is because `**/node_modules/**` is in its default ignoreRoot list - which causes it to ignore `packages/node_modules`.

However, this has been the case for a *long* time - but grunt dev was working just fine a couple weeks ago. I don't see any obvious updates to nodemon that could have caused this. Nor am I going to spend a bunch of time figuring it out.

This PR fixes things using the documented pattern if you want nodemon to watch files under a `node_modules` directory - docs that haven't changed in 6 years - https://github.com/remy/nodemon/blob/master/faq.md#overriding-the-underlying-default-ignore-rules