### PR TITLE
Handle undefined username when generating user icon

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/multiplayer.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/multiplayer.js
@@ -398,14 +398,13 @@ RED.multiplayer = (function () {
             anonIconBody.setAttribute("d",`M ${radius/2} ${radius/2 + 5} h -2.5 c -2 1 -2 -5 0.5 -4.5 c 2 1 2 1 4 0 c 2.5 -0.5  2.5 5.5  0 4.5  z`);
             group.appendChild(anonIconBody)
         } else {
-            const labelText = user.username ? user.username.substring(0,2) : user
             const label = document.createElementNS("http://www.w3.org/2000/svg","text");
-            if (user.username) {
+            if (user.username || user.email) {
                 label.setAttribute("class","red-ui-multiplayer-annotation-label");
-                label.textContent = user.username.substring(0,2)
+                label.textContent = (user.username || user.email).substring(0,2)
             } else {
                 label.setAttribute("class","red-ui-multiplayer-annotation-label red-ui-multiplayer-user-count")
-                label.textContent = user
+                label.textContent = 'nr'
             }
             label.setAttribute("text-anchor", "middle")
             label.setAttribute("x",radius/2);

--- a/packages/node_modules/@node-red/editor-client/src/js/user.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/user.js
@@ -351,10 +351,10 @@ RED.user = (function() {
             userIcon.css({
                 backgroundImage: "url("+user.image+")",
             })
-        } else if (user.anonymous) {
+        } else if (user.anonymous || (!user.username && !user.email)) {
             $('<i class="fa fa-user"></i>').appendTo(userIcon);
         } else {
-            $('<span>').text(user.username.substring(0,2)).appendTo(userIcon);
+            $('<span>').text((user.username || user.email).substring(0,2)).appendTo(userIcon);
         }
         if (user.profileColor !== undefined) {
             userIcon.addClass('red-ui-user-profile-color-' + user.profileColor)


### PR DESCRIPTION
Fixes #5036

If `user.username` is not defined we can't use it to generate the two-letter user icon.

This fixes it by falling back to `user.email` if set, otherwise shows the default user icon.