### PR TITLE
Ensure generated mqtt clientId uses only valid chars

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
+++ b/packages/node_modules/@node-red/nodes/core/network/10-mqtt.js
@@ -675,7 +675,7 @@ module.exports = function(RED) {
             node.options.password = node.password;
             node.options.keepalive = node.keepalive;
             node.options.clean = node.cleansession;
-            node.options.clientId = node.clientid || 'nodered_' + RED.util.generateId();
+            node.options.clientId = node.clientid || 'nodered' + RED.util.generateId();
             node.options.reconnectPeriod = RED.settings.mqttReconnectTime||5000;
             delete node.options.protocolId; //V4+ default
             delete node.options.protocolVersion; //V4 default

--- a/test/nodes/core/network/21-mqtt_spec.js
+++ b/test/nodes/core/network/21-mqtt_spec.js
@@ -58,7 +58,7 @@ describe('MQTT Nodes', function () {
                 mqttBroker.should.have.property('options');
                 mqttBroker.options.should.have.property('clean', true);
                 mqttBroker.options.should.have.property('clientId');
-                mqttBroker.options.clientId.should.containEql('nodered_');
+                mqttBroker.options.clientId.should.containEql('nodered');
                 mqttBroker.options.should.have.property('keepalive').type("number");
                 mqttBroker.options.should.have.property('reconnectPeriod').type("number");
                 //as this is not a v5 connection, ensure v5 properties are not present


### PR DESCRIPTION
This PR supersedes #4989

It includes the good work by @meeki007 from the original PR and adds the missing fix for the unit test.