### PR TITLE
Do not assume rawBody middleware is last in stack when moving it

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/21-httpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httpin.js
@@ -129,8 +129,17 @@ module.exports = function(RED) {
     if(typeof RED.httpNode === 'function' && (rootApp = getRootApp(RED.httpNode))) {
         // Add middleware to the stack
         rootApp.use(rawBodyCapture);
-        // Move the middleware to top of the stack 
-        rootApp._router.stack.unshift(rootApp._router.stack.pop());
+        // Find the newly added middleware and move it to the top of the stack
+        // Do not assume its the last entry in the stack as some frameworks (eg loopback)
+        // add middleware in particular orders
+        for (let i = 0; i < rootApp._router.stack.length; i++) {
+            const layer = rootApp._router.stack[i];
+            if (layer && layer.handle === rawBodyCapture) {
+                // Move the middleware to top of the stack 
+                rootApp._router.stack.unshift(rootApp._router.stack.splice(i, 1)[0]);
+                break;
+            }
+        }
     }
 
     function createRequestWrapper(node,req) {


### PR DESCRIPTION
Fixes #5287


The HTTP In node manipulates the middleware stack to ensure the raw body parser comes first. It previously assumed the just-added middleware would be last in the list, but as reported in the parent issue, loopback doesn't work like that.

This PR scans the stack to find the body parser, rather than assume it's last in the list. We still reinserts at the top of the stack - need to validate if that is okay in loopback.