### PR TITLE
Fix dropped statuses when resolving missing types

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -529,7 +529,8 @@ var RED = (function() {
         RED.comms.subscribe("status/#",function(topic,msg) {
             var parts = topic.split("/");
             var node = RED.nodes.node(parts[1]);
-            if (node) {
+            // Nodes of type unknown do not have i18n
+            if (node && typeof node._ === "function") {
                 if (msg.hasOwnProperty("text") && msg.text !== null && /^[@a-zA-Z]/.test(msg.text)) {
                     msg.text = node._(msg.text.toString(),{defaultValue:msg.text.toString()});
                 }

--- a/packages/node_modules/@node-red/runtime/lib/api/comms.js
+++ b/packages/node_modules/@node-red/runtime/lib/api/comms.js
@@ -87,6 +87,15 @@ function publish(topic, data, retain, session, excludeSession) {
     })
 }
 
+function republishStatus() {
+    for (const topic in retained) {
+        if (/^status(\/.*)?$/.test(topic)) {
+            connections.forEach((connection) => {
+                connection.send(topic, retained[topic]);
+            });
+        }
+    }
+}
 
 var api = module.exports = {
     init: function(_runtime) {
@@ -101,6 +110,8 @@ var api = module.exports = {
         events.on("comms",handleCommsEvent);
         events.removeListener("event-log",handleEventLog);
         events.on("event-log",handleEventLog);
+        events.removeListener("comms:republish-status", republishStatus);
+        events.on("comms:republish-status", republishStatus);
     },
 
     /**

--- a/packages/node_modules/@node-red/runtime/lib/nodes/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/index.js
@@ -177,6 +177,9 @@ function installModule(module,version,url) {
             }
             if (info.nodes.length) {
                 events.emit("runtime-event",{id:"node/added",retain:false,payload:info.nodes});
+                // If the installed module resolves missing types, nodes will be started before the editor 
+                // is notified of added types. Therefore, statuses published before the type resolution will be lost.
+                events.emit("comms:republish-status");
             }
         }
         return info;


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

If a user installs a module that resolves missing types, previously stopped flows will start before the editor is notified of the added types. Therefore, statuses published before the editor loads the definitions will be dropped.

The bug occurs when the editor receives a status but the node at that time is still of type `unknown`, which causes an error because i18n (`node._`) does not exist on these nodes. Replacing the node definition fails and the status is dropped.

To resolve this bug, I propose ignoring the status if i18n is not available and also republishing statuses when the module installation is complete (after the editor is notified of the added types).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
