### PR TITLE
Add got to runtime package

### DIFF
--- a/packages/node_modules/@node-red/runtime/package.json
+++ b/packages/node_modules/@node-red/runtime/package.json
@@ -23,6 +23,7 @@
         "cronosjs": "1.7.1",
         "express": "4.21.2",
         "fs-extra": "11.3.0",
+        "got": "12.6.1",
         "json-stringify-safe": "5.0.1",
         "rfdc": "^1.3.1",
         "semver": "7.7.1"


### PR DESCRIPTION
The usage notification work added a use of `got` in the runtime module; but it didn't get added to that package's package.json file. It worked because `got` is a top level dependency and included in the `nodes` module - so would be discoverable on the node path.

However, when running in the FlowFuse Device Agent that also uses got, without an explicit dependency listed, it ends up loading the `got` from the agent - which is potentially a different version.