### PR TITLE
5404/Editor/Bug: Junction error in Quick Add dialog

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -6545,6 +6545,9 @@ RED.view = (function() {
                     suggestedNodes = [suggestedNodes]
                 }
                 suggestedNodes = suggestedNodes.filter(n => {
+                    if (n.type === 'junction') {                        
+                        return true
+                    }
                     const def = RED.nodes.getType(n.type)
                     if (def?.set && def.set.enabled === false) {
                         // Exclude disabled node set


### PR DESCRIPTION
## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Resolves https://github.com/node-red/node-red/issues/5404

In the `setSuggestedFlow` method for the quick add menu, there is a missing check for the `junction` node type which causes the console error as well as prevents the preview item from appearing in the editor when this menu option is hovered.

This view file contains similar checks for the `junction` node type so I followed the current pattern for this fix.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
