### PR TITLE
Fix non-strict comparison when saving node properties

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/properties.js
@@ -157,7 +157,7 @@
      */
      function isEqual(originalValue, newValue) {
         try {
-            if(originalValue == newValue) {
+            if(originalValue === newValue) {
                 return true; 
             }
             return JSON.stringify(originalValue) === JSON.stringify(newValue);


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes https://github.com/node-red/node-red-dashboard/issues/850:

I think the comparison should be strict, @Steve-Mcl, do you agree?

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
