### PR TITLE
Allow limited Strings for msg.rejectUnauthorized

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httprequest.js
@@ -599,7 +599,18 @@ in your Node-RED user directory (${RED.settings.userDir}).
                 }
             } else {
                 if (msg.hasOwnProperty('rejectUnauthorized')) {
-                    opts.https = { rejectUnauthorized: msg.rejectUnauthorized };
+                    if (typeof msg.rejectUnauthorized === 'boolean') {
+                        opts.https = { rejectUnauthorized: msg.rejectUnauthorized }
+                    } else if (typeof msg.rejectUnauthorized === 'string') {
+                        if (msg.rejectUnauthorized.toLowerCase() === 'true' || msg.rejectUnauthorized.toLowerCase() === 'false') {
+                            opts.https = { rejectUnauthorized: (msg.rejectUnauthorized.toLowerCase() === 'true') }
+                        } else {
+                            node.warn(RED._("httpin.errors.rejectunauthorized-invalid"))
+                        }
+                    } else {
+                        node.warn(RED._("httpin.errors.rejectunauthorized-invalid"))
+                    }
+                    
                 }
             }
 

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -563,7 +563,8 @@
             "timeout-isnan": "Timeout value is not a valid number, ignoring",
             "timeout-isnegative": "Timeout value is negative, ignoring",
             "invalid-payload": "Invalid payload",
-            "invalid-url": "Invalid url"
+            "invalid-url": "Invalid url",
+            "rejectunauthorized-invalid": "msg.rejectUnauthorized should be a boolean"
         },
         "status": {
             "requesting": "requesting"


### PR DESCRIPTION
fixes #5171

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
If `msg.rejectUnauthorized` is a string allow "true", "false" (and upper case versions) otherwise show a warning and use default behaviour.

Boolean values used as is, any other types also ignored.

Targeting `dev` but may also want to back port to the 4.0.x branch

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
