### PR TITLE
Force a redraw after clearing suggested flow on mouse down

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -6725,6 +6725,7 @@ RED.view = (function() {
             if (suggestion.clickToApply) {
                 $(window).on('mousedown.suggestedFlow', function (evnt) {
                     clearSuggestedFlow();
+                    RED.view.redraw(true);
                 })
             }
         }


### PR DESCRIPTION
Fixes #5244

We already had a mouse handler to deal with this, but we weren't forcing a redraw - so the suggested flow remained visible.