### PR TITLE
Exec: Make encoding handling consistent between stdout and err

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/90-exec.js
+++ b/packages/node_modules/@node-red/nodes/core/function/90-exec.js
@@ -109,7 +109,7 @@ module.exports = function(RED) {
                     child.stderr.on('data', function (data) {
                         if (node.activeProcesses.hasOwnProperty(child.pid) && node.activeProcesses[child.pid] !== null) {
                             if (isUtf8(data)) { msg.payload = data.toString(); }
-                            else { msg.payload = Buffer.from(data); }
+                            else { msg.payload = data; }
                             nodeSend([null,RED.util.cloneMessage(msg),null]);
                         }
                     });
@@ -146,7 +146,8 @@ module.exports = function(RED) {
                         delete msg.payload;
                         if (stderr) {
                             msg2 = RED.util.cloneMessage(msg);
-                            msg2.payload = stderr;
+                            msg2.payload = Buffer.from(stderr,"binary");
+                            if (isUtf8(msg2.payload)) { msg2.payload = msg2.payload.toString(); }
                         }
                         msg.payload = Buffer.from(stdout,"binary");
                         if (isUtf8(msg.payload)) { msg.payload = msg.payload.toString(); }


### PR DESCRIPTION
Fixes #5139 

Aligns how the node handles the encoding of stdout and stderr to match each other.