### PR TITLE
Fix up port event cancelling on node-select

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -3640,9 +3640,9 @@ RED.view = (function() {
         return tooltip;
     }
 
-    function portMouseOver(port,d,portType,portIndex) {
+    function portMouseOver(port,d,portType,portIndex, event) {
         if (mouse_mode === RED.state.SELECTING_NODE) {
-            d3.event.stopPropagation();
+            (d3.event || event).stopPropagation();
             return;
         }
         clearTimeout(portLabelHoverTimeout);
@@ -3681,9 +3681,9 @@ RED.view = (function() {
         }
         port.classed("red-ui-flow-port-hovered",active);
     }
-    function portMouseOut(port,d,portType,portIndex) {
+    function portMouseOut(port,d,portType,portIndex, event) {
         if (mouse_mode === RED.state.SELECTING_NODE) {
-            d3.event.stopPropagation();
+            (d3.event || event).stopPropagation();
             return;
         }
         clearTimeout(portLabelHoverTimeout);


### PR DESCRIPTION
Fixes #5335 

This was a consequence of a mix of d3 and native event handler mechanisms being used on different parts of the flow UI.

We do need to consolidate (away from d3 by preference), but for now, handle this one case.