### PR TITLE
Node filter support for typedInput's builtin node

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -519,10 +519,25 @@
                 }
             },
             expand: function () {
-                var that = this;
+                const that = this;
+                let filter;
+                if (that.options.node) {
+                    let nodeFilter = that.options.node.filter;
+                    if (typeof nodeFilter === "string" || typeof nodeFilter === "object") {
+                        if (!Array.isArray(nodeFilter)) {
+                            nodeFilter = [nodeFilter];
+                        }
+                        filter = function (node) {
+                            return nodeFilter.includes(node.type);
+                        };
+                    } else if (typeof nodeFilter === "function") {
+                        filter = nodeFilter;
+                    }
+                }
                 RED.tray.hide();
                 RED.view.selectNodes({
                     single: true,
+                    filter: filter,
                     selected: [that.value()],
                     onselect: function (selection) {
                         that.value(selection.id);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -523,7 +523,7 @@
                 let filter;
                 if (that.options.node) {
                     let nodeFilter = that.options.node.filter;
-                    if (typeof nodeFilter === "string" || typeof nodeFilter === "object") {
+                    if ((typeof nodeFilter === "string" || typeof nodeFilter === "object") && nodeFilter) {
                         if (!Array.isArray(nodeFilter)) {
                             nodeFilter = [nodeFilter];
                         }


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Closes #5153.

Allows filtering selectable nodes with typedInput's `node` mode.

Prototypes are:
```ts
filter: string;            // node type
filter: string[];          // list of node type
filter: (node) => boolean; // function that returns a boolean
```

Example:
```js
$(elm).typedInput({
    default: "node",
    types: ["node"],
    node: {
       filter: "debug"
       //filter: ["debug", "inject"]
       //filter: (node) => node.type === "debug"
    }
})
```

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
