### PR TITLE
Add several click-outside-edit-tray behaviors

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -160,7 +160,13 @@
             "moveToBack": "Move to back",
             "moveToFront": "Move to front",
             "moveBackwards": "Move backwards",
-            "moveForwards": "Move forwards"
+            "moveForwards": "Move forwards",
+            "clickOutsideEditTray": "Click behavior outside the edit tray",
+            "clickOptions": {
+                "nothing": "Do nothing",
+                "discard": "Discard changes and close",
+                "save": "Save changes and close"
+            }
         }
     },
     "actions": {

--- a/packages/node_modules/@node-red/editor-client/locales/fr/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/fr/editor.json
@@ -160,7 +160,13 @@
       "moveToBack": "Déplacer vers l'arrière",
       "moveToFront": "Déplacer vers l'avant",
       "moveBackwards": "Reculer",
-      "moveForwards": "Avancer"
+      "moveForwards": "Avancer",
+      "clickOutsideEditTray": "Comportement du clic en dehors de la zone d'édition",
+      "clickOptions": {
+        "nothing": "Ne rien faire",
+        "discard": "Annuler les modifications et fermer",
+        "save": "Enregistrer les modifications et fermer"
+      }
     }
   },
   "actions": {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tray.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tray.js
@@ -230,6 +230,21 @@
             editorStack = $("#red-ui-editor-stack");
             $(window).on("resize", handleWindowResize);
             RED.events.on("sidebar:resize",handleWindowResize);
+            $("#red-ui-editor-shade").on("click", function () {
+                if (openingTray) { return; }
+
+                const clickOutsideEditTray = RED.settings.get("editor.view.click-outside-edit-tray", "save");
+                if (clickOutsideEditTray !== "nothing") {
+                    const tray = stack[stack.length - 1];
+                    if (tray && clickOutsideEditTray === "discard") {
+                        RED.actions.invoke("core:cancel-edit-tray");
+                    } else if (tray && clickOutsideEditTray === "save") {
+                        if (tray.primaryButton) {
+                            tray.primaryButton.click();
+                        }
+                    }
+                }
+            });
         },
         show: function show(options) {
             lowerTrayZ();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
@@ -141,7 +141,8 @@ RED.userSettings = (function() {
             options: [
                 {setting:"view-node-status",oldSetting:"menu-menu-item-status",label:"menu.label.displayStatus",default: true, toggle:true,onchange:"core:toggle-status"},
                 {setting:"view-node-info-icon", label:"menu.label.displayInfoIcon", default: true, toggle:true,onchange:"core:toggle-node-info-icon"},
-                {setting:"view-node-show-label",label:"menu.label.showNodeLabelDefault",default: true, toggle:true}
+                {setting:"view-node-show-label",label:"menu.label.showNodeLabelDefault",default: true, toggle:true},
+                { setting: "click-outside-edit-tray", label: "menu.label.clickOutsideEditTray", default: "nothing", options: (done) => done(["nothing", "discard", "save"].map((option) => ({ val: option, text: RED._("menu.label.clickOptions." + option) }))) }
             ]
         },
         {


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Closes #5247.

Foreword: The purpose of that change was to prevent changes from being saved when clicking outside the edit tray and a poor revert is not enough to move forward... In theory, the changes should be discard, but in practice, users have their own preferences.

Revert the click-outside-edit-tray behavior to save changes and close the edit tray.

Also adds to the settings a selection input to allow the user to choose the desired behavior. The options and their behavior are as follows:

- `nothing`: do nothing
- `discard`: discard changes and close
- `save`: save changes and close

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
