### PR TITLE
Import `got` module only once when sending metrics

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/telemetry/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/telemetry/index.js
@@ -51,7 +51,6 @@ async function report () {
     }
     // If enabled, gather metrics
     const metrics = await gather()
-    runtime.log.debug(`Telemetry metrics: ${JSON.stringify(metrics, null, 2)}`)
 
     // Post metrics to endpoint - handle any error silently
 

--- a/packages/node_modules/@node-red/runtime/lib/telemetry/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/telemetry/index.js
@@ -6,6 +6,9 @@ const cronosjs = require('cronosjs')
 const METRICS_DIR = path.join(__dirname, 'metrics')
 const INITIAL_PING_DELAY = 1000 * 60 * 30 // 30 minutes from startup
 
+/** @type {import("got").Got | undefined} */
+let got
+
 let runtime
 
 let scheduleTask
@@ -48,11 +51,14 @@ async function report () {
     }
     // If enabled, gather metrics
     const metrics = await gather()
-    console.log(JSON.stringify(metrics, null, 2))
+    runtime.log.debug(`Telemetry metrics: ${JSON.stringify(metrics, null, 2)}`)
 
     // Post metrics to endpoint - handle any error silently
 
-    const { got } = await import('got')
+    if (!got) {
+        got = (await import('got')).got
+    }
+
     runtime.log.debug('Sending telemetry')
     const response = await got.post('https://telemetry.nodered.org/ping', {
         json: metrics,


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

- `console.log` is replaced by `debug`
- No need to import the `got` module every time `report` is called

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
