### PR TITLE
Add event-log widget to status bar

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/event-log.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/event-log.js
@@ -15,11 +15,14 @@
  **/
 RED.eventLog = (function() {
 
-    var template = '<script type="text/x-red" data-template-name="_eventLog"><div class="form-row node-text-editor-row"><div style="height: 100%;min-height: 150px;" class="node-text-editor" id="red-ui-event-log-editor"></div></div></script>';
+    const template = '<script type="text/x-red" data-template-name="_eventLog"><div class="form-row node-text-editor-row"><div style="height: 100%;min-height: 150px;" class="node-text-editor" id="red-ui-event-log-editor"></div></div></script>';
 
-    var eventLogEditor;
-    var backlog = [];
-    var shown = false;
+    let eventLogEditor;
+    let backlog = [];
+    let shown = false;
+
+    const activeLogs = new Set()
+
 
     function appendLogLine(line) {
         backlog.push(line);
@@ -38,6 +41,18 @@ RED.eventLog = (function() {
         init: function() {
             $(template).appendTo("#red-ui-editor-node-configs");
             RED.actions.add("core:show-event-log",RED.eventLog.show);
+
+            const statusWidget = $('<button type="button" class="red-ui-footer-button red-ui-event-log-status" style="line-height: normal"><img style="width: 80%" src="red/images/spin.svg"/></div></button>');
+            statusWidget.on("click", function(evt) {
+                RED.actions.invoke("core:show-event-log");
+            })
+            RED.statusBar.add({
+                id: "red-ui-event-log-status",
+                align: "right",
+                element: statusWidget
+            });
+            // RED.statusBar.hide("red-ui-event-log-status");
+
         },
         show: function() {
             if (shown) {
@@ -98,6 +113,12 @@ RED.eventLog = (function() {
         },
         log: function(id,payload) {
             var ts = (new Date(payload.ts)).toISOString()+" ";
+            if (!payload.end) {
+                activeLogs.add(id)
+            } else {
+                activeLogs.delete(id);
+            }
+
             if (payload.type) {
                 ts += "["+payload.type+"] "
             }
@@ -110,6 +131,11 @@ RED.eventLog = (function() {
                 lines.forEach(function(line) {
                     appendLogLine(ts+line);
                 })
+            }
+            if (activeLogs.size > 0) {
+                RED.statusBar.show("red-ui-event-log-status");
+            } else {
+                RED.statusBar.hide("red-ui-event-log-status");
             }
         },
         startEvent: function(name) {

--- a/packages/node_modules/@node-red/util/lib/exec.js
+++ b/packages/node_modules/@node-red/util/lib/exec.js
@@ -78,7 +78,7 @@ module.exports = {
                     stdout: stdout,
                     stderr: stderr
                 }
-                emit && events.emit("event-log", {id:invocationId,payload:{ts: Date.now(),data:"rc="+code}});
+                emit && events.emit("event-log", {id:invocationId,payload:{ts: Date.now(), data:"rc="+code, end: true}});
 
                 if (code === 0) {
                     resolve(result)


### PR DESCRIPTION
Based on user feedback, if an install is taking a long time you may close the palette manager window at which point you have no indication that anything is happening. Sometimes the request can timeout, but the install still runs in the background.

This PR adds a spinner widget to the statusBar that is shown if there is ongoing activity in the event log. Clicking on it opens up the event log.

<img width="165" alt="image" src="https://github.com/user-attachments/assets/1a6984bc-55e9-4d29-8a5c-b43f796cd8e8" />
