### PR TITLE
Fix complete node to not feedback immediately connected nodes

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/24-complete.js
+++ b/packages/node_modules/@node-red/nodes/core/common/24-complete.js
@@ -21,6 +21,15 @@ module.exports = function(RED) {
         RED.nodes.createNode(this,n);
         var node = this;
         this.scope = n.scope;
+
+        // auto-filter out any directly connected nodes to avoid simple loopback
+        const w = node.wires.flat().toString();
+        for (let i=0; i < this.scope.length; i++) {
+            if (w.includes(this.scope[i])) {
+                this.scope.splice(i, 1);
+            }
+        }
+
         this.on("input",function(msg, send, done) {
             send(msg);
             done();

--- a/packages/node_modules/@node-red/nodes/core/common/24-complete.js
+++ b/packages/node_modules/@node-red/nodes/core/common/24-complete.js
@@ -20,7 +20,7 @@ module.exports = function(RED) {
     function CompleteNode(n) {
         RED.nodes.createNode(this,n);
         var node = this;
-        this.scope = n.scope;
+        this.scope = n.scope || [];
 
         // auto-filter out any directly connected nodes to avoid simple loopback
         const w = this.wires.flat();

--- a/packages/node_modules/@node-red/nodes/core/common/24-complete.js
+++ b/packages/node_modules/@node-red/nodes/core/common/24-complete.js
@@ -23,7 +23,7 @@ module.exports = function(RED) {
         this.scope = n.scope;
 
         // auto-filter out any directly connected nodes to avoid simple loopback
-        const w = this.wires.flat().toString();
+        const w = this.wires.flat();
         for (let i=0; i < this.scope.length; i++) {
             if (w.includes(this.scope[i])) {
                 this.scope.splice(i, 1);

--- a/packages/node_modules/@node-red/nodes/core/common/24-complete.js
+++ b/packages/node_modules/@node-red/nodes/core/common/24-complete.js
@@ -23,7 +23,7 @@ module.exports = function(RED) {
         this.scope = n.scope;
 
         // auto-filter out any directly connected nodes to avoid simple loopback
-        const w = node.wires.flat().toString();
+        const w = this.wires.flat().toString();
         for (let i=0; i < this.scope.length; i++) {
             if (w.includes(this.scope[i])) {
                 this.scope.splice(i, 1);

--- a/packages/node_modules/@node-red/nodes/core/common/25-status.js
+++ b/packages/node_modules/@node-red/nodes/core/common/25-status.js
@@ -21,6 +21,15 @@ module.exports = function(RED) {
         RED.nodes.createNode(this,n);
         var node = this;
         this.scope = n.scope;
+
+        // auto-filter out any directly connected nodes to avoid simple loopback
+        const w = node.wires.flat().toString();
+        for (let i=0; i < this.scope.length; i++) {
+            if (w.includes(this.scope[i])) {
+                this.scope.splice(i, 1);
+            }
+        }
+
         this.on("input", function(msg, send, done) {
             send(msg);
             done();

--- a/packages/node_modules/@node-red/nodes/core/common/25-status.js
+++ b/packages/node_modules/@node-red/nodes/core/common/25-status.js
@@ -23,7 +23,7 @@ module.exports = function(RED) {
         this.scope = n.scope;
 
         // auto-filter out any directly connected nodes to avoid simple loopback
-        const w = this.wires.flat().toString();
+        const w = this.wires.flat();
         for (let i=0; i < this.scope.length; i++) {
             if (w.includes(this.scope[i])) {
                 this.scope.splice(i, 1);

--- a/packages/node_modules/@node-red/nodes/core/common/25-status.js
+++ b/packages/node_modules/@node-red/nodes/core/common/25-status.js
@@ -20,7 +20,7 @@ module.exports = function(RED) {
     function StatusNode(n) {
         RED.nodes.createNode(this,n);
         var node = this;
-        this.scope = n.scope;
+        this.scope = n.scope || [];
 
         // auto-filter out any directly connected nodes to avoid simple loopback
         const w = this.wires.flat();

--- a/packages/node_modules/@node-red/nodes/core/common/25-status.js
+++ b/packages/node_modules/@node-red/nodes/core/common/25-status.js
@@ -23,7 +23,7 @@ module.exports = function(RED) {
         this.scope = n.scope;
 
         // auto-filter out any directly connected nodes to avoid simple loopback
-        const w = node.wires.flat().toString();
+        const w = this.wires.flat().toString();
         for (let i=0; i < this.scope.length; i++) {
             if (w.includes(this.scope[i])) {
                 this.scope.splice(i, 1);

--- a/test/nodes/core/common/24-complete_spec.js
+++ b/test/nodes/core/common/24-complete_spec.js
@@ -1,18 +1,3 @@
-/**
- * Copyright JS Foundation and other contributors, http://js.foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- **/
 
 var should = require("should");
 var catchNode = require("nr-test-utils").require("@node-red/nodes/core/common/24-complete.js");

--- a/test/nodes/core/common/24-complete_spec.js
+++ b/test/nodes/core/common/24-complete_spec.js
@@ -15,17 +15,17 @@
  **/
 
 var should = require("should");
-var catchNode = require("nr-test-utils").require("@node-red/nodes/core/common/25-status.js");
+var catchNode = require("nr-test-utils").require("@node-red/nodes/core/common/24-complete.js");
 var helper = require("node-red-node-test-helper");
 
-describe('status Node', function() {
+describe('complete Node', function() {
 
     afterEach(function() {
         helper.unload();
     });
 
     it('should output a message when called', function(done) {
-        var flow = [ { id:"n1", type:"status", name:"status", wires:[["n2"]], scope:[] },
+        var flow = [ { id:"n1", type:"complete", name:"status", wires:[["n2"]], scope:[] },
             {id:"n2", type:"helper"} ];
         helper.load(catchNode, flow, function() {
             var n1 = helper.getNode("n1");


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This fix automatically filters out any nodes that are directly connected to the complete node that would otherwise feedback straight into the complete node... It DOES NOT filter nodes that are indirectly connected - but does fix the simple use case where someone connects a debug direct to the complete node to see what is returned but forgets to remove it from the scope of the complete node.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
