### PR TITLE
Fix lock icon for read-only user

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/deploy.js
@@ -180,7 +180,7 @@ RED.deploy = (function() {
     }
 
     function updateLockedState() {
-        if (RED.settings.user?.permissions === 'read') {
+        if (!RED.user.hasPermission('flows.write')) {
             $(".red-ui-deploy-button-group").addClass("readOnly");
             $("#red-ui-header-button-deploy").addClass("disabled");
         } else {


### PR DESCRIPTION
If a user has read-only access to the editor, the deploy button should show a lock icon to give a visual cue to the fact they can't deploy changes.

<img width="161" height="59" alt="image" src="https://github.com/user-attachments/assets/270accaf-f4db-40de-ada1-dd04ba23960b" />


This worked if the permission was `'read'`. However, it failed if the permission was `['read']` - which is a valid permission value.

This fixes things by using the `hasPermission` check for `flows.write` which is semantically the right thing to be doing.