### PR TITLE
Swap manage/install-all buttons in dependency notification

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2069,20 +2069,8 @@ RED.nodes = (function() {
                 // Provide option to install missing modules
                 notificationOptions.buttons = [
                     {
-                        text: RED._("palette.editor.manageModules"),
-                        class: "primary",
-                        click: function(e) {
-                            unknownNotification.close();
-
-                            RED.actions.invoke('core:manage-palette', {
-                                view: 'install',
-                                filter: '"' + missingModules.join('", "') + '"'
-                            });
-                        }
-                    },
-                    {
                         text: RED._("palette.editor.installAll"),
-                        class: "pull-left",
+                        class: "primary",
                         click: function(e) {
                             unknownNotification.close();
 
@@ -2092,6 +2080,18 @@ RED.nodes = (function() {
                                     modules[moduleName] = options.modules[moduleName];
                                     return modules;
                                 }, {}),
+                            });
+                        }
+                    },
+                    {
+                        text: RED._("palette.editor.manageModules"),
+                        class: "pull-left",
+                        click: function(e) {
+                            unknownNotification.close();
+
+                            RED.actions.invoke('core:manage-palette', {
+                                view: 'install',
+                                filter: '"' + missingModules.join('", "') + '"'
                             });
                         }
                     }


### PR DESCRIPTION
Based on UX feedback, this PR swaps around the 'manage modules' and 'install all' buttons in the notification when importing unknown nodes with module meta-data available:

<img width="540" alt="image" src="https://github.com/user-attachments/assets/8e18ef28-b8e3-4dd4-a5f7-01196f5caf2e" />
