### PR TITLE
Handle dragging node into group and splicing link at same time

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -2170,19 +2170,24 @@ RED.view = (function() {
                         n.n.moved = true;
                     }
                 }
-
-                // Check to see if we need to splice a link
+                // If a node has moved and ends up being spliced into a link, keep
+                // track of which historyEvent to add the splice info to
+                let targetSpliceEvent = null
                 if (moveEvent.nodes.length > 0) {
                     historyEvent.events.push(moveEvent)
-                    if (activeSpliceLink) {
-                        var linkToSplice = d3.select(activeSpliceLink).data()[0];
-                        spliceLink(linkToSplice, movingSet.get(0).n, moveEvent)
-                    }
+                    targetSpliceEvent = moveEvent
                 }
                 if (moveAndChangedGroupEvent.nodes.length > 0) {
                     historyEvent.events.push(moveAndChangedGroupEvent)
+                    targetSpliceEvent = moveAndChangedGroupEvent
                 }
-                
+                // activeSpliceLink will only be set if the movingSet has a single
+                // node that is able to splice.
+                if (targetSpliceEvent && activeSpliceLink) {
+                    var linkToSplice = d3.select(activeSpliceLink).data()[0];
+                    spliceLink(linkToSplice, movingSet.get(0).n, targetSpliceEvent)
+                }
+
                 // Only continue if something has moved
                 if (historyEvent.events.length > 0) {
                     RED.nodes.dirty(true);


### PR DESCRIPTION
Fixes #5026

Ensures that if a node is dragged into a group *and* onto a wire at the same time, that the link splice happens.