### PR TITLE
Handle subflow virtual port nodes when generating quick-add context

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -1627,7 +1627,9 @@ RED.nodes = (function() {
                 if (node.type === "group") {
                     nns = nns.concat(createExportableNodeSet(node.nodes, { exportedIds, exportedSubflows, exportedConfigNodes }));
                 }
-            } else {
+            } else if (!node.direction) {
+                // node.direction indicates its a virtual subflow node (input/output/status) that cannot be
+                // exported so should be skipped over.
                 var convertedSubflow = convertSubflow(node, { credentials: false });
                 nns.push(convertedSubflow);
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1418,7 +1418,12 @@ RED.view = (function() {
             if (quickAddLink?.virtualLink) {
                 context.virtualLink = true;
             }
-            context.flow = RED.nodes.createExportableNodeSet(RED.nodes.getAllFlowNodes(quickAddLink.node))
+            if (quickAddLink.node?.type === 'subflow') {
+                // This is a subflow 'virtual' port node. 
+                context.flow = []
+            } else {
+                context.flow = RED.nodes.createExportableNodeSet(RED.nodes.getAllFlowNodes(quickAddLink.node))
+            }
         }
 
         // console.log(context)


### PR DESCRIPTION
Fixes #5242 

When triggering Quick-Add dialog from a subflow virtual port, we were trying to generate an exportable flow config that included the virtual port - which isn't possible.

This PR fixes it by filtering for that case, plus protects `createExportableNodeSet` from trying to export these virtual ports.