### PR TITLE
Hide event log status widget by default

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/event-log.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/event-log.js
@@ -51,7 +51,7 @@ RED.eventLog = (function() {
                 align: "right",
                 element: statusWidget
             });
-            // RED.statusBar.hide("red-ui-event-log-status");
+            RED.statusBar.hide("red-ui-event-log-status");
 
         },
         show: function() {


### PR DESCRIPTION
Left-over from testing - should have uncommented this line before merge 🤦🏻 