### PR TITLE
i18n: add Dutch (nl-NL) locale for nodes and runtime

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/messages.json
@@ -1,0 +1,1162 @@
+{
+    "common": {
+        "label": {
+            "payload": "Payload",
+            "topic": "Onderwerp",
+            "name": "Naam",
+            "username": "Gebruikersnaam",
+            "password": "Wachtwoord",
+            "property": "Eigenschap",
+            "selectNodes": "Selecteer nodes...",
+            "expand": "Uitvouwen"
+        },
+        "status": {
+            "connected": "verbonden",
+            "not-connected": "niet verbonden",
+            "disconnected": "verbinding verbroken",
+            "connecting": "verbinden",
+            "error": "fout",
+            "ok": "OK"
+        },
+        "notification": {
+            "error": "<strong>Fout</strong>: __message__",
+            "errors": {
+                "not-deployed": "node niet geïmplementeerd",
+                "no-response": "geen reactie van server",
+                "unexpected": "onverwachte fout (__status__) __message__"
+            }
+        },
+        "errors": {
+            "nooverride": "Waarschuwing: msg-eigenschappen kunnen niet langer ingestelde node-eigenschappen overschrijven. Zie bit.ly/nr-override-msg-props"
+        }
+    },
+    "inject": {
+        "inject": "injecteren",
+        "injectNow": "nu injecteren",
+        "repeat": "herhaal = __repeat__",
+        "crontab": "crontab = __crontab__",
+        "stopped": "gestopt",
+        "failed": "Injectie mislukt: __error__",
+        "label": {
+            "properties": "Eigenschappen",
+            "repeat": "Herhalen",
+            "flow": "flow context",
+            "global": "global context",
+            "str": "tekst",
+            "num": "getal",
+            "bool": "boolean",
+            "json": "object",
+            "bin": "buffer",
+            "date": "tijdstempel",
+            "env": "omgevingsvariabele",
+            "object": "object",
+            "string": "tekst",
+            "boolean": "boolean",
+            "number": "getal",
+            "Array": "array",
+            "invalid": "Ongeldig JSON-object"
+        },
+        "timestamp": "tijdstempel",
+        "none": "geen",
+        "interval": "interval",
+        "interval-time": "interval tussen tijdstippen",
+        "time": "op een specifiek tijdstip",
+        "seconds": "seconden",
+        "minutes": "minuten",
+        "hours": "uren",
+        "between": "tussen",
+        "previous": "vorige waarde",
+        "at": "om",
+        "and": "en",
+        "every": "elke",
+        "days": [
+            "Maandag",
+            "Dinsdag",
+            "Woensdag",
+            "Donderdag",
+            "Vrijdag",
+            "Zaterdag",
+            "Zondag"
+        ],
+        "on": "op",
+        "onstart": "Eenmaal injecteren na",
+        "onceDelay": "seconden, daarna",
+        "success": "Succesvol geïnjecteerd: __label__",
+        "errors": {
+            "failed": "injectie mislukt, zie log voor details",
+            "toolong": "Interval te groot",
+            "invalid-expr": "Ongeldige JSONata-expressie: __error__",
+            "invalid-jsonata": "__prop__: ongeldige eigenschapsexpressie: __error__",
+            "invalid-prop": "__prop__: ongeldige eigenschapsexpressie: __error__",
+            "invalid-json": "__prop__: ongeldige JSON-gegevens: __error__",
+            "invalid-repeat": "Ongeldige herhalingswaarde"
+        }
+    },
+    "catch": {
+        "catch": "opvangen: alles",
+        "catchGroup": "opvangen: groep",
+        "catchNodes": "opvangen: __number__",
+        "catchUncaught": "opvangen: niet-opgevangen",
+        "label": {
+            "source": "Vang fouten op van",
+            "selectAll": "alles selecteren",
+            "uncaught": "Negeer fouten die door andere Catch-nodes worden afgehandeld"
+        },
+        "scope": {
+            "all": "alle nodes",
+            "group": "in dezelfde groep",
+            "selected": "geselecteerde nodes"
+        }
+    },
+    "status": {
+        "status": "status: alles",
+        "statusGroup": "status: groep",
+        "statusNodes": "status: __number__",
+        "label": {
+            "source": "Rapporteer status van",
+            "sortByType": "sorteren op type"
+        },
+        "scope": {
+            "all": "alle nodes",
+            "group": "in dezelfde groep",
+            "selected": "geselecteerde nodes"
+        }
+    },
+    "complete": {
+        "completeNodes": "voltooid: __number__",
+        "errors": {
+            "scopeUndefined": "bereik niet gedefinieerd"
+        }
+    },
+    "debug": {
+        "output": "Uitvoer",
+        "status": "status",
+        "none": "Geen",
+        "invalid-exp": "Ongeldige JSONata-expressie: __error__",
+        "msgprop": "berichteigenschap",
+        "msgobj": "volledig msg-object",
+        "autostatus": "zelfde als debug-uitvoer",
+        "messageCount": "berichtenteller",
+        "to": "Naar",
+        "debtab": "debug-tabblad",
+        "tabcon": "debug-tabblad en console",
+        "toSidebar": "debug-venster",
+        "toConsole": "systeemconsole",
+        "toStatus": "node-status (32 tekens)",
+        "severity": "Niveau",
+        "node": "node",
+        "notification": {
+            "activated": "Succesvol geactiveerd: __label__",
+            "deactivated": "Succesvol gedeactiveerd: __label__"
+        },
+        "sidebar": {
+            "label": "debug",
+            "name": "Debug-berichten",
+            "filterAll": "alle nodes",
+            "filterSelected": "geselecteerde nodes",
+            "filterCurrent": "huidige flow",
+            "debugNodes": "Debug-nodes",
+            "clearLog": "Berichten wissen",
+            "clearFilteredLog": "Gefilterde berichten wissen",
+            "filterLog": "Berichten filteren",
+            "openWindow": "Openen in nieuw venster",
+            "copyPath": "Pad kopiëren",
+            "copyPayload": "Waarde kopiëren",
+            "pinPath": "Open vastzetten",
+            "selectAll": "alles selecteren",
+            "selectNone": "niets selecteren",
+            "all": "alle",
+            "filtered": "gefilterd"
+        },
+        "messageMenu": {
+            "collapseAll": "Alle paden inklappen",
+            "clearPinned": "Vastgezette paden wissen",
+            "filterNode": "Deze node filteren",
+            "clearFilter": "Filter wissen"
+        }
+    },
+    "link": {
+        "linkIn": "link in",
+        "linkOut": "link out",
+        "linkCall": "link call",
+        "linkOutReturn": "link return",
+        "outMode": "Modus",
+        "sendToAll": "Verzenden naar alle verbonden link-nodes",
+        "returnToCaller": "Terug naar aanroepende link-node",
+        "timeout": "timeout",
+        "linkCallType": "Link-type",
+        "staticLinkCall": "Vast doel",
+        "dynamicLinkCall": "Dynamisch doel (msg.target)",
+        "dynamicLinkLabel": "Dynamisch",
+        "errors": {
+            "missingReturn": "Ontbrekende return-node-informatie",
+            "linkUndefined": "link niet gedefinieerd"
+        }
+    },
+    "tls": {
+        "tls": "TLS-configuratie",
+        "label": {
+            "use-local-files": "Gebruik sleutel en certificaten van lokale bestanden",
+            "upload": "Uploaden",
+            "cert": "Certificaat",
+            "key": "Privésleutel",
+            "passphrase": "Wachtwoordzin",
+            "ca": "CA-certificaat",
+            "verify-server-cert": "Servercertificaat verifiëren",
+            "servername": "Servernaam",
+            "alpnprotocol": "ALPN-protocol"
+        },
+        "placeholder": {
+            "cert": "pad naar certificaat (PEM-formaat)",
+            "key": "pad naar privésleutel (PEM-formaat)",
+            "ca": "pad naar CA-certificaat (PEM-formaat)",
+            "passphrase": "wachtwoordzin privésleutel (optioneel)",
+            "servername": "voor gebruik met SNI",
+            "alpnprotocol": "voor gebruik met ALPN"
+        },
+        "error": {
+            "missing-file": "Geen certificaat/sleutelbestand opgegeven",
+            "invalid-cert": "Certificaat niet opgegeven",
+            "invalid-key": "Privésleutel niet opgegeven"
+        }
+    },
+    "exec": {
+        "exec": "exec",
+        "spawn": "spawn",
+        "label": {
+            "command": "Commando",
+            "append": "Toevoegen",
+            "timeout": "Timeout",
+            "timeoutplace": "optioneel",
+            "return": "Uitvoer",
+            "seconds": "seconden",
+            "stdout": "stdout",
+            "stderr": "stderr",
+            "retcode": "returncode",
+            "winHide": "Console verbergen"
+        },
+        "placeholder": {
+            "extraparams": "extra invoerparameters"
+        },
+        "opt": {
+            "exec": "wanneer het commando voltooid is - exec-modus",
+            "spawn": "terwijl het commando draait - spawn-modus"
+        },
+        "oldrc": "Gebruik oude stijl uitvoer (compatibiliteitsmodus)"
+    },
+    "function": {
+        "function": "",
+        "label": {
+            "setup": "Setup",
+            "function": "Bij bericht",
+            "initialize": "Bij start",
+            "finalize": "Bij stoppen",
+            "outputs": "Uitvoeren",
+            "modules": "Modules",
+            "timeout": "Timeout"
+        },
+        "text": {
+            "initialize": "// Code hier wordt eenmaal uitgevoerd\n// wanneer de node wordt gestart.\n",
+            "finalize": "// Code hier wordt uitgevoerd wanneer de\n// node wordt gestopt of opnieuw geïmplementeerd.\n"
+        },
+        "require": {
+            "var": "variabele",
+            "module": "module",
+            "moduleName": "Modulenaam",
+            "importAs": "Importeren als"
+        },
+        "error": {
+            "externalModuleNotAllowed": "Function-node mag geen externe modules laden",
+            "moduleNotAllowed": "Module __module__ niet toegestaan",
+            "externalModuleLoadError": "Function-node kon externe modules niet laden",
+            "moduleLoadError": "Kon module __module__ niet laden: __error__",
+            "moduleNameError": "Ongeldige module-variabelenaam: __name__",
+            "moduleNameReserved": "Gereserveerde variabelenaam: __name__",
+            "inputListener": "Kan geen listener toevoegen aan 'input'-event binnen Function",
+            "non-message-returned": "Function probeerde een bericht van type __type__ te verzenden",
+            "invalid-js": "Fout in JavaScript-code",
+            "missing-module": "Module __module__ ontbreekt"
+        }
+    },
+    "template": {
+        "template": "template",
+        "label": {
+            "template": "Sjabloon",
+            "property": "Eigenschap",
+            "format": "Syntaxismarkering",
+            "syntax": "Formaat",
+            "output": "Uitvoer als",
+            "mustache": "Mustache-sjabloon",
+            "plain": "Platte tekst",
+            "json": "Geparseerde JSON",
+            "yaml": "Geparseerde YAML",
+            "none": "geen"
+        },
+        "templatevalue": "Dit is de payload: {{payload}} !"
+    },
+    "delay": {
+        "action": "Actie",
+        "for": "Voor",
+        "delaymsg": "Elk bericht vertragen",
+        "delayfixed": "Vaste vertraging",
+        "delayvarmsg": "Vertraging overschrijven met msg.delay",
+        "randomdelay": "Willekeurige vertraging",
+        "limitrate": "Snelheidslimiet",
+        "limitall": "Alle berichten",
+        "limittopic": "Voor elk msg.topic",
+        "fairqueue": "Elk onderwerp om de beurt verzenden",
+        "timedqueue": "Alle onderwerpen verzenden",
+        "milisecs": "Milliseconden",
+        "secs": "Seconden",
+        "sec": "Seconde",
+        "mins": "Minuten",
+        "min": "Minuut",
+        "hours": "Uren",
+        "hour": "Uur",
+        "days": "Dagen",
+        "day": "Dag",
+        "between": "Tussen",
+        "and": "&",
+        "rate": "Snelheid",
+        "msgper": "bericht(en) per",
+        "queuemsg": "Tussenliggende berichten in wachtrij plaatsen",
+        "dropmsg": "Tussenliggende berichten laten vallen",
+        "sendmsg": "Tussenliggende berichten naar 2e uitvoer verzenden",
+        "allowrate": "sta msg.rate (in ms) toe om snelheid te overschrijven",
+        "label": {
+            "delay": "vertraging",
+            "variable": "variabel",
+            "limit": "limiet",
+            "limitTopic": "limiet onderwerp",
+            "random": "willekeurig",
+            "rate": "snelheid",
+            "random-first": "eerste willekeurige waarde",
+            "random-last": "laatste willekeurige waarde",
+            "units": {
+                "second": {
+                    "plural": "Seconden",
+                    "singular": "Seconde"
+                },
+                "minute": {
+                    "plural": "Minuten",
+                    "singular": "Minuut"
+                },
+                "hour": {
+                    "plural": "Uren",
+                    "singular": "Uur"
+                },
+                "day": {
+                    "plural": "Dagen",
+                    "singular": "Dag"
+                }
+            }
+        },
+        "errors": {
+            "too-many": "te veel wachtende berichten in delay-node",
+            "invalid-timeout": "Ongeldige vertragingswaarde",
+            "invalid-rate": "Ongeldige snelheidswaarde",
+            "invalid-rate-unit": "Ongeldige snelheidseenheidwaarde",
+            "invalid-random-first": "Ongeldige eerste willekeurige waarde",
+            "invalid-random-last": "Ongeldige laatste willekeurige waarde"
+        }
+    },
+    "trigger": {
+        "send": "Verzenden",
+        "then": "dan",
+        "then-send": "dan verzenden",
+        "output": {
+            "string": "de tekst",
+            "number": "het getal",
+            "existing": "het bestaande msg-object",
+            "original": "het originele msg-object",
+            "latest": "het laatste msg-object",
+            "nothing": "niets"
+        },
+        "wait-reset": "wachten op reset",
+        "wait-for": "wachten op",
+        "wait-loop": "opnieuw verzenden elke",
+        "for": "Afhandeling",
+        "bytopics": "elk",
+        "alltopics": "alle berichten",
+        "duration": {
+            "ms": "Milliseconden",
+            "s": "Seconden",
+            "m": "Minuten",
+            "h": "Uren"
+        },
+        "extend": " vertraging verlengen bij nieuw bericht",
+        "override": "vertraging overschrijven met msg.delay",
+        "second": " tweede bericht naar aparte uitvoer verzenden",
+        "label": {
+            "trigger": "trigger",
+            "trigger-block": "trigger & blokkeren",
+            "trigger-loop": "opnieuw verzenden elke",
+            "reset": "Reset de trigger als:",
+            "resetMessage": "msg.reset is ingesteld",
+            "resetPayload": "msg.payload is gelijk aan",
+            "resetprompt": "optioneel",
+            "duration": "duur",
+            "topic": "onderwerp"
+        }
+    },
+    "comment": {
+        "comment": "commentaar"
+    },
+    "unknown": {
+        "label": {
+            "unknown": "onbekend"
+        },
+        "manageModules": "Modules beheren",
+        "tip": "<p>Deze node is een type dat onbekend is in uw Node-RED-installatie.</p><p><i>Als u implementeert met de node in deze staat, wordt de configuratie behouden, maar de flow start niet totdat het ontbrekende type is geïnstalleerd.</i></p><p>Zie de Info-zijbalk voor meer hulp</p>"
+    },
+    "mqtt": {
+        "label": {
+            "broker": "Server",
+            "example": "bijv. localhost",
+            "output": "Uitvoer",
+            "qos": "QoS",
+            "retain": "Behouden",
+            "clientid": "Client-ID",
+            "port": "Poort",
+            "keepalive": "Keep Alive",
+            "cleansession": "Schone sessie gebruiken",
+            "autoUnsubscribe": "Automatisch afmelden bij verbreken verbinding",
+            "cleanstart": "Schone start gebruiken",
+            "use-tls": "TLS gebruiken",
+            "tls-config": "TLS-configuratie",
+            "verify-server-cert": "Servercertificaat verifiëren",
+            "compatmode": "Gebruik legacy MQTT 3.1-ondersteuning",
+            "userProperties": "Gebruikerseigenschappen",
+            "subscriptionIdentifier": "Abonnements-ID",
+            "flags": "Vlaggen",
+            "nl": "Ontvang geen berichten gepubliceerd door deze client",
+            "rap": "Behoud retain-vlag van originele publicatie",
+            "rh": "Afhandeling behouden berichten",
+            "rh0": "Behouden berichten verzenden",
+            "rh1": "Alleen verzenden voor nieuwe abonnementen",
+            "rh2": "Niet verzenden",
+            "responseTopic": "Antwoordonderwerp",
+            "contentType": "Inhoudstype",
+            "correlationData": "Correlatiegegevens",
+            "expiry": "Vervaltijd (sec)",
+            "sessionExpiry": "Sessievervaltijd (sec)",
+            "topicAlias": "Alias",
+            "payloadFormatIndicator": "Formaat",
+            "payloadFormatIndicatorFalse": "niet-gespecificeerde bytes (Standaard)",
+            "payloadFormatIndicatorTrue": "UTF-8 gecodeerde payload",
+            "protocolVersion": "Protocol",
+            "protocolVersion3": "MQTT V3.1 (legacy)",
+            "protocolVersion4": "MQTT V3.1.1",
+            "protocolVersion5": "MQTT V5",
+            "topicAliasMaximum": "Alias Max",
+            "maximumPacketSize": "Max pakketgrootte",
+            "receiveMaximum": "Ontvangst Max",
+            "session": "Sessie",
+            "delay": "Vertraging",
+            "action": "Actie",
+            "staticTopic": "Abonneren op enkel onderwerp",
+            "dynamicTopic": "Dynamisch abonnement",
+            "auto-connect": "Automatisch verbinden",
+            "auto-mode-depreciated": "Deze optie is verouderd. Gebruik de nieuwe automatische detectiemodus.",
+            "none": "geen",
+            "other": "anders"
+        },
+        "sections-label": {
+            "birth-message": "Bericht verzonden bij verbinding (birth-bericht)",
+            "will-message": "Bericht verzonden bij onverwachte verbreking (will-bericht)",
+            "close-message": "Bericht verzonden voor verbreken (close-bericht)"
+        },
+        "tabs-label": {
+            "connection": "Verbinding",
+            "security": "Beveiliging",
+            "messages": "Berichten"
+        },
+        "placeholder": {
+            "clientid": "Laat leeg voor automatisch gegenereerd",
+            "clientid-nonclean": "Moet ingesteld zijn voor niet-schone sessies",
+            "will-topic": "Laat leeg om will-bericht uit te schakelen",
+            "birth-topic": "Laat leeg om birth-bericht uit te schakelen",
+            "close-topic": "Laat leeg om close-bericht uit te schakelen"
+        },
+        "state": {
+            "connected": "Verbonden met broker: __broker__",
+            "disconnected": "Verbinding verbroken met broker: __broker__",
+            "connect-failed": "Verbinding mislukt met broker: __broker__",
+            "broker-disconnected": "Broker __broker__ heeft client verbroken: __reasonCode__ __reasonString__"
+        },
+        "retain": "Behouden",
+        "output": {
+            "buffer": "een Buffer",
+            "string": "een String",
+            "base64": "een Base64-gecodeerde string",
+            "auto": "automatisch detecteren (string of buffer)",
+            "auto-detect": "automatisch detecteren (geparseerd JSON-object, string of buffer)",
+            "json": "een geparseerd JSON-object"
+        },
+        "true": "waar",
+        "false": "onwaar",
+        "tip": "Tip: Laat onderwerp, qos of retain leeg als u ze via msg-eigenschappen wilt instellen.",
+        "errors": {
+            "not-defined": "onderwerp niet gedefinieerd",
+            "missing-config": "ontbrekende broker-configuratie",
+            "invalid-topic": "Ongeldig onderwerp opgegeven",
+            "nonclean-missingclientid": "Geen client-ID ingesteld, schone sessie gebruiken",
+            "invalid-json-string": "Ongeldige JSON-string",
+            "invalid-json-parse": "Kon JSON-string niet parseren",
+            "invalid-action-action": "Ongeldige actie opgegeven",
+            "invalid-action-alreadyconnected": "Verbreek verbinding met broker voordat u verbindt",
+            "invalid-action-badsubscription": "msg.topic ontbreekt of is ongeldig",
+            "invalid-client-id": "Ontbrekend Client-ID"
+        }
+    },
+    "httpin": {
+        "label": {
+            "method": "Methode",
+            "url": "URL",
+            "doc": "Docs",
+            "return": "Retourneren",
+            "upload": "Bestandsuploads accepteren",
+            "parsing": "Verzoekbody niet parseren",
+            "status": "Statuscode",
+            "headers": "Headers",
+            "other": "anders",
+            "paytoqs": {
+                "ignore": "Negeren",
+                "query": "Toevoegen aan query-string parameters",
+                "body": "Verzenden als verzoekbody"
+            },
+            "utf8String": "UTF8-string",
+            "binaryBuffer": "binaire buffer",
+            "jsonObject": "geparseerd JSON-object",
+            "authType": "Type",
+            "bearerToken": "Token"
+        },
+        "setby": "- ingesteld door msg.method -",
+        "basicauth": "Authenticatie gebruiken",
+        "use-tls": "Beveiligde (SSL/TLS) verbinding inschakelen",
+        "tls-config": "TLS-configuratie",
+        "basic": "basis-authenticatie",
+        "digest": "digest-authenticatie",
+        "bearer": "bearer-authenticatie",
+        "use-proxy": "Proxy gebruiken",
+        "persist": "Verbinding keep-alive inschakelen",
+        "proxy-config": "Proxyconfiguratie",
+        "use-proxyauth": "Proxy-authenticatie gebruiken",
+        "noproxy-hosts": "Hosts negeren",
+        "senderr": "Alleen niet-2xx-antwoorden naar Catch-node verzenden",
+        "utf8": "een UTF-8-string",
+        "binary": "een binaire buffer",
+        "json": "een geparseerd JSON-object",
+        "tip": {
+            "in": "De URL zal relatief zijn aan ",
+            "res": "De berichten verzonden naar deze node <b>moeten</b> afkomstig zijn van een <i>http input</i>-node",
+            "req": "Tip: Als het JSON parseren mislukt, wordt de opgehaalde string ongewijzigd geretourneerd."
+        },
+        "httpreq": "http-verzoek",
+        "errors": {
+            "not-created": "Kan http-in-node niet maken wanneer httpNodeRoot op false staat",
+            "missing-path": "ontbrekend pad",
+            "no-response": "Geen response-object",
+            "json-error": "JSON-parseerfout",
+            "no-url": "Geen URL opgegeven",
+            "deprecated-call": "Verouderde aanroep naar __method__",
+            "invalid-transport": "niet-http-transport gevraagd",
+            "timeout-isnan": "Timeout-waarde is geen geldig getal, wordt genegeerd",
+            "timeout-isnegative": "Timeout-waarde is negatief, wordt genegeerd",
+            "invalid-payload": "Ongeldige payload",
+            "invalid-url": "Ongeldige URL",
+            "rejectunauthorized-invalid": "msg.rejectUnauthorized moet een boolean zijn"
+        },
+        "status": {
+            "requesting": "aanvragen"
+        },
+        "insecureHTTPParser": "Strikte HTTP-parsing uitschakelen"
+    },
+    "websocket": {
+        "label": {
+            "type": "Type",
+            "path": "Pad",
+            "url": "URL",
+            "subprotocol": "Subprotocol"
+        },
+        "listenon": "Luisteren op",
+        "connectto": "Verbinden met",
+        "sendrec": "Verzenden/Ontvangen",
+        "payload": "payload",
+        "message": "volledig bericht",
+        "sendheartbeat": "Heartbeat verzenden",
+        "tip": {
+            "path1": "Standaard bevat <code>payload</code> de gegevens die via een websocket worden verzonden of ontvangen. De listener kan worden geconfigureerd om het volledige berichtobject als een JSON-geformatteerde string te verzenden of ontvangen.",
+            "path2": "Dit pad zal relatief zijn aan <code>__path__</code>.",
+            "url1": "URL moet ws:&#47;&#47; of wss:&#47;&#47; schema gebruiken en naar een bestaande websocket-listener wijzen.",
+            "url2": "Standaard bevat <code>payload</code> de gegevens die via een websocket worden verzonden of ontvangen. De client kan worden geconfigureerd om het volledige berichtobject als een JSON-geformatteerde string te verzenden of ontvangen.",
+            "headers": "Headers worden alleen ingediend tijdens het protocol-upgrademechanisme, van HTTP naar het WS/WSS-protocol."
+        },
+        "status": {
+            "connected": "verbonden __count__",
+            "connected_plural": "verbonden __count__"
+        },
+        "errors": {
+            "connect-error": "Er is een fout opgetreden bij de ws-verbinding: ",
+            "send-error": "Er is een fout opgetreden bij het verzenden: ",
+            "missing-conf": "Ontbrekende serverconfiguratie",
+            "duplicate-path": "Kan geen twee WebSocket-listeners op hetzelfde pad hebben: __path__",
+            "missing-server": "Ontbrekende serverconfiguratie",
+            "missing-client": "Ontbrekende clientconfiguratie"
+        }
+    },
+    "watch": {
+        "watch": "bewaken",
+        "label": {
+            "files": "Bestand(en)",
+            "recursive": "Submappen recursief bewaken"
+        },
+        "placeholder": {
+            "files": "Kommagescheiden lijst van bestanden en/of mappen"
+        },
+        "tip": "Op Windows moet u dubbele backslashes \\\\ gebruiken in mapnamen."
+    },
+    "tcpin": {
+        "label": {
+            "type": "Type",
+            "output": "Uitvoer",
+            "port": "poort",
+            "host": "op host",
+            "payload": "payload(s)",
+            "delimited": "gescheiden door",
+            "close-connection": "Verbinding sluiten na elk verzonden bericht?",
+            "decode-base64": "Base64-bericht decoderen?",
+            "server": "Server",
+            "return": "Retourneren",
+            "ms": "ms",
+            "chars": "tekens",
+            "close": "Sluiten",
+            "optional": "(optioneel)",
+            "reattach": "scheidingsteken opnieuw toevoegen"
+        },
+        "type": {
+            "listen": "Luisteren op",
+            "connect": "Verbinden met",
+            "reply": "Antwoorden naar TCP"
+        },
+        "output": {
+            "stream": "stream van",
+            "single": "enkel",
+            "buffer": "Buffer",
+            "string": "String",
+            "base64": "Base64-string"
+        },
+        "return": {
+            "timeout": "na een vaste timeout van",
+            "character": "wanneer ontvangen teken is",
+            "number": "na een vast aantal tekens",
+            "never": "nooit - verbinding open houden",
+            "immed": "onmiddellijk - niet wachten op antwoord"
+        },
+        "status": {
+            "connecting": "verbinden met __host__:__port__",
+            "connected": "verbonden met __host__:__port__",
+            "listening-port": "luisteren op poort __port__",
+            "stopped-listening": "gestopt met luisteren op poort",
+            "connection-from": "verbinding van __host__:__port__",
+            "connection-closed": "verbinding gesloten van __host__:__port__",
+            "connections": "__count__ verbinding",
+            "connections_plural": "__count__ verbindingen"
+        },
+        "errors": {
+            "connection-lost": "verbinding verloren met __host__:__port__",
+            "timeout": "timeout sloot socket poort __port__",
+            "cannot-listen": "kan niet luisteren op poort __port__, fout: __error__",
+            "error": "fout: __error__",
+            "socket-error": "socket-fout van __host__:__port__",
+            "no-host": "Host en/of poort niet ingesteld",
+            "connect-timeout": "verbindingstimeout",
+            "connect-fail": "verbinding mislukt",
+            "bad-string": "kon niet converteren naar string",
+            "invalid-host": "Ongeldige host",
+            "invalid-port": "Ongeldige poort"
+        }
+    },
+    "udp": {
+        "label": {
+            "listen": "Luisteren naar",
+            "onport": "op poort",
+            "using": "gebruikend",
+            "output": "Uitvoer",
+            "group": "Groep",
+            "interface": "Lokale IF",
+            "send": "Verzenden van",
+            "toport": "naar poort",
+            "address": "Adres",
+            "decode-base64": "Base64-gecodeerde payload decoderen?",
+            "port": "poort"
+        },
+        "placeholder": {
+            "interface": "(optioneel) lokale interface of adres om aan te binden",
+            "interfaceprompt": "(optioneel) lokale interface of adres om aan te binden",
+            "address": "bestemmings-IP"
+        },
+        "udpmsgs": "UDP-berichten",
+        "mcmsgs": "multicast-berichten",
+        "udpmsg": "UDP-bericht",
+        "bcmsg": "broadcast-bericht",
+        "mcmsg": "multicast-bericht",
+        "output": {
+            "buffer": "een Buffer",
+            "string": "een String",
+            "base64": "een Base64-gecodeerde string"
+        },
+        "bind": {
+            "random": "binden aan willekeurige lokale poort",
+            "local": "binden aan lokale poort",
+            "target": "binden aan doelpoort"
+        },
+        "tip": {
+            "in": "Tip: Zorg ervoor dat uw firewall de gegevens doorlaat.",
+            "out": "Tip: laat adres en poort leeg als u ze wilt instellen via <code>msg.ip</code> en <code>msg.port</code>.",
+            "port": "Poorten al in gebruik: "
+        },
+        "status": {
+            "listener-at": "UDP-listener op __host__:__port__",
+            "mc-group": "UDP-multicast-groep __group__",
+            "listener-stopped": "UDP-listener gestopt",
+            "output-stopped": "UDP-uitvoer gestopt",
+            "mc-ready": "UDP-multicast gereed: __iface__:__outport__ -> __host__:__port__",
+            "bc-ready": "UDP-broadcast gereed: __outport__ -> __host__:__port__",
+            "ready": "UDP gereed: __outport__ -> __host__:__port__",
+            "ready-nolocal": "UDP gereed: __host__:__port__",
+            "re-use": "UDP hergebruik socket: __outport__ -> __host__:__port__"
+        },
+        "errors": {
+            "access-error": "UDP-toegangsfout, u hebt mogelijk root-toegang nodig voor poorten onder 1024",
+            "error": "fout: __error__",
+            "bad-mcaddress": "Ongeldig multicast-adres",
+            "interface": "Moet IP-adres zijn van de vereiste interface",
+            "ip-notset": "UDP: IP-adres niet ingesteld",
+            "port-notset": "UDP: poort niet ingesteld",
+            "port-invalid": "UDP: poortnummer niet geldig",
+            "alreadyused": "UDP: poort __port__ al in gebruik",
+            "ifnotfound": "UDP: interface __iface__ niet gevonden",
+            "invalid-group": "ongeldige multicast-groep"
+        }
+    },
+    "switch": {
+        "switch": "switch",
+        "label": {
+            "property": "Eigenschap",
+            "rule": "regel",
+            "repair": "berichtsequenties herstellen",
+            "value-rules": "waarde-regels",
+            "sequence-rules": "sequentie-regels"
+        },
+        "previous": "vorige waarde",
+        "and": "en",
+        "checkall": "alle regels controleren",
+        "stopfirst": "stoppen na eerste match",
+        "ignorecase": "hoofdletters negeren",
+        "rules": {
+            "btwn": "is tussen",
+            "cont": "bevat",
+            "regex": "komt overeen met regex",
+            "true": "is waar",
+            "false": "is onwaar",
+            "null": "is null",
+            "nnull": "is niet null",
+            "istype": "is van type",
+            "empty": "is leeg",
+            "nempty": "is niet leeg",
+            "head": "kop",
+            "tail": "staart",
+            "index": "index tussen",
+            "exp": "JSONata-exp",
+            "else": "anders",
+            "hask": "heeft sleutel"
+        },
+        "errors": {
+            "invalid-expr": "Ongeldige JSONata-expressie: __error__",
+            "too-many": "te veel wachtende berichten in switch-node"
+        }
+    },
+    "change": {
+        "label": {
+            "rules": "Regels",
+            "rule": "regel",
+            "set": "stel __property__ in",
+            "change": "wijzig __property__",
+            "delete": "verwijder __property__",
+            "move": "verplaats __property__",
+            "changeCount": "wijzigen: __count__ regels",
+            "regex": "Reguliere expressies gebruiken",
+            "deepCopy": "Diepe kopie van waarde"
+        },
+        "action": {
+            "set": "Instellen",
+            "change": "Wijzigen",
+            "delete": "Verwijderen",
+            "move": "Verplaatsen",
+            "toValue": "naar de waarde",
+            "to": "naar",
+            "search": "Zoeken naar",
+            "replace": "Vervangen door"
+        },
+        "errors": {
+            "invalid-from": "Ongeldige 'from'-eigenschap: __error__",
+            "invalid-json": "Ongeldige 'to' JSON-eigenschap",
+            "invalid-expr": "Ongeldige JSONata-expressie: __error__",
+            "no-override": "Kan eigenschap van niet-objecttype niet instellen: __property__",
+            "invalid-prop": "Ongeldige eigenschapsexpressie: __property__",
+            "invalid-json-data": "Ongeldige JSON-gegevens: __error__"
+        }
+    },
+    "range": {
+        "range": "bereik",
+        "label": {
+            "action": "Actie",
+            "inputrange": "Het invoerbereik mappen",
+            "resultrange": "naar het doelbereik",
+            "from": "van",
+            "to": "naar",
+            "roundresult": "Resultaat afronden naar dichtstbijzijnde geheel getal?",
+            "minin": "invoer van",
+            "maxin": "invoer naar",
+            "minout": "doel van",
+            "maxout": "doel naar"
+        },
+        "placeholder": {
+            "min": "bijv. 0",
+            "maxin": "bijv. 99",
+            "maxout": "bijv. 255"
+        },
+        "scale": {
+            "payload": "Schaal de berichteigenschap",
+            "limit": "Schalen en beperken tot het doelbereik",
+            "wrap": "Schalen en wrappen binnen het doelbereik",
+            "drop": "Schalen, maar bericht laten vallen als buiten invoerbereik"
+        },
+        "tip": "Tip: Deze node werkt ALLEEN met getallen.",
+        "errors": {
+            "notnumber": "Geen getal"
+        }
+    },
+    "csv": {
+        "label": {
+            "columns": "Kolommen",
+            "separator": "Scheidingsteken",
+            "c2o": "CSV naar Object opties",
+            "o2c": "Object naar CSV opties",
+            "input": "Invoer",
+            "skip-s": "Eerste",
+            "skip-e": "regels overslaan",
+            "firstrow": "eerste rij bevat kolomnamen",
+            "output": "Uitvoer",
+            "includerow": "kolomnamenrij opnemen",
+            "newline": "Nieuwe regel",
+            "usestrings": "numerieke waarden parseren",
+            "include_empty_strings": "lege strings opnemen",
+            "include_null_values": "null-waarden opnemen",
+            "spec": "Parser"
+        },
+        "spec": {
+            "rfc": "RFC4180",
+            "legacy": "Legacy",
+            "legacy_warning": "Legacy-modus wordt in een toekomstige release verwijderd."
+        },
+        "placeholder": {
+            "columns": "kommagescheiden kolomnamen"
+        },
+        "separator": {
+            "comma": "komma",
+            "tab": "tab",
+            "space": "spatie",
+            "semicolon": "puntkomma",
+            "colon": "dubbele punt",
+            "hashtag": "hashtag",
+            "other": "anders..."
+        },
+        "output": {
+            "row": "een bericht per rij",
+            "array": "een enkel bericht [array]"
+        },
+        "newline": {
+            "linux": "Linux (\\n)",
+            "mac": "Mac (\\r)",
+            "windows": "Windows (\\r\\n)"
+        },
+        "hdrout": {
+            "none": "nooit kolomheaders verzenden",
+            "all": "altijd kolomheaders verzenden",
+            "once": "headers eenmaal verzenden, tot msg.reset"
+        },
+        "errors": {
+            "bad_template": "Onjuiste kolomsjabloon.",
+            "csv_js": "Deze node verwerkt alleen CSV-strings of JS-objecten.",
+            "obj_csv": "Geen kolomsjabloon opgegeven voor object -> CSV.",
+            "bad_csv": "Onjuiste CSV-gegevens - uitvoer waarschijnlijk corrupt."
+        }
+    },
+    "html": {
+        "label": {
+            "select": "Selector",
+            "output": "Uitvoer",
+            "in": "in",
+            "prefix": "Eigenschapsnaam voor HTML-inhoud"
+        },
+        "output": {
+            "html": "de HTML-inhoud van de elementen",
+            "text": "alleen de tekstinhoud van de elementen",
+            "attr": "een object van alle attributen van de elementen",
+            "compl": "een object van alle attributen van de elementen en HTML-inhoud"
+        },
+        "format": {
+            "single": "als een enkel bericht met een array",
+            "multi": "als meerdere berichten, één voor elk element"
+        }
+    },
+    "json": {
+        "errors": {
+            "dropped-object": "Niet-object payload genegeerd",
+            "dropped": "Niet-ondersteund payloadtype genegeerd",
+            "dropped-error": "Kon payload niet converteren",
+            "schema-error": "JSON Schema-fout",
+            "schema-error-compile": "JSON Schema-fout: kon schema niet compileren"
+        },
+        "label": {
+            "o2j": "Object naar JSON opties",
+            "pretty": "JSON-string formatteren",
+            "action": "Actie",
+            "property": "Eigenschap",
+            "actions": {
+                "toggle": "Converteren tussen JSON-string en object",
+                "str": "Altijd converteren naar JSON-string",
+                "obj": "Altijd converteren naar JavaScript-object"
+            }
+        }
+    },
+    "yaml": {
+        "errors": {
+            "dropped-object": "Niet-object payload genegeerd",
+            "dropped": "Niet-ondersteund payloadtype genegeerd",
+            "dropped-error": "Kon payload niet converteren"
+        }
+    },
+    "xml": {
+        "label": {
+            "represent": "Eigenschapsnaam voor XML-tagattributen",
+            "prefix": "Eigenschapsnaam voor tagtekstinhoud",
+            "advanced": "Geavanceerde opties",
+            "x2o": "XML naar Object opties"
+        },
+        "errors": {
+            "xml_js": "Deze node verwerkt alleen XML-strings of JS-objecten."
+        }
+    },
+    "file": {
+        "label": {
+            "write": "bestand schrijven",
+            "read": "bestand lezen",
+            "filename": "Bestandsnaam",
+            "path": "pad",
+            "action": "Actie",
+            "addnewline": "Nieuwe regel (\\n) toevoegen aan elke payload?",
+            "createdir": "Map aanmaken als deze niet bestaat?",
+            "outputas": "Uitvoer",
+            "breakchunks": "Opdelen in chunks",
+            "breaklines": "Opdelen in regels",
+            "sendError": "Bericht verzenden bij fout (legacy-modus)",
+            "encoding": "Codering",
+            "deletelabel": "verwijder __file__",
+            "utf8String": "UTF8-string",
+            "utf8String_plural": "UTF8-strings",
+            "binaryBuffer": "binaire buffer",
+            "binaryBuffer_plural": "binaire buffers",
+            "allProps": "alle bestaande eigenschappen opnemen in elk bericht"
+        },
+        "action": {
+            "append": "toevoegen aan bestand",
+            "overwrite": "bestand overschrijven",
+            "delete": "bestand verwijderen"
+        },
+        "output": {
+            "utf8": "een enkele UTF8-string",
+            "buffer": "een enkel Buffer-object",
+            "lines": "een bericht per regel",
+            "stream": "een stream van Buffers"
+        },
+        "status": {
+            "wrotefile": "geschreven naar bestand: __file__",
+            "deletedfile": "bestand verwijderd: __file__",
+            "appendedfile": "toegevoegd aan bestand: __file__"
+        },
+        "encoding": {
+            "none": "standaard",
+            "setbymsg": "ingesteld door msg.encoding",
+            "native": "Native",
+            "unicode": "Unicode",
+            "japanese": "Japans",
+            "chinese": "Chinees",
+            "korean": "Koreaans",
+            "taiwan": "Taiwan/Hong Kong",
+            "windows": "Windows-codepagina's",
+            "iso": "ISO-codepagina's",
+            "ibm": "IBM-codepagina's",
+            "mac": "Mac-codepagina's",
+            "koi8": "KOI8-codepagina's",
+            "misc": "Overig"
+        },
+        "errors": {
+            "nofilename": "Geen bestandsnaam opgegeven",
+            "invaliddelete": "Waarschuwing: Ongeldige verwijdering. Gebruik de specifieke verwijderoptie in het configuratiedialoogvenster.",
+            "deletefail": "kon bestand niet verwijderen: __error__",
+            "writefail": "kon niet naar bestand schrijven: __error__",
+            "appendfail": "kon niet aan bestand toevoegen: __error__",
+            "createfail": "kon bestand niet aanmaken: __error__"
+        },
+        "tip": "Tip: De bestandsnaam moet een absoluut pad zijn, anders is het relatief aan de werkmap van het Node-RED-proces."
+    },
+    "split": {
+        "split": "splitsen",
+        "intro": "Splits <code>msg.payload</code> gebaseerd op type:",
+        "object": "<b>Object</b>",
+        "objectSend": "Verzend een bericht voor elk sleutel/waarde-paar",
+        "strBuff": "<b>String</b> / <b>Buffer</b>",
+        "array": "<b>Array</b>",
+        "splitThe": "Splits eigenschap",
+        "splitUsing": "Splitsen met",
+        "splitLength": "Vaste lengte van",
+        "stream": "Behandelen als een stream van berichten",
+        "addname": " Kopieer sleutel naar "
+    },
+    "join": {
+        "join": "samenvoegen",
+        "mode": {
+            "mode": "Modus",
+            "auto": "automatisch",
+            "merge": "sequenties samenvoegen",
+            "reduce": "sequentie reduceren",
+            "custom": "handmatig"
+        },
+        "combine": "Combineer elk",
+        "completeMessage": "volledig bericht",
+        "create": "om te maken",
+        "type": {
+            "string": "een String",
+            "array": "een Array",
+            "buffer": "een Buffer",
+            "object": "een sleutel/waarde-object",
+            "merged": "een samengevoegd object"
+        },
+        "using": "gebruikend de waarde van",
+        "key": "als de sleutel",
+        "joinedUsing": "samengevoegd met",
+        "send": "Verzend het bericht:",
+        "afterCount": "Na een aantal berichtdelen",
+        "useparts": "Bestaande msg.parts-eigenschap gebruiken",
+        "count": "aantal",
+        "subsequent": "en elk volgend bericht.",
+        "afterTimeout": "Na een timeout volgend op het eerste bericht",
+        "seconds": "seconden",
+        "complete": "Na een bericht met de <code>msg.complete</code>-eigenschap ingesteld",
+        "tip": "Deze modus gaat ervan uit dat deze node ofwel gekoppeld is aan een <i>split</i>-node of dat de ontvangen berichten een correct geconfigureerde <code>msg.parts</code>-eigenschap hebben.",
+        "too-many": "te veel wachtende berichten in join-node",
+        "message-prop": "berichteigenschap",
+        "merge": {
+            "topics-label": "Samengevoegde onderwerpen",
+            "topics": "onderwerpen",
+            "topic": "onderwerp",
+            "on-change": "Samengevoegd bericht verzenden bij aankomst van nieuw onderwerp"
+        },
+        "reduce": {
+            "exp": "Reduceer-exp",
+            "exp-value": "exp",
+            "init": "Initiële waarde",
+            "right": "Evalueren in omgekeerde volgorde (laatste naar eerste)",
+            "fixup": "Herstel-exp"
+        },
+        "errors": {
+            "invalid-expr": "Ongeldige JSONata-expressie: __error__",
+            "invalid-type": "Kan __error__ niet samenvoegen naar buffer"
+        }
+    },
+    "sort": {
+        "sort": "sorteren",
+        "target": "Sorteren",
+        "seq": "berichtsequentie",
+        "key": "Sleutel",
+        "elem": "elementwaarde",
+        "order": "Volgorde",
+        "ascending": "oplopend",
+        "descending": "aflopend",
+        "as-number": "als getal",
+        "invalid-exp": "Ongeldige JSONata-expressie in sort-node: __message__",
+        "too-many": "Te veel wachtende berichten in sort-node",
+        "clear": "wachtend bericht in sort-node wissen"
+    },
+    "batch": {
+        "batch": "batch",
+        "mode": {
+            "label": "Modus",
+            "num-msgs": "Groeperen op aantal berichten",
+            "interval": "Groeperen op tijdsinterval",
+            "concat": "Sequenties samenvoegen"
+        },
+        "count": {
+            "label": "Aantal berichten",
+            "overlap": "Overlap",
+            "count": "aantal",
+            "invalid": "Ongeldig aantal en overlap"
+        },
+        "interval": {
+            "label": "Interval",
+            "seconds": "seconden",
+            "empty": "leeg bericht verzenden wanneer geen bericht aankomt"
+        },
+        "concat": {
+            "topics-label": "Onderwerpen",
+            "topic": "onderwerp"
+        },
+        "too-many": "te veel wachtende berichten in batch-node",
+        "unexpected": "onverwachte modus",
+        "no-parts": "geen parts-eigenschap in bericht",
+        "honourParts": "Sta msg.parts toe om ook batch-operatie te voltooien.",
+        "error": {
+            "invalid-count": "Ongeldig aantal",
+            "invalid-overlap": "Ongeldige overlap",
+            "invalid-interval": "Ongeldig interval"
+        }
+    },
+    "rbe": {
+        "rbe": "filter",
+        "label": {
+            "func": "Modus",
+            "init": "Initiële waarde verzenden",
+            "start": "Startwaarde",
+            "name": "Naam",
+            "septopics": "Modus apart toepassen voor elk ",
+            "gap": "waardeverandering",
+            "property": "eigenschap",
+            "topic": "onderwerp"
+        },
+        "placeholder": {
+            "bandgap": "bijv. 10 of 5%",
+            "start": "laat leeg om eerste ontvangen gegevens te gebruiken"
+        },
+        "opts": {
+            "rbe": "blokkeren tenzij waarde verandert",
+            "rbei": "blokkeren tenzij waarde verandert (initiële waarde negeren)",
+            "deadband": "blokkeren tenzij waardeverandering groter is dan",
+            "deadbandEq": "blokkeren tenzij waardeverandering groter of gelijk is aan",
+            "narrowband": "blokkeren als waardeverandering groter is dan",
+            "narrowbandEq": "blokkeren als waardeverandering groter of gelijk is aan",
+            "in": "vergeleken met laatste invoerwaarde",
+            "out": "vergeleken met laatste geldige uitvoerwaarde"
+        },
+        "warn": {
+            "nonumber": "geen getal gevonden in payload"
+        }
+    },
+    "global-config": {
+        "label": {
+            "open-conf": "Configuratie openen"
+        }
+    }
+}

--- a/packages/node_modules/@node-red/runtime/locales/nl-NL/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/nl-NL/runtime.json
@@ -1,0 +1,195 @@
+{
+    "runtime": {
+        "welcome": "Welkom bij Node-RED",
+        "version": "__component__ versie: __version__",
+        "unsupported_version": "Niet-ondersteunde versie van __component__. Vereist: __requires__ Gevonden: __version__",
+        "paths": {
+            "settings": "Instellingenbestand: __path__",
+            "httpStatic": "HTTP Static    : __path__"
+        }
+    },
+    "server": {
+        "loading": "Palet-nodes laden",
+        "palette-editor": {
+            "disabled": "Paleteditor uitgeschakeld: gebruikersinstellingen",
+            "npm-not-found": "Paleteditor uitgeschakeld: npm-commando niet gevonden",
+            "npm-too-old": "Paleteditor uitgeschakeld: npm-versie te oud. Vereist npm >= 3.x"
+        },
+        "errors": "Kon __count__ node-type niet registreren",
+        "errors_plural": "Kon __count__ node-types niet registreren",
+        "errors-help": "Voer uit met -v voor details",
+        "missing-modules": "Ontbrekende node-modules:",
+        "node-version-mismatch": "Node-module kan niet worden geladen op deze versie. Vereist: __version__",
+        "set-has-no-types": "Set heeft geen types. naam: '__name__', module: '__module__', bestand: '__file__'",
+        "type-already-registered": "'__type__' al geregistreerd door module __module__",
+        "removing-modules": "Modules verwijderen uit configuratie",
+        "added-types": "Toegevoegde node-types:",
+        "removed-types": "Verwijderde node-types:",
+        "removed-plugins": "Verwijderde plugins:",
+        "install": {
+            "invalid": "Ongeldige modulenaam",
+            "installing": "Module installeren: __name__, versie: __version__",
+            "installed": "Module geïnstalleerd: __name__",
+            "install-failed": "Installatie mislukt",
+            "install-failed-long": "Installatie van module __name__ mislukt:",
+            "install-failed-not-found": "$t(server.install.install-failed-long) module niet gevonden",
+            "install-failed-name": "$t(server.install.install-failed-long) ongeldige modulenaam: __name__",
+            "install-failed-url": "$t(server.install.install-failed-long) ongeldige URL: __url__",
+            "post-install-error": "Fout bij uitvoeren 'postInstall' hook:",
+            "upgrading": "Module upgraden: __name__ naar versie: __version__",
+            "upgraded": "Module geüpgraded: __name__. Herstart Node-RED om de nieuwe versie te gebruiken",
+            "upgrade-failed-not-found": "$t(server.install.install-failed-long) versie niet gevonden",
+            "uninstalling": "Module verwijderen: __name__",
+            "uninstall-failed": "Verwijdering mislukt",
+            "uninstall-failed-long": "Verwijdering van module __name__ mislukt:",
+            "uninstalled": "Module verwijderd: __name__",
+            "old-ext-mod-dir-warning": "\n\n---------------------------------------------------------------------\nNode-RED 1.3 externe modules-map gedetecteerd:\n    __oldDir__\nDeze map wordt niet meer gebruikt. Externe modules worden\nopnieuw geïnstalleerd in uw Node-RED-gebruikersmap:\n   __newDir__\nVerwijder de oude externalModules-map om dit bericht te stoppen.\n---------------------------------------------------------------------\n"
+        },
+        "deprecatedOption": "Gebruik van __old__ is VEROUDERD. Gebruik in plaats daarvan __new__",
+        "unable-to-listen": "Kan niet luisteren op __listenpath__",
+        "port-in-use": "Fout: poort in gebruik",
+        "uncaught-exception": "Niet-opgevangen uitzondering:",
+        "admin-ui-disabled": "Admin-UI uitgeschakeld",
+        "now-running": "Server draait nu op __listenpath__",
+        "failed-to-start": "Server starten mislukt:",
+        "headless-mode": "Draait in headless-modus",
+        "httpadminauth-deprecated": "Gebruik van httpAdminAuth is VEROUDERD. Gebruik in plaats daarvan adminAuth",
+        "https": {
+            "refresh-interval": "HTTPS-instellingen verversen elke __interval__ uur",
+            "settings-refreshed": "Server HTTPS-instellingen zijn vernieuwd",
+            "refresh-failed": "Vernieuwen van HTTPS-instellingen mislukt: __message__",
+            "function-required": "httpsRefreshInterval vereist dat de https-eigenschap een functie is"
+        }
+    },
+    "api": {
+        "flows": {
+            "error-save": "Fout bij opslaan van flows: __message__",
+            "error-reload": "Fout bij herladen van flows: __message__"
+        },
+        "library": {
+            "error-load-entry": "Fout bij laden van bibliotheekitem '__path__': __message__",
+            "error-save-entry": "Fout bij opslaan van bibliotheekitem '__path__': __message__",
+            "error-load-flow": "Fout bij laden van flow '__path__': __message__",
+            "error-save-flow": "Fout bij opslaan van flow '__path__': __message__"
+        },
+        "nodes": {
+            "enabled": "Ingeschakelde node-types:",
+            "disabled": "Uitgeschakelde node-types:",
+            "error-enable": "Inschakelen van node mislukt:"
+        }
+    },
+    "comms": {
+        "error": "Communicatiekanalfout: __message__",
+        "error-server": "Communicatieserverfout: __message__",
+        "error-send": "Communicatieverzendfout: __message__"
+    },
+    "settings": {
+        "user-not-available": "Kan gebruikersinstellingen niet opslaan: __message__",
+        "not-available": "Instellingen niet beschikbaar",
+        "property-read-only": "Eigenschap '__prop__' is alleen-lezen",
+        "readonly-mode": "Runtime in alleen-lezen modus. Wijzigingen worden niet opgeslagen."
+    },
+    "library": {
+        "unknownLibrary": "Onbekende bibliotheek: __library__",
+        "unknownType": "Onbekend bibliotheektype: __type__",
+        "readOnly": "Bibliotheek __library__ is alleen-lezen",
+        "failedToInit": "Initialiseren van bibliotheek __library__ mislukt: __error__",
+        "invalidProperty": "Ongeldige eigenschap __prop__: '__value__'"
+    },
+    "nodes": {
+        "credentials": {
+            "error": "Fout bij laden van referenties: __message__",
+            "error-saving": "Fout bij opslaan van referenties: __message__",
+            "not-registered": "Referentietype '__type__' is niet geregistreerd",
+            "system-key-warning": "\n\n---------------------------------------------------------------------\nUw flow-referentiebestand is versleuteld met een systeemgegenereerde sleutel.\n\nAls de systeemgegenereerde sleutel om welke reden dan ook verloren gaat,\nkan uw referentiebestand niet worden hersteld. U moet het verwijderen\nen uw referenties opnieuw invoeren.\n\nU zou uw eigen sleutel moeten instellen met de 'credentialSecret'-optie\nin uw instellingenbestand. Node-RED zal dan uw referentiebestand\nopnieuw versleutelen met uw gekozen sleutel bij de volgende implementatie.\n---------------------------------------------------------------------\n",
+            "unencrypted": "Onversleutelde referenties gebruiken",
+            "encryptedNotFound": "Versleutelde referenties niet gevonden"
+        },
+        "flows": {
+            "safe-mode": "Flows gestopt in veilige modus. Implementeer om te starten.",
+            "registered-missing": "Ontbrekend type geregistreerd: __type__",
+            "error": "Fout bij laden van flows: __message__",
+            "starting-modified-nodes": "Gewijzigde nodes starten",
+            "starting-modified-flows": "Gewijzigde flows starten",
+            "starting-flows": "Flows starten",
+            "started-modified-nodes": "Gewijzigde nodes gestart",
+            "started-modified-flows": "Gewijzigde flows gestart",
+            "started-flows": "Flows gestart",
+            "stopping-modified-nodes": "Gewijzigde nodes stoppen",
+            "stopping-modified-flows": "Gewijzigde flows stoppen",
+            "stopping-flows": "Flows stoppen",
+            "stopped-modified-nodes": "Gewijzigde nodes gestopt",
+            "stopped-modified-flows": "Gewijzigde flows gestopt",
+            "stopped-flows": "Flows gestopt",
+            "stopped": "Gestopt",
+            "stopping-error": "Fout bij stoppen van node: __message__",
+            "updated-flows": "Flows bijgewerkt",
+            "added-flow": "Flow toevoegen: __label__",
+            "updated-flow": "Flow bijgewerkt: __label__",
+            "removed-flow": "Flow verwijderd: __label__",
+            "missing-types": "Wachten op registratie van ontbrekende types:",
+            "missing-type-provided": " - __type__ (geleverd door npm-module __module__)",
+            "missing-type-install-1": "Om een van deze ontbrekende modules te installeren, voer uit:",
+            "missing-type-install-2": "in de map:"
+        },
+        "flow": {
+            "unknown-type": "Onbekend type: __type__",
+            "missing-types": "ontbrekende types",
+            "error-loop": "Bericht heeft maximum aantal catches overschreden",
+            "non-message-returned": "Node probeerde een bericht van type __type__ te verzenden"
+        },
+        "index": {
+            "unrecognised-id": "Onbekend ID: __id__",
+            "type-in-use": "Type in gebruik: __msg__",
+            "unrecognised-module": "Onbekende module: __module__"
+        },
+        "registry": {
+            "localfilesystem": {
+                "module-not-found": "Kan module '__module__' niet vinden"
+            }
+        }
+    },
+    "storage": {
+        "index": {
+            "forbidden-flow-name": "verboden flow-naam"
+        },
+        "localfilesystem": {
+            "user-dir": "Gebruikersmap  : __path__",
+            "flows-file": "Flows-bestand  : __path__",
+            "create": "Nieuw __type__-bestand aanmaken",
+            "empty": "Bestaand __type__-bestand is leeg",
+            "invalid": "Bestaand __type__-bestand is geen geldige JSON",
+            "restore": "__type__-bestandsback-up herstellen: __path__",
+            "restore-fail": "Herstellen van __type__-bestandsback-up mislukt: __message__",
+            "fsync-fail": "Bestand __path__ naar schijf schrijven mislukt: __message__",
+            "warn_name": "Flows-bestandsnaam niet ingesteld. Naam genereren met hostnaam.",
+            "projects": {
+                "changing-project": "Actief project instellen: __project__",
+                "active-project": "Actief project: __project__",
+                "projects-directory": "Projectenmap: __projectsDirectory__",
+                "project-not-found": "Project niet gevonden: __project__",
+                "no-active-project": "Geen actief project: standaard flows-bestand gebruiken",
+                "disabled": "Projecten uitgeschakeld: editorTheme.projects.enabled=false",
+                "disabledNoFlag": "Projecten uitgeschakeld: stel editorTheme.projects.enabled=true in om in te schakelen",
+                "git-not-found": "Projecten uitgeschakeld: git-commando niet gevonden",
+                "git-version-old": "Projecten uitgeschakeld: git __version__ niet ondersteund. Vereist 2.x",
+                "summary": "Een Node-RED-project",
+                "readme": "### Over\n\nDit is het README.md-bestand van uw project. Het helpt gebruikers te begrijpen wat uw\nproject doet, hoe het te gebruiken en al het andere dat ze mogelijk moeten weten."
+            }
+        }
+    },
+    "context": {
+        "log-store-init": "Context store  : '__name__' [__info__]",
+        "error-loading-module": "Fout bij laden van context store: __message__",
+        "error-loading-module2": "Fout bij laden van context store '__module__': __message__",
+        "error-module-not-defined": "Context store '__storage__' mist 'module'-optie",
+        "error-invalid-module-name": "Ongeldige context store naam: '__name__'",
+        "error-invalid-default-module": "Standaard context store onbekend: '__storage__'",
+        "unknown-store": "Onbekende context store '__name__' opgegeven. Standaard store gebruiken.",
+        "localfilesystem": {
+            "invalid-json": "Ongeldige JSON in contextbestand '__file__'",
+            "error-circular": "Context __scope__ bevat een circulaire referentie die niet kan worden opgeslagen",
+            "error-write": "Fout bij schrijven van context: __message__"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add Dutch (nl-NL) translations for the nodes and runtime packages:

- `@node-red/nodes/locales/nl-NL/messages.json` - All core node labels, errors, and status messages
- `@node-red/runtime/locales/nl-NL/runtime.json` - Server messages, flow status, storage messages

Follow-up to #5440 (editor-client Dutch locale).

## Test plan

- [x] Set language to Dutch (nl-NL) in Node-RED settings
- [x] Verify node labels and error messages appear in Dutch
- [x] Verify runtime/server messages appear in Dutch in the console