### PR TITLE
Add .editorconfig to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ docs
 .nyc_output
 sync.ffs_db
 package-lock.json
+.editorconfig


### PR DESCRIPTION
I use [EditorConfig](https://editorconfig.org/) to adjust my editor settings for indentation.

My settings should probably be best ignored, unless there is a desire to have a project wide .editorconfig

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Added a .editorconfig and it's probably best ignored. 

I don't know but perhaps it might also be helpful to have a project wide .editorconfig - if there is demand. It's designed to be editor agnostic so there is no vim v. emacs v. vscode debate involved.

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
