### PR TITLE
Fix inject node validation to support binary and hexadecimal numbers

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.html
@@ -248,8 +248,9 @@
                                 errors.push(RED._("node-red:inject.errors.invalid-json", { prop: 'msg.'+v[i].p, error: e.message }))
                             }
                         } else if (v[i].vt === "num"){
-                            if (!/^[+-]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?$/.test(v[i].v)) {
-                                errors.push(RED._("node-red:inject.errors.invalid-prop", { prop: 'msg.'+v[i].p, error: v[i].v }))
+                            const numValidation = RED.utils.validateTypedProperty(v[i].v, 'num', { prop: 'msg.'+v[i].p });
+                            if (numValidation !== true) {
+                                errors.push(numValidation || RED._("node-red:inject.errors.invalid-prop", { prop: 'msg.'+v[i].p, error: v[i].v }))
                             }
                         }
                     }


### PR DESCRIPTION
The inject node was using a restrictive regex that only accepted decimal numbers, while the switch node properly supported binary (0b) and hexadecimal (0x) formats. This inconsistency caused the inject node to show validation errors for valid number formats.

Updated the inject node to use the same validateTypedProperty utility function as the switch node, ensuring consistent number validation across both nodes.

Fixes #5208


- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Use more of the utils that are available seems to be the fix.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `npm run test` to verify the unit tests pass
- [X] I have added suitable unit tests to cover the new/changed functionality
