### PR TITLE
Add an additional git_auth_failed condition

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/git/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/git/index.js
@@ -51,6 +51,8 @@ function runGitCommand(args,cwd,env,emit) {
             err.code = "git_auth_failed";
         } else if(/Authentication failed/i.test(stderr)) {
             err.code = "git_auth_failed";
+        } else if (/The requested URL returned error: 403/i.test(stderr)) {
+            err.code = "git_auth_failed";
         } else if (/commit your changes or stash/i.test(stderr)) {
             err.code = "git_local_overwrite";
         } else if (/CONFLICT/.test(err.stdout)) {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

The following error log on push did not trigger the username/password prompt.

```
remote: Permission to PlanktoScope/dashboard.git denied to sonnyp.
fatal: unable to access 'https://github.com/PlanktoScope/dashboard.git/': The requested URL returned error: 403
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
  - I would but there is no spec file for this
