### PR TITLE
TreeList: Fix arrow navigation through filtered TreeList

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
@@ -172,8 +172,9 @@
                         evt.preventDefault();
                         evt.stopPropagation();
                         if (focussed.children && Array.isArray(focussed.children) && focussed.children.length > 0 && focussed.treeList.container.hasClass("expanded")) {
-                            target = focussed.children[0];
-                        } else {
+                            target = that._getFirstVisibleChild(focussed);
+                        }
+                        if (!target) {
                             target = that._getNextSibling(focussed);
                             while (!target && focussed.parent) {
                                 focussed = focussed.parent;
@@ -228,12 +229,31 @@
                 this.data(this.options.data);
             }
         },
+        _isItemVisible: function(item) {
+            return item.treeList && item.treeList.container && item.treeList.container.parent().css('display') !== 'none';
+        },
+        _getFirstVisibleChild: function(item) {
+            if (!item.children || !Array.isArray(item.children)) {
+                return null;
+            }
+            for (var i = 0; i < item.children.length; i++) {
+                if (this._isItemVisible(item.children[i])) {
+                    return item.children[i];
+                }
+            }
+            return null;
+        },
         _getLastDescendant: function(item) {
             // Gets the last visible descendant of the item
             if (!item.children || !item.treeList.container.hasClass("expanded") || item.children.length === 0) {
                 return item;
             }
-            return this._getLastDescendant(item.children[item.children.length-1]);
+            for (var i = item.children.length - 1; i >= 0; i--) {
+                if (this._isItemVisible(item.children[i])) {
+                    return this._getLastDescendant(item.children[i]);
+                }
+            }
+            return item;
         },
         _getPreviousSibling: function(item) {
             var candidates;
@@ -243,11 +263,12 @@
                 candidates = item.parent.children;
             }
             var index = candidates.indexOf(item);
-            if (index === 0) {
-                return null;
-            } else {
-                return candidates[index-1];
+            for (var i = index - 1; i >= 0; i--) {
+                if (this._isItemVisible(candidates[i])) {
+                    return candidates[i];
+                }
             }
+            return null;
         },
         _getNextSibling: function(item) {
             var candidates;
@@ -257,11 +278,12 @@
                 candidates = item.parent.children;
             }
             var index = candidates.indexOf(item);
-            if (index === candidates.length - 1) {
-                return null;
-            } else {
-                return candidates[index+1];
+            for (var i = index + 1; i < candidates.length; i++) {
+                if (this._isItemVisible(candidates[i])) {
+                    return candidates[i];
+                }
             }
+            return null;
         },
         _addChildren: function(container,parent,children,depth,onCompleteChildren) {
             var that = this;


### PR DESCRIPTION
## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Resolves https://github.com/node-red/node-red/issues/5430

EditableList hides filtered items with `.hide()`. Added a css display check when picking the next/previous sibling/child in the TreeList component. With this change, users should be able to navigate through the visible list. Went with this approach for the initial fix as it's a small code change.

Could alternatively:
- Make updates to have TreeList go through an actual filtered set of nodes so we don't have to do any checks like this.
- Add some kind of `isFiltered` flag to the items. Would prefer the above.

### Before change

https://github.com/user-attachments/assets/2e77256f-9e6d-4be5-9c64-cb5ae8355cab

### After change

https://github.com/user-attachments/assets/4afb00f1-83fa-492b-8b1b-325e8da188b3

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [X] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
