### PR TITLE
Notify installed plugins from the Palette Manager

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/nodes/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/index.js
@@ -172,9 +172,10 @@ function installModule(module,version,url) {
         if (info.pending_version) {
             events.emit("runtime-event",{id:"node/upgraded",retain:false,payload:{module:info.name,version:info.pending_version}});
         } else {
-            if (!info.nodes.length && info.plugins.length) {
+            if (info.plugins.length) {
                 events.emit("runtime-event",{id:"plugin/added",retain:false,payload:info.plugins});
-            } else {
+            }
+            if (info.nodes.length) {
                 events.emit("runtime-event",{id:"node/added",retain:false,payload:info.nodes});
             }
         }


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

If a palette containing both nodes AND plugins is installed from the Palette Manager, plugins will not be loaded by the editor without a refresh.

The `node/added` event is triggered to add new types (sets) to the editor, but plugins are not sent. They are only sent if the module does not contain any nodes.

Steps to reproduce:

1. Install `node-red-contrib-uibuilder`
2. See 10 nodes and 0 plugin
3. Refresh the browser
4. See 10 nodes and 2 plugins

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
