### PR TITLE
Do not select a nearest node if move is active

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-tools.js
@@ -368,6 +368,8 @@ RED.view.tools = (function() {
 
 
     function gotoNearestNode(direction) {
+        // Do not select a nearest node if move is active
+        if (RED.view.state() == 3) { return }
         var selection = RED.view.selection();
         if (selection.nodes && selection.nodes.length === 1) {
             var origin = selection.nodes[0];


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #5197.

Do not select a nearest node if move is active to avoid to overwrite the node selection.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
