### PR TITLE
Better Monaco `esc` key bubbling

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
@@ -1426,6 +1426,15 @@ RED.editor.codeEditor.monaco = (function() {
             ed.gotoLine(row, col);
         }
         ed.type = type;
+
+        ed.onKeyDown((event) => {
+            if (event.keyCode === monaco.KeyCode.Escape) {
+                if (monacoWidgetsAreOpen(ed)) {
+                    event.preventDefault();
+                }
+            }
+        })
+
         return ed;
     }
 
@@ -1433,6 +1442,16 @@ RED.editor.codeEditor.monaco = (function() {
         if(!el.offsetHeight && !el.offsetWidth) { return false; }
         if(getComputedStyle(el).visibility === 'hidden') { return false; }
         return true;
+    }
+
+    function monacoWidgetsAreOpen(editor) {
+        /** @type {HTMLElement} */
+        const editorDomNode = editor.getDomNode()
+        const suggestVisible = !!editorDomNode.querySelector('.monaco-editor .suggest-widget.visible');
+        const parameterHintsVisible = !!editorDomNode.querySelector('.monaco-editor .parameter-hints-widget.visible');
+        const findWidgetVisible = !!editorDomNode.querySelector('.monaco-editor .find-widget.visible');
+        const renameInputVisible = !!editorDomNode.querySelector('.monaco-editor .rename-box');
+        return suggestVisible || parameterHintsVisible || findWidgetVisible || renameInputVisible
     }
 
     return {


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Proposed changes
Although this could be considered a bug fix, I have raised it against dev as it is intended to coincide with #5201 (more of a convenience to windows users who cannot use `CTRL+ESC`)

This PR listens to the monaco editors `onKeyDown` event and if the escape key was pressed, checks if any of the monaco widgets are open. If they are, we prevent default.

This permits user to use the muscle memory to escape (for example) multiple cursors, F2 rename box, find box, suggestion popup, etc without the ESC key bubbling up to the scope of the edit dialog.

**NOTE**

It is STILL possible to escape & exit the edit dialog by pressing escape one more time.
If we feel it is too risky, there are a couple of addition options we can take.
1. Prevent esc bubbling out of the monaco editor all together
3. Prevent esc bubbling out of the monaco editor if it contains changes
4. Show a modal asking the user if they really want to lose changes
   1. NB: this would only work for the content of the active/focused editor (changes to another monaco editor in the edit dialog would not capture this)

**NOTE** Regardless of whether we change the default "close without save" shortcut  to `ESC` in #5201 we should apply this PR for instances where a user specifically changes the shortcut to `ESC` themselves.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
