### PR TITLE
Ensure linkcall timeout is greater than 0

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/validators.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/validators.js
@@ -13,23 +13,53 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+
 RED.validators = {
-    number: function(blankAllowed,mopt){
+    number: function(options,mopt) {
+        const DEFAULTS = {
+            blankAllowed: false,
+        }
+        // Also supports:
+        // - '>' : greater than
+        // - '>=' : greater than or equal to
+        // - '<' : less than
+        // - '<=' : less than or equal to
+        if (typeof options === 'boolean') {
+            options = {
+                blankAllowed: options
+            }
+        }
+        options = Object.assign(DEFAULTS, options)
+
         return function(v, opt) {
-            if (blankAllowed && (v === '' || v === undefined)) {
+            if (options.blankAllowed && (v === '' || v === undefined || v === null)) {
                 return true
             }
             if (v !== '') {
-                if (/^NaN$|^[+-]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?$|^[+-]?(0b|0B)[01]+$|^[+-]?(0o|0O)[0-7]+$|^[+-]?(0x|0X)[0-9a-fA-F]+$/.test(v)) {
-                    return true
-                }
                 if (/^\${[^}]+}$/.test(v)) {
                     // Allow ${ENV_VAR} value
                     return true
                 }
-            }
-            if (!isNaN(v)) {
-                return true
+                const parsedResult = new Number(v)
+                if (!isNaN(v)) {
+                    let isValid = true
+                    // This is a number - check for any additional constraints
+                    if (Object.hasOwn(options, '>') && !(parsedResult > options['>'])) {
+                        isValid = false
+                    }
+                    if (isValid && Object.hasOwn(options, '>=') && !(parsedResult >= options['>='])) {
+                        isValid = false
+                    }
+                    if (isValid && Object.hasOwn(options, '<') && !(parsedResult < options['<'])) {
+                        isValid = false
+                    }
+                    if (isValid && Object.hasOwn(options, '<=') && !(parsedResult <= options['<='])) {
+                        isValid = false
+                    }
+                    if (isValid) {
+                        return true
+                    }
+                }
             }
             if (opt && opt.label) {
                 return RED._("validator.errors.invalid-num-prop", {

--- a/packages/node_modules/@node-red/nodes/core/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.html
@@ -306,7 +306,7 @@
             timeout: {
                 value: "30",
                 label: RED._("node-red:link.timeout"),
-                validate:RED.validators.number(true)
+                validate: RED.validators.number({ blankAllowed: true, '>': 0 }),
             }
         },
         inputs: 1,

--- a/packages/node_modules/@node-red/nodes/core/common/60-link.js
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.js
@@ -187,7 +187,7 @@ module.exports = function(RED) {
         const messageEvents = {};
 
         let timeout = parseFloat(n.timeout || "30") * 1000;
-        if (isNaN(timeout)) {
+        if (isNaN(timeout) || timeout <= 0) {
             timeout = 30000;
         }
         function getTargetNode(msg) {


### PR DESCRIPTION
Reported here: https://discourse.nodered.org/t/link-call-set-to-dynamic-can-there-be-other-link-nodes-in-the-flow/97438/8

This ensures the Link Call node has a timeout > 0.

I've updated the built-in number validator to allow additional constraints to be specified on the validator.