### PR TITLE
Add code to error object sent by Catch node

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -675,6 +675,9 @@ class Flow {
                         count: count
                     }
                 };
+                if (logMessage.hasOwnProperty('code')) {
+                    errorMessage.error.code = logMessage.code;
+                }
                 if (logMessage.hasOwnProperty('stack')) {
                     errorMessage.error.stack = logMessage.stack;
                 }

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -838,13 +838,19 @@ function encodeObject(msg,opts) {
                 data: {
                     name: msg.msg.name,
                     message: hasOwnProperty.call(msg.msg, 'message') ? msg.msg.message : msg.msg.toString(),
+                    code: msg.msg.code,
                     cause: cause + "",
                     stack: msg.msg.stack,
                 }
             }
-            // Remove cause if not defined
-            if (!cause) {
+            // We optimistically added these properties to the object
+            // to ensure they are shown above 'stack'. But we don't want
+            // to include them if they are undefined 
+            if (cause === undefined) {
                 delete value.data.cause
+            }
+            if (msg.msg.code === undefined) {
+                delete value.data.code
             }
             msg.msg = JSON.stringify(value);
         } else if (msg.msg instanceof Buffer) {
@@ -914,19 +920,26 @@ function encodeObject(msg,opts) {
                             }
                         } else if (value instanceof Error || /Error/.test(value?.__proto__?.name)) {
                             const cause = value.cause
+                            const code = value.code
                             value = {
                                 __enc__: true,
                                 type: 'error',
                                 data: {
                                     name: value.name,
                                     message: hasOwnProperty.call(value, 'message') ? value.message : value.toString(),
+                                    code,
                                     cause: cause + "",
                                     stack: value.stack,
                                 }
                             }
-                            // Remove cause if not defined
-                            if (!cause) {
+                            // We optimistically added these properties to the object
+                            // to ensure they are shown above 'stack'. But we don't want
+                            // to include them if they are undefined 
+                            if (cause === undefined) {
                                 delete value.data.cause
+                            }
+                            if (code === undefined) {
+                                delete value.data.code
                             }
                         } else if (Array.isArray(value) && value.length > debuglength) {
                             value = {


### PR DESCRIPTION
Closes #5080 

Add `code` property to the error object emitted by the Catch node.

Also updates the changes from  #5079 to also include `code` if present in Error objects.