### PR TITLE
Fix tooltip snapping based on `typedInput` type

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -1581,7 +1581,8 @@
                     if (tooltip) {
                         tooltip.setContent(valid);
                     } else {
-                        tooltip = RED.popover.tooltip(this.elementDiv, valid);
+                        const target = this.typeMap[type]?.options ? this.optionSelectLabel : this.elementDiv;
+                        tooltip = RED.popover.tooltip(target, valid);
                         this.element.data("tooltip", tooltip);
                     }
                 }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

If the `typedInput` is a list of options, the tooltip should snap to its label element.

```js
$("#node-input-example").typedInput({type:"fruit", types:[{
    value: "fruit",
    options: [
        { value: "apple", label: "Apple"},
        { value: "banana", label: "Banana"},
        { value: "cherry", label: "Cherry"},
    ],
    validate: function (v) {...}
}]})
```

<img width="224" alt="Capture d’écran 2025-02-13 à 14 08 20" src="https://github.com/user-attachments/assets/baa4fc87-18d3-466d-9422-3b26092e6e50" />

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
