### PR TITLE
Add `splice` property to nodes:add event context

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -660,7 +660,9 @@ RED.view = (function() {
                         return;
                     }
                     var historyEvent = result.historyEvent;
-                    var nn = RED.nodes.add(result.node, { source: 'palette' });
+                    const linkToSplice = $(ui.helper).data("splice");
+
+                    var nn = RED.nodes.add(result.node, { source: 'palette', splice: !!linkToSplice });
 
                     var showLabel = RED.utils.getMessageProperty(RED.settings.get('editor'),"view.view-node-show-label");
                     if (showLabel !== undefined &&  (nn._def.hasOwnProperty("showLabel")?nn._def.showLabel:true) && !nn._def.defaults.hasOwnProperty("l")) {
@@ -719,7 +721,6 @@ RED.view = (function() {
                         nn.y -= gridOffset.y;
                     }
 
-                    var linkToSplice = $(ui.helper).data("splice");
                     if (linkToSplice) {
                         spliceLink(linkToSplice, nn, historyEvent)
                     }
@@ -1560,7 +1561,7 @@ RED.view = (function() {
                 if (nn.type === 'junction') {
                     nn = RED.nodes.addJunction(nn);
                 } else {
-                    nn = RED.nodes.add(nn, { source: 'typeSearch' });
+                    nn = RED.nodes.add(nn, { source: 'typeSearch', splice: !!linkToSplice });
                 }
                 if (quickAddLink) {
                     var drag_line = quickAddLink;


### PR DESCRIPTION
We recently added a context object to the `nodes:add` event to help distinguish if a node was added as a result of user iteration, and if so, whether that was by dragging from the palette or via typeSearch.

This extends that context object to have a `splice` property - set to true if the added node was spliced into a link.