### PR TITLE
Fix race condition in projects initialization by returning gitTools.init() promise

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/index.js
@@ -92,7 +92,7 @@ function init(_settings, _runtime) {
 
     if (projectsEnabled) {
         return sshTools.init(settings,runtime).then(function() {
-            gitTools.init(_settings).then(function(gitConfig) {
+            return gitTools.init(_settings).then(function(gitConfig) {
                 if (!gitConfig || /^1\./.test(gitConfig.version)) {
                     if (!gitConfig) {
                         projectLogMessages.push(log._("storage.localfilesystem.projects.git-not-found"))


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

### Problem
There is a race condition in the projects initialization code that causes the active project to intermittently fail to load on startup. This manifests as:
- "No active project : using default flows file" warning appearing randomly
- Flows loading from the wrong location
- Inconsistent behavior between application restarts

### Root Cause
In `lib/storage/localfilesystem/projects/index.js` at line 95, the `gitTools.init()` promise is not returned, breaking the promise chain. This causes the `init()` function to resolve before the active project settings are loaded asynchronously.

```javascript
// Current (broken):
return sshTools.init(settings,runtime).then(function() {
    gitTools.init(_settings).then(function(gitConfig) {  // Missing return!
        // ... async operations to load and set activeProject
    });
});
```

When `getFlows()` is called later during startup, it may execute before `activeProject` is set (line 139), causing the runtime to fall back to the default flows file.

### Solution
Add the missing `return` statement on line 95 to properly chain the promise:

```javascript
return sshTools.init(settings,runtime).then(function() {
    return gitTools.init(_settings).then(function(gitConfig) {  // Added return
        // ... async operations to load and set activeProject
    });
});
```

This ensures the entire initialization sequence completes before the runtime proceeds to load flows.

### Testing
The race condition is timing-dependent. It typically occurs when:
- Projects feature is enabled (`editorTheme.projects.enabled: true`)
- An active project exists in settings
- Palette nodes load quickly

After the fix, the active project loads consistently on every startup.
