### PR TITLE
Refresh config node sidebar when changing lock state of a flow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -767,6 +767,7 @@ RED.workspaces = (function() {
             RED.history.push(historyEvent);
             RED.events.emit("flows:change",workspace);
             RED.nodes.dirty(true);
+            RED.sidebar.config.refresh();
             RED.nodes.filterNodes({z:workspace.id}).forEach(n => n.dirty = true)
             RED.view.redraw(true);
         }


### PR DESCRIPTION
Follow up to #5061 - ensures the config nodes sidebar is refreshed when locking/unlocking a flow via the built-in actions (rather than the edit dialog).