### PR TITLE
Fix node documentation icon for long catalog loading

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -336,6 +336,16 @@ RED.palette.editor = (function() {
 
             const moduleInfo = nodeEntries[module].info;
             const nodeEntry = nodeEntries[module].elements;
+
+            if (!moduleInfo.url) {
+                if (loadedIndex[module] && loadedIndex[module].url) {
+                    // Add the link to the node documentation if the catalog contains it
+                    moduleInfo.url = loadedIndex[module].url;
+                    const titleRow = $(nodeEntry.container).find("div.red-ui-palette-module-header > div.red-ui-palette-module-meta.red-ui-palette-module-name");
+                    $('<a target="_blank" class="red-ui-palette-module-link"><i class="fa fa-external-link"></i></a>').attr('href', moduleInfo.url).appendTo(titleRow);
+                }
+            }
+
             if (nodeEntry) {
                 const setCount = [];
 


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

#5143 added the icon to the node documentation. To do this, when adding an element to the node list (`nodeList.editableList('addItem', element)`), the URL is looked up in the catalog list and added to the node entry.

The problematic is that elements can be added before all catalogs are loaded; the DOM is built without the icon because the catalog list is empty at that time.

When all catalogs are loaded, each element of the list is refreshed (with `refreshNodeModuleList`), except that the URL is not updated because not handled in `_refreshNodeModule`.

I only noticed this problem now because my connection is slow. Before that I thought that loading catalogs during initialization left enough time before the construction of node elements.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
