### PR TITLE
Move `Selection to Subflow` to the context menu

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -800,8 +800,7 @@ var RED = (function() {
             {id:"menu-item-workspace-delete",label:RED._("menu.label.delete"),onselect:"core:remove-flow"}
         ]});
         menuOptions.push({id:"menu-item-subflow",label:RED._("menu.label.subflows"), options: [
-            {id:"menu-item-subflow-create",label:RED._("menu.label.createSubflow"),onselect:"core:create-subflow"},
-            {id:"menu-item-subflow-convert",label:RED._("menu.label.selectionToSubflow"),disabled:true,onselect:"core:convert-to-subflow"},
+            {id:"menu-item-subflow-create",label:RED._("menu.label.createSubflow"),onselect:"core:create-subflow"}
         ]});
         menuOptions.push({id:"menu-item-group",label:RED._("menu.label.groups"), options: [
             {id:"menu-item-group-group",label:RED._("menu.label.groupSelection"),disabled:true,onselect:"core:group-selection"},

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
@@ -187,6 +187,13 @@ RED.contextMenu = (function () {
                     { onselect: 'core:copy-group-style', label: RED._("keyboard.copyGroupStyle"), disabled: !hasGroup },
                     { onselect: 'core:paste-group-style', label: RED._("keyboard.pasteGroupStyle"), disabled: !hasGroup}
                 )
+
+                menuItems.push({
+                    label: RED._('sidebar.info.subflow'),
+                    options: [
+                        { onselect: 'core:convert-to-subflow', label: RED._("menu.label.selectionToSubflow") },
+                    ]
+                })
             }
             if (canEdit && hasMultipleSelection) {
                 menuItems.push({

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/subflow.js
@@ -574,13 +574,6 @@ RED.subflow = (function() {
                 hideWorkspaceToolbar();
             }
         });
-        RED.events.on("view:selection-changed",function(selection) {
-            if (!selection.nodes || RED.workspaces.isLocked()) {
-                RED.menu.setDisabled("menu-item-subflow-convert",true);
-            } else {
-                RED.menu.setDisabled("menu-item-subflow-convert",false);
-            }
-        });
 
         RED.actions.add("core:create-subflow",createSubflow);
         RED.actions.add("core:convert-to-subflow",convertToSubflow);


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Closes #5261.

Move `Selection to Subflow` from the menu to the context menu.

Preview:

<img width="545" height="215" alt="Capture d’écran 2025-10-10 à 14 25 26" src="https://github.com/user-attachments/assets/9a72d4fe-1463-4758-9168-ec0ca4b51793" />

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
