### PR TITLE
Ensure quick-add filter is applied properly when retriggering add

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1378,6 +1378,13 @@ RED.view = (function() {
                 quickAddLink.virtualLink = true;
             }
             hideDragLines();
+        } else if (quickAddLink) {
+            // continuing an existing quick add - set the filter accordingly
+            if (quickAddLink.portType === PORT_TYPE_OUTPUT) {
+                filter = {input:true}
+            } else {
+                filter = {output:true}
+            }
         }
         if (linkToSplice || spliceMultipleLinks) {
             filter = {


### PR DESCRIPTION
Fixes #5405 

The logic for setting the quick-add filter wasn't being applied when the user repositions an existing quick-add dialog  (see #5405 for the specific scenario).

This was because `drag_lines` was being cleared on the first open of the dialog, meaning it wasn't set for the second open and the filter wasn't set.
