### PR TITLE
Add tooltip to delete button in node property UI

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/editableList.js
@@ -340,8 +340,10 @@
                 var deleteButton = $('<a/>',{href:"#",class:"red-ui-editableList-item-remove red-ui-button red-ui-button-small"}).appendTo(li);
                 $('<i/>',{class:"fa fa-remove"}).appendTo(deleteButton);
                 li.addClass("red-ui-editableList-item-removable");
+                var removeTip = RED.popover.tooltip(deleteButton, RED._("common.label.delete"));
                 deleteButton.on("click", function(evt) {
                     evt.preventDefault();
+                    removeTip.close();
                     var data = row.data('data');
                     li.addClass("red-ui-editableList-item-deleting")
                     li.fadeOut(300, function() {

--- a/packages/node_modules/@node-red/nodes/core/network/05-tls.html
+++ b/packages/node_modules/@node-red/nodes/core/network/05-tls.html
@@ -167,12 +167,15 @@
             $("#tls-config-button-cert-clear").on("click", function() {
                 clearNameData("cert");
             });
+            RED.popover.tooltip($("#tls-config-button-cert-clear"), RED._("common.label.delete"));
             $("#tls-config-button-key-clear").on("click", function() {
                 clearNameData("key");
             });
+            RED.popover.tooltip($("#tls-config-button-key-clear"), RED._("common.label.delete"));
             $("#tls-config-button-ca-clear").on("click", function() {
                 clearNameData("ca");
             });
+            RED.popover.tooltip($("#tls-config-button-ca-clear"), RED._("common.label.delete"));
 
             if (RED.settings.tlsConfigDisableLocalFiles) {
                 $("#node-config-row-uselocalfiles").hide();


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
The Delete button in the global environment variables has a tooltip, but the Delete button in the node property UI does not. This pull request adds a tooltip to the node property UI for tls-config and other general nodes, such as inject, change, switch nodes.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
