### PR TITLE
Support text drag & drop into markdown editor

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/markdown.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/markdown.js
@@ -27,6 +27,12 @@
         reader.readAsDataURL(file);
     }
 
+    function file2Text(file,cb) {
+        file.arrayBuffer().then(d => {
+            cb( new TextDecoder().decode(d) )
+        }).catch(ex => { cb(`error: ${ex}`) })
+    }
+
     var initialized = false;
     var currentEditor = null;
     /**
@@ -52,7 +58,8 @@
                     if (files.length === 1) {
                         var file = files[0];
                         var name = file.name.toLowerCase();
-
+                        var fileType = file.type.toLowerCase();
+                        
                         if (name.match(/\.(apng|avif|gif|jpeg|png|svg|webp)$/)) {
                             file2base64Image(file, function (image) {
                                 var session = currentEditor.getSession();
@@ -63,7 +70,30 @@
                             });
                             return;
                         }
+
+                        if ( fileType.startsWith("text/") ) {
+                            file2Text(file, function (txt) {
+                                var session = currentEditor.getSession();
+                                var pos = session.getCursorPosition();
+                                session.insert(pos, txt);
+                                $("#red-ui-image-drop-target").hide();
+                            });
+                            return;
+                        }
+                        
                     }
+                } else if ($.inArray("text/plain", ev.originalEvent.dataTransfer.types) != -1) {
+                    let item = Object.values(ev.originalEvent.dataTransfer.items).filter(d => d.type == "text/plain")[0]
+
+                    if (item) {
+                         item.getAsString(txt => {
+                            var session = currentEditor.getSession();
+                            var pos = session.getCursorPosition();
+                            session.insert(pos, txt);
+                            $("#red-ui-image-drop-target").hide();
+                         })
+                         return
+                    }                    
                 }
                 $("#red-ui-image-drop-target").hide();
             });


### PR DESCRIPTION
Along with image drop, this change adds text drop into the editor. 

This is useful for highlighting text and then drag that text into the description of a node. Similar creating a mermaid diagram using a third-party tool and then drag the text into the description.

Also drop text files is also supported for longer texts.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Along with image drag&drop, this adds drop highlighted text and text files into the markdown editor.

Forum topic: https://discourse.nodered.org/t/text-and-text-file-drag-drop-into-the-description-editor/95532

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
