### PR TITLE
Fix library icon handling within library browser component

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/library.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/library.js
@@ -245,10 +245,15 @@ RED.library = (function() {
                         if (lib.types && lib.types.indexOf(options.url) === -1) {
                             return;
                         }
+                        let icon = 'fa fa-hdd-o';
+                        if (lib.icon) {
+                            const fullIcon = RED.utils.separateIconPath(lib.icon);
+                            icon = (fullIcon.module==="font-awesome"?"fa ":"")+fullIcon.file;
+                        }
                         listing.push({
                             library: lib.id,
                             type: options.url,
-                            icon: lib.icon || 'fa fa-hdd-o',
+                            icon,
                             label: RED._(lib.label||lib.id),
                             path: "",
                             expanded: true,
@@ -303,10 +308,15 @@ RED.library = (function() {
                         if (lib.types && lib.types.indexOf(options.url) === -1) {
                             return;
                         }
+                        let icon = 'fa fa-hdd-o';
+                        if (lib.icon) {
+                            const fullIcon = RED.utils.separateIconPath(lib.icon);
+                            icon = (fullIcon.module==="font-awesome"?"fa ":"")+fullIcon.file;
+                        }
                         listing.push({
                             library: lib.id,
                             type: options.url,
-                            icon: lib.icon || 'fa fa-hdd-o',
+                            icon,
                             label: RED._(lib.label||lib.id),
                             path: "",
                             expanded: true,


### PR DESCRIPTION
Closes #5004

PR #5004 proposed a fix for the icons missing in the Function library browser. However the proposed fix would have then broken the icons in the Import/Export dialog.

If a library wants to use a font-awesome icon (eg `fa-foo`), its icon property is expected to be `font-awesome/fa-foo`. This was being handled properly by the Import/Export dialog, but not by the library browser.

The fix here is to apply the same parsing logic across both dialogs.