### PR TITLE
Update markdown drop-target appearance

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -58,7 +58,6 @@
         "confirmDelete": "Confirm delete",
         "delete": "Are you sure you want to delete '__label__'?",
         "dropFlowHere": "Drop the flow here",
-        "dropImageHere": "Drop the image here",
         "addFlow": "Add flow",
         "addFlowToRight": "Add flow to the right",
         "closeFlow": "Close flow",

--- a/packages/node_modules/@node-red/editor-client/locales/es-ES/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/es-ES/editor.json
@@ -58,7 +58,6 @@
         "confirmDelete": "Confirmar eliminación",
         "delete": "¿Estás seguro de que quieres eliminar '__label__'?",
         "dropFlowHere": "Suelta el flujo aquí",
-        "dropImageHere": "Suelta la imagen aquí",
         "addFlow": "Añadir flujo",
         "addFlowToRight": "Añadir flujo a la derecha",
         "closeFlow": "Cerrar flujo",

--- a/packages/node_modules/@node-red/editor-client/locales/fr/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/fr/editor.json
@@ -58,7 +58,6 @@
     "confirmDelete": "Confirmer la suppression",
     "delete": "Êtes-vous sûr de vouloir supprimer '__label__' ?",
     "dropFlowHere": "Lâchez le flux ici",
-    "dropImageHere": "Lâchez l'image ici",
     "addFlow": "Ajouter un flux",
     "addFlowToRight": "Ajouter un flux à droite",
     "closeFlow": "Fermer le flux",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -58,7 +58,6 @@
         "confirmDelete": "削除の確認",
         "delete": "本当に '__label__' を削除しますか？",
         "dropFlowHere": "ここにフローをドロップしてください",
-        "dropImageHere": "ここに画像ファイルをドロップしてください",
         "addFlow": "フローの追加",
         "addFlowToRight": "右側にフローを追加",
         "closeFlow": "フローを閉じる",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editor.js
@@ -46,8 +46,8 @@
             initialised = selectedCodeEditor.init();
         }
 
-        $('<div id="red-ui-image-drop-target"><div data-i18n="[append]workspace.dropImageHere"><i class="fa fa-download"></i><br></div></div>').appendTo('#red-ui-editor');
-        $("#red-ui-image-drop-target").hide();
+        $('<div id="red-ui-drop-target-markdown-editor"><div><i class="fa fa-download"></i><br></div></div>').appendTo('#red-ui-editor');
+        $("#red-ui-drop-target-markdown-editor").hide();
     }
 
     function create(options) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/markdown.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/markdown.js
@@ -41,16 +41,22 @@
     function initImageDrag(elem, editor) {
         $(elem).on("dragenter", function (ev) {
             ev.preventDefault();
-            $("#red-ui-image-drop-target").css({display:'table'}).focus();
+            $("#red-ui-drop-target-markdown-editor").css({
+                display:'table',
+                top: $(elem).offset().top,
+                left: $(elem).offset().left,
+                width: $(elem).width(),
+                height: $(elem).height()
+            }).focus();
             currentEditor = editor;
         });
 
         if (!initialized) {
             initialized = true;
-            $("#red-ui-image-drop-target").on("dragover", function (ev) {
+            $("#red-ui-drop-target-markdown-editor").on("dragover", function (ev) {
                 ev.preventDefault();
             }).on("dragleave", function (ev) {
-                $("#red-ui-image-drop-target").hide();
+                $("#red-ui-drop-target-markdown-editor").hide();
             }).on("drop", function (ev) {
                 ev.preventDefault();
                 if ($.inArray("Files",ev.originalEvent.dataTransfer.types) != -1) {
@@ -66,7 +72,7 @@
                                 var img = `<img src="${image}"/>\n`;
                                 var pos = session.getCursorPosition();
                                 session.insert(pos, img);
-                                $("#red-ui-image-drop-target").hide();
+                                $("#red-ui-drop-target-markdown-editor").hide();
                             });
                             return;
                         }
@@ -76,11 +82,10 @@
                                 var session = currentEditor.getSession();
                                 var pos = session.getCursorPosition();
                                 session.insert(pos, txt);
-                                $("#red-ui-image-drop-target").hide();
+                                $("#red-ui-drop-target-markdown-editor").hide();
                             });
                             return;
-                        }
-                        
+                        }                       
                     }
                 } else if ($.inArray("text/plain", ev.originalEvent.dataTransfer.types) != -1) {
                     let item = Object.values(ev.originalEvent.dataTransfer.items).filter(d => d.type == "text/plain")[0]
@@ -90,12 +95,12 @@
                             var session = currentEditor.getSession();
                             var pos = session.getCursorPosition();
                             session.insert(pos, txt);
-                            $("#red-ui-image-drop-target").hide();
+                            $("#red-ui-drop-target-markdown-editor").hide();
                          })
                          return
                     }                    
                 }
-                $("#red-ui-image-drop-target").hide();
+                $("#red-ui-drop-target-markdown-editor").hide();
             });
         }
     }

--- a/packages/node_modules/@node-red/editor-client/src/sass/dragdrop.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/dragdrop.scss
@@ -38,12 +38,13 @@
     }
 }
 
-#red-ui-image-drop-target {
+#red-ui-drop-target-markdown-editor {
     position: absolute;
     top: 0; bottom: 0;
     left: 0; right: 0;
     background: var(--red-ui-dnd-background);
     display:table;
+    border-radius: 3px;
     width: 100%;
     height: 100%;
     display: none;


### PR DESCRIPTION
Follow on to #5056 

This updates the drop-target appearance for the markdown editor to be a bit more intuitive that it's handling the drop event into the markdown editor window.

Removes the text message (previously 'Drop Image here' - as it now handles images and text).

<img width="590" alt="image" src="https://github.com/user-attachments/assets/be76d808-8d61-4c77-ae39-c3ce9c912a7f" />
