### PR TITLE
Fix: Avoid communication queue overflow with warning and throttling mechan…

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/comms.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/comms.js
@@ -314,6 +314,8 @@ function addActiveConnection(connection) {
     runtimeAPI.comms.addConnection({client: connection});
 }
 function removeActiveConnection(connection) {
+    // Clear pending messages.
+    connection.stack = []
     for (var i=0;i<activeConnections.length;i++) {
         if (activeConnections[i] === connection) {
             activeConnections.splice(i,1);

--- a/packages/node_modules/@node-red/editor-api/lib/editor/comms.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/comms.js
@@ -36,6 +36,9 @@ var anonymousUser;
 var heartbeatTimer;
 var lastSentTime;
 
+const MAX_STACK_SIZE = 10_000;
+const MAX_STACK_SIZE_WARN_COOLDOWN_MILLIS = 30_000;
+
 function init(_server,_settings,_runtimeAPI) {
     server = _server;
     settings = _settings;
@@ -62,6 +65,8 @@ function CommsConnection(ws, user) {
     this.stack = [];
     this.user = user;
     this.lastSentTime = 0;
+    this.lastOverflowWarning = 0;
+    this.totalDroppedSinceLastWarning = 0;
     var self = this;
 
     log.audit({event: "comms.open"});
@@ -172,7 +177,40 @@ function CommsConnection(ws, user) {
 
 CommsConnection.prototype.send = function(topic,data) {
     if (topic && data) {
-        this.stack.push({topic:topic,data:data});
+        if (this.stack.length < MAX_STACK_SIZE) {
+            this.stack.push({topic:topic,data:data});
+        } else {
+            // Overflow.
+            this.totalDroppedSinceLastWarning++;
+
+            var now = Date.now();
+            if (this.lastOverflowWarning === 0 || now - this.lastOverflowWarning > MAX_STACK_SIZE_WARN_COOLDOWN_MILLIS) {
+                // Set the timestamp now so that the call to log.warn will not create a
+                // stack overflow due to the if-condition matching.
+                this.lastOverflowWarning = now;
+
+                // Assemble warning message.
+                let lastDroppedMessage = {topic:topic,data:data}
+                let warnMessage = `Communication queue overflow for session ${this.session} - dropped ${this.totalDroppedSinceLastWarning} message(s) in last period (limit: ${MAX_STACK_SIZE}).\nCheck extensive usage of debug nodes or status updates from third-party nodes.\nLast dropped message: ${JSON.stringify(lastDroppedMessage)}`
+                log.warn(warnMessage);
+
+                // Send notification directly via WebSocket for immediate feedback (bypassing the queue).
+                try {
+                    this.ws.send(JSON.stringify([{
+                        topic: "debug",
+                        data: {
+                            level: log.WARN,
+                            format: "warning",
+                            msg: warnMessage,
+                        }
+                    }]));
+                } catch(err) {
+                    // Silently ignore WebSocket send errors during overflow.
+                }
+                // Reset the counter.
+                this.totalDroppedSinceLastWarning = 0;
+            }
+        }
     }
     this._queueSend();
 }


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] ~~New feature (non-breaking change which adds functionality)~~

## Proposed changes

If debug nodes or status updates from nodes are used extensively, messages accumulate in the `CommsConnection`.
It holds a queue to which the messages get appended.
The logic for sending up to 50 messages every 50ms leads to excessive memory usage if the UI is opened by a user and messages are arriving faster than every 1ms which is often the case for high-volume data processing where one may receive thousands of updates per second if users forgot to disable/properly manage debug nodes.
This may result in system instability and also makes debugging the issue hard as the "suspected memory leak" only shows when the UI is opened somewhere.

A missing discard of pending messages on disconnect also leads to a slow decline of memory usage because of 1 message/ms being handled.

The proposed changes introduce the following:
- Cap the message queue size at 10,000
- If the limit is exceeded, log a warning to the server log and immediately to the UI log
- Drop new messages
- Overflow warnings use a cooldown of 30 seconds before firing again.

Although this is not a clean solution, this fixes the problem with system instability.

In the future, better detection of the actual sources/culprits may be introduced for improved feedback and to avoid the hard drop of messages.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] ~~I have added suitable unit tests to cover the new/changed functionality~~
