### PR TITLE
Show subflow flow context under node section of sidebar

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/api/context.js
+++ b/packages/node_modules/@node-red/runtime/lib/api/context.js
@@ -96,7 +96,11 @@ var api = module.exports = {
             } else if (scope === 'node') {
                 var node = runtime.nodes.getNode(id);
                 if (node) {
-                    ctx = node.context();
+                    if (/^subflow:/.test(node.type)) {
+                        ctx = runtime.nodes.getContext(node.id);
+                    } else {
+                        ctx = node.context();
+                    }
                 }
             }
             if (ctx) {


### PR DESCRIPTION
Currently there is no way to view the Flow level context of a subflow. This is because when viewing the subflow template, we aren't viewing a concrete instance of the subflow to show the information in the Flow section of the context sidebar.

With this PR, when a subflow instance node is selected in a regular flow, its flow level context will now be shown under the 'node' section of the context sidebar. This feels a sensible and pragmatic way to expose this level of context in the editor.
