### PR TITLE
feat: Add custom label for default deploy button in settings.editorTheme

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -44,6 +44,7 @@ RED.deploy = (function() {
     /**
      * options:
      *   type: "default" - Button with drop-down options - no further customisation available
+     *      label: the text to display - default: "Deploy"
      *   type: "simple"  - Button without dropdown. Customisations:
      *      label: the text to display - default: "Deploy"
      *      icon : the icon to use. Null removes the icon. default: "red/images/deploy-full-o.svg"
@@ -51,13 +52,14 @@ RED.deploy = (function() {
     function init(options) {
         options = options || {};
         var type = options.type || "default";
+        var label = options.label || RED._("deploy.deploy");
 
         if (type == "default") {
             $('<li><span class="red-ui-deploy-button-group button-group">'+
               '<a id="red-ui-header-button-deploy" class="red-ui-deploy-button disabled" href="#">'+
                 '<span class="red-ui-deploy-button-content">'+
                  '<img id="red-ui-header-button-deploy-icon" src="red/images/deploy-full-o.svg"> '+
-                 '<span>'+RED._("deploy.deploy")+'</span>'+
+                 '<span>'+label+'</span>'+
                 '</span>'+
                 '<span class="red-ui-deploy-button-spinner hide">'+
                  '<img src="red/images/spin.svg"/>'+
@@ -78,7 +80,6 @@ RED.deploy = (function() {
             mainMenuItems.push({id:"deploymenu-item-reload", icon:"red/images/deploy-reload.svg",label:RED._("deploy.restartFlows"),sublabel:RED._("deploy.restartFlowsDesc"),onselect:"core:restart-flows"})
             RED.menu.init({id:"red-ui-header-button-deploy-options", options: mainMenuItems });
         } else if (type == "simple") {
-            var label = options.label || RED._("deploy.deploy");
             var icon = 'red/images/deploy-full-o.svg';
             if (options.hasOwnProperty('icon')) {
                 icon = options.icon;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
With [editorTheme.deployButton](https://nodered.org/docs/user-guide/runtime/configuration) is possible to customize the _Deploy_ button, but changes on _icon_ or _label_ will only take effect if the `type="simple"`.  
I would like to customize the _label_ and also keep the _default_ deploy drop-down options.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
