### PR TITLE
Ignore state of disabled nodes/flows during deployment

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -425,11 +425,15 @@ RED.deploy = (function() {
             const unknownNodes = [];
             const invalidNodes = [];
 
+            const isDisabled = function (node) {
+                return (node.d || RED.nodes.workspace(node.z)?.disabled);
+            };
+
             RED.nodes.eachConfig(function (node) {
                 if (node.valid === undefined) {
                     RED.editor.validateNode(node);
                 }
-                if (!node.valid && !node.d) {
+                if (!node.valid && !isDisabled(node)) {
                     invalidNodes.push(getNodeInfo(node));
                 }
                 if (node.type === "unknown") {
@@ -439,7 +443,7 @@ RED.deploy = (function() {
                 }
             });
             RED.nodes.eachNode(function (node) {
-                if (!node.valid && !node.d) {
+                if (!node.valid && !isDisabled(node)) {
                     invalidNodes.push(getNodeInfo(node));
                 }
                 if (node.type === "unknown") {
@@ -453,7 +457,7 @@ RED.deploy = (function() {
 
             const unusedConfigNodes = [];
             RED.nodes.eachConfig(function (node) {
-                if ((node._def.hasUsers !== false) && (node.users.length === 0)) {
+                if ((node._def.hasUsers !== false) && (node.users.length === 0) && !isDisabled(node)) {
                     unusedConfigNodes.push(getNodeInfo(node));
                     hasUnusedConfig = true;
                 }


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Ref: https://discourse.nodered.org/t/deploy-with-improperly-configured-nodes/95464.

Ignore invalid nodes and unused config nodes if they are disabled or the parent flow is disabled.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
