### PR TITLE
Update dompurify

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "@node-rs/bcrypt": "1.10.7"
     },
     "devDependencies": {
-        "dompurify": "2.5.8",
+        "dompurify": "3.2.5",
         "grunt": "1.6.1",
         "grunt-chmod": "~1.1.1",
         "grunt-cli": "~1.5.0",


### PR DESCRIPTION
Closes #5118
Updates to the latest 3.x branch from 2.x. The only breaking change is dropping support for IE - which we haven't supported for a while.
