### PR TITLE
Add node actions to enable/disable the Inject node button

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/core/common/20-inject.html
@@ -220,6 +220,21 @@
             }
         });
     }
+    /** Enable or disable the node button */
+    function updateNodeButton(node, enable) {
+        RED.history.push({
+            t: "edit",
+            changed: node.changed,
+            changes: { buttonDisabled: node.buttonDisabled },
+            dirty: RED.nodes.dirty(),
+            node: node,
+        });
+        node.buttonDisabled = !enable;
+        node.changed = true;
+        node.dirty = true;
+        RED.nodes.dirty(true);
+        RED.view.redraw();
+    }
     RED.nodes.registerType('inject',{  
         category: 'common',
         color:"#a6bbcf",
@@ -276,6 +291,26 @@
             topic: {value:""},
             payload: {value:"", validate: RED.validators.typedInput("payloadType", false) },
             payloadType: {value:"date"},
+            buttonDisabled: { value: false }
+        },
+        contextMenu: function () {
+            const node = this;
+            return [
+                {
+                    label: node._("inject.actions.disableButton"),
+                    disabled: !!node.buttonDisabled,
+                    onselect: function () {
+                        updateNodeButton(node, false);
+                    },
+                },
+                {
+                    label: node._("inject.actions.enableButton"),
+                    disabled: !node.buttonDisabled,
+                    onselect: function () {
+                        updateNodeButton(node, true);
+                    },
+                },
+            ];
         },
         icon: "inject.svg",
         inputs:0,
@@ -717,7 +752,7 @@
         },
         button: {
             enabled: function() {
-                return !this.changed
+                return !this.changed && !this.buttonDisabled
             },
             onclick: function () {
                 if (this.changed) {

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -82,6 +82,10 @@
         "onstart": "Inject once after",
         "onceDelay": "seconds, then",
         "success": "Successfully injected: __label__",
+        "actions": {
+            "disableButton": "Disable the button",
+            "enableButton": "Enable the button"
+        },
         "errors": {
             "failed": "inject failed, see log for details",
             "toolong": "Interval too large",

--- a/packages/node_modules/@node-red/nodes/locales/fr/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/fr/messages.json
@@ -82,6 +82,10 @@
         "onstart": "Injecter une fois après",
         "onceDelay": "secondes, puis",
         "success": "Injecté avec succès : __label__",
+        "actions": {
+            "disableButton": "Désactiver le bouton",
+            "enableButton": "Activer le bouton"
+        },
         "errors": {
             "failed": "l'injection a échoué, voir le journal pour plus de détails",
             "toolong": "Intervalle trop grande",


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Closes #4806 and rework of #5150.

Add [node actions](https://github.com/node-red/node-red/pull/5332) to enable or disable the button of the `Inject` node.

Node actions set the `buttonDisabled` node property.

Preview:

<img width="691" height="102" alt="Capture d’écran 2025-10-28 à 15 02 33" src="https://github.com/user-attachments/assets/4a1024ba-3219-47a2-aa60-402771bb2b66" />


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
