### PR TITLE
Allow config nodes to be selected

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
@@ -255,6 +255,7 @@ RED.sidebar = (function() {
 
         $('<div id="red-ui-sidebar-content"></div>').appendTo("#red-ui-sidebar");
         $('<div id="red-ui-sidebar-footer" class="red-ui-component-footer"></div>').appendTo("#red-ui-sidebar");
+        $('<div id="red-ui-sidebar-header-shade" class="hide"></div>').appendTo("#red-ui-sidebar");
         $('<div id="red-ui-sidebar-shade" class="hide"></div>').appendTo("#red-ui-sidebar");
 
         RED.actions.add("core:toggle-sidebar",function(state){

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
@@ -69,6 +69,10 @@ RED.sidebar.config = (function() {
 
             category = $('<ul class="red-ui-palette-content red-ui-sidebar-node-config-list"></ul>').appendTo(container);
             category.on("click", function(e) {
+                if (RED.view.state() === RED.state.SELECTING_NODE) {
+                    // Do not clear selection if we are in select node mode
+                    return;
+                }
                 $(content).find(".red-ui-palette-node").removeClass("selected");
             });
             container.i18n();
@@ -125,6 +129,8 @@ RED.sidebar.config = (function() {
         return categories[name];
     }
 
+    /** @type {SelectNodesOptions & {done: (node: object) => void}|undefined} */
+    let selectNodesOptions;
     function createConfigNodeList(id,nodes) {
         var category = getOrCreateCategory(id.replace(/\./i,"-"))
         var list = category.list;
@@ -217,8 +223,12 @@ RED.sidebar.config = (function() {
 
                 nodeDiv.on('click',function(e) {
                     e.stopPropagation();
-                    RED.view.select(false);
-                    if (e.metaKey) {
+                    // RED.view.select(false);
+                    if (selectNodesOptions && selectNodesOptions.single) {
+                        selectNodesOptions.done(node);
+                        return;
+                    }
+                    if (e.metaKey || RED.view.state() === RED.state.SELECTING_NODE) {
                         $(this).toggleClass("selected");
                     } else {
                         $(content).find(".red-ui-palette-node").removeClass("selected");
@@ -470,9 +480,131 @@ RED.sidebar.config = (function() {
         }
         RED.sidebar.show("config");
     }
+
+    /**
+     * Clears the selected state of all config nodes
+     */
+    function clearSelection() {
+        $(content).find(".red-ui-palette-node").removeClass("selected");
+    }
+
+    /**
+     * Returns a list of selected config nodes
+     * @returns {object[]}
+     */
+    function selection() {
+        /** @type {object[]} */
+        const selected = [];
+        $(content).find(".red-ui-palette-node.selected").each(function () {
+            const id = $(this).data("node");
+            const node = RED.nodes.node(id);
+            if (node) {
+                selected.push(node);
+            }
+        });
+        return selected;
+    }
+
+    /**
+     * Selects config nodes
+     * @param {string|string[]} selection Ids of config node to select
+     */
+    function select(selection) {
+        // TODO: Handle selection-changed event
+        clearSelection();
+        if (typeof selection === "string") {
+            $(content).find(".red-ui-palette-node_id_" + selection + " .red-ui-palette-node").addClass("selected");
+        } else if (Array.isArray(selection)) {
+            selection.forEach((id) => {
+                $(content).find(".red-ui-palette-node_id_" + id + " .red-ui-palette-node").addClass("selected");
+            });
+        }
+    }
+
+    /**
+     * @typedef {object} SelectNodesOptions
+     * @property {boolean} [interactive]
+     * @property {boolean} [single]
+     * @property {string} [prompt]
+     * @property {string[]} [selected]
+     * @property {() => void} [oncancel]
+     * @property {(nodes: object|object[]) => void} [onselect]
+     *
+     * @param {SelectNodesOptions} [options] 
+     */
+    function selectNodes(options = {}) {
+        $("#red-ui-workspace-tabs-shade").show();
+        $("#red-ui-palette-shade").show();
+        $("#red-ui-editor-shade").show();
+        $("#red-ui-header-shade").show();
+        $("#red-ui-sidebar-header-shade").show();
+        // TODO: $(content).addClass("red-ui-sidebar-select-mode");
+
+        RED.sidebar.show("config");
+        RED.view.state(RED.state.SELECTING_NODE);
+        select(options.selected);
+
+        let notification;
+        const closeNotification = function () {
+            clearSelection();
+            $("#red-ui-workspace-tabs-shade").hide();
+            $("#red-ui-palette-shade").hide();
+            $("#red-ui-editor-shade").hide();
+            $("#red-ui-header-shade").hide();
+            $("#red-ui-sidebar-header-shade").hide();
+            //$(content).removeClass("red-ui-workspace-select-mode");
+            RED.view.state(RED.state.DEFAULT);
+            notification?.close();
+        }
+        selectNodesOptions = options;
+        options.cancel = function () {
+            closeNotification();
+        };
+        options.done = function (nodes) {
+            if (options.interactive === false) {
+                nodes = selection();
+            }
+            closeNotification();
+            if (options.onselect) {
+                options.onselect(nodes);
+            }
+            return nodes;
+        };
+        const buttons = [{
+            text: RED._("common.label.cancel"),
+            click: function () {
+                closeNotification();
+                if (options.oncancel) {
+                    options.oncancel();
+                }
+            }
+        }];
+        if (!options.single) {
+            buttons.push({
+                text: RED._("common.label.done"),
+                class: "primary",
+                click: function () {
+                    options.done(selection());
+                }
+            });
+        }
+        if (options.interactive !== false) {
+            notification = RED.notify(options.prompt || RED._("workspace.selectNodes"),{
+                modal: false,
+                fixed: true,
+                type: "compact",
+                buttons: buttons
+            });
+        }
+    }
+
     return {
         init:init,
         show:show,
-        refresh:refreshConfigNodeList
+        refresh:refreshConfigNodeList,
+        select: select,
+        selectNodes: selectNodes,
+        selection: selection,
+        clearSelection: clearSelection,
     }
 })();

--- a/packages/node_modules/@node-red/editor-client/src/sass/base.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/base.scss
@@ -44,9 +44,16 @@ body {
     overflow:hidden;
 }
 
-#red-ui-palette-shade, #red-ui-editor-shade, #red-ui-header-shade, #red-ui-sidebar-shade  {
+#red-ui-palette-shade,
+#red-ui-editor-shade,
+#red-ui-header-shade,
+#red-ui-sidebar-shade,
+#red-ui-sidebar-header-shade  {
     @include mixins.shade;
     z-index: 5;
+}
+#red-ui-sidebar-header-shade {
+    height: 35px;
 }
 #red-ui-sidebar-shade  {
     left: -8px;


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Part of #5329.

Like `RED.view.selectNodes`, allow config nodes to be selected.

In the future, each configuration node should be individually drawable to avoid rebuilding the entire tree.

### Todo list

- [ ] `red-ui-sidebar-select-mode`

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
