### PR TITLE
Do not select group when triggering quick-add within it

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1265,11 +1265,6 @@ RED.view = (function() {
         var targetGroup = options.group;
         var touchTrigger = options.touchTrigger;
 
-        if (targetGroup) {
-            selectedGroups.add(targetGroup,false);
-            RED.view.redraw();
-        }
-
         // `point` is the place in the workspace the mouse has clicked.
         //  This takes into account scrolling and scaling of the workspace.
         var ox = point[0];
@@ -1591,9 +1586,6 @@ RED.view = (function() {
                 // auto select dropped node - so info shows (if visible)
                 clearSelection();
                 nn.selected = true;
-                if (targetGroup) {
-                    selectedGroups.add(targetGroup,false);
-                }
                 movingSet.add(nn);
                 updateActiveNodes();
                 updateSelection();


### PR DESCRIPTION
Fixes #5020 

When triggering quick-add within a group, the group was being selected. This left things in a bad state with both the added node and its group selected. This is not a state we should get into. The code that handles dragging something into a group was then getting tripped up because it was trying to add the parent group into the child group.

This fixes it by not getting into that bad state. Looking at the code, I think this was a remnant of the previous refactoring of group UX and should have been removed then.