### PR TITLE
Fix label state for link nodes when dropped into the workspace

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -655,8 +655,12 @@ RED.view = (function() {
                     var nn = RED.nodes.add(result.node);
 
                     var showLabel = RED.utils.getMessageProperty(RED.settings.get('editor'),"view.view-node-show-label");
-                    if (showLabel !== undefined &&  (nn._def.hasOwnProperty("showLabel")?nn._def.showLabel:true) && !nn._def.defaults.hasOwnProperty("l")) {
-                        nn.l = showLabel;
+                    if (showLabel !== undefined && !nn._def.defaults.hasOwnProperty("l")) {
+                        if (nn._def.hasOwnProperty("showLabel")) {
+                            nn.l = nn._def.showLabel;
+                        } else {
+                            nn.l = showLabel;
+                        }
                     }
 
                     var helperOffset = d3.touches(ui.helper.get(0))[0]||d3.mouse(ui.helper.get(0));


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #5090.

**NOTE**: Does the `showLabel` definition take precedence over the user setting?

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
