### PR TITLE
Update sf instance env vars when removed from template

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1836,8 +1836,18 @@ RED.editor = (function() {
                                 }
                             });
                         }
-
+                        let envToRemove = new Set()
                         if (!isSameObj(old_env, new_env)) {
+                            // Get a list of env properties that have been removed
+                            // by comparing old_env and new_env
+                            if (old_env) {
+                                old_env.forEach(env => { envToRemove.add(env.name) })
+                            }
+                            if (new_env) {
+                                new_env.forEach(env => {
+                                    envToRemove.delete(env.name)
+                                })
+                            }
                             editState.changes.env = editing_node.env;
                             editing_node.env = new_env;
                             editState.changed = true;
@@ -1846,10 +1856,11 @@ RED.editor = (function() {
 
 
                         if (editState.changed) {
-                            var wasChanged = editing_node.changed;
+                            let wasChanged = editing_node.changed;
                             editing_node.changed = true;
                             validateNode(editing_node);
-                            var subflowInstances = [];
+                            let subflowInstances = [];
+                            let instanceHistoryEvents = []
                             RED.nodes.eachNode(function(n) {
                                 if (n.type == "subflow:"+editing_node.id) {
                                     subflowInstances.push({
@@ -1859,13 +1870,35 @@ RED.editor = (function() {
                                     n._def.color = editing_node.color;
                                     n.changed = true;
                                     n.dirty = true;
+                                    if (n.env) {
+                                        const oldEnv = n.env
+                                        const newEnv = []
+                                        let envChanged = false
+                                        n.env.forEach((env, index) => {
+                                            if (envToRemove.has(env.name)) {
+                                                envChanged = true
+                                            } else {
+                                                newEnv.push(env)
+                                            }
+                                        })
+                                        if (envChanged) {
+                                            instanceHistoryEvents.push({
+                                                t: 'edit',
+                                                node: n,
+                                                changes: { env: oldEnv },
+                                                dirty: n.dirty,
+                                                changed: n.changed
+                                            })
+                                            n.env = newEnv
+                                        }
+                                    }
                                     updateNodeProperties(n);
                                     validateNode(n);
                                 }
                             });
                             RED.events.emit("subflows:change",editing_node);
                             RED.nodes.dirty(true);
-                            var historyEvent = {
+                            let historyEvent = {
                                 t:'edit',
                                 node:editing_node,
                                 changes:editState.changes,
@@ -1875,7 +1908,13 @@ RED.editor = (function() {
                                     instances:subflowInstances
                                 }
                             };
-
+                            if (instanceHistoryEvents.length > 0) {
+                                historyEvent = {
+                                    t: 'multi',
+                                    events: [ historyEvent, ...instanceHistoryEvents ],
+                                    dirty: wasDirty
+                                }
+                            }
                             RED.history.push(historyEvent);
                         }
                         editing_node.dirty = true;


### PR DESCRIPTION
Fixes #5010 

This updates the env vars of subflow instances when a subflow env var is removed - whilst also allowing it to be undone.