### PR TITLE
Do not use css display when counting filtered palette nodes

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -80,7 +80,7 @@ RED.palette = (function() {
             getNodeCount: function (visibleOnly) {
                 const nodes = catDiv.find(".red-ui-palette-node")
                 if (visibleOnly) {
-                    return nodes.filter(function() { return $(this).css('display') !== 'none'}).length
+                    return nodes.filter(function() { return $(this).attr("data-filter") !== "true"}).length
                 } else {
                     return nodes.length
                 }
@@ -572,8 +572,10 @@ RED.palette = (function() {
             var currentLabel = $(el).attr("data-palette-label");
             var type = $(el).attr("data-palette-type");
             if (val === "" || re.test(type) || re.test(currentLabel)) {
+                $(el).attr("data-filter", null)
                 $(this).show();
             } else {
+                $(el).attr("data-filter", "true")
                 $(this).hide();
             }
         });


### PR DESCRIPTION
Fixes #4926 

As far as I can tell, in safari, querying the `display` css variable of an element whose parent is hidden returns `none` regardless of what is set on the element itself. This broke the filtering logic in the palette sidebar - as it thought all nodes where hidden.

This fixes it by using a data attribute on the node to track whether it is hidden or not.