### PR TITLE
Fix `onremove` is not called on a pure editor plugin

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -684,7 +684,7 @@
                     "title": "Remove nodes"
                 },
                 "removePlugin": {
-                    "body": "<p>Removed plugin __module__. Please reload the editor to clear left-overs.</p>"
+                    "body": "<p>Removed plugin __module__. Please reload the editor to continue.</p>"
                 },
                 "update": {
                     "body": "<p>Updating '__module__'</p><p>Updating the node will require a restart of Node-RED to complete the update. This must be done manually.</p>",

--- a/packages/node_modules/@node-red/editor-client/locales/fr/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/fr/editor.json
@@ -682,7 +682,7 @@
           "title": "Supprimer les noeuds"
         },
         "removePlugin": {
-          "body": "<p>Suppression du plugin '__module__'. Veuillez recharger l'éditeur afin d'appliquer les changements.</p>"
+          "body": "<p>Suppression du plugin '__module__'. Veuillez recharger l'éditeur pour continuer.</p>"
         },
         "update": {
           "body": "<p>Mise à jour de '__module__'</p><p>La mise à jour du noeud nécessitera un redémarrage de Node-RED pour terminer la mise à jour. Cela doit être fait manuellement.</p>",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -1612,22 +1612,32 @@ RED.palette.editor = (function() {
                                         refreshUpdateStatus();
                                     }
 
+                                    const pluginList = [];
+                                    Object.entries(entry.pluginSet).forEach(([key, set]) => {
+                                        if (set.plugins && set.plugins.length) {
+                                            // Adds ID of plugins that exist in the runtime
+                                            pluginList.push(...set.plugins.map((plugin) => plugin.id));
+                                        } else {
+                                            // Adds ID of plugins that only exist in the editor
+                                            pluginList.push(key);
+                                        }
+                                    });
+
                                     // We assume that a plugin that implements onremove
                                     // cleans the editor accordingly of its left-overs.
                                     let found_onremove = true;
-
-                                    let keys = Object.keys(entry.pluginSet);
-                                    keys.forEach((key) => {
-                                        let set = entry.pluginSet[key];
-                                        for (let i=0; i<set.plugins?.length; i++) {
-                                            let plgn = RED.plugins.getPlugin(set.plugins[i].id);
-                                            if (plgn && plgn.onremove  && typeof plgn.onremove === 'function') {
-                                                plgn.onremove();
-                                            } else {
-                                                if (plgn && plgn.onadd && typeof plgn.onadd === 'function') {
-                                                    // if there's no 'onadd', there shouldn't be any left-overs
-                                                    found_onremove = false;
+                                    pluginList.forEach((id) => {
+                                        const plugin = RED.plugins.getPlugin(id);
+                                        if (plugin) {
+                                            if (plugin.onremove && typeof plugin.onremove === 'function') {
+                                                try {
+                                                    plugin.onremove();
+                                                } catch (error) {
+                                                    console.warn(`Error while calling 'onremove' for plugin '${id}': `, error);
                                                 }
+                                            } else if (plugin.onadd && typeof plugin.onadd === 'function') {
+                                                // if there's no 'onadd', there shouldn't be any left-overs
+                                                found_onremove = false;
                                             }
                                         }
                                     });

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -1615,10 +1615,10 @@ RED.palette.editor = (function() {
                                     const pluginList = [];
                                     Object.entries(entry.pluginSet).forEach(([key, set]) => {
                                         if (set.plugins && set.plugins.length) {
-                                            // Adds ID of plugins that exist in the runtime
+                                            // Adds ID of plugins that exist in the runtime and possibly in the editor
                                             pluginList.push(...set.plugins.map((plugin) => plugin.id));
                                         } else {
-                                            // Adds ID of plugins that only exist in the editor
+                                            // Adds plugin ID that only exist in the editor
                                             pluginList.push(key);
                                         }
                                     });
@@ -1629,16 +1629,20 @@ RED.palette.editor = (function() {
                                     pluginList.forEach((id) => {
                                         const plugin = RED.plugins.getPlugin(id);
                                         if (plugin) {
-                                            if (plugin.onremove && typeof plugin.onremove === 'function') {
+                                            if (typeof plugin.onremove === 'function') {
                                                 try {
                                                     plugin.onremove();
                                                 } catch (error) {
                                                     console.warn(`Error while calling 'onremove' for plugin '${id}': `, error);
                                                 }
-                                            } else if (plugin.onadd && typeof plugin.onadd === 'function') {
+                                            } else if (typeof plugin.onadd === 'function') {
                                                 // if there's no 'onadd', there shouldn't be any left-overs
                                                 found_onremove = false;
                                             }
+                                        } else {
+                                            // Either the plugin exists only in the runtime or it is a known limitation
+                                            // of purely editor plugins which must have their ID identical to that
+                                            // defined in the package.json
                                         }
                                     });
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -1636,8 +1636,11 @@ RED.palette.editor = (function() {
                                                     console.warn(`Error while calling 'onremove' for plugin '${id}': `, error);
                                                 }
                                             } else if (typeof plugin.onadd === 'function') {
-                                                // if there's no 'onadd', there shouldn't be any left-overs
+                                                // We assume that the plugin adds something to the editor but is not able to remove it
+                                                // Notify the user to refresh the editor to remove that plugin
                                                 found_onremove = false;
+                                            } else {
+                                                // If there's no 'onadd', there shouldn't be any left-overs
                                             }
                                         } else {
                                             // Either the plugin exists only in the runtime or it is a known limitation


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

The `onremove` method is not called on a plugin that exists only in the editor.

If `set.plugins` is empty, the plugin has no part in the runtime.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
