### PR TITLE
Ignore disabled nodes when checking for dependency modules

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/externalModules.js
+++ b/packages/node_modules/@node-red/registry/lib/externalModules.js
@@ -171,6 +171,10 @@ async function checkFlowDependencies(flowConfig) {
     const checkedSubflows = {};
     while (nodes.length > 0) {
         let n = nodes.shift();
+        if (n.d) {
+            // Ignore disabled nodes
+            continue
+        }
         if (subflowTypes[n.type] && !checkedSubflows[n.type]) {
             checkedSubflows[n.type] = true;
             nodes = nodes.concat(subflowTypes[n.type].flow)


### PR DESCRIPTION
Fixes #5256 

Skip over disabled nodes when searching for external modules to install