### PR TITLE
Support for disabled categories in Sidebar Config

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
@@ -52,6 +52,7 @@ RED.sidebar.config = (function() {
             if (label) {
                 lockIcon = $('<span style="margin-right: 5px"><i class="fa fa-lock"/></span>').appendTo(header)
                 lockIcon.toggle(!!isLocked)
+                $('<span class="red-ui-sidebar-config-category-disabled-icon" style="margin-right: 5px"><i class="fa fa-ban"/></span>').appendTo(header)
                 $('<span class="red-ui-palette-node-config-label"/>').text(label).appendTo(header);
             } else {
                 $('<span class="red-ui-palette-node-config-label" data-i18n="sidebar.config.'+name+'">').appendTo(header);
@@ -251,6 +252,8 @@ RED.sidebar.config = (function() {
             if (!validList[id]) {
                 $(this).remove();
                 delete categories[id];
+            } else if (RED.nodes.workspace(id)) {
+                $(this).toggleClass("red-ui-sidebar-config-category-disabled", RED.nodes.workspace(id).disabled);
             }
         })
         var globalConfigNodes = [];

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
@@ -14,6 +14,25 @@
  * limitations under the License.
  **/
 
+.red-ui-sidebar-config-category-disabled-icon {
+    display: none;
+}
+
+.red-ui-sidebar-config-category-disabled {
+    .red-ui-sidebar-config-tray-header {
+        font-style: italic;
+        color: var(--red-ui-tab-text-color-disabled-inactive) !important;
+        .red-ui-sidebar-config-category-disabled-icon {
+            display: inline;
+        }
+    }
+    .red-ui-sidebar-node-config-list {
+        .red-ui-palette-node-config {
+            @extend .red-ui-palette-node-config-disabled;
+        }
+    }
+}
+
 .red-ui-sidebar-node-config {
     position: relative;
     background: var(--red-ui-secondary-background);


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

In the same vein of Sidebar Config improvements, this PR adds support for disabled categories:

- Normal
<img width="317" src="https://github.com/user-attachments/assets/9a272501-d3e4-44ed-a85a-c2b4c2f1d2f0" />

- Disabled
<img width="317" src="https://github.com/user-attachments/assets/dc0d9820-0e11-4c1c-b052-3b2cb1fa9725" />

- Disabled and Locked
<img width="317" src="https://github.com/user-attachments/assets/62cff4b6-cb18-4c52-9013-d5eee39461f4" />

---

We should look into matching the way lock is handled to how disable is handled.

Category persistence also seems to be broken.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
