### PR TITLE
Speed up split node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -146,16 +146,16 @@ module.exports = function(RED) {
                     var pos = 0;
                     var data = value;
                     msg.parts.len = node.arraySplt;
+		    const newmsg = RED.utils.cloneMessge(msg)
                     for (var i=0; i<count; i++) {
                         var m = data.slice(pos,pos+node.arraySplt);
                         if (node.arraySplt === 1) {
                             m = m[0];
                         }
-                        const newmsg = RED.util.cloneMessage(msg)
                         RED.util.setMessageProperty(newmsg,node.property,m);
                         newmsg.parts.index = i;
                         pos += node.arraySplt;
-                        send(newmsg);
+                        send(RED.utils.cloneMessage(newmsg));
                     }
                     done();
                 }

--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -146,7 +146,7 @@ module.exports = function(RED) {
                     var pos = 0;
                     var data = value;
                     msg.parts.len = node.arraySplt;
-                    const newmsg = RED.utils.cloneMessge(msg)
+                    const newmsg = RED.util.cloneMessage(msg)
                     for (var i=0; i<count; i++) {
                         var m = data.slice(pos,pos+node.arraySplt);
                         if (node.arraySplt === 1) {
@@ -155,7 +155,7 @@ module.exports = function(RED) {
                         RED.util.setMessageProperty(newmsg,node.property,m);
                         newmsg.parts.index = i;
                         pos += node.arraySplt;
-                        send(RED.utils.cloneMessage(newmsg));
+                        send(RED.util.cloneMessage(newmsg));
                     }
                     done();
                 }

--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -146,7 +146,7 @@ module.exports = function(RED) {
                     var pos = 0;
                     var data = value;
                     msg.parts.len = node.arraySplt;
-		    const newmsg = RED.utils.cloneMessge(msg)
+                    const newmsg = RED.utils.cloneMessge(msg)
                     for (var i=0; i<count; i++) {
                         var m = data.slice(pos,pos+node.arraySplt);
                         if (node.arraySplt === 1) {


### PR DESCRIPTION
fixes #5251

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
The code changed from 4.0.x to 4.1.x

This change to to prevent making changes to the orginial input `msg` object incase any values were stored in context (pass by reference).

The change meant that for every output message the whole original input `msg` was being cloned, which could be huge, causing a big performance regresion.

This fix ensures the clone of the orginial `msg` is only done once and the much smaller output message is then cloned again to update `msg.parts` object for each output. This results in lots of small clones rather than lots of very large clones.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
