### PR TITLE
Do not update suggestion whilst typeSearch hiding

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/typeSearch.js
@@ -266,6 +266,11 @@ RED.typeSearch = (function() {
         if (nodeItem === activeSuggestion) {
             return
         }
+        if (!visible && nodeItem) {
+            // Do not update suggestion if the dialog is not visible
+            // - for example, whilst the dialog is closing and the user mouses over a new item
+            return
+        }
         activeSuggestion = nodeItem
         if (suggestCallback) {
             if (!nodeItem) {


### PR DESCRIPTION
Just after merging #5180 I find one more bug to squash...

After clicking on a typeSearch entry to select it, the typeSearch dialog hides via an animation. If the user moves their mouse whilst it is closing, it can trigger the mouse-enter event on another entry in the dialog causing a suggestion to be shown. That suggestion is then orphaned as the 'clearSuggestion' logic in the hide function has already been called.

This PR fixes it by not triggering a suggestion update if the `visible` flag is false.