### PR TITLE
Fix flushing when in variable delay mode

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.js
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.js
@@ -192,7 +192,8 @@ module.exports = function(RED) {
                     }
                     done();
                 }, delayvar, () => done());
-                node.idList.push(id);
+                if (Object.keys(msg).length === 2 && msg.hasOwnProperty("flush")) { id.clear(); }
+                else { node.idList.push(id); }
                 if (msg.hasOwnProperty("reset")) { clearDelayList(true); }
                 if (msg.hasOwnProperty("flush")) { flushDelayList(msg.flush); done(); }
                 if (delayvar >= 0) {


### PR DESCRIPTION
to close #5381

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This fixes the bug identified in #5381 where the delay node would send an extra unwanted message after the when flushing a message in variable delay mode. (Basically we weren't removing the fiush message itself from the queue if it was just a flush only message)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
