### PR TITLE
Show deprecated message if module flagged

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -656,6 +656,8 @@
             "more": "+ __count__ more",
             "upload": "Upload module tgz file",
             "refresh": "Refresh module list",
+            "deprecated": "deprecated",
+            "deprecatedTip": "This module has been deprecated",
             "errors": {
                 "catalogLoadFailed": "<p>Failed to load node catalogue.</p><p>Check the browser console for more information</p>",
                 "installFailed": "<p>Failed to install: __module__</p><p>__message__</p><p>Check the log for more information</p>",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -1198,7 +1198,17 @@ RED.palette.editor = (function() {
                     var headerRow = $('<div>',{class:"red-ui-palette-module-header"}).appendTo(container);
                     var titleRow = $('<div class="red-ui-palette-module-meta red-ui-palette-module-name"><i class="fa fa-cube"></i></div>').appendTo(headerRow);
                     $('<span>').text(entry.name||entry.id).appendTo(titleRow);
-                    $('<a target="_blank" class="red-ui-palette-module-link"><i class="fa fa-external-link"></i></a>').attr('href',entry.url).appendTo(titleRow);
+                    if (entry.url) {
+                        $('<a target="_blank" class="red-ui-palette-module-link"><i class="fa fa-external-link"></i></a>').attr('href',entry.url).appendTo(titleRow);
+                    }
+                    if (entry.deprecated) {
+                        const deprecatedWarning = $('<span class="red-ui-palette-module-deprecated"></span>').text(RED._('palette.editor.deprecated')).appendTo(titleRow);
+                        let message = $('<span>').text(RED._('palette.editor.deprecatedTip'))
+                        if (typeof entry.deprecated === 'string') {
+                            $('<p>').text(entry.deprecated).appendTo(message)
+                        }
+                        RED.popover.tooltip(deprecatedWarning, message);
+                    }
                     var descRow = $('<div class="red-ui-palette-module-meta"></div>').appendTo(headerRow);
                     $('<div>',{class:"red-ui-palette-module-description"}).text(entry.description).appendTo(descRow);
                     var metaRow = $('<div class="red-ui-palette-module-meta"></div>').appendTo(headerRow);

--- a/packages/node_modules/@node-red/editor-client/src/sass/palette-editor.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/palette-editor.scss
@@ -126,14 +126,19 @@
         margin-left: 5px;
     }
 
+    .red-ui-palette-module-deprecated {
+        cursor: pointer;
+        color: var(--red-ui-text-color-error);
+        font-size: 0.7em;
+        border: 1px solid var(--red-ui-text-color-error);
+        border-radius: 30px;
+        padding: 2px 5px;
+    }
+
     .red-ui-palette-module-description {
         margin-left: 20px;
         font-size: 0.9em;
         color: var(--red-ui-secondary-text-color);
-    }
-    .red-ui-palette-module-link {
-    }
-    .red-ui-palette-module-set-button-group {
     }
     .red-ui-palette-module-content {
         display: none;


### PR DESCRIPTION
Closes #5126 

If the catalogue.json has a `deprecated` flag, the palette manager will now show an indicated against the node in the Install tab

Note: for the purposes of this screenshot, I've hardcoded some values to get it to show up - as it stands the public catalogue doesn't yet include the deprecated flag. The module shown was a randomly picked. The `Do <b>not</b> use me` is custom text provided by the catalogue.json in place of a boolean for the `deprecated` field - as shown here, HTML is escaped so content cannot be injected into the editor via this field.

<img width="622" alt="image" src="https://github.com/user-attachments/assets/48787482-ac6c-4d1f-9c3a-3d93dcfc0a2b" />
