### PR TITLE
Add URL/URLSearchParams to Function sandbox

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -162,6 +162,8 @@ module.exports = function(RED) {
             console:console,
             util:util,
             Buffer:Buffer,
+            URL: URL,
+            URLSearchParams: URLSearchParams,
             Date: Date,
             RED: {
                 util: {


### PR DESCRIPTION
Closes #4927 
Adds `URL` and `URLSearchParams` as standard globals to the Function node. No reason to hold these out.