### PR TITLE
Fix `pending_version` not set after module update

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -769,6 +769,11 @@ RED.palette.editor = (function() {
         });
 
         RED.events.on('registry:module-updated', function(ns) {
+            if (nodeEntries[ns.module]) {
+                // Set the node/plugin as updated
+                nodeEntries[ns.module].info.pending_version = ns.version;
+            }
+
             refreshNodeModule(ns.module);
             refreshUpdateStatus();
         });


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

In #4945, I modified the `nodeEntries[module].info` object to separate the set into `nodeSet` and `pluginSet`.

With this change `nodeEntries[module].info` no longer contains a reference to the registry (`RED.nodes.registry.getModule(module)`) but to a new object.

So have to define `pending_version` during the update event to add it to `nodeEntries[module].info`.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
