### PR TITLE
Let split node send original msg to complete node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -151,10 +151,11 @@ module.exports = function(RED) {
                         if (node.arraySplt === 1) {
                             m = m[0];
                         }
-                        RED.util.setMessageProperty(msg,node.property,m);
-                        msg.parts.index = i;
+                        const newmsg = RED.util.cloneMessage(msg)
+                        RED.util.setMessageProperty(newmsg,node.property,m);
+                        newmsg.parts.index = i;
                         pos += node.arraySplt;
-                        send(RED.util.cloneMessage(msg));
+                        send(newmsg);
                     }
                     done();
                 }


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
When the split node has "completed" handling of the incoming msg it sends a message to the complete node (if one is configured of course) - currently this contains a payload of the last part/value of the split. I think that really it should send the original payload (IE it is saying I have completed handling of "this" input message). 

This change ensures that the split sends the correct parts to the output - but the original message to the complete node.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
