### PR TITLE
(Palette Manager): Allow update from the `install` tab

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -776,6 +776,15 @@ RED.palette.editor = (function() {
 
             refreshNodeModule(ns.module);
             refreshUpdateStatus();
+
+            for (let i = 0; i < filteredList.length; i++) {
+                if (filteredList[i].info.id === ns.module) {
+                    const updateButton = filteredList[i].elements.updateButton;
+                    updateButton.addClass('disabled');
+                    updateButton.text(RED._('palette.editor.updated'));
+                    break;
+                }
+            }
         });
         RED.events.on('registry:node-set-enabled', function(ns) {
             refreshNodeModule(ns.module);
@@ -1353,9 +1362,33 @@ RED.palette.editor = (function() {
                             install(entry,container,function(xhr) {});
                         }
                     })
+
+                    const updateButton = $('<a href="#" class="red-ui-button red-ui-button-small"></a>').text(RED._('palette.editor.update')).appendTo(buttonGroup);
+                    updateButton.on("click", function (evt) {
+                        evt.preventDefault();
+                        if ($(this).hasClass('disabled')) {
+                            return;
+                        }
+                        update(entry, loadedIndex[entry.id].version, loadedIndex[entry.id].pkg_url, container, function(err){});
+                    });
+                    updateButton.hide();
+
                     if (nodeEntries.hasOwnProperty(entry.id)) {
-                        installButton.addClass('disabled');
-                        installButton.text(RED._('palette.editor.installed'));
+                        const moduleInfo = nodeEntries[entry.id].info;
+                        if (moduleInfo.pending_version) {
+                            installButton.hide();
+                            updateButton.text(RED._('palette.editor.updated')).addClass('disabled').css('display', 'inline-block');
+                        } else if (updateAllowed &&
+                            semVerCompare(loadedIndex[entry.id].version, moduleInfo.version) > 0 &&
+                            RED.utils.checkModuleAllowed(entry.id, null, updateAllowList, updateDenyList)
+                        ) {
+                            installButton.hide();
+                            updateButton.show();
+                            updateButton.text(RED._('palette.editor.update',{ version: loadedIndex[entry.id].version }));
+                        } else {
+                            installButton.addClass('disabled');
+                            installButton.text(RED._('palette.editor.installed'));
+                        }
                     } else if (duplicateType) {
                         installButton.addClass('disabled');
                         installButton.text(RED._('palette.editor.conflict'));
@@ -1369,7 +1402,8 @@ RED.palette.editor = (function() {
                     }
 
                     object.elements = {
-                        installButton:installButton
+                        installButton:installButton,
+                        updateButton:updateButton
                     }
                 } else {
                     $('<div>',{class:"red-ui-search-empty"}).text(RED._('search.empty')).appendTo(container);
@@ -1466,7 +1500,8 @@ RED.palette.editor = (function() {
         }
 
         let notification;
-        let msg = RED._("palette.editor.confirm.update.body", { module: entry.name });
+        const name = entry.name || entry.id;
+        let msg = RED._("palette.editor.confirm.update.body", { module: name });
         const buttons = [
             {
                 text: RED._("common.label.cancel"),
@@ -1484,11 +1519,11 @@ RED.palette.editor = (function() {
                         evt.preventDefault();
                         RED.actions.invoke("core:show-event-log");
                     });
-                    installNodeModule(entry.name, version, url, function (xhr) {
+                    installNodeModule(name, version, url, function (xhr) {
                         spinner.remove();
                         if (xhr) {
                             if (xhr.responseJSON) {
-                                const notification = RED.notify(RED._('palette.editor.errors.updateFailed',{module: entry.name,message:xhr.responseJSON.message}),{
+                                const notification = RED.notify(RED._('palette.editor.errors.updateFailed',{module: name,message:xhr.responseJSON.message}),{
                                     type: 'error',
                                     modal: true,
                                     fixed: true,
@@ -1516,7 +1551,7 @@ RED.palette.editor = (function() {
             }
         ];
 
-        const currentVersion = semverre.exec(nodeEntries[entry.name].info.version);
+        const currentVersion = semverre.exec(nodeEntries[name].info.version);
         const targetVersion = semverre.exec(version);
         if (currentVersion && targetVersion) {
             if (targetVersion[1] > currentVersion[1]) {


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

To avoid confusion between current and next versions, this PR adds an `Update` button to the `Install` tab of the Palette Manager.

If the palette is not installed, the active button is `install`.
If the palette is installed:
- and up-to-date - `installed`
- update possible (and allowed) - `update`
- updated - `updated`

The `update` function has been modified to accept `entry.id` as `name` because `entry.name` is not always defined.

Forum discussion: https://discourse.nodered.org/t/update-notification-in-manage-palette/99128

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
