### PR TITLE
let regex typedinput be expandable

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -430,6 +430,7 @@
                 var value = this.value();
                 RED.editor.editText({
                     value: value,
+                    title: "Regex editor",
                     stateId: RED.editor.generateViewStateId("typedInput", that, "regex"),
                     focus: true,
                     complete: function (v) {


### PR DESCRIPTION


<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Currently the regex typed input is just a simple text line edit - which is rather small for any complex regex. By letting it be expandable into another edit window so it's easier to read whole regex and debug them. Currently this is just re-using the text edit panel. 

Maybe one day this could be made into a specific regex tester a bit like the jsonata one... but that maybe a bit OTT.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
