### PR TITLE
Add support for node: prefixed modules in function node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.html
@@ -197,14 +197,6 @@
     // object that maps from library name to its descriptor
     var allLibs = [];
 
-    function moduleName(module) {
-        var match = /^([^@]+)@(.+)/.exec(module);
-        if (match) {
-            return [match[1], match[2]];
-        }
-        return [module, undefined];
-    }
-
     function getAllUsedModules() {
         var moduleSet = new Set();
         for (var id in knownFunctionNodes) {
@@ -302,7 +294,7 @@
                     if (val === "_custom_") {
                         val = $(this).val();
                     }
-                    var varName = val.trim().replace(/^@/,"").replace(/@.*$/,"").replace(/[-_/\.].?/g, function(v) { return v[1]?v[1].toUpperCase():"" });
+                    var varName = val.trim().replace(/^node:/,"").replace(/^@/,"").replace(/@.*$/,"").replace(/[-_/\.].?/g, function(v) { return v[1]?v[1].toUpperCase():"" });
                     fvar.val(varName);
                     fvar.trigger("change");
 

--- a/packages/node_modules/@node-red/registry/lib/externalModules.js
+++ b/packages/node_modules/@node-red/registry/lib/externalModules.js
@@ -92,7 +92,7 @@ function requireModule(module) {
 
     const parsedModule = parseModuleName(module);
 
-    if (BUILTIN_MODULES.indexOf(parsedModule.module) !== -1) {
+    if (parsedModule.builtin) {
         return require(parsedModule.module + parsedModule.subpath);
     }
     if (!knownExternalModules[parsedModule.module]) {
@@ -113,7 +113,7 @@ function importModule(module) {
 
     const parsedModule = parseModuleName(module);
 
-    if (BUILTIN_MODULES.indexOf(parsedModule.module) !== -1) {
+    if (parsedModule.builtin) {
         return import(parsedModule.module + parsedModule.subpath);
     }
     if (!knownExternalModules[parsedModule.module]) {
@@ -135,15 +135,22 @@ function importModule(module) {
 }
 
 function parseModuleName(module) {
-    var match = /((?:@[^/]+\/)?[^/@]+)(\/[^/@]+)?(?:@([\s\S]+))?/.exec(module);
+    const match = /((?:@[^/]+\/)?[^/@]+)(\/[^/@]+)?(?:@([\s\S]+))?/.exec(module);
     if (match) {
+        const moduleName = match[1]
+        let isBuiltIn = false
+        if (/^node:/.test(moduleName)) {
+            isBuiltIn = BUILTIN_MODULES.includes(moduleName.substring(5))
+        } else {
+            isBuiltIn = BUILTIN_MODULES.includes(moduleName)
+        }
         return {
             spec: module,
-            module: match[1],
+            module: moduleName,
             subpath: match[2] || '',
             version: match[3],
-            builtin: BUILTIN_MODULES.indexOf(match[1]) !== -1,
-            known: !!knownExternalModules[match[1]]
+            builtin: isBuiltIn,
+            known: !!knownExternalModules[moduleName]
         }
     }
     return null;


### PR DESCRIPTION
Fixes #5065 

Adds support in the Function node for importing built-in Node.js modules using the `node:` prefix. Whilst this is optional syntax for most modules, as noted in the related issue, some upcoming modules (`node:sqlite`) require the prefix to avoid namespace clashes with 3rd party modules.

The auto-generated variable name suggestion for `node:foo` will be `foo` - ie, we strip off `node:` rather than do something like `nodeFoo`. That's up for debate, but this'll do for now.