### PR TITLE
TreeList: Fix widget treeList keyboard navigation scroll behavior

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
@@ -188,7 +188,10 @@
                     } else {
                         that._topList.find(".focus").removeClass("focus")
                     }
-                    target.treeList.label.addClass('focus')
+                    if (target.treeList.label) {
+                        target.treeList.label.addClass('focus')
+                    }
+                    that.reveal(target);
                 }
             });
             this._data = [];


### PR DESCRIPTION
## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Resolves https://github.com/node-red/node-red/issues/5420

The widget's `select()` method doesn't call `reveal()`, so keyboard navigation never scrolled items into view. Added `reveal()` call.

https://github.com/user-attachments/assets/946458ad-4cfc-4a07-93e1-9d1816a8a55c

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
