### PR TITLE
Handle plugin name in `plugins.getConfig`

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/admin/plugins.js
+++ b/packages/node_modules/@node-red/editor-api/lib/admin/plugins.js
@@ -46,6 +46,7 @@ module.exports = {
         let opts = {
             user: req.user,
             module: req.params[0],
+            name: req.params[2],
             req: apiUtils.getRequestLogObject(req)
         }
 

--- a/packages/node_modules/@node-red/registry/lib/plugins.js
+++ b/packages/node_modules/@node-red/registry/lib/plugins.js
@@ -74,11 +74,19 @@ function getPluginConfigs(lang) {
     return pluginConfigCache[lang];
 }
 
-function getPluginConfig(id, lang) {
+function getPluginConfig(module, name) {
     let result = '';
     let moduleConfigs = registry.getModuleList();
-    if (moduleConfigs.hasOwnProperty(id)) {
-        result = generateModulePluginConfig(moduleConfigs[id]);
+    if (moduleConfigs.hasOwnProperty(module)) {
+        if (!name) {
+            result = generateModulePluginConfig(moduleConfigs[module]);
+        } else {
+            const config = moduleConfigs[module].plugins[name];
+            if (config && config.enabled && !config.err && config.config) {
+                result += "\n<!-- --- [red-plugin:"+config.id+"] --- -->\n";
+                result += config.config;
+            }
+        }
     }
     return result;
 }

--- a/packages/node_modules/@node-red/runtime/lib/api/plugins.js
+++ b/packages/node_modules/@node-red/runtime/lib/api/plugins.js
@@ -81,7 +81,7 @@ var api = module.exports = {
             return;
         }
         runtime.log.audit({event: "plugins.configs.get"}, opts.req);
-        return runtime.plugins.getPluginConfig(opts.module, opts.lang);
+        return runtime.plugins.getPluginConfig(opts.module, opts.name);
     },
 
     /**


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

If I do a GET request to `/plugins/my-plugin-module/my-plugin`, the response should be the configuration of the `my-plugin` plugin and not each configuration contained in `my-plugin-module`.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
