### PR TITLE
Let group optionally display description info below nodes within the group

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -28,7 +28,8 @@
             "unlock": "Unlock",
             "locked": "Locked",
             "unlocked": "Unlocked",
-            "format": "Format"
+            "format": "Format",
+            "showinfo": "Display raw description tab info below nodes"
         },
         "type": {
             "string": "string",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/group.js
@@ -29,7 +29,7 @@ RED.group = (function() {
             '<label style="width: 70px;margin-right:10px" for="node-input-style-stroke" data-i18n="editor:common.label.line"></label>'+
         '</div>'+
         '<div class="form-row" style="padding-left: 100px;" id="node-input-row-style-fill">'+
-            '<label style="width: 70px;margin-right: 10px "  for="node-input-style-fill" data-i18n="editor:common.label.fill"></label>'+
+            '<label style="width: 70px;margin-right: 10px"  for="node-input-style-fill" data-i18n="editor:common.label.fill"></label>'+
         '</div>'+
         '<div class="form-row">'+
             '<label for="node-input-style-label" data-i18n="editor:common.label.label"></label>'+
@@ -48,8 +48,12 @@ RED.group = (function() {
                     '</span>'+
                 '</div>'+
             '</div>'+
+            '<div class="form-row">'+
+                '<label>&nbsp;</label>'+
+                '<input type="checkbox" id="node-input-showinfo" style="display:inline-block; width:15px; vertical-align:top;>'+
+                '<label for="node-input-showinfo" style="width:70%;"><span data-i18n="editor:common.label.showinfo"></span></label>'+
+            '</div>'+
         '</div>'+
-
         '</script>';
 
     var colorPalette = [
@@ -87,13 +91,13 @@ RED.group = (function() {
         "label-position": "nw"
     };
 
-
     var groupDef = {
         defaults:{
             name:{value:""},
             style:{value:{label:true}},
             nodes:{value:[]},
             env: {value:[]},
+            showinfo: {value:false}
         },
         category: "config",
         oneditprepare: function() {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -6598,7 +6598,7 @@ RED.view = (function() {
                         if (labelPos[0] === 'n') {
                             labelY = 0+15; // Allow for font-height
                         } else {
-                            labelY = d.h - 8 - (d.labels.length + d.info.split(/[-_*]{3}/)[0].trim().split("\n").length - 1 - 1) * 16;
+                            labelY = d.h - 8 - (d.labels.length -1 + d.info.split(/[-_*]{3}/)[0].trim().split("\n").length - 1) * 16;
                         }
                         if (labelPos[1] === 'w') {
                             labelX = 5;
@@ -6619,6 +6619,7 @@ RED.view = (function() {
                              .attr("text-anchor",labelAnchor);
                         if (d.labels) {
                             var ypos = 0;
+                            var labelPos = d.style["label-position"] || "nw";
                             if (labelPos[0] !== 'n') { ypos = -16; }
                             g.selectAll(".red-ui-flow-group-label-text").remove();
                             d.labels.forEach(function (name) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -6537,7 +6537,6 @@ RED.view = (function() {
                         if (d.labels && d.labels.length>0 && d?.showinfo) {
                             var gl = 0;
                             if (d.hasOwnProperty("info")) { gl = d.info.split(infoRegex)[0].trim().split("\n").length - 1 }
-                            console.log("GL2",gl,d.info.split(infoRegex))
                             d.h += gl * 16;
                             if (labelPos[0] !== "n") {
                                 d.h += 16;

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -6536,6 +6536,7 @@ RED.view = (function() {
                             var gl = 0;
                             if (d.hasOwnProperty("info")) { gl = d.info.split(/[-_*]{3}/)[0].trim().split("\n").length - 1 }
                             d.h += gl * 16;
+                            var labelPos = d.style["label-position"] || "nw";
                             if (labelPos[0] !== "n") {
                                 d.h += 16;
                             }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -140,15 +140,15 @@ RED.view = (function() {
 
     /**
      * The jQuery object for the workspace chart `#red-ui-workspace-chart` div element
-     * @type {JQuery<HTMLElement>} #red-ui-workspace-chart HTML Element 
-     */ 
+     * @type {JQuery<HTMLElement>} #red-ui-workspace-chart HTML Element
+     */
     let chart;
     /**
      * The d3 object `#red-ui-workspace-chart` svg element
      * @type {d3.Selection<HTMLElement, Any, Any, Any>}
-     */ 
+     */
     let outer;
-    /** 
+    /**
      * The d3 object `#red-ui-workspace-chart` svg element (specifically for events)
      * @type {d3.Selection<d3.BaseType, any, any, any>}
      */
@@ -218,7 +218,7 @@ RED.view = (function() {
             /**
              * Make the specified node the first node of the moving set, if
              * it is already in the set.
-             * @param {Node} node 
+             * @param {Node} node
              */
             makePrimary: function (node) {
                 const index = set.findIndex(n => n.n === node)
@@ -452,14 +452,14 @@ RED.view = (function() {
                         touch1["pageY"]+(a/2)
                     ]
                     startTouchDistance = Math.sqrt((a*a)+(b*b));
-                    
+
                     // Store initial scale for ratio-based zoom calculation
                     gesture = {
                         initialScale: scaleFactor,
                         initialDistance: startTouchDistance,
                         mode: null  // Will be determined on first significant move
                     };
-                    
+
                     // Start gesture with fixed focal point (store in workspace coordinates)
                     var focalPoint = [
                         (touch0["pageX"] + touch1["pageX"]) / 2 - offset.left,
@@ -515,7 +515,7 @@ RED.view = (function() {
                         var offset = chart.offset();
                         var scrollPos = [chart.scrollLeft(),chart.scrollTop()];
                         var moveTouchDistance = Math.sqrt((a*a)+(b*b));
-                        
+
                         // Calculate center point of two fingers
                         var currentTouchCenter = [
                             (touch0["pageX"] + touch1["pageX"]) / 2,
@@ -526,10 +526,10 @@ RED.view = (function() {
                             // Determine gesture mode on first significant movement
                             if (!gesture.mode) {
                                 var distanceChange = Math.abs(moveTouchDistance - startTouchDistance);
-                                var centerChange = moveTouchCenter ? 
-                                    Math.sqrt(Math.pow(currentTouchCenter[0] - moveTouchCenter[0], 2) + 
+                                var centerChange = moveTouchCenter ?
+                                    Math.sqrt(Math.pow(currentTouchCenter[0] - moveTouchCenter[0], 2) +
                                              Math.pow(currentTouchCenter[1] - moveTouchCenter[1], 2)) : 0;
-                                
+
                                 // Lock into zoom mode if distance changes significantly (>10px)
                                 // Lock into pan mode if center moves significantly (>5px) without distance change
                                 if (distanceChange > 10) {
@@ -538,25 +538,25 @@ RED.view = (function() {
                                     gesture.mode = 'pan';
                                 }
                             }
-                            
+
                             // Once mode is determined, stay in that mode for the entire gesture
                             if (gesture.mode === 'zoom') {
                                 oldScaleFactor = scaleFactor;
                                 // Use smooth ratio-based scaling for natural pinch-to-zoom
                                 var zoomRatio = moveTouchDistance / startTouchDistance;
                                 var minZoom = calculateMinZoom();
-                                var newScaleFactor = Math.min(RED.view.zoomConstants.MAX_ZOOM, 
+                                var newScaleFactor = Math.min(RED.view.zoomConstants.MAX_ZOOM,
                                                              Math.max(minZoom, gesture.initialScale * zoomRatio));
 
                                 // Use gesture state management to maintain fixed focal point
                                 var gestureState = RED.view.zoomAnimator.updateGesture(newScaleFactor);
-                                
+
                                 // Only call zoomView if scale is actually changing (not at limits)
                                 if (Math.abs(scaleFactor - newScaleFactor) >= 0.001) {
                                     // Get focal point converted back to current screen coordinates
                                     var currentScrollPos = [chart.scrollLeft(), chart.scrollTop()];
                                     var focalPoint = RED.view.zoomAnimator.getGestureFocalPoint(currentScrollPos, scaleFactor);
-                                    
+
                                     if (focalPoint) {
                                         // Use the fixed focal point from gesture start (converted from workspace coords)
                                         zoomView(newScaleFactor, focalPoint);
@@ -583,7 +583,7 @@ RED.view = (function() {
                                 if (moveTouchCenter) {
                                     var dx = currentTouchCenter[0] - moveTouchCenter[0];
                                     var dy = currentTouchCenter[1] - moveTouchCenter[1];
-                                    
+
                                     // Pan the canvas
                                     var currentScroll = [chart.scrollLeft(), chart.scrollTop()];
                                     chart.scrollLeft(currentScroll[0] - dx);
@@ -599,7 +599,7 @@ RED.view = (function() {
                     }
                     d3.event.preventDefault();
             });
-        
+
         const handleChartKeyboardEvents = (event) => {
             // Handle Alt toggle for pulling nodes out of groups
             if (mouse_mode === RED.state.MOVING_ACTIVE && event.key === 'Alt' && groupAddParentGroup) {
@@ -646,7 +646,7 @@ RED.view = (function() {
         }
         chart.on("keydown", handleChartKeyboardEvents)
         chart.on("keyup", handleChartKeyboardEvents)
-        
+
         // // // Window-level keyup listener to catch spacebar release when cursor is outside canvas
         // // function handleWindowSpacebarUp(e) {
         // //     if ((e.keyCode === 32 || e.key === ' ') && spacebarPressed) {
@@ -662,7 +662,7 @@ RED.view = (function() {
         // // Additional window-level keyup listener to ensure spacebar state is cleared
         // // when cursor leaves canvas area while spacebar is held
         // window.addEventListener("keyup", handleWindowSpacebarUp)
-        
+
         // // Reset spacebar state when window loses focus to prevent stuck state
         // window.addEventListener("blur", function() {
         //     if (spacebarPressed) {
@@ -671,7 +671,7 @@ RED.view = (function() {
         //         outer.style('cursor', '');
         //     }
         // })
-        
+
         // Recalculate minimum zoom when window resizes
         $(window).on("resize.red-ui-view", function() {
             // Recalculate minimum zoom to ensure canvas fits in viewport
@@ -807,14 +807,14 @@ RED.view = (function() {
         var lastWheelEventTime = 0;
         var wheelEventContinuityThreshold = 100; // Events within 100ms are same gesture
         var gestureEndThreshold = 500; // 500ms+ gap means gesture ended
-        
+
         // Prevent browser zoom on non-canvas areas
         document.addEventListener("wheel", function(e) {
             if (e.ctrlKey && !e.target.closest('#red-ui-workspace-chart')) {
                 e.preventDefault();
             }
         }, { passive: false });
-        
+
         chart.on("wheel", function(evt) {
             if (mouse_mode === RED.state.PANNING) {
                 // Ignore wheel events while panning
@@ -824,10 +824,10 @@ RED.view = (function() {
             if (evt.ctrlKey || evt.altKey || spacebarPressed) {
                 evt.preventDefault();
                 evt.stopPropagation();
-                
+
                 var currentTime = Date.now();
                 var timeSinceLastEvent = currentTime - lastWheelEventTime;
-                
+
                 // Get cursor position relative to the chart
                 var offset = chart.offset();
                 var cursorPos = [
@@ -835,7 +835,7 @@ RED.view = (function() {
                     evt.originalEvent.pageY - offset.top
                 ];
                 var delta = evt.originalEvent.deltaY;
-                
+
                 // For trackpad pinch (Ctrl+wheel), use smooth proportional zoom
                 if (evt.ctrlKey && !evt.altKey && !spacebarPressed) {
                     // Detect input device: trackpad has small deltas, mouse wheel has large deltas
@@ -843,14 +843,14 @@ RED.view = (function() {
                     // Invert delta: spreading fingers (negative deltaY) should zoom in
                     var scaleDelta = RED.view.zoomAnimator.calculateZoomDelta(scaleFactor, -delta, isTrackpadInput);
                     var minZoom = calculateMinZoom();
-                    var newScale = Math.min(RED.view.zoomConstants.MAX_ZOOM, 
+                    var newScale = Math.min(RED.view.zoomConstants.MAX_ZOOM,
                                           Math.max(minZoom, scaleFactor + scaleDelta));
-                    
+
                     // Session-based gesture tracking:
                     // - If no active gesture OR gap > gestureEndThreshold, start new gesture
                     // - If gap < wheelEventContinuityThreshold, continue current gesture
                     // - If gap between continuity and end threshold, keep current gesture but don't update focal point
-                    
+
                     if (!RED.view.zoomAnimator.isGestureActive() || timeSinceLastEvent > gestureEndThreshold) {
                         // Start new gesture session - store focal point in workspace coordinates
                         var scrollPos = [chart.scrollLeft(), chart.scrollTop()];
@@ -860,7 +860,7 @@ RED.view = (function() {
                         // No need to update focal point
                     }
                     // For gaps between continuity and end threshold, keep existing gesture state
-                    
+
                     // Update gesture with new scale, maintaining locked focal point
                     RED.view.zoomAnimator.updateGesture(newScale);
                     // Only call zoomView if scale is actually changing (not at limits)
@@ -870,10 +870,10 @@ RED.view = (function() {
                         var focalPoint = RED.view.zoomAnimator.getGestureFocalPoint(currentScrollPos, scaleFactor);
                         zoomView(newScale, focalPoint); // Direct call, no animation
                     }
-                    
+
                     // Update last event time for continuity tracking
                     lastWheelEventTime = currentTime;
-                    
+
                     // Reset gesture timeout - end gesture when no more events come in for gestureEndThreshold
                     if (trackpadGestureTimer) {
                         clearTimeout(trackpadGestureTimer);
@@ -1072,8 +1072,8 @@ RED.view = (function() {
 
                     var group = $(ui.helper).data("group");
                     if (group) {
-                        var oldX = group.x; 
-                        var oldY = group.y; 
+                        var oldX = group.x;
+                        var oldY = group.y;
                         RED.group.addToGroup(group, nn);
                         var moveEvent = null;
                         if ((group.x !== oldX) ||
@@ -1493,7 +1493,7 @@ RED.view = (function() {
             let topX, topY, bottomX, bottomY
             let cp
             let midX = Math.floor(destX-dx/2);
-            let midY = Math.floor(destY-dy/2);          
+            let midY = Math.floor(destY-dy/2);
             if (Math.abs(dy) < 10) {
                 bottomY = Math.max(origY, destY) + (hasStatus?35:25)
                 let startCurveHeight = bottomY - origY
@@ -1788,7 +1788,7 @@ RED.view = (function() {
                 context.virtualLink = true;
             }
             if (quickAddLink.node?.type === 'subflow') {
-                // This is a subflow 'virtual' port node. 
+                // This is a subflow 'virtual' port node.
                 context.flow = []
             } else {
                 context.flow = RED.nodes.createExportableNodeSet(RED.nodes.getAllFlowNodes(quickAddLink.node))
@@ -2050,8 +2050,8 @@ RED.view = (function() {
                 RED.editor.validateNode(nn);
 
                 if (targetGroup) {
-                    var oldX = targetGroup.x; 
-                    var oldY = targetGroup.y; 
+                    var oldX = targetGroup.x;
+                    var oldY = targetGroup.y;
                     RED.group.addToGroup(targetGroup, nn);
                     var moveEvent = null;
                     if ((targetGroup.x !== oldX) ||
@@ -2813,8 +2813,8 @@ RED.view = (function() {
             // to this group. But it could be a mix of nodes and existing groups.
             // In which case, we don't want to rehome all of the nodes inside
             // existing groups - we just want to rehome the top level objects.
-            var oldX = activeHoverGroup.x; 
-            var oldY = activeHoverGroup.y; 
+            var oldX = activeHoverGroup.x;
+            var oldY = activeHoverGroup.y;
             if (groupAddParentGroup) {
                 removedFromGroup = RED.nodes.group(groupAddParentGroup)
             }
@@ -2822,7 +2822,7 @@ RED.view = (function() {
             for (let j=0;j<movingSet.length();j++) {
                 const n = movingSet.get(j)
                 if (!n.n.g || (removedFromGroup && n.n.g === removedFromGroup.id)) {
-                    rehomedNodes.add(n)  
+                    rehomedNodes.add(n)
                     RED.group.addToGroup(activeHoverGroup, n.n);
                 }
             }
@@ -2846,7 +2846,7 @@ RED.view = (function() {
             for (let j=0;j<movingSet.length();j++) {
                 const n = movingSet.get(j)
                 if (n.n.g && n.n.g === removedFromGroup.id) {
-                    rehomedNodes.add(n)  
+                    rehomedNodes.add(n)
                     RED.group.removeFromGroup(removedFromGroup, n.n);
                 }
             }
@@ -2883,7 +2883,7 @@ RED.view = (function() {
         // This ensures canvas always fills the viewport
         return Math.max(calculatedMinZoom, RED.view.zoomConstants.MIN_ZOOM);
     }
-    
+
     // Track focal point for sequential button/hotkey zoom operations
     // Store in workspace coordinates so it remains valid after viewport shifts
     var buttonZoomWorkspaceCenter = null;
@@ -3129,9 +3129,9 @@ RED.view = (function() {
 
         // Calculate the actual minimum zoom to fit canvas
         var minZoom = calculateMinZoom();
-        
+
         // Clamp target factor to valid range
-        targetFactor = Math.max(minZoom, 
+        targetFactor = Math.max(minZoom,
                                 Math.min(RED.view.zoomConstants.MAX_ZOOM, targetFactor));
 
         // If we're already at the target, no need to animate
@@ -3187,7 +3187,7 @@ RED.view = (function() {
                 // Calculate new scroll position to maintain focal point
                 var currentScreenSize = [chart.width(), chart.height()];
                 var newScrollPos;
-                
+
                 if (focalPoint) {
                     // Keep the focal point at the same screen position
                     newScrollPos = [
@@ -4224,7 +4224,7 @@ RED.view = (function() {
                                         links:oldDstLinks
                                     }
                                 });
-                               
+
                                 src.changed = true;
                                 dst.changed = true;
                             }
@@ -4717,7 +4717,7 @@ RED.view = (function() {
             clickElapsed < dblClickInterval &&
             d.type !== 'junction'
         lastClickNode = mousedown_node;
-     
+
         if (d.selected && isControlPressed(d3.event)) {
             mousedown_node.selected = false;
             movingSet.remove(mousedown_node);
@@ -5658,7 +5658,7 @@ RED.view = (function() {
                 statusBackground.setAttribute("height",13);
                 statusBackground.setAttribute("rx",2);
                 statusBackground.setAttribute("ry",2);
-                
+
                 statusEl.appendChild(statusBackground);
                 node[0][0].__statusBackground__ = statusBackground;
 
@@ -6506,6 +6506,7 @@ RED.view = (function() {
                         d.h = 40;
                         recalculateLabelOffsets = true;
                     }
+
                     if (recalculateLabelOffsets) {
                         if (!d.minWidth) {
                             if (d.style.label && d.name) {
@@ -6530,6 +6531,11 @@ RED.view = (function() {
                                     d.y -= h;
                                 }
                             }
+                        }
+                        if (d.labels && d.labels.length>0 && d?.showinfo) {
+                            var gl = 0;
+                            if (d.hasOwnProperty("info")) { gl = d.info.split("\n").length - 1 }
+                            d.h += gl * 20;
                         }
                     }
 
@@ -6571,7 +6577,6 @@ RED.view = (function() {
                     } else {
                         selectGroup.classList.remove("red-ui-flow-node-highlighted");
                     }
-
 
                     g.selectAll(".red-ui-flow-group-body")
                         .attr("width",d.w)
@@ -6620,6 +6625,16 @@ RED.view = (function() {
                                     .attr("x", 0)
                                     .attr("y", ypos);
                                 ypos += 16;
+                                if (d?.showinfo) {
+                                    const dl = d.info.split("\n")
+                                    for (var i=0;i<dl.length;i++) {
+                                        label.append("tspan")
+                                            .classed("red-ui-flow-group-label-text", true)
+                                            .text(dl[i])
+                                            .attr("x", 4)
+                                            .attr("y", d.h-((dl.length-i)*20));
+                                    }
+                                }
                             });
                         } else {
                             g.selectAll(".red-ui-flow-group-label-text").remove();
@@ -6865,7 +6880,7 @@ RED.view = (function() {
                     }
                     if (!touchImport) {
                         mouse_mode = RED.state.IMPORT_DRAGGING;
-                        startSelectionMove()  
+                        startSelectionMove()
                     }
                 }
 
@@ -7317,9 +7332,9 @@ RED.view = (function() {
 
     /**
      * Add a suggested flow to the workspace.
-     * 
+     *
      * This appears as a ghost set of nodes.
-     * 
+     *
      * {
      *     "nodes": [
      *         {
@@ -7329,24 +7344,24 @@ RED.view = (function() {
      *         }
      *     ],
      *     "source": <sourceNode>,
-     *     "sourcePort": <sourcePort>, 
+     *     "sourcePort": <sourcePort>,
      * }
      * If `nodes` is a single node without an id property, it will be generated
      * using its default properties.
-     * 
+     *
      * If `nodes` has multiple, they must all have ids and will be assumed to be 'importable'.
      * In other words, a piece of valid flow json.
-     * 
+     *
      * `source`/`sourcePort` are option and used to indicate a node the suggestion should be connected to.
      * If provided, a ghost wire will be added between the source and the first node in the suggestion.
-     * 
+     *
      * Limitations:
      *  - does not support groups, subflows or whole tabs
      *  - does not support config nodes
-     * 
+     *
      * To clear the current suggestion, pass in `null`.
-     * 
-     * 
+     *
+     *
      * @param {Object} suggestion - The suggestion object
      */
     function setSuggestedFlow (suggestion) {
@@ -7362,7 +7377,7 @@ RED.view = (function() {
         currentSuggestion = suggestion
         if (suggestion && suggestion.nodes) {
             // If suggestion.nodes is an array of arrays, then there are multiple suggestions being provided
-            // Normalise the shape of the suggestion.nodes to be an array of arrays 
+            // Normalise the shape of the suggestion.nodes to be an array of arrays
             if (!Array.isArray(suggestion.nodes[0])) {
                 suggestion.nodes = [suggestion.nodes]
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -6535,7 +6535,10 @@ RED.view = (function() {
                         if (d.labels && d.labels.length>0 && d?.showinfo) {
                             var gl = 0;
                             if (d.hasOwnProperty("info")) { gl = d.info.split("\n").length - 1 }
-                            d.h += gl * 20;
+                            d.h += gl * 16;
+                            if (labelPos[0] !== "n") {
+                                d.h += 16;
+                            }
                         }
                     }
 
@@ -6543,7 +6546,6 @@ RED.view = (function() {
                     g.selectAll(".red-ui-flow-group-outline")
                         .attr("width",d.w)
                         .attr("height",d.h)
-
 
                     var selectGroup = document.getElementById("group_select_"+d.id);
                     selectGroup.setAttribute("transform","translate("+d.x+","+d.y+")");
@@ -6596,7 +6598,7 @@ RED.view = (function() {
                         if (labelPos[0] === 'n') {
                             labelY = 0+15; // Allow for font-height
                         } else {
-                            labelY = d.h - 5 -(d.labels.length -1) * 16;
+                            labelY = d.h - 8 - (d.labels.length + gl - 1) * 16;
                         }
                         if (labelPos[1] === 'w') {
                             labelX = 5;
@@ -6617,6 +6619,7 @@ RED.view = (function() {
                              .attr("text-anchor",labelAnchor);
                         if (d.labels) {
                             var ypos = 0;
+                            if (labelPos[0] !== 'n') { ypos = -16; }
                             g.selectAll(".red-ui-flow-group-label-text").remove();
                             d.labels.forEach(function (name) {
                                 label.append("tspan")
@@ -6627,12 +6630,14 @@ RED.view = (function() {
                                 ypos += 16;
                                 if (d?.showinfo) {
                                     const dl = d.info.split("\n")
-                                    for (var i=0;i<dl.length;i++) {
+                                    for (let i=0; i<dl.length; i++) {
+                                        let ioff = (dl.length - i) * 16;
+                                        if (labelPos[0] !== 'n') { ioff = ioff + (dl.length-1)*16; }
                                         label.append("tspan")
                                             .classed("red-ui-flow-group-label-text", true)
                                             .text(dl[i])
                                             .attr("x", 4)
-                                            .attr("y", d.h-((dl.length-i)*20));
+                                            .attr("y", d.h - 5 - ioff);
                                     }
                                 }
                             });

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -6534,7 +6534,7 @@ RED.view = (function() {
                         }
                         if (d.labels && d.labels.length>0 && d?.showinfo) {
                             var gl = 0;
-                            if (d.hasOwnProperty("info")) { gl = d.info.split("\n").length - 1 }
+                            if (d.hasOwnProperty("info")) { gl = d.info.split(/[-_*]{3}/)[0].trim().split("\n").length - 1 }
                             d.h += gl * 16;
                             if (labelPos[0] !== "n") {
                                 d.h += 16;
@@ -6629,10 +6629,10 @@ RED.view = (function() {
                                     .attr("y", ypos);
                                 ypos += 16;
                                 if (d?.showinfo) {
-                                    const dl = d.info.split("\n")
+                                    const dl = d.info.split(/[-_*]{3}/)[0].trim().split("\n")
                                     for (let i=0; i<dl.length; i++) {
                                         let ioff = (dl.length - i) * 16;
-                                        if (labelPos[0] !== 'n') { ioff = ioff + (dl.length-1)*16; }
+                                        if (labelPos[0] !== 'n') { ioff = ioff + (dl.length + 1) * 16; }
                                         label.append("tspan")
                                             .classed("red-ui-flow-group-label-text", true)
                                             .text(dl[i])

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -6598,7 +6598,7 @@ RED.view = (function() {
                         if (labelPos[0] === 'n') {
                             labelY = 0+15; // Allow for font-height
                         } else {
-                            labelY = d.h - 8 - (d.labels.length + gl - 1) * 16;
+                            labelY = d.h - 8 - (d.labels.length + d.info.split(/[-_*]{3}/)[0].trim().split("\n").length - 1 - 1) * 16;
                         }
                         if (labelPos[1] === 'w') {
                             labelX = 5;

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -6447,6 +6447,7 @@ RED.view = (function() {
             }
             group[0].reverse();
             var groupOpCount=0;
+            var infoRegex = new RegExp(/(^ *[*_-]{3,} *$|<hr\/?>)/m);
             group.each(function(d,i) {
                 groupOpCount++
                 if (d.resize) {
@@ -6519,8 +6520,9 @@ RED.view = (function() {
                             }
                         }
                         d.w = Math.max(d.minWidth,d.w);
+                        var labelPos = "nw";
                         if (d.style.label && d.labels.length > 0) {
-                            var labelPos = d.style["label-position"] || "nw";
+                            labelPos = d.style["label-position"] || "nw";
                             var h = (d.labels.length-1) * 16;
                             if (labelPos[0] === "s") {
                                 h += 8;
@@ -6534,9 +6536,9 @@ RED.view = (function() {
                         }
                         if (d.labels && d.labels.length>0 && d?.showinfo) {
                             var gl = 0;
-                            if (d.hasOwnProperty("info")) { gl = d.info.split(/[-_*]{3}/)[0].trim().split("\n").length - 1 }
+                            if (d.hasOwnProperty("info")) { gl = d.info.split(infoRegex)[0].trim().split("\n").length - 1 }
+                            console.log("GL2",gl,d.info.split(infoRegex))
                             d.h += gl * 16;
-                            var labelPos = d.style["label-position"] || "nw";
                             if (labelPos[0] !== "n") {
                                 d.h += 16;
                             }
@@ -6599,7 +6601,7 @@ RED.view = (function() {
                         if (labelPos[0] === 'n') {
                             labelY = 0+15; // Allow for font-height
                         } else {
-                            labelY = d.h - 8 - (d.labels.length -1 + d.info.split(/[-_*]{3}/)[0].trim().split("\n").length - 1) * 16;
+                            labelY = d.h - 8 - (d.labels.length -1 + d.info.split(infoRegex)[0].trim().split("\n").length - 1) * 16;
                         }
                         if (labelPos[1] === 'w') {
                             labelX = 5;
@@ -6620,7 +6622,6 @@ RED.view = (function() {
                              .attr("text-anchor",labelAnchor);
                         if (d.labels) {
                             var ypos = 0;
-                            var labelPos = d.style["label-position"] || "nw";
                             if (labelPos[0] !== 'n') { ypos = -16; }
                             g.selectAll(".red-ui-flow-group-label-text").remove();
                             d.labels.forEach(function (name) {
@@ -6631,7 +6632,7 @@ RED.view = (function() {
                                     .attr("y", ypos);
                                 ypos += 16;
                                 if (d?.showinfo) {
-                                    const dl = d.info.split(/[-_*]{3}/)[0].trim().split("\n")
+                                    const dl = d.info.split(infoRegex)[0].trim().split("\n");
                                     for (let i=0; i<dl.length; i++) {
                                         let ioff = (dl.length - i) * 16;
                                         if (labelPos[0] !== 'n') { ioff = ioff + (dl.length + 1) * 16; }
@@ -6639,7 +6640,7 @@ RED.view = (function() {
                                             .classed("red-ui-flow-group-label-text", true)
                                             .text(dl[i])
                                             .attr("x", 4)
-                                            .attr("y", d.h - 5 - ioff);
+                                            .attr("y", d.h - 6 - ioff);
                                     }
                                 }
                             });


### PR DESCRIPTION
…group

to help folk doc flows more visibly

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Based of this discussion https://discourse.nodered.org/t/ways-to-improve-flow-documentation/99924
This PR adds an optional checkbox to the group config that when enabled shows the raw text from the description tab as visible text below the nodes in the group.

We can't easily render markdown as SVG so this just adds the raw text - but does respect line breaks so the user can create useful documentation.

<img width="805" height="254" alt="Screenshot 2025-12-16 at 09 29 02" src="https://github.com/user-attachments/assets/8270eb63-57c3-440c-b918-64721869b95b" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
