### PR TITLE
Allow user to disable the node button from the UI

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -445,6 +445,7 @@
         }
     },
     "editor": {
+        "button": "Button",
         "configEdit": "Edit",
         "configAdd": "Add",
         "configUpdate": "Update",
@@ -468,6 +469,8 @@
         "searchIcons": "Search icons",
         "useDefault": "use default",
         "description": "Description",
+        "disabled": "Disabled",
+        "enabled": "Enabled",
         "show": "Show",
         "hide": "Hide",
         "locale": "Select UI Language",

--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1377,6 +1377,9 @@ RED.nodes = (function() {
                     node.l = n.l;
                 }
             }
+            if (n._def.button && n.hasOwnProperty("b") && n.b) {
+                node.b = true;
+            }
         }
         if (n.info) {
             node.info = n.info;
@@ -2336,6 +2339,9 @@ RED.nodes = (function() {
                     }
                     if (n.hasOwnProperty('g')) {
                         node.g = n.g;
+                    }
+                    if (n.hasOwnProperty('b')) {
+                        node.b = n.b;
                     }
                     if (options.markChanged) {
                         node.changed = true

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/appearance.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/panes/appearance.js
@@ -130,6 +130,20 @@
                         node.l = true;
                     }
                 }
+
+                if (node._def.button) {
+                    if ($("#node-input-enable-button").prop("checked")) {
+                        if (node.hasOwnProperty("b") && node.b) {
+                            editState.changes.b = node.b;
+                            editState.changed = true;
+                            delete node.b;
+                        }
+                    } else if (!node.b) {
+                        editState.changes.b = node.b;
+                        editState.changed = true;
+                        node.b = true;
+                    }
+                }
             }
         };
     });
@@ -193,6 +207,21 @@
             // });
             $("#red-ui-editor-subflow-user-count")
                 .text(RED._("subflow.subflowInstances", {count:node.instances.length})).show();
+        }
+
+        if (node._def.button) {
+            $('<div class="form-row">'+
+                '<label for="node-input-enable-button" data-i18n="editor.button"></label>'+
+                '<span style="margin-right: 2px;"/>'+
+                '<input type="checkbox" id="node-input-enable-button"/>'+
+            '</div>').appendTo(dialogForm);
+
+            $("#node-input-enable-button").toggleButton({
+                enabledLabel: RED._("editor.enabled"),
+                disabledLabel: RED._("editor.disabled")
+            });
+
+            $("#node-input-enable-button").prop("checked", !node.b).trigger("change");
         }
 
         $('<div class="form-row">'+

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4126,7 +4126,7 @@ RED.view = (function() {
     function isButtonEnabled(d) {
         var buttonEnabled = true;
         var ws = RED.nodes.workspace(RED.workspaces.active());
-        if (ws && !ws.disabled && !d.d && !ws.locked) {
+        if (ws && !ws.disabled && !d.d && !d.b && !ws.locked) {
             if (d._def.button.hasOwnProperty('enabled')) {
                 if (typeof d._def.button.enabled === "function") {
                     buttonEnabled = d._def.button.enabled.call(d);
@@ -4149,7 +4149,7 @@ RED.view = (function() {
         }
         var activeWorkspace = RED.workspaces.active();
         var ws = RED.nodes.workspace(activeWorkspace);
-        if (ws && !ws.disabled && !d.d && !ws.locked) {
+        if (ws && !ws.disabled && !d.d && !d.b && !ws.locked) {
             if (d._def.button.toggle) {
                 d[d._def.button.toggle] = !d[d._def.button.toggle];
                 d.dirty = true;


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Closes #4806.

Allow user to disable the node button from the `Appearance` tab.

<img width="566" alt="Capture d’écran 2025-06-04 à 09 34 05" src="https://github.com/user-attachments/assets/326f9ad7-fd35-4c89-b8cf-4c8b3050191b" />

Similar to the label behavior, if the `node.b` property is `true`, the button is disabled, otherwise it keeps its initial behavior.

I can add the control to the context menu too if needed.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
