### PR TITLE
Fix undo node output changes inside a Subflow

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/history.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/history.js
@@ -582,22 +582,23 @@ RED.history = (function() {
                         RED.editor.updateNodeProperties(n);
                         RED.editor.validateNode(n);
                     });
-                } else {
-                    var outputMap;
-                    if (ev.outputMap) {
-                        outputMap = {};
-                        inverseEv.outputMap = {};
-                        for (var port in ev.outputMap) {
-                            if (ev.outputMap.hasOwnProperty(port) && ev.outputMap[port] !== "-1") {
-                                outputMap[ev.outputMap[port]] = port;
-                                inverseEv.outputMap[ev.outputMap[port]] = port;
-                            }
+                }
+
+                let outputMap;
+                if (ev.outputMap) {
+                    outputMap = {};
+                    inverseEv.outputMap = {};
+                    for (var port in ev.outputMap) {
+                        if (ev.outputMap.hasOwnProperty(port) && ev.outputMap[port] !== "-1") {
+                            outputMap[ev.outputMap[port]] = port;
+                            inverseEv.outputMap[ev.outputMap[port]] = port;
                         }
                     }
-                    ev.node.__outputs = inverseEv.changes.outputs;
-                    RED.editor.updateNodeProperties(ev.node,outputMap);
-                    RED.editor.validateNode(ev.node);
                 }
+                ev.node.__outputs = inverseEv.changes.outputs;
+                RED.editor.updateNodeProperties(ev.node,outputMap);
+                RED.editor.validateNode(ev.node);
+
                 // If it's a Config Node, validate user nodes too.
                 // NOTE: The Config Node must be validated before validating users.
                 if (ev.node.users) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1179,7 +1179,7 @@ RED.editor = (function() {
                             if (editState.outputMap) {
                                 historyEvent.outputMap = editState.outputMap;
                             }
-                            if (subflowInstances) {
+                            if (subflowInstances && subflowInstances.length) {
                                 historyEvent.subflow = {
                                     instances:subflowInstances
                                 }


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #5275.

- If no instance, there is no point in adding it to the history.
- If I modify the switch node (inside the Subflow) and this Subflow has an instance, the history will have `ev.subflow` and will not update the outputs. I propose to remove the `else`.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
