### PR TITLE
Add tooltip for event log view

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -164,6 +164,7 @@
         }
     },
     "actions": {
+        "open-event-log": "Open event log",
         "toggle-navigator": "Toggle navigator",
         "zoom-out": "Zoom out",
         "zoom-reset": "Reset zoom",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -164,6 +164,7 @@
         }
     },
     "actions": {
+        "open-event-log": "イベントログを開く",
         "toggle-navigator": "ナビゲータの表示/非表示を切替",
         "zoom-out": "縮小",
         "zoom-reset": "拡大/縮小を初期化",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/event-log.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/event-log.js
@@ -51,6 +51,7 @@ RED.eventLog = (function() {
                 align: "right",
                 element: statusWidget
             });
+            RED.popover.tooltip(statusWidget, RED._('actions.open-event-log'));
             RED.statusBar.hide("red-ui-event-log-status");
 
         },


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
Users may want to know how the event log view works before clicking the button. Therefore, I added a tooltip to the button.

<img width="1161" height="517" alt="Screenshot 2025-08-03 at 9 27 53" src="https://github.com/user-attachments/assets/34966686-d968-4223-bbf4-a74ec0c3960e" />

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
