### PR TITLE
Exclude internal properties from node definition

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -44,6 +44,51 @@ RED.nodes = (function() {
 
     var dirty = false;
 
+    const internalProperties = [
+        "changed",
+        "dirty",
+        "id",
+        "inputLabels",
+        "moved",
+        "outputLabels",
+        "selected",
+        "type",
+        "users",
+        "valid",
+        "validationErrors",
+        "wires",
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "i",
+        "j",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "q",
+        "r",
+        "s",
+        "t",
+        "u",
+        "v",
+        "w",
+        "x",
+        "y",
+        "z",
+        "_",
+        "_config",
+        "_def",
+        "_orig"
+    ];
+
     function setDirty(d) {
         dirty = d;
         if (!d) {
@@ -231,7 +276,6 @@ RED.nodes = (function() {
                 def.type = nt;
                 nodeDefinitions[nt] = def;
 
-
                 if (def.defaults) {
                     for (var d in def.defaults) {
                         if (def.defaults.hasOwnProperty(d)) {
@@ -241,6 +285,11 @@ RED.nodes = (function() {
                                 } catch(err) {
                                     console.warn(err);
                                 }
+                            }
+
+                            if (internalProperties.includes(d)) {
+                                console.warn(`registerType: ${nt}: the property "${d}" is internal and cannot be used.`);
+                                delete def.defaults[d];
                             }
                         }
                     }


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #5133.

If the node definition contains internal properties, they will be removed from the definition.

**NOTE**: `icon`, `info`, and `label` have special behavior.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
