### PR TITLE
Fix: Prevent node from connecting to itself after delete-selection-and-reconnect action

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -3070,6 +3070,10 @@ RED.nodes = (function() {
                         })
                     }
                     targetNodes.forEach(target => {
+                        // Two nodes with the same ID cannot be connected to each other.
+                        if(sourceNode.id === target.id) {
+                            return
+                        }
                         let linkId = `${sourceNode.id}[${inLink.sourcePort}] -> ${target.id}`
                         if (!createdLinkIds.has(linkId)) {
                             createdLinkIds.add(linkId);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Hi @knolleary ,

This PR Closes #5038

Added a fix to prevent two nodes from being connected when the user presses Ctrl + Backspace or Ctrl + Delete. The fix ensures that the source and target node IDs are not the same before linking them.


https://github.com/user-attachments/assets/01ebb7b1-b426-4167-b5dc-130492ad93d6



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
