### PR TITLE
Fix `RED.comms.subscribe` callback on error

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/comms.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/comms.js
@@ -120,8 +120,8 @@ RED.comms = (function() {
                                                 subscribers[i](msg.topic,msg.data);
                                             } catch (error) {
                                                 // need to decide what to do with this uncaught error
-                                                console.warn('Uncaught error from RED.comms.subscribe: ' + err.toString())
-                                                console.warn(err)
+                                                console.warn('Uncaught error from RED.comms.subscribe: ' + error.toString())
+                                                console.warn(error)
                                             }
                                         }
                                     }


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Introduced by #5263, the error to print is `error` and not `err`.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
