### PR TITLE
Simplify error logging when issue in settings file

### DIFF
--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -163,13 +163,7 @@ try {
     settings.settingsFile = settingsFile;
 } catch(err) {
     console.log("Error loading settings file: "+settingsFile)
-    if (err.code == 'MODULE_NOT_FOUND') {
-        if (err.toString().indexOf(settingsFile) === -1) {
-            console.log(err.toString());
-        }
-    } else {
-        console.log(err);
-    }
+    console.log(err);
     process.exit(1);
 }
 


### PR DESCRIPTION
There was a gap in the `if` statements around logging errors in the settings file that would mean no error gets logged for certain scenarios.

Having examined the logic, I've kept it simple - no reason not to always log the full error.