### PR TITLE
Prevent the editor to open the same dialog multiple times

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -2263,7 +2263,6 @@ RED.editor = (function() {
 
     function showTypeEditor(type, options) {
         if (customEditTypes.hasOwnProperty(type)) {
-            if (editStack.find((item) => Object.keys(item).length === 1 && item.type === type)) { return }
             if (editStack.length > 0) {
                 options.parent = editStack[editStack.length-1].id;
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1017,6 +1017,7 @@ RED.editor = (function() {
 
     function showEditDialog(node, defaultTab) {
         if (buildingEditDialog) { return }
+        if (editStack.includes(node)) { return }
         buildingEditDialog = true;
         if (node.z && RED.workspaces.isLocked(node.z)) { return }
         var editing_node = node;
@@ -1334,6 +1335,7 @@ RED.editor = (function() {
         var editing_config_node = RED.nodes.node(id);
         var activeEditPanes = [];
 
+        if (editStack.includes(editing_config_node)) { return }
         if (editing_config_node && editing_config_node.z && RED.workspaces.isLocked(editing_config_node.z)) { return }
 
         var configNodeScope = ""; // default to global
@@ -1777,6 +1779,7 @@ RED.editor = (function() {
 
     function showEditSubflowDialog(subflow, defaultTab) {
         if (buildingEditDialog) { return }
+        if (editStack.includes(subflow)) { return }
         buildingEditDialog = true;
 
         editStack.push(subflow);
@@ -1993,6 +1996,7 @@ RED.editor = (function() {
 
     function showEditGroupDialog(group, defaultTab) {
         if (buildingEditDialog) { return }
+        if (editStack.includes(group)) { return }
         buildingEditDialog = true;
         if (group.z && RED.workspaces.isLocked(group.z)) { return }
         var editing_node = group;
@@ -2107,6 +2111,7 @@ RED.editor = (function() {
 
     function showEditFlowDialog(workspace, defaultTab) {
         if (buildingEditDialog) { return }
+        if (editStack.includes(workspace)) { return }
         buildingEditDialog = true;
         var activeEditPanes = [];
         RED.view.state(RED.state.EDITING);
@@ -2258,6 +2263,7 @@ RED.editor = (function() {
 
     function showTypeEditor(type, options) {
         if (customEditTypes.hasOwnProperty(type)) {
+            if (editStack.find((item) => Object.keys(item).length === 1 && item.type === type)) { return }
             if (editStack.length > 0) {
                 options.parent = editStack[editStack.length-1].id;
             }


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Closes #5115.

Prevent the editor to open the same dialog multiple times.

When closing the dialog box, `pop()` is used, so I don't suggest changing the stack order.

NOTE: I have a doubt about `showTypeEditor`.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
