### PR TITLE
Let switch node regex mode optionally return matches

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.html
@@ -112,7 +112,6 @@
             }
             if (type === "regex") {
                 r.case = rule.find(".node-input-rule-case").prop("checked");
-                r.match = rule.find(".node-input-rule-match").prop("checked");
             }
         }
         return r;
@@ -236,7 +235,6 @@
 
             var andLabel = this._("switch.and");
             var caseLabel = this._("switch.ignorecase");
-            var matchLabel = this._("switch.returnmatches");
 
             $("#node-input-rule-container").css('min-height','150px').css('min-width','450px').editableList({
                 addItem: function(container,i,opt) {
@@ -303,7 +301,6 @@
 
                     var rowInputCell = $('<div>',{style:"flex-grow:1; margin-left: 5px;"}).appendTo(row);
 
-
                     var valueField = null;
                     var numValueField = null;
                     var expValueField = null;
@@ -317,8 +314,6 @@
 
                     var caseSensitive = $('<input/>',{id:"node-input-rule-case-"+i,class:"node-input-rule-case",type:"checkbox",style:"width:auto;vertical-align:top"}).appendTo(row2);
                     $('<label/>',{for:"node-input-rule-case-"+i,style:"margin-left: 3px;"}).text(caseLabel).appendTo(row2);
-                    var returnMatch = $('<input/>',{id:"node-input-rule-match-"+i,class:"node-input-rule-match",type:"checkbox",style:"width:auto;vertical-align:top"}).appendTo(row2);
-                    $('<label/>',{for:"node-input-rule-match-"+i,style:"margin-left: 3px;"}).text(matchLabel).appendTo(row2);
 
                     selectField.on("change", function() {
                         var fieldToFocus;
@@ -423,7 +418,6 @@
                         valueField.typedInput('value',rule.v);
                     }
                     caseSensitive.prop('checked',!!rule.case);
-                    returnMatch.prop('checked',!!rule.match);
                     selectField.change();
 
                     var currentOutputs = JSON.parse(outputCount.val()||"{}");

--- a/packages/node_modules/@node-red/nodes/core/function/10-switch.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-switch.js
@@ -30,10 +30,7 @@ module.exports = function(RED) {
         'false': function(a) { return a === false; },
         'null': function(a) { return (typeof a == "undefined" || a === null); },
         'nnull': function(a) { return (typeof a != "undefined" && a !== null); },
-        'regex': function(a, b, c, d, e, f) {
-            if (f) { return (a + "").matchAll(new RegExp(b,d?'ig':'g')); }
-            else { return (a + "").match(new RegExp(b,d?'i':'')); }
-        },
+        'regex': function(a, b, c, d) { return (a + "").matchAll(new RegExp(b,d?'ig':'g')); },
         'empty': function(a) {
             if (typeof a === 'string' || Array.isArray(a) || Buffer.isBuffer(a)) {
                 return a.length === 0;
@@ -200,9 +197,9 @@ module.exports = function(RED) {
                     state.elseflag = true;
                 }
                 try {
-                    const r = operators[rule.t](property,v1,v2,rule.case,msg.parts,rule.match )
+                    const r = operators[rule.t](property,v1,v2,rule.case,msg.parts)
                     if (r) {
-                        if (rule.match == true && rule.t === "regex") {
+                        if (rule.t === "regex") {
                             msg.matches = [];
                             for (const match of r) {
                                 const le = match.length

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -760,7 +760,6 @@
         "checkall": "checking all rules",
         "stopfirst": "stopping after first match",
         "ignorecase": "ignore case",
-        "returnmatches": "return msg.matches",
         "rules": {
             "btwn": "is between",
             "cont": "contains",

--- a/test/nodes/core/function/10-switch_spec.js
+++ b/test/nodes/core/function/10-switch_spec.js
@@ -469,14 +469,14 @@ describe('switch Node', function() {
         customFlowSwitchTest(flow, true, "oneTWOthree", done);
     });
 
-    it('should match regex with return-matches flag set true', function(done) {
-        var flow = [{id:"switchNode1",type:"switch",name:"switchNode",property:"payload",rules:[{"t":"regex","v":"(b[aio]..)","vt":"str","match":true}],checkall:true,outputs:1,wires:[["helperNode1"]]},
+    it('should match regex and return matches', function(done) {
+        var flow = [{id:"switchNode1",type:"switch",name:"switchNode",property:"payload",rules:[{"t":"regex","v":"(b[aio]..)","vt":"str"}],checkall:true,outputs:1,wires:[["helperNode1"]]},
                     {id:"helperNode1", type:"helper", wires:[]}];
         customFlowMessageSwitchTest(flow, true, {payload:"foobishbashboshpoo",matches:[{"match":"bish","index":3,"groups":["bish"]},{"match":"bash","index":7,"groups":["bash"]},{"match":"bosh","index":11,"groups":["bosh"]}]}, done);
     });
 
-    it('should match regex with return-matches flag set true - 2', function(done) {
-        var flow = [{id:"switchNode1",type:"switch",name:"switchNode",property:"payload",rules:[{"t":"regex","v":"[b][iao]","vt":"str","match":true}],checkall:true,outputs:1,wires:[["helperNode1"]]},
+    it('should match regex and return matches - 2', function(done) {
+        var flow = [{id:"switchNode1",type:"switch",name:"switchNode",property:"payload",rules:[{"t":"regex","v":"[b][iao]","vt":"str"}],checkall:true,outputs:1,wires:[["helperNode1"]]},
                     {id:"helperNode1", type:"helper", wires:[]}];
         customFlowMessageSwitchTest(flow, true, {payload:"foobishbashboshpoo",matches:[{"match":"bi","index":3,"groups":[]},{"match":"ba","index":7,"groups":[]},{"match":"bo","index":11,"groups":[]}]}, done);
     });


### PR DESCRIPTION
and adds tests

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

As per discussion https://discourse.nodered.org/t/switch-node-pass-on-regexp-matches-with-the-msg/99936 this PR adds an option to the regex condition of the switch node to allow it to return the matches and match groups. It doesn't change the default behaviour or any other modes.

This does of course change the message passing though (by adding msg.matches property) - which is unlike any other switch option - so may not be desired though it doesn't affect any other options. Other alternatives mean adding extra nodes to either redo the extraction of groups or using a function node.

And adds tests for new option.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
