### PR TITLE
Prevent symbol usage warning in monaco

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
@@ -691,6 +691,7 @@ RED.editor.codeEditor.monaco = (function() {
                         2322,  //Type 'unknown' is not assignable to type 'string'
                         2339,  //property does not exist on
                         2345,  //Argument of type xxx is not assignable to parameter of type 'DateTimeFormatOptions'
+                        2538,  //Ignore symbols as index property error. 
                         7043,  //i forget what this one is,
                         80001, //Convert to ES6 module
                         80004, //JSDoc types may be moved to TypeScript types.


### PR DESCRIPTION
closes #5047 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Prevent monaco error complaining about symbols

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
