### PR TITLE
Add 'url' module to default server-side types in Monaco editor

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
@@ -108,7 +108,7 @@ RED.editor.codeEditor.monaco = (function() {
         "node-red-util": {package: "node-red", module: "util", path: "node-red/util.d.ts" },
         "node-red-func": {package: "node-red", module: "func", path: "node-red/func.d.ts" },
     }
-    const defaultServerSideTypes = [ knownModules["node-red-util"], knownModules["node-red-func"], knownModules["globals"], knownModules["console"], knownModules["buffer"], knownModules["timers"] , knownModules["util"] ];
+    const defaultServerSideTypes = [ knownModules["node-red-util"], knownModules["node-red-func"], knownModules["globals"], knownModules["console"], knownModules["buffer"], knownModules["timers"], knownModules["url"] , knownModules["util"] ];
 
     const modulesCache = {};
 


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

URL and URLSearchParams are [available for use in a function](https://github.com/node-red/node-red/blob/9ad329e5a184cbd749f4cacf30ae775d1205eba6/packages/node_modules/%40node-red/nodes/core/function/10-function.js#L165-L166) however they appear as errors in the monaco editor. 
This PR fixes that be adding the `url` module to the known modules list.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
