### PR TITLE
Add a border to better distinguish typedInput type/option dropdowns

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
@@ -198,6 +198,7 @@ button.red-ui-typedInput-option-expand {
 }
 
 button.red-ui-typedInput-option-trigger {
+    border-left: 1px solid var(--red-ui-form-input-border-color);
     border-top-left-radius: 0px;
     border-bottom-left-radius: 0px;
     border-top-right-radius: 4px;


### PR DESCRIPTION
Easier to see there are separate dropdowns in the TypedInput:

<img width="316" alt="image" src="https://github.com/user-attachments/assets/42de774a-7bb5-487a-875a-1988b8cefd98" />
