### PR TITLE
fix: set label in themeSettings.deployButton despite type attribute

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -185,13 +185,12 @@ module.exports = {
         }
 
         if (theme.deployButton) {
+            themeSettings.deployButton = {};
+            if (theme.deployButton.label) {
+                themeSettings.deployButton.label = theme.deployButton.label;
+            }
             if (theme.deployButton.type == "simple") {
-                themeSettings.deployButton = {
-                    type: "simple"
-                }
-                if (theme.deployButton.label) {
-                    themeSettings.deployButton.label = theme.deployButton.label;
-                }
+                themeSettings.deployButton.type = theme.deployButton.type;
                 if (theme.deployButton.icon) {
                     url = serveFile(themeApp,"/deploy/",theme.deployButton.icon);
                     if (url) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Previously i introduced a change that allows to set the _label_ in the "Deploy" button in the UI editor([PR-5030](https://github.com/node-red/node-red/pull/5030)) despite of _deployButton.type_.
After the [v4.0.9](https://github.com/node-red/node-red/releases/tag/4.0.9) release, the change was not taking effect. The solution was not complete.
Hereby this PR. Deeper in the codebase, i found out that the _deployButton_ is only set in _themeSettings_ if `type=="simple"`. Values that will be fetched by the runtime. Therefore i made changes to set the _label_ before this condition.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
