### PR TITLE
add burst mode to delay node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.html
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.html
@@ -63,6 +63,7 @@
             <label></label>
             <select id="node-input-rate-type" style="width:270px !important">
                 <option value="all" data-i18n="delay.limitall"></option>
+                <option value="burst" data-i18n="delay.limitburst"></option>
                 <option value="topic" data-i18n="delay.limittopic"></option>
             </select>
         </div>
@@ -185,6 +186,8 @@
                     return this._("delay.label.limit")+" "+rate;
                 } else if (this.pauseType == "timed") {
                     return this._("delay.label.limitTopic")+" "+rate;
+                } else if (this.pauseType == "burst") {
+                    return this._("delay.label.burst")+" "+rate;
                 } else {
                     return this._("delay.label.limitTopic")+" "+rate;
                 }
@@ -245,6 +248,9 @@
                 $("#node-input-delay-action").val('rate');
                 $("#node-input-rate-type").val('topic');
                 $("#node-input-rate-topic-type").val('timed');
+            } else if (this.pauseType == "burst") {
+                $("#node-input-delay-action").val('rate');
+                $("#node-input-rate-type").val('burst');
             }
 
             if (!this.timeoutUnits) {
@@ -294,12 +300,17 @@
                 if (this.value === "all") {
                     $("#rate-details-per-topic").hide();
                     $("#node-input-drop-select-queue").attr('disabled', false);
+                    $("#rate-override").show();
+                } else if (this.value === "burst") {
+                    $("#rate-details-per-topic").hide();
+                    $("#node-input-drop-select-queue").attr('disabled', true);
+                    $("#rate-override").hide();
                 } else if (this.value === "topic") {
                     if ($("#node-input-drop-select").val() === "queue") {
-                        $("#node-input-drop-select").val("drop");
                     }
                     $("#node-input-drop-select-queue").attr('disabled', true);
                     $("#rate-details-per-topic").show();
+                    $("#rate-override").show();
                 }
             }).trigger("change");
         },
@@ -312,6 +323,8 @@
                 action = $("#node-input-rate-type").val();
                 if (action === "all") {
                     this.pauseType = "rate";
+                } else if (action === "burst") {
+                    this.pauseType = "burst";
                 } else {
                     this.pauseType = $("#node-input-rate-topic-type").val();
                 }

--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.js
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.js
@@ -42,6 +42,7 @@ module.exports = function(RED) {
         this.timeoutUnits = n.timeoutUnits;
         this.randomUnits = n.randomUnits;
         this.rateUnits = n.rateUnits;
+        this.burst = n.rate;
 
         if (n.timeoutUnits === "milliseconds") {
             this.timeout = n.timeout;
@@ -57,12 +58,16 @@ module.exports = function(RED) {
 
         if (n.rateUnits === "minute") {
             this.rate = (60 * 1000)/n.rate;
+            this.timer = n.nbRateUnits * (60 * 1000);
         } else if (n.rateUnits === "hour") {
             this.rate = (60 * 60 * 1000)/n.rate;
+            this.timer = n.nbRateUnits * (60 * 60 * 1000);
         } else if (n.rateUnits === "day") {
             this.rate = (24 * 60 * 60 * 1000)/n.rate;
+            this.timer = n.nbRateUnits * (24 * 60 * 60 * 1000);
         } else {  // Default to seconds
             this.rate = 1000/n.rate;
+            this.timer = n.nbRateUnits * 1000;
         }
 
         this.rate *= (n.nbRateUnits > 0 ? n.nbRateUnits : 1);
@@ -332,6 +337,42 @@ module.exports = function(RED) {
                 clearTimeout(node.busy);
                 node.buffer.forEach((msgInfo) => msgInfo.done());
                 node.buffer = [];
+                node.status({});
+            });
+        }
+
+        // Handle the burst mode
+        else if (node.pauseType === "burst") {
+            node.timers = [];
+            node.inflight = 0;
+            node.status({ fill: "green", shape: "ring", text: "" })
+            node.on("input", function(msg, send, done) {
+                if (msg.hasOwnProperty("reset")) {
+                    node.timers.forEach((t) => clearTimeout(t));
+                    node.timers = [];
+                    node.inflight = 0;
+                    node.status({ fill: "green", shape: "ring", text: "" });
+                    done();
+                    return;
+                }
+                if (node.inflight < node.burst) {
+                    node.inflight += 1;
+                    send(msg);
+                    node.timers[node.inflight-1] = setTimeout(() => {
+                        if (node.inflight == node.burst) {
+                            node.status({ fill: "green", shape: "ring", text: "" });
+                        }
+                        node.inflight -= 1;
+                    }, node.timer);
+                }
+                else {
+                    if (node.outputs === 2) { send([null,msg]); }
+                    node.status({ fill: "red", shape: "dot", text: "" });
+                }
+                done();
+            });
+            node.on("close", function() {
+                node.timers.forEach((t) => clearTimeout(t));
                 node.status({});
             });
         }

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/89-delay.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/89-delay.html
@@ -16,6 +16,7 @@
 
 <script type="text/html" data-help-name="delay">
     <p>Delays each message passing through the node or limits the rate at which they can pass.</p>
+    <p>Not all input parameters apply to all modes.</p>
     <h3>Inputs</h3>
     <dl class="message-properties">
         <dt class="optional">delay <span class="property-type">number</span></dt>
@@ -47,9 +48,11 @@
         Each message is delayed independently of any other message, based on
         the time of its arrival.
     </p>
-    <p>When configured to rate limit messages, their delivery is spread across
-        the configured time period. The status shows the number of messages currently in the queue.
-        It can optionally discard intermediate messages as they arrive.</p>
+    <p>When configured to rate limit messages, the node can operate in several modes.
+        By default the messages are delivered evenly spread across
+        the configured time period. e.g. 3 msgs in 12 seconds means 1 message every 4 seconds.
+        The status shows the number of messages currently in the queue.
+        It can optionally discard intermediate messages as they arrive.
     </p>
     <p>If set to allow override of the rate, the new rate will be applied immediately,
         and will remain in effect until changed again, the node is reset, or the flow is restarted.</p>
@@ -58,6 +61,12 @@
         automatically dropped. At each time interval, the node can either release
         the most recent message for all topics, or release the most recent message
         for the next topic.
+    </p>
+    <p>In burst mode, messages are passed through up to the configured limit immediately,
+        any further messages will be dropped or sent to the second output until the time
+        period has elapsed. At that point the next burst of messages can be sent.
+        The status shows green when messages can be sent immediately, and red when
+        messages are blocked.
     </p>
     <p><b>Note</b>: In rate limit mode the maximum queue depth can be set by a property in your
         <i>settings.js</i> file. For example <code>nodeMessageBufferMaxLength: 1000,</code></p>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -308,7 +308,8 @@
         "delayvarmsg": "Override delay with msg.delay",
         "randomdelay": "Random delay",
         "limitrate": "Rate Limit",
-        "limitall": "All messages",
+        "limitall": "All messages - even spacing",
+        "limitburst": "All messages - burst mode",
         "limittopic": "For each msg.topic",
         "fairqueue": "Send each topic in turn",
         "timedqueue": "Send all topics",
@@ -332,6 +333,7 @@
         "label": {
             "delay": "delay",
             "variable": "variable",
+            "burst": "burst",
             "limit": "limit",
             "limitTopic": "limit topic",
             "random": "random",

--- a/test/nodes/core/function/89-delay_spec.js
+++ b/test/nodes/core/function/89-delay_spec.js
@@ -1009,6 +1009,67 @@ describe('delay Node', function() {
         });
     });
 
+    it('can handle a burst in burst mode', function(done) {
+        this.timeout(2000);
+        var flow = [{"id":"delayNode1","type":"delay","name":"delayNode","pauseType":"burst","timeout":1,"timeoutUnits":"seconds","rate":3,"nbRateUnits":1,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[["helperNode1"]]},
+                    {id:"helperNode1", type:"helper", wires:[]}];
+        helper.load(delayNode, flow, function() {
+            var delayNode1 = helper.getNode("delayNode1");
+            var helperNode1 = helper.getNode("helperNode1");
+            var t = Date.now();
+            var c = 0;
+            helperNode1.on("input", function(msg) {
+                msg.should.have.a.property('payload');
+                c += 1;
+                if (c > 3) { done(err)}
+                done();
+            });
+
+            setTimeout( function() {
+                if (c === 3) { done(); }
+            }, 700);
+
+            // send test messages
+            delayNode1.receive({payload:1});
+            setImmediate( function() { delayNode1.receive({payload:2}); }  );
+            setImmediate( function() { delayNode1.receive({payload:3}); }  );
+            setImmediate( function() { delayNode1.receive({payload:4}); }  );
+            setImmediate( function() { delayNode1.receive({payload:5}); }  );
+        });
+    });
+
+    it('can reset a burst in burst mode', function(done) {
+        this.timeout(2000);
+        var flow = [{"id":"delayNode1","type":"delay","name":"delayNode","pauseType":"burst","timeout":1,"timeoutUnits":"seconds","rate":3,"nbRateUnits":1,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[["helperNode1"]]},
+                    {id:"helperNode1", type:"helper", wires:[]}];
+        helper.load(delayNode, flow, function() {
+            var delayNode1 = helper.getNode("delayNode1");
+            var helperNode1 = helper.getNode("helperNode1");
+            var t = Date.now();
+            var c = 0;
+            helperNode1.on("input", function(msg) {
+                msg.should.have.a.property('payload');
+                c += 1;
+                if (c > 4) { done(err)}
+                done();
+            });
+
+            setTimeout( function() {
+                if (c === 4) { done(); }
+            }, 700);
+
+            // send test messages
+            delayNode1.receive({payload:1});
+            setImmediate( function() { delayNode1.receive({payload:2}); }  );
+            setImmediate( function() { delayNode1.receive({payload:3}); }  );
+            setImmediate( function() { delayNode1.receive({payload:4}); }  );
+            setImmediate( function() { delayNode1.receive({payload:5}); }  );
+            setImmediate( function() { delayNode1.receive({reset:true}); }  );
+            setImmediate( function() { delayNode1.receive({payload:6}); }  );
+        });
+    });
+
+
     it('sending a msg with reset to empty queue doesnt send anything', function(done) {
         this.timeout(2000);
         var flow = [{"id":"delayNode1","type":"delay","name":"delayNode","pauseType":"rate","timeout":1,"timeoutUnits":"seconds","rate":2,"rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"wires":[["helperNode1"]]},


### PR DESCRIPTION
and tests

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Adds a burst mode to the delay node as per this discussion - https://discourse.nodered.org/t/delay-node-rate-limit-strange-behaviour-confusing-limit-rates-is-it-lying-us-a-little/100005 - It has also been mentioned several times before that we don't handle bursts as the present implementation is confusing.

This PR - add a new mode - burst - (vs the old mode, evenly spaced) - this allows the number of msgs specified through then blocks  - using the time period specified as a sliding time window to unlock as required... excess messages can either be dropped, or sent to the second output - they are not queued.

<img width="229" height="133" alt="Screenshot 2025-12-22 at 09 47 31" src="https://github.com/user-attachments/assets/3143f7cc-c317-4817-b8d2-a3852b27504e" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
