### PR TITLE
Default Palette Search: Sort by Downloads

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -647,7 +647,7 @@
             "tab-nodes": "Nodes",
             "tab-install": "Install",
             "sort": "sort:",
-            "sortDownloads": "downloads",
+            "sortRelevance": "relevance",
             "sortAZ": "a-z",
             "sortRecent": "recent",
             "more": "+ __count__ more",

--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -647,7 +647,7 @@
             "tab-nodes": "Nodes",
             "tab-install": "Install",
             "sort": "sort:",
-            "sortRelevance": "relevance",
+            "sortDownloads": "downloads",
             "sortAZ": "a-z",
             "sortRecent": "recent",
             "more": "+ __count__ more",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -1066,7 +1066,7 @@ RED.palette.editor = (function() {
         const sortRelevance = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle selected"><i class="fa fa-sort-amount-desc"></i></a>').appendTo(sortGroup);
         const sortAZ = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle"><i class="fa fa-sort-alpha-asc"></i></a>').appendTo(sortGroup);
         const sortRecent = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle"><i class="fa fa-calendar"></i></a>').appendTo(sortGroup);
-        RED.popover.tooltip(sortRelevance,RED._("palette.editor.sortDownloads"));
+        RED.popover.tooltip(sortRelevance,RED._("palette.editor.sortRelevance"));
         RED.popover.tooltip(sortAZ,RED._("palette.editor.sortAZ"));
         RED.popover.tooltip(sortRecent,RED._("palette.editor.sortRecent"));
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -597,10 +597,26 @@ RED.palette.editor = (function() {
         }
     }
     function sortModulesRelevance(A,B) {
-        return sortModulesDownloads(A,B);
+        const defaultSort = sortModulesDownloads(A,B);
+        const currentFilter = searchInput.searchBox('value').trim();
+        if (defaultSort === 0) {
+            // same number of downloads
+            if (currentFilter === "") {
+                return sortModulesAZ(A,B);
+            }
+            var i = A.info.index.indexOf(currentFilter) - B.info.index.indexOf(currentFilter);
+            if (i === 0) {
+                return sortModulesAZ(A,B);
+            }
+            return i;
+        }
+        return defaultSort;
     }
     function sortModulesDownloads(A,B) {
-        return B.info.downloads.week - A.info.downloads.week;
+        // check A has the info.downloads property - if not exising, prioritise it (likely a custom user catalogue)
+        const a = A.info && typeof A.info.downloads !== 'undefined' ? A.info.downloads.week : Number.MAX_SAFE_INTEGER;
+        const b = B.info && typeof B.info.downloads !== 'undefined' ? B.info.downloads.week : Number.MAX_SAFE_INTEGER;
+        return b - a;
     }
     function sortModulesAZ(A,B) {
         return A.info.id.localeCompare(B.info.id);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -1135,7 +1135,9 @@ RED.palette.editor = (function() {
                     var metaRow = $('<div class="red-ui-palette-module-meta"></div>').appendTo(headerRow);
                     $('<span class="red-ui-palette-module-version" title="Latest Version"><i class="fa fa-tag"></i> '+entry.version+'</span>').appendTo(metaRow);
                     $('<span class="red-ui-palette-module-updated" title="Last Updated"><i class="fa fa-calendar"></i> '+formatUpdatedAt(entry.updated_at)+'</span>').appendTo(metaRow);
-                    $('<span class="red-ui-palette-module-downloads" title="Downloads - Last 7 Days"><i class="fa fa-download"></i> '+(new Intl.NumberFormat().format(entry.downloads.week))+'</span>').appendTo(metaRow);
+                    if (entry.downloads?.week !== undefined) {
+                        $('<span class="red-ui-palette-module-downloads" title="Downloads - Last 7 Days"><i class="fa fa-download"></i> '+(new Intl.NumberFormat().format(entry.downloads.week))+'</span>').appendTo(metaRow);
+                    }
                     if (loadedCatalogs.length > 1) {
                         $('<span class="red-ui-palette-module-updated"><i class="fa fa-cubes"></i>' + (entry.catalog.name || entry.catalog.url) + '</span>').appendTo(metaRow);
                     }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -583,7 +583,9 @@ RED.palette.editor = (function() {
             packageList.editableList('addItem',{count:loadedList.length})
             return;
         }
+        // sort the filtered modules
         filteredList.sort(activeSort);
+        // render the items in the package list
         for (var i=0;i<Math.min(10,filteredList.length);i++) {
             packageList.editableList('addItem',filteredList[i]);
         }
@@ -595,15 +597,10 @@ RED.palette.editor = (function() {
         }
     }
     function sortModulesRelevance(A,B) {
-        var currentFilter = searchInput.searchBox('value').trim();
-        if (currentFilter === "") {
-            return sortModulesAZ(A,B);
-        }
-        var i = A.info.index.indexOf(currentFilter) - B.info.index.indexOf(currentFilter);
-        if (i === 0) {
-            return sortModulesAZ(A,B);
-        }
-        return i;
+        return sortModulesDownloads(A,B);
+    }
+    function sortModulesDownloads(A,B) {
+        return B.info.downloads.week - A.info.downloads.week;
     }
     function sortModulesAZ(A,B) {
         return A.info.id.localeCompare(B.info.id);
@@ -1053,7 +1050,7 @@ RED.palette.editor = (function() {
         const sortRelevance = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle selected"><i class="fa fa-sort-amount-desc"></i></a>').appendTo(sortGroup);
         const sortAZ = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle"><i class="fa fa-sort-alpha-asc"></i></a>').appendTo(sortGroup);
         const sortRecent = $('<a href="#" class="red-ui-palette-editor-install-sort-option red-ui-sidebar-header-button-toggle"><i class="fa fa-calendar"></i></a>').appendTo(sortGroup);
-        RED.popover.tooltip(sortRelevance,RED._("palette.editor.sortRelevance"));
+        RED.popover.tooltip(sortRelevance,RED._("palette.editor.sortDownloads"));
         RED.popover.tooltip(sortAZ,RED._("palette.editor.sortAZ"));
         RED.popover.tooltip(sortRecent,RED._("palette.editor.sortRecent"));
 
@@ -1120,8 +1117,9 @@ RED.palette.editor = (function() {
                     var descRow = $('<div class="red-ui-palette-module-meta"></div>').appendTo(headerRow);
                     $('<div>',{class:"red-ui-palette-module-description"}).text(entry.description).appendTo(descRow);
                     var metaRow = $('<div class="red-ui-palette-module-meta"></div>').appendTo(headerRow);
-                    $('<span class="red-ui-palette-module-version"><i class="fa fa-tag"></i> '+entry.version+'</span>').appendTo(metaRow);
-                    $('<span class="red-ui-palette-module-updated"><i class="fa fa-calendar"></i> '+formatUpdatedAt(entry.updated_at)+'</span>').appendTo(metaRow);
+                    $('<span class="red-ui-palette-module-version" title="Latest Version"><i class="fa fa-tag"></i> '+entry.version+'</span>').appendTo(metaRow);
+                    $('<span class="red-ui-palette-module-updated" title="Last Updated"><i class="fa fa-calendar"></i> '+formatUpdatedAt(entry.updated_at)+'</span>').appendTo(metaRow);
+                    $('<span class="red-ui-palette-module-downloads" title="Downloads - Last 7 Days"><i class="fa fa-download"></i> '+(new Intl.NumberFormat().format(entry.downloads.week))+'</span>').appendTo(metaRow);
                     if (loadedCatalogs.length > 1) {
                         $('<span class="red-ui-palette-module-updated"><i class="fa fa-cubes"></i>' + (entry.catalog.name || entry.catalog.url) + '</span>').appendTo(metaRow);
                     }

--- a/packages/node_modules/@node-red/editor-client/src/sass/palette-editor.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/palette-editor.scss
@@ -119,6 +119,9 @@
     .red-ui-palette-module-updated {
         margin-left: 10px;
     }
+    .red-ui-palette-module-downloads {
+        margin-left: 10px;
+    }
     .red-ui-palette-module-link {
         margin-left: 5px;
     }
@@ -230,7 +233,7 @@
     white-space: nowrap;
     @include mixins.enable-selection;
 }
-.red-ui-palette-module-version, .red-ui-palette-module-updated, .red-ui-palette-module-link {
+.red-ui-palette-module-version, .red-ui-palette-module-updated, .red-ui-palette-module-link, .red-ui-palette-module-downloads {
     font-style:italic;
     font-size: 0.8em;
     @include mixins.enable-selection;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

- Modifies the Palette search to prioritise downloads (in the past 7 days) first. This retuns far more appropriate results in an easier order to parse. The more popular a package is, the more likely it is that the person searching a given term is looking for that package.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
