### PR TITLE
Properly handle scale factor in getLinksAtPoint for firefox

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -401,7 +401,7 @@ RED.palette = (function() {
                                     } else {
                                         // Firefox doesn't do getIntersectionList and that
                                         // makes us sad
-                                        nodes = RED.view.getLinksAtPoint(mouseX,mouseY);
+                                        nodes = RED.view.getLinksAtPoint(mouseX / RED.view.scale(), mouseY / RED.view.scale());
                                     }
                                     var mx = mouseX / RED.view.scale();
                                     var my = mouseY / RED.view.scale();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1908,7 +1908,7 @@ RED.view = (function() {
                             } else {
                                 // Firefox doesn"t do getIntersectionList and that
                                 // makes us sad
-                                nodes = RED.view.getLinksAtPoint(mouseX*scaleFactor,mouseY*scaleFactor);
+                                nodes = RED.view.getLinksAtPoint(mouseX, mouseY);
                             }
                             for (var i=0;i<nodes.length;i++) {
                                 if (d3.select(nodes[i]).classed("red-ui-flow-link-background")) {
@@ -6333,6 +6333,12 @@ RED.view = (function() {
             var links = outer.selectAll(".red-ui-flow-link-background")[0];
             for (var i=0;i<links.length;i++) {
                 var bb = links[i].getBBox();
+                if (bb.height === 0) {
+                    // For horizontal links, add some real height to make them easier
+                    // to hit.
+                    bb.y -= Math.max(5, 5 / scaleFactor);
+                    bb.height = Math.max(10, 10 / scaleFactor);
+                }
                 if (x >= bb.x && y >= bb.y && x <= bb.x+bb.width && y <= bb.y+bb.height) {
                     result.push(links[i])
                 }


### PR DESCRIPTION
Fixes up the application of scale factor in FireFox when dealing with dragging a node from the palette over a link, as well as dragging an existing node over a link.

Also adds some padding to the bounding box used to detect collisions when its zero height - ie a horizontal link.