### PR TITLE
feat: import default export if plugin is a transpiled es module

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/loader.js
+++ b/packages/node_modules/@node-red/registry/lib/loader.js
@@ -406,6 +406,7 @@ async function loadPlugin(plugin) {
     }
     try {
         var r = require(plugin.file);
+        r = r.__esModule ? r.default : r
         if (typeof r === "function") {
 
             var red = registryUtil.createNodeApi(plugin);


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Use the same approach for plugins, which I used for nodes in https://github.com/node-red/node-red/pull/3669
Basically: when a plugin is transpiled from es modules/typescript, import the default export.
Currently `export =` would need to be used, but that becomes the only export and so nothing else can be exported, which is quite unhandy. See the original PR for more detailed explanation.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
