### PR TITLE
Add selection-to-subflow context menu item

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/contextMenu.js
@@ -223,6 +223,11 @@ RED.contextMenu = (function () {
                     { onselect: 'core:show-export-dialog', label: RED._("menu.label.export") }
                 )
             }
+            if (hasSelection && canEdit) {
+                menuItems.push(
+                    { onselect: 'core:convert-to-subflow', label: RED._("menu.label.selectionToSubflow") }
+                )
+            }
             menuItems.push(
                 { onselect: 'core:select-all-nodes', label: RED._("keyboard.selectAll") }
             )


### PR DESCRIPTION
Adds 'selection to subflow' action to the context menu if there are nodes selected.

<img width="269" height="80" alt="image" src="https://github.com/user-attachments/assets/9660dcdd-9db5-446b-a4d8-0ee58e1f7c60" />
