### PR TITLE
Update help document of filter node

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/rbe.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/rbe.html
@@ -1,5 +1,5 @@
 <script type="text/html" data-help-name="rbe">
-    <p>Report by Exception (RBE) node - only passes on data if the payload has changed.
+    <p>filter node - only passes on data if the payload has changed.
        It can also block unless, or ignore if the value changes by a specified amount (Dead- and Narrowband mode).</p>
     <h3>Inputs</h3>
     <dl class="message-properties">
@@ -12,7 +12,7 @@
         </dt>
         <dd>if specified the function will work on a per topic basis. This property can be set by configuration.</dd>
         <dt class="optional">reset<span class="property-type">any</span></dt>
-        <dd>if set clears the stored value for the specified msg.topic, or
+        <dd>if set clears the stored value for the specified <code>msg.topic</code>, or
             all topics if msg.topic is not specified.</dd>
     </dl>
     <h3>Outputs</h3>

--- a/packages/node_modules/@node-red/nodes/locales/ja/function/rbe.html
+++ b/packages/node_modules/@node-red/nodes/locales/ja/function/rbe.html
@@ -1,7 +1,7 @@
 <!-- Source revision: https://github.com/node-red/node-red-nodes/commit/467907776088422882076f46d85e25601449564d -->
 
 <script type="text/html" data-help-name="rbe">
-    <p>Report by Exception(例外データの報告)ノード - ペイロードの値が変化した場合だけデータを送信。</p>
+    <p>filterノード - ペイロードの値が変化した場合だけデータを送信。</p>
     <p>値が指定した量変化するまでブロックすることもできます- 不感帯(deadband)モード。</p>
     <h3>入力</h3>    <dl class="message-properties">
         <dt>payload
@@ -12,7 +12,7 @@
         </dt>
         <dd>指定すると、トピックごとに動作します。</dd>
         <dt class="optional">reset<span class="property-type">任意</span></dt>
-        <dd>値を設定すると、保存した値をクリアします。msg.topicを指定した場合は対応する値、指定しなければ全てのトピックが対象となります。</dd>
+        <dd>値を設定すると、保存した値をクリアします。<code>msg.topic</code>を指定した場合は対応する値、指定しなければ全てのトピックが対象となります。</dd>
     </dl>
     <h3>出力</h3>
     <dl class="message-properties">


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I found that the help document for the filter node uses the old name, rbe node. There is also no code block for msg.topic. Therefore, I fixed them in this pull request.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
