### PR TITLE
Add the `changed` badge to the config node

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
@@ -150,9 +150,6 @@ RED.sidebar.config = (function() {
                     $('<li class="red-ui-palette-node-config-type">'+node.type+'</li>').appendTo(list);
                     currentType = node.type;
                 }
-                if (node.changed) {
-                    labelText += "!!"
-                }
                 var entry = $('<li class="red-ui-palette-node_id_'+node.id.replace(/\./g,"-")+'"></li>').appendTo(list);
                 var nodeDiv = $('<div class="red-ui-palette-node-config red-ui-palette-node"></div>').appendTo(entry);
                 entry.data('node',node.id);
@@ -181,15 +178,31 @@ RED.sidebar.config = (function() {
                     }
                 }
 
+                if (node.changed) {
+                    const nodeDivAnnotations = $('<svg class="red-ui-palette-node-annotations red-ui-flow-node-changed" width="10" height="10" style="left:calc(100% - 15px);"></svg>').appendTo(nodeDiv);
+                    const changedBadge = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+                    changedBadge.setAttribute("cx", "5");
+                    changedBadge.setAttribute("cy", "5");
+                    changedBadge.setAttribute("r", "5");
+                    nodeDivAnnotations.append($(changedBadge));
+                }
+
                 if (!node.valid) {
-                    nodeDiv.addClass("red-ui-palette-node-config-invalid")
-                    const nodeDivAnnotations = $('<svg class="red-ui-palette-node-annotations red-ui-flow-node-error" width="10" height="10"></svg>').appendTo(nodeDiv)
-                    const errorBadge = document.createElementNS("http://www.w3.org/2000/svg","path");
+                    nodeDiv.addClass("red-ui-palette-node-config-invalid");
+                    const nodeDivAnnotations = $('<svg class="red-ui-palette-node-annotations red-ui-flow-node-error" width="10" height="10"></svg>').appendTo(nodeDiv);
+                    const errorBadge = document.createElementNS("http://www.w3.org/2000/svg", "path");
                     errorBadge.setAttribute("d","M 0,9 l 10,0 -5,-8 z");
-                    nodeDivAnnotations.append($(errorBadge))
+                    nodeDivAnnotations.append($(errorBadge));
+
+                    if (node.changed) {
+                        nodeDivAnnotations.css("left", "calc(100% - 28px)");
+                    } else {
+                        nodeDivAnnotations.css("left", "calc(100% - 15px)");
+                    }
+
                     RED.popover.tooltip(nodeDivAnnotations, function () {
                         if (node.validationErrors && node.validationErrors.length > 0) {
-                            return RED._("editor.errors.invalidProperties")+"<br>  - "+node.validationErrors.join("<br>  - ")
+                            return RED._("editor.errors.invalidProperties") + "<br>  - " + node.validationErrors.join("<br>  - ");
                         }
                     })
                 }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
@@ -188,30 +188,25 @@ RED.sidebar.config = (function() {
                 }
 
                 if (node.changed) {
-                    const nodeDivAnnotations = $('<svg class="red-ui-palette-node-annotations red-ui-flow-node-changed" width="10" height="10" viewBox="-1 -1 12 12" style="left:calc(100% - 15px);"></svg>').appendTo(nodeDiv);
-                    const changedBadge = document.createElementNS("http://www.w3.org/2000/svg", "circle");
-                    changedBadge.setAttribute("cx", "5");
-                    changedBadge.setAttribute("cy", "5");
-                    changedBadge.setAttribute("r", "5");
-                    nodeDivAnnotations.append($(changedBadge));
+                    const nodeDivAnnotations = $('<svg class="red-ui-palette-node-annotations red-ui-flow-node-changed" width="10" height="10" viewBox="-1 -1 12 12"></svg>').appendTo(nodeDiv);
+                    const changeBadge = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+                    changeBadge.setAttribute("cx", "5");
+                    changeBadge.setAttribute("cy", "5");
+                    changeBadge.setAttribute("r", "5");
+                    nodeDivAnnotations.append($(changeBadge));
 
                     const categoryHeader = list.parent().find(".red-ui-sidebar-config-tray-header.red-ui-palette-header");
                     categoryHeader.addClass("red-ui-sidebar-config-changed");
+                    nodeDiv.addClass("red-ui-palette-node-config-changed");
                 }
 
                 if (!node.valid) {
-                    nodeDiv.addClass("red-ui-palette-node-config-invalid");
                     const nodeDivAnnotations = $('<svg class="red-ui-palette-node-annotations red-ui-flow-node-error" width="10" height="10"></svg>').appendTo(nodeDiv);
                     const errorBadge = document.createElementNS("http://www.w3.org/2000/svg", "path");
-                    errorBadge.setAttribute("d","M 0,9 l 10,0 -5,-8 z");
+                    errorBadge.setAttribute("d", "M 0,9 l 10,0 -5,-8 z");
                     nodeDivAnnotations.append($(errorBadge));
 
-                    if (node.changed) {
-                        nodeDivAnnotations.css("left", "calc(100% - 28px)");
-                    } else {
-                        nodeDivAnnotations.css("left", "calc(100% - 15px)");
-                    }
-
+                    nodeDiv.addClass("red-ui-palette-node-config-invalid");
                     RED.popover.tooltip(nodeDivAnnotations, function () {
                         if (node.validationErrors && node.validationErrors.length > 0) {
                             return RED._("editor.errors.invalidProperties") + "<br>  - " + node.validationErrors.join("<br>  - ");

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
@@ -56,7 +56,16 @@ RED.sidebar.config = (function() {
             } else {
                 $('<span class="red-ui-palette-node-config-label" data-i18n="sidebar.config.'+name+'">').appendTo(header);
             }
+
             $('<span class="red-ui-sidebar-node-config-filter-info"></span>').appendTo(header);
+
+            const changeBadgeContainer = $('<svg class="red-ui-sidebar-config-category-changed red-ui-flow-node-changed" width="10" height="10" viewBox="-1 -1 12 12"></svg>').appendTo(header);
+            const changeBadge = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+            changeBadge.setAttribute("cx", "5");
+            changeBadge.setAttribute("cy", "5");
+            changeBadge.setAttribute("r", "5");
+            changeBadgeContainer.append(changeBadge);
+
             category = $('<ul class="red-ui-palette-content red-ui-sidebar-node-config-list"></ul>').appendTo(container);
             category.on("click", function(e) {
                 $(content).find(".red-ui-palette-node").removeClass("selected");
@@ -179,12 +188,15 @@ RED.sidebar.config = (function() {
                 }
 
                 if (node.changed) {
-                    const nodeDivAnnotations = $('<svg class="red-ui-palette-node-annotations red-ui-flow-node-changed" width="10" height="10" style="left:calc(100% - 15px);"></svg>').appendTo(nodeDiv);
+                    const nodeDivAnnotations = $('<svg class="red-ui-palette-node-annotations red-ui-flow-node-changed" width="10" height="10" viewBox="-1 -1 12 12" style="left:calc(100% - 15px);"></svg>').appendTo(nodeDiv);
                     const changedBadge = document.createElementNS("http://www.w3.org/2000/svg", "circle");
                     changedBadge.setAttribute("cx", "5");
                     changedBadge.setAttribute("cy", "5");
                     changedBadge.setAttribute("r", "5");
                     nodeDivAnnotations.append($(changedBadge));
+
+                    const categoryHeader = list.parent().find(".red-ui-sidebar-config-tray-header.red-ui-palette-header");
+                    categoryHeader.addClass("red-ui-sidebar-config-changed");
                 }
 
                 if (!node.valid) {
@@ -265,6 +277,10 @@ RED.sidebar.config = (function() {
                 $(this).remove();
                 delete categories[id];
             }
+
+            // Remove the `changed` badge from the category header
+            const categoryHeader = $(this).find(".red-ui-sidebar-config-tray-header.red-ui-palette-header");
+            categoryHeader.removeClass("red-ui-sidebar-config-changed");
         })
         var globalConfigNodes = [];
         var configList = {};

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
@@ -117,7 +117,7 @@ ul.red-ui-sidebar-node-config-list li.red-ui-palette-node-config-type {
 }
 .red-ui-palette-node-annotations {
     position: absolute;
-    left: calc(100% - 15px);
+    //left: calc(100% - 15px);
     top: -8px;
     display: block;
 }

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
@@ -115,6 +115,15 @@ ul.red-ui-sidebar-node-config-list li.red-ui-palette-node-config-type {
 .red-ui-palette-node-config-invalid {
     border-color: var(--red-ui-form-input-border-error-color)
 }
+.red-ui-sidebar-config-tray-header.red-ui-palette-header:not(.red-ui-sidebar-config-changed) .red-ui-flow-node-changed {
+    display: none;
+}
+.red-ui-sidebar-config-tray-header.red-ui-palette-header.red-ui-sidebar-config-changed .red-ui-flow-node-changed {
+    display: inline-block;
+    position: absolute;
+    top: 1px;
+    right: 1px;
+}
 .red-ui-palette-node-annotations {
     position: absolute;
     //left: calc(100% - 15px);

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-config.scss
@@ -84,6 +84,11 @@ ul.red-ui-sidebar-node-config-list {
     background: var(--red-ui-node-config-background);
     color: var(--red-ui-primary-text-color);
     cursor: pointer;
+    &.red-ui-palette-node-config-invalid.red-ui-palette-node-config-changed {
+        .red-ui-palette-node-annotations.red-ui-flow-node-error {
+            left: calc(100% - 28px);
+        }
+    }
 }
 ul.red-ui-sidebar-node-config-list li.red-ui-palette-node-config-type {
     color: var(--red-ui-secondary-text-color);
@@ -126,7 +131,7 @@ ul.red-ui-sidebar-node-config-list li.red-ui-palette-node-config-type {
 }
 .red-ui-palette-node-annotations {
     position: absolute;
-    //left: calc(100% - 15px);
+    left: calc(100% - 15px);
     top: -8px;
     display: block;
 }


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Work done in #4782 but rebased onto master.

Add the `changed` badge to the config node and the category.

<img width="273" alt="Capture d’écran 2024-10-25 à 11 27 29" src="https://github.com/user-attachments/assets/da52a097-d4b5-4bf1-a86a-5f4bbe65e049">

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
