### PR TITLE
Let TypedInput width be calculated - but forced

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/ui/common/typedInput.scss
@@ -20,7 +20,6 @@
     border: 1px solid var(--red-ui-form-input-border-color);
     border-radius: 5px;
     height: 34px;
-    // width: calc(100% - var(--typedInput-width-adjust));
     line-height: 14px;
     display: inline-flex;
     padding: 0;

--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.html
@@ -2,7 +2,7 @@
 <script type="text/html" data-template-name="file">
     <div class="form-row node-input-filename">
          <label for="node-input-filename"><i class="fa fa-file"></i> <span data-i18n="file.label.filename"></span></label>
-         <input id="node-input-filename" type="text" style="width: calc(100% - var(--typedInput-width-adjust)) !important;">
+         <input id="node-input-filename" type="text" style="width: 100% !important;">
          <input type="hidden" id="node-input-filenameType">
     </div>
     <div class="form-row">
@@ -38,7 +38,7 @@
 <script type="text/html" data-template-name="file in">
     <div class="form-row">
          <label for="node-input-filename"><i class="fa fa-file"></i> <span data-i18n="file.label.filename"></span></label>
-         <input id="node-input-filename" type="text" style="width: calc(100% - var(--typedInput-width-adjust)) !important;">
+         <input id="node-input-filename" type="text" style="width: 100% !important;">
          <input type="hidden" id="node-input-filenameType">
     </div>
     <div class="form-row">


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

As per discussion here - https://discourse.nodered.org/t/resize-path-field-on-resizing-editor-panel/100088 - this PR lets the typeInput box in editpanels calc it's width and resize to 100%.

BUT - this does so by using the !important tag to force it...  which may or may not be a good thing...
If used without !important quite a few nodes have hardcoded style attributes that override it . so until they can all be cleaned up then this is probably the way to go... but if we are going to clean them up then we ought to apply same calc logic/style to a lot of other input fields to make them all scale nicely (at least visually)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
