### PR TITLE
Fix incorrect tip regarding moving nodes with arrows

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/de/infotips.json
+++ b/packages/node_modules/@node-red/editor-client/locales/de/infotips.json
@@ -6,7 +6,7 @@
         "tip3": "Sie können Ihre Node-Palette mit {{ core:manage-palette }} verwalten",
         "tip4": "Ihre Flow-Konfigurationsnodes werden in der Seitenleiste angezeigt, die über das Menü oder mit {{ core:show-config-tab }} angezeigt werden kann",
         "tip5": "Aktiviere oder deaktiviere diese Tipps in den Einstellungen im Tab 'Ansicht'",
-        "tip6": "Sie können die ausgewählten Nodes mit den [left]/[up]/[down]/[right]-Tasten verschieben. Wenn Sie dabei [Shift] gedrückt halten, können Sie den Fensterausschnitt verschieben.",
+        "tip6": "Sie können die ausgewählten Nodes mit [Strg] + ↑↓←→-Tasten verschieben. Mit [Shift] + ↑↓←→ verschieben Sie sie um einen Rasterabstand.",
         "tip7": "Wenn Sie ein Node auf eine Verbindung ziehen, wird es in die Verbindung eingefügt",
         "tip8": "Sie können die ausgewählten Nodes oder den aktuellen Flow-Tab mit {{ core:show-export-dialog }} exportieren",
         "tip9": "Sie können einen Flow importieren, indem Sie sein JSON in den Editor ziehen oder mittels {{ core:show-import-dialog }}",

--- a/packages/node_modules/@node-red/editor-client/locales/en-US/infotips.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/infotips.json
@@ -6,7 +6,7 @@
         "tip3": "You can manage your palette of nodes with {{core:manage-palette}}",
         "tip4": "Your flow configuration nodes are listed in the sidebar panel. It can be accessed from the menu or with {{core:show-config-tab}}",
         "tip5": "Enable or disable these tips from the option in the settings",
-        "tip6": "Move the selected nodes using the [left] [up] [down] and [right] keys. Hold [shift] to nudge them further",
+        "tip6": "Move the selected nodes using [ctrl] + ↑↓←→ keys. Hold [shift] + ↑↓←→ to move them one grid space",
         "tip7": "Dragging a node onto a wire will splice it into the link",
         "tip8": "Export the selected nodes, or the current tab with {{core:show-export-dialog}}",
         "tip9": "Import a flow by dragging its JSON into the editor, or with {{core:show-import-dialog}}",

--- a/packages/node_modules/@node-red/editor-client/locales/fr/infotips.json
+++ b/packages/node_modules/@node-red/editor-client/locales/fr/infotips.json
@@ -6,7 +6,7 @@
     "tip3": "Vous pouvez gérer votre palette de noeuds avec {{core:manage-palette}}",
     "tip4": "Vos noeuds de configuration de flux sont répertoriés dans le panneau de la barre latérale. Ils sont accessibles depuis le menu ou avec {{core:show-config-tab}}",
     "tip5": "Activer ou désactiver ces conseils à partir de l'option dans les paramètres",
-    "tip6": "Déplacer les noeuds sélectionnés à l'aide des touches [gauche] [haut] [bas] et [droite]. Maintenir la touche [shift] enfoncée pour les pousser plus loin",
+    "tip6": "Déplacer les noeuds sélectionnés à l'aide de [ctrl] + ↑↓←→. Maintenir [shift] + ↑↓←→ pour les déplacer d'un espace de grille",
     "tip7": "Faire glisser un noeud sur un fil le raccordera au lien",
     "tip8": "Exporter les noeuds sélectionnés, ou l'onglet actuel avec {{core:show-export-dialog}}",
     "tip9": "Importer un flux en faisant glisser son JSON dans l'éditeur, ou avec {{core:show-import-dialog}}",


### PR DESCRIPTION
Fixes #5175

The tip6 incorrectly stated that nodes could be moved using just arrow keys and that Shift would 'nudge them further'. This has been corrected to show that: CTRL + arrow keys are required to move selected nodes and SHIFT + arrow keys move nodes by one grid space.

Updated infotips.json files for en-US, de, and fr locales to reflect the correct keyboard shortcuts.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
