### PR TITLE
Add splice history events to original add event

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1520,6 +1520,7 @@ RED.view = (function() {
                 }
                 var nn;
                 var historyEvent;
+                let addHistoryEvent;
                 if (/^_action_:/.test(type)) {
                     const actionName = type.substring(9)
                     quickAddActive = false;
@@ -1553,6 +1554,7 @@ RED.view = (function() {
                     nn = result.node;
                     historyEvent = result.historyEvent;
                 }
+                addHistoryEvent = historyEvent;
                 if (keepAdding) {
                     mouse_mode = RED.state.QUICK_JOINING;
                 }
@@ -1707,7 +1709,8 @@ RED.view = (function() {
 
                 if (linkToSplice) {
                     resetMouseVars();
-                    spliceLink(linkToSplice, nn, historyEvent)
+                    // Add any history event data to the original add event
+                    spliceLink(linkToSplice, nn, addHistoryEvent)
                 }
                 RED.history.push(historyEvent);
                 RED.nodes.dirty(true);


### PR DESCRIPTION
Fixes #5219 

When adding a node into a group, the history event is stacked into a multi-type event.

When that also includes a link splice, the multi event was being updated with the splice undo details - whereas it needs to be on the original 'add' event.

This fixes that.