### PR TITLE
Fix node tab filtering

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -34,7 +34,7 @@ RED.palette.editor = (function() {
     let packageList;
 
     // Nodes tab - filter
-    let activeFilter = "";
+    let activeFilterTerms = [];
     // Nodes tab - search input
     let filterInput;
     // Install tab - search input
@@ -421,7 +421,19 @@ RED.palette.editor = (function() {
     }
 
     function filterChange(val) {
-        activeFilter = val.toLowerCase();
+        const activeFilter = val.toLowerCase();
+        activeFilterTerms = []
+        activeFilter.split(',').forEach(term => {
+            term = term.trim()
+            if (term) {
+                const isExact = term[0] === '"' && term[term.length-1] === '"'
+                activeFilterTerms.push({
+                    exact: isExact,
+                    term: isExact ? term.substring(1,term.length-1) : term
+                })
+            }
+        })
+
         var visible = nodeList.editableList('filter');
         var size = nodeList.editableList('length');
         if (val === "") {
@@ -669,6 +681,9 @@ RED.palette.editor = (function() {
             title: RED._("palette.editor.palette"),
             get: getSettingsPane,
             close: function() {
+                if (filterInput) {
+                    filterInput.searchBox('value',"");
+                }
                 settingsPane.detach();
             },
             focus: function() {
@@ -870,11 +885,26 @@ RED.palette.editor = (function() {
                 return A.info.name.localeCompare(B.info.name);
             },
             filter: function(data) {
-                if (activeFilter === "" ) {
+                if (activeFilterTerms.length === 0) {
                     return true;
                 }
-
-                return (activeFilter==="")||(data.index.indexOf(activeFilter) > -1);
+                for (let i = 0; i < activeFilterTerms.length; i++) {
+                    const searchTerm = activeFilterTerms[i]
+                    const location = data.index.indexOf(searchTerm.term)
+                    if (
+                        (
+                            searchTerm.exact &&
+                            (
+                                location === 0 && (
+                                    data.index.length === searchTerm.term.length ||
+                                    data.index[searchTerm.term.length] === ','
+                                )
+                            )
+                         ) ||
+                         (!searchTerm.exact && location > -1)) {
+                            return true
+                         }
+                }
             },
             addItem: function(container,i,object) {
                 var entry = object.info;


### PR DESCRIPTION
#4599 added the ability to pre-populate the filter list of the Palette Manager. This was applied to both the Node and Install tab, however just spotted, the filter didn't work on the Node tab. 4599 only needed it for the Install tab - so wasn't noticied there.

The Update Available notification relies on it working on the Node tab, which this PR fixes.

It also clears the filter when the dialog is closed - which feels a better behaviour than remembering the old filter.