### PR TITLE
Improve debug display of error objects

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -1285,7 +1285,6 @@ RED.utils = (function() {
             payload = JSON.parse(payload);
         } else if (/error/i.test(format)) {
             payload = JSON.parse(payload);
-            payload = (payload.name?payload.name+": ":"")+payload.message;
         } else if (format === 'null') {
             payload = null;
         } else if (format === 'undefined') {

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -828,18 +828,25 @@ function encodeObject(msg,opts) {
             debuglength = opts.maxLength;
         }
         var msgType = typeof msg.msg;
-        if (msg.msg instanceof Error) {
+        if (msg.msg instanceof Error || /Error/.test(msg.msg?.__proto__?.name)) {
             msg.format = "error";
-            var errorMsg = {};
-            if (msg.msg.name) {
-                errorMsg.name = msg.msg.name;
+
+            const cause = msg.msg.cause
+            const value = {
+                __enc__: true,
+                type: 'error',
+                data: {
+                    name: msg.msg.name,
+                    message: msg.msg.message,
+                    cause: cause + "",
+                    stack: msg.msg.stack,
+                }
             }
-            if (hasOwnProperty.call(msg.msg, 'message')) {
-                errorMsg.message = msg.msg.message;
-            } else {
-                errorMsg.message = msg.msg.toString();
+            // Remove cause if not defined
+            if (!cause) {
+                delete value.data.cause
             }
-            msg.msg = JSON.stringify(errorMsg);
+            msg.msg = JSON.stringify(value);
         } else if (msg.msg instanceof Buffer) {
             msg.format = "buffer["+msg.msg.length+"]";
             msg.msg = msg.msg.toString('hex');
@@ -857,6 +864,7 @@ function encodeObject(msg,opts) {
                 msg.format = "Object";
             }
             if (/error/i.test(msg.format)) {
+                // TODO: check if this is needed
                 msg.msg = JSON.stringify({
                     name: msg.msg.name,
                     message: msg.msg.message
@@ -904,8 +912,22 @@ function encodeObject(msg,opts) {
                                 __enc__: true,
                                 type: "internal"
                             }
-                        } else if (value instanceof Error) {
-                            value = value.toString()
+                        } else if (value instanceof Error || /Error/.test(value?.__proto__?.name)) {
+                            const cause = value.cause
+                            value = {
+                                __enc__: true,
+                                type: 'error',
+                                data: {
+                                    name: value.name,
+                                    message: value.message,
+                                    cause: cause + "",
+                                    stack: value.stack,
+                                }
+                            }
+                            // Remove cause if not defined
+                            if (!cause) {
+                                delete value.data.cause
+                            }
                         } else if (Array.isArray(value) && value.length > debuglength) {
                             value = {
                                 __enc__: true,

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -837,7 +837,7 @@ function encodeObject(msg,opts) {
                 type: 'error',
                 data: {
                     name: msg.msg.name,
-                    message: msg.msg.message,
+                    message: hasOwnProperty.call(msg.msg, 'message') ? msg.msg.message : msg.msg.toString(),
                     cause: cause + "",
                     stack: msg.msg.stack,
                 }
@@ -919,7 +919,7 @@ function encodeObject(msg,opts) {
                                 type: 'error',
                                 data: {
                                     name: value.name,
-                                    message: value.message,
+                                    message: hasOwnProperty.call(value, 'message') ? value.message : value.toString(),
                                     cause: cause + "",
                                     stack: value.stack,
                                 }
@@ -999,8 +999,19 @@ function encodeObject(msg,opts) {
                         return value;
                     });
                 } else {
-                    try { msg.msg = msg.msg.toString(); }
-                    catch(e) { msg.msg = "[Type not printable]" + util.inspect(msg.msg); }
+                    try {
+                        msg.msg = msg.msg.toString();
+                    } catch(e) {
+                        msg.msg.format = 'error'
+                        msg.msg = JSON.stringify({
+                            __enc__: true,
+                            type: 'error',
+                            data: {
+                                message: "[Type not serializable]",
+                                stack: e.stack
+                            }
+                        })
+                    }
                 }
             }
         } else if (msgType === "function") {
@@ -1031,17 +1042,14 @@ function encodeObject(msg,opts) {
         return msg;
     } catch(e) {
         msg.format = "error";
-        var errorMsg = {};
-        if (e.name) {
-            errorMsg.name = e.name;
-        }
-        if (hasOwnProperty.call(e, 'message')) {
-            errorMsg.message = 'encodeObject Error: ['+e.message + '] Value: '+util.inspect(msg.msg);
-        } else {
-            errorMsg.message = 'encodeObject Error: ['+e.toString() + '] Value: '+util.inspect(msg.msg);
-        }
-        if (errorMsg.message.length > debuglength) {
-            errorMsg.message = errorMsg.message.substring(0,debuglength);
+        const errorMsg = {
+            __enc__: true,
+            type: 'error',
+            data: {
+                name: e.name,
+                message: 'encodeObject Error: ' + (hasOwnProperty.call(e, 'message') ? e.message : e.toString()),
+                stack: e.stack,
+            }
         }
         msg.msg = JSON.stringify(errorMsg);
         return msg;

--- a/test/nodes/core/common/21-debug_spec.js
+++ b/test/nodes/core/common/21-debug_spec.js
@@ -173,9 +173,19 @@ describe('debug node', function() {
             websocket_test(function() {
                 n1.emit("input", {payload: new Error("oops")});
             }, function(msg) {
-                JSON.parse(msg).should.eql([{
-                    topic:"debug",data:{id:"n1",msg:'{"name":"Error","message":"oops"}',property:"payload",format:"error",path:"global"}
-                }]);
+                const fullMsg = JSON.parse(msg)
+                fullMsg[0].should.have.property('topic', 'debug')
+                fullMsg[0].should.have.property('data')
+                fullMsg[0].data.should.have.property('id', 'n1')
+                fullMsg[0].data.should.have.property('property', 'payload')
+                fullMsg[0].data.should.have.property('format', 'error')
+                fullMsg[0].data.should.have.property('path', 'global')
+                fullMsg[0].data.should.have.property('msg')
+                const msgData = JSON.parse(fullMsg[0].data.msg)
+                msgData.should.have.property('__enc__', true)
+                msgData.should.have.property('type', 'error')
+                msgData.data.should.have.property('name', 'Error')
+                msgData.data.should.have.property('message', 'oops')
             }, done);
         });
     });


### PR DESCRIPTION
Improves display of error objects so it shows stack and other information.

Previously, it would display `<Name>: <message>` as a String. With this PR it now shows errors as objects with their common properties - name, message, stack and cause (if set). The type hint is also set to 'error' to be clear.

<img width="422" alt="image" src="https://github.com/user-attachments/assets/9e874b92-5c1d-4d31-aad6-db496b373942" />

