### PR TITLE
Fix env autocomplete result if searchKey starts with `${`

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -179,7 +179,7 @@
                     optEl.appendTo(element);
                 }
                 matches.push({
-                    value: isSubkey ? val + v + '}' : v,
+                    value: isSubkey ? val.substring(0, i + 2) + v + '}' : v,
                     label: element,
                     i: valMatch.index
                 });


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #5289.

If `subKey` is active, must remove everything after the last `${` to replace the entry.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
