### PR TITLE
Allow env var access to context

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -719,6 +719,14 @@ class Flow {
         });
     }
 
+    getContext(scope) {
+        if (scope === 'flow') {
+            return this.context
+        } else if (scope === 'global') {
+            return context.get('global')
+        }
+    }
+
     dump() {
         console.log("==================")
         console.log(this.TYPE, this.id);

--- a/packages/node_modules/@node-red/runtime/lib/flows/Group.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Group.js
@@ -49,6 +49,14 @@ class Group {
         }
         return this.parent.getSetting(key);
     }
+
+    error(msg) {
+        this.parent.error(msg);
+    }
+
+    getContext(scope) {
+        return this.parent.getContext(scope);
+    }
 }
 
 module.exports = {

--- a/packages/node_modules/@node-red/runtime/lib/flows/util.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/util.js
@@ -100,7 +100,24 @@ async function evaluateEnvProperties(flow, env, credentials) {
             }
         } else if (type ==='jsonata') {
             pendingEvaluations.push(new Promise((resolve, _) => {
-                redUtil.evaluateNodeProperty(value, 'jsonata', {_flow: flow}, null, (err, result) => {
+                redUtil.evaluateNodeProperty(value, 'jsonata',{
+                    // Fake a node object to provide access to _flow and context
+                    _flow: flow,
+                    context: () => {
+                        return {
+                            flow: {
+                                get: (value, store, callback) => {
+                                    return flow.getContext('flow').get(value, store, callback)
+                                }
+                            },
+                            global: {
+                                get: (value, store, callback) => {
+                                    return flow.getContext('global').get(value, store, callback)
+                                }
+                            }
+                        }
+                    }
+                }, null, (err, result) => {
                     if (!err) {
                         if (typeof result  === 'object') {
                             result = { value: result, __clone__: true}


### PR DESCRIPTION
Fixes #5009 

This allows an env var definition to use `$global/flowContext()` lookups.

Using context in an env var definition isn't that useful, as the value is evaluated when the flow starts and doesn't update if context changes.

But that said, nor should trying to use it cause NR to crash as reported in #5009.

