### PR TITLE
Only apply colours for non-default log lines

### DIFF
--- a/packages/node_modules/@node-red/util/lib/log.js
+++ b/packages/node_modules/@node-red/util/lib/log.js
@@ -52,11 +52,11 @@ var levelColours = {
     10: 'red',
     20: 'red',
     30: 'yellow',
-    40: 'white',
+    40: '',
     50: 'cyan',
     60: 'gray',
-    98: 'white',
-    99: 'white'
+    98: '',
+    99: ''
 };
 
 var logHandlers = [];
@@ -99,7 +99,12 @@ const utilLog = function (msg, level) {
         d.getMinutes().toString().padStart(2, '0'),
         d.getSeconds().toString().padStart(2, '0')
     ].join(':');
-    console.log(chalk[levelColours[level] || 'white'](`${d.getDate()} ${months[d.getMonth()]} ${time} - ${msg}`))
+    const logLine = `${d.getDate()} ${months[d.getMonth()]} ${time} - ${msg}`
+    if (levelColours[level]) {
+        console.log(chalk[levelColours[level]](logLine))
+    } else {
+        console.log(logLine)
+    }
 }
 
 var consoleLogger = function(msg) {


### PR DESCRIPTION
Updates the log colouring to only apply colour to the non-info lines. This ensures the bulk of the log uses the terminal's default colour.

See https://github.com/node-red/node-red/issues/5076#issuecomment-2844955064

