### PR TITLE
Prevents label from taking up all the space for env autocomplete

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -165,7 +165,7 @@
                 valEl.appendTo(element)
 
                 if (optSrc) {
-                    const optEl = $('<div>').css({ "font-size": "0.8em" });
+                    const optEl = $('<div/>', { class: "red-ui-autoComplete-env-label" });
                     let label
                     if (optSrc.type === 'global-config') {
                         label = RED._('sidebar.context.global')

--- a/packages/node_modules/@node-red/editor-client/src/sass/ui/common/autoComplete.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/ui/common/autoComplete.scss
@@ -13,4 +13,12 @@
     text-overflow: ellipsis;
     direction: rtl;
     text-align: left;
+    padding-right: 16px;
+}
+.red-ui-autoComplete-env-label {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 0.8em;
+    max-width: 70%;
 }


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #5286.

It may not be perfect, but it limits how far the label can go.

Previews:

<img width="350" height="191" alt="Capture d’écran 2025-10-08 à 15 15 26" src="https://github.com/user-attachments/assets/7c4da9e8-c7d3-4f1f-830f-e6682c3c8c65" />

<img width="580" height="191" alt="Capture d’écran 2025-10-08 à 15 16 02" src="https://github.com/user-attachments/assets/dc258c78-bfb0-468a-bbbd-6952c5a9dcce" />


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
