### PR TITLE
Handle deleting of subflow context entries

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/api/context.js
+++ b/packages/node_modules/@node-red/runtime/lib/api/context.js
@@ -241,7 +241,11 @@ var api = module.exports = {
             } else if (scope === 'node') {
                 var node = runtime.nodes.getNode(id);
                 if (node) {
-                    ctx = node.context();
+                    if (/^subflow:/.test(node.type)) {
+                        ctx = runtime.nodes.getContext(node.id);
+                    } else {
+                        ctx = node.context();
+                    }
                 }
             }
             if (ctx) {


### PR DESCRIPTION
Closes #5069

PR #5025 added the ability to view Subflow context in the sidebar. It didn't update the 'delete entry' route to handle the same. This PR fixes that.