### PR TITLE
Allow actions show-next-tab and previous to loop

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
@@ -443,12 +443,18 @@ RED.tabs = (function() {
         }
         function activatePreviousTab() {
             var previous = findPreviousVisibleTab();
+            if (previous.length === 0) {
+                previous = ul.find("li.red-ui-tab:not(.hide-tab)").last();
+            }
             if (previous.length > 0) {
                 activateTab(previous.find("a"));
             }
         }
         function activateNextTab() {
             var next = findNextVisibleTab();
+            if (next.length === 0) {
+                next = ul.find("li.red-ui-tab:not(.hide-tab)").first();
+            }
             if (next.length > 0) {
                 activateTab(next.find("a"));
             }
@@ -607,9 +613,6 @@ RED.tabs = (function() {
             while(previous.length > 0 && previous.hasClass("hide-tab")) {
                 previous = previous.prev();
             }
-            if (previous.length === 0) {
-                previous = ul.find("li.red-ui-tab:not(.hide-tab)").last();
-            }
             return previous;
         }
         function findNextVisibleTab(li) {
@@ -619,9 +622,6 @@ RED.tabs = (function() {
             var next = li.next();
             while(next.length > 0 && next.hasClass("hide-tab")) {
                 next = next.next();
-            }
-            if (next.length === 0) {
-                next = ul.find("li.red-ui-tab:not(.hide-tab)").first();
             }
             return next;
         }


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Request: https://discourse.nodered.org/t/show-next-previous-tab-should-wrap/99696

Allow actions `show-next-tab` and `show-previous-tab` to loop; returns to the first tab if we have reached the end, and vice versa.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
