### PR TITLE
Reveal node in search results via mouseover

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
@@ -440,6 +440,12 @@ RED.search = (function() {
                     $('<div>',{class:"red-ui-search-result-node-type"}).text(node.type).appendTo(contentDiv);
                     $('<div>',{class:"red-ui-search-result-node-id"}).text(node.id).appendTo(contentDiv);
 
+                    div.on("mouseover", function(evt) {
+                        if ( node.z == RED.workspaces.active() ) {
+                            RED.view.reveal(node.id)
+                        }
+                    });
+                    
                     div.on("click", function(evt) {
                         evt.preventDefault();
                         currentIndex = i;


### PR DESCRIPTION
## Types of changes

This highlights nodes in the search results using a mouseover trigger.

See forum https://discourse.nodered.org/t/highlight-nodes-in-search-results-list/99747 for a discussion.

Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Highlight nodes in the search results using mouseover. Only those nodes in the current active workspace are revealed. Switching between workspaces would be too confusing - IMHO.

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
