### PR TITLE
Handle link nodes with show/hide label action

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
@@ -46,10 +46,20 @@ RED.contextMenu = (function () {
                             hasEnabledNode = true;
                         }
                     }
-                    if (n.l === undefined || n.l) {
-                        hasLabeledNode = true;
+                    if (n.l === undefined) {
+                        // Check if the node sets showLabel in the defaults
+                        // as that determines the default behaviour for the node
+                        if (n._def.showLabel !== false) {
+                            hasLabeledNode = true;
+                        } else {
+                            hasUnlabeledNode = true;
+                        }
                     } else {
-                        hasUnlabeledNode = true;
+                        if (n.l) {
+                            hasLabeledNode = true;
+                        } else {
+                            hasUnlabeledNode = true;
+                        }
                     }
                 }
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
@@ -176,8 +176,8 @@ RED.view.tools = (function() {
         }
         nodes.forEach(function(n) {
             var modified = false;
-            var oldValue = n.l === undefined?true:n.l;
-            var showLabel = n._def.hasOwnProperty("showLabel")?n._def.showLabel:true;
+            var showLabel = n._def.hasOwnProperty("showLabel") ? n._def.showLabel : true;
+            var oldValue = n.l === undefined ? showLabel : n.l;
 
             if (labelShown) {
                 if (n.l === false || (!showLabel && !n.hasOwnProperty('l'))) {


### PR DESCRIPTION
Fixes #5090 

The code that determined whether to enable the show/hide label context menu items was not handling the link nodes properly.

If a node doesn't have an `l` property, we need to check if `showLabel` is set on its definition to see what the default value of `l` should be. We cannot assume that lack of an `l` property means the label is shown - as link nodes set `showLabel` to false.

Whilst verifying this fix, I also spotted the history handling of the show/hide action was also incorrect. It was also  it was setting the old value to the wrong default (without taking into account the `showLabel` value).