### PR TITLE
i18n: add Dutch (nl-NL) help documentation for core nodes

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/common/20-inject.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/common/20-inject.html
@@ -1,0 +1,40 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="inject">
+<p>Injecteert een bericht in een flow, handmatig of met regelmatige intervallen. De payload
+van het bericht kan verschillende types hebben, waaronder strings, JavaScript-objecten of de huidige tijd.</p>
+<h3>Uitvoer</h3>
+<dl class="message-properties">
+    <dt>payload<span class="property-type">divers</span></dt>
+    <dd>De geconfigureerde payload van het bericht.</dd>
+    <dt class="optional">topic <span class="property-type">string</span></dt>
+    <dd>Een optionele eigenschap die in de node kan worden geconfigureerd.</dd>
+</dl>
+<h3>Details</h3>
+<p>De Inject-node kan een flow starten met een specifieke payload-waarde.
+De standaard payload is een tijdstempel van de huidige tijd in milliseconden sinds 1 januari 1970.</p>
+<p>De node ondersteunt ook het injecteren van strings, getallen, booleans, JavaScript-objecten of flow/global context-waarden.</p>
+<p>Standaard wordt de node handmatig geactiveerd door op de knop in de editor te klikken. De node kan ook worden ingesteld om
+met regelmatige intervallen of volgens een schema te injecteren.</p>
+<p>De node kan ook worden geconfigureerd om eenmaal te injecteren elke keer dat de flows worden gestart.</p>
+<p>Het maximale <i>interval</i> dat kan worden opgegeven is ongeveer 596 uur / 24 dagen. Als u echter intervallen
+langer dan één dag nodig heeft, overweeg dan een scheduler-node te gebruiken die bestand is tegen stroomuitval en herstarts.</p>
+<p><b>Let op</b>: De opties <i>"Interval tussen tijden"</i> en <i>"op een specifiek tijdstip"</i> gebruiken het standaard cron-systeem.
+Dit betekent dat 20 minuten op het volgende hele uur, 20 minuten over en 40 minuten over zal zijn - niet over 20 minuten vanaf nu.
+Als u elke 20 minuten vanaf nu wilt - gebruik dan de <i>"interval"</i>-optie.</p>
+<p><b>Let op</b>: Om een nieuwe regel in een string op te nemen moet u de Function- of Template-node gebruiken om de payload te maken.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/common/21-debug.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/common/21-debug.html
@@ -1,0 +1,26 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="debug">
+    <p>Toont geselecteerde berichteigenschappen in het debug-zijbalktabblad en optioneel in het runtime-logboek. Standaard wordt <code>msg.payload</code> weergegeven, maar de node kan worden geconfigureerd om elke eigenschap, het volledige bericht of het resultaat van een JSONata-expressie weer te geven.</p>
+    <h3>Details</h3>
+    <p>De debug-zijbalk biedt een gestructureerde weergave van de berichten die het ontvangt, waardoor het gemakkelijker wordt om hun structuur te begrijpen.</p>
+    <p>JavaScript-objecten en arrays kunnen naar behoefte worden in- en uitgeklapt. Buffer-objecten kunnen worden weergegeven als ruwe gegevens of als een string indien mogelijk.</p>
+    <p>Naast elk bericht toont de debug-zijbalk informatie over het tijdstip waarop het bericht is ontvangen, de node die het heeft verzonden en het type van het bericht.
+       Door op de bron-node-ID te klikken wordt die node in de werkruimte weergegeven.</p>
+    <p>De knop op de node kan worden gebruikt om de uitvoer in of uit te schakelen. Het wordt aanbevolen om Debug-nodes die niet worden gebruikt uit te schakelen of te verwijderen.</p>
+    <p>De node kan ook worden geconfigureerd om alle berichten naar het runtime-logboek te sturen, of om een korte tekst (32 tekens) naar de statustekst onder de debug-node te sturen.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/common/24-complete.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/common/24-complete.html
@@ -1,0 +1,29 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="complete">
+    <p>Start een flow wanneer een andere node klaar is met het verwerken van een bericht.</p>
+    <h3>Details</h3>
+    <p>Als een node aan de runtime meldt wanneer het klaar is met het verwerken van een bericht,
+        kan deze node worden gebruikt om een tweede flow te starten.</p>
+    <p>Dit kan bijvoorbeeld worden gebruikt samen met een node zonder uitvoerpoort,
+        zoals de E-mail verzendnode, om de flow voort te zetten.</p>
+    <p>Deze node moet worden geconfigureerd om de gebeurtenis voor geselecteerde nodes in de
+        flow af te handelen. In tegenstelling tot de Catch-node biedt deze geen 'alles afhandelen'-modus die automatisch
+        op alle nodes in de flow van toepassing is.</p>
+    <p>Niet alle nodes activeren deze gebeurtenis - dit hangt af van of ze
+        zijn geïmplementeerd om deze functie te ondersteunen die werd geïntroduceerd in Node-RED 1.0.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/common/25-catch.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/common/25-catch.html
@@ -1,0 +1,42 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="catch">
+    <p>Vangt fouten op die worden gegenereerd door nodes op hetzelfde tabblad.</p>
+    <h3>Uitvoer</h3>
+    <dl class="message-properties">
+        <dt>error.message <span class="property-type">string</span></dt>
+        <dd>het foutbericht.</dd>
+        <dt>error.source.id <span class="property-type">string</span></dt>
+        <dd>de ID van de node die de fout heeft gegenereerd.</dd>
+        <dt>error.source.type <span class="property-type">string</span></dt>
+        <dd>het type van de node die de fout heeft gegenereerd.</dd>
+        <dt>error.source.name <span class="property-type">string</span></dt>
+        <dd>de naam, indien ingesteld, van de node die de fout heeft gegenereerd.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>Als een node een fout genereert tijdens het verwerken van een bericht, stopt de flow meestal.
+       Deze node kan worden gebruikt om die fouten op te vangen en ze met een
+       speciale flow af te handelen.</p>
+    <p>Standaard vangt de node fouten op die worden gegenereerd door elke node op hetzelfde tabblad. Als alternatief
+    kan deze worden gericht op specifieke nodes, of geconfigureerd om alleen fouten op te vangen die
+    nog niet zijn opgevangen door een 'gerichte' catch-node.</p>
+    <p>Wanneer een fout wordt gegenereerd, ontvangen alle overeenkomende catch-nodes het bericht.</p>
+    <p>Als een fout wordt gegenereerd binnen een subflow, wordt de fout afgehandeld door eventuele
+       catch-nodes binnen de subflow. Als er geen bestaat, wordt de fout doorgegeven
+       naar het tabblad waarop de subflow-instantie zich bevindt.</p>
+   <p>Als het bericht al een <code>error</code>-eigenschap heeft, wordt deze gekopieerd naar <code>_error</code>.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/common/25-status.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/common/25-status.html
@@ -1,0 +1,34 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="status">
+    <p>Rapporteert statusberichten van andere nodes op hetzelfde tabblad.</p>
+    <h3>Uitvoer</h3>
+    <dl class="message-properties">
+        <dt>status.text <span class="property-type">string</span></dt>
+        <dd>de statustekst.</dd>
+        <dt>status.source.type <span class="property-type">string</span></dt>
+        <dd>het type van de node die de status heeft gerapporteerd.</dd>
+        <dt>status.source.id <span class="property-type">string</span></dt>
+        <dd>de ID van de node die de status heeft gerapporteerd.</dd>
+        <dt>status.source.name <span class="property-type">string</span></dt>
+        <dd>de naam, indien ingesteld, van de node die de status heeft gerapporteerd.</dd>
+    </dl>
+    <h3>Details</h3>
+   <p>Deze node produceert geen <code>payload</code>.</p>
+   <p>Standaard rapporteert de node de status van alle nodes op hetzelfde werkruimtetabblad.
+   De node kan worden geconfigureerd om selectief de status van individuele nodes te rapporteren.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/common/60-link.html
@@ -1,0 +1,66 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="link in">
+    <p>Maak virtuele verbindingen tussen flows.</p>
+    <h3>Details</h3>
+    <p>De node kan worden verbonden met elke <code>link out</code>-node die op elk tabblad bestaat.
+       Eenmaal verbonden gedragen ze zich alsof ze met elkaar zijn verbonden.</p>
+    <p>De verbindingen tussen link-nodes worden alleen weergegeven wanneer een link-node is geselecteerd.
+       Als er verbindingen naar andere tabbladen zijn, wordt een virtuele node getoond waarop kan worden geklikt
+       om naar het juiste tabblad te springen.</p>
+    <p><b>Let op: </b>Links kunnen niet worden gemaakt naar of vanuit een subflow.</p>
+</script>
+
+<script type="text/html" data-help-name="link out">
+    <p>Maak virtuele verbindingen tussen flows.</p>
+    <h3>Details</h3>
+    <p>Deze node kan worden geconfigureerd om berichten te verzenden naar alle <code>link in</code>-nodes
+       waarmee deze is verbonden, of om een reactie terug te sturen naar de <code>link call</code>-node
+       die de flow heeft geactiveerd.</p>
+    <p>In de modus 'verzenden naar alle' worden de verbindingen tussen link-nodes alleen weergegeven wanneer
+       de node is geselecteerd. Als er verbindingen naar andere tabbladen zijn, wordt een virtuele node
+       getoond waarop kan worden geklikt om naar het juiste tabblad te springen.</p>
+    <p><b>Let op: </b>Links kunnen niet worden gemaakt naar of vanuit een subflow.</p>
+</script>
+
+<script type="text/html" data-help-name="link call">
+    <p>Roept een flow aan die begint met een <code>link in</code>-node en geeft de reactie door.</p>
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+      <dt class="optional">target<span class="property-type">string</span></dt>
+      <dd>Wanneer de optie <b>Link-type</b> is ingesteld op "Dynamisch doel", stel <code>msg.target</code> in op de naam van de
+          <code>link in</code>-node die u wilt aanroepen.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>Deze node kan worden verbonden met een <code>link in</code>-node die op elk tabblad bestaat.
+       De flow die met die node is verbonden moet eindigen met een <code>link out</code>-node die is geconfigureerd
+       in 'return'-modus.</p>
+    <p>Wanneer deze node een bericht ontvangt, wordt het doorgegeven aan de verbonden <code>link in</code>-node.
+       Vervolgens wacht de node op een reactie die dan wordt doorgestuurd.</p>
+    <p>Als er geen reactie wordt ontvangen binnen de geconfigureerde timeout, standaard 30 seconden, logt de node
+       een fout die kan worden opgevangen met de <code>catch</code>-node.</p>
+    <p>Wanneer de optie <b>Link-type</b> is ingesteld op "Dynamisch doel" kan <code>msg.target</code> worden gebruikt om een
+       <code>link in</code> aan te roepen op naam of ID.
+    <ul>
+      <li>Als er een <code>link in</code>-node is met dezelfde ID, wordt deze aangeroepen</li>
+      <li>Als er twee of meer <code>link in</code>-nodes zijn met dezelfde naam, wordt een fout gegenereerd</li>
+      <li>Een <code>link call</code> kan geen <code>link in</code>-node binnen een subflow aanroepen</li>
+    </ul>
+    </p>
+    De flow die met die node is verbonden moet eindigen met een <code>link out</code>-node die is geconfigureerd
+    in 'return'-modus.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/common/90-comment.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/common/90-comment.html
@@ -1,0 +1,22 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="comment">
+    <p>Een node die u kunt gebruiken om commentaar aan uw flows toe te voegen.</p>
+    <h3>Details</h3>
+    <p>Het bewerkingspaneel accepteert Markdown-syntax. De tekst wordt weergegeven in
+    het informatie-zijpaneel.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/common/91-global-config.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/common/91-global-config.html
@@ -1,0 +1,3 @@
+<script type="text/html" data-help-name="global-config">
+    <p>Een node voor het bewaren van globale configuratie van flows.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/common/98-unknown.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/common/98-unknown.html
@@ -1,0 +1,28 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="unknown">
+    <p>Deze node is een type dat onbekend is in uw Node-RED-installatie.</p>
+    <h3>Details</h3>
+    <p><i>Als u implementeert met de node in deze staat, wordt de configuratie behouden, maar
+    de flow start niet totdat het ontbrekende type is geïnstalleerd.</i></p>
+    <p>Gebruik de optie <code>Menu - Palet beheren</code>
+    om nodes te zoeken en te installeren, of <b>npm install &lt;module&gt;</b> om
+    eventuele ontbrekende modules te installeren, herstart vervolgens Node-RED en importeer de nodes opnieuw.</p>
+    <p>Het is mogelijk dat dit node-type al is geïnstalleerd, maar een afhankelijkheid mist. Controleer het Node-RED-opstartlogboek
+    op eventuele foutberichten die verband houden met het ontbrekende node-type.</p>
+    <p>Anders moet u contact opnemen met de auteur van de flow om een kopie van het ontbrekende node-type te verkrijgen.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/function/10-function.html
@@ -1,0 +1,64 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="function">
+    <p>Een JavaScript-functie die wordt uitgevoerd op de berichten die door de node worden ontvangen.</p>
+    <p>De berichten worden doorgegeven als een JavaScript-object genaamd <code>msg</code>.</p>
+    <p>Volgens conventie heeft het een <code>msg.payload</code>-eigenschap die
+       de inhoud van het bericht bevat.</p>
+    <p>De functie wordt verwacht een berichtobject (of meerdere berichtobjecten) te retourneren, maar kan ervoor kiezen
+       niets te retourneren om een flow te stoppen.</p>
+    <p>Het <b>Bij start</b>-tabblad bevat code die wordt uitgevoerd wanneer de node wordt gestart.
+        Het <b>Bij stoppen</b>-tabblad bevat code die wordt uitgevoerd wanneer de node wordt gestopt.</p>
+    <p>Als de Bij start-code een Promise-object retourneert, begint de node pas met het verwerken van berichten
+        nadat de promise is opgelost.</p>
+    <h3>Details</h3>
+    <p>Zie de <a target="_blank" href="https://nodered.org/docs/writing-functions.html">online documentatie</a>
+    voor meer informatie over het schrijven van functies.</p>
+    <h4>Berichten verzenden</h4>
+    <p>De functie kan de berichten retourneren die het wil doorgeven aan de volgende nodes
+    in de flow, of kan <code>node.send(messages)</code> aanroepen.</p>
+    <p>Het kan retourneren/verzenden:</p>
+    <ul>
+      <li>een enkel berichtobject - doorgegeven aan nodes verbonden met de eerste uitvoer</li>
+      <li>een array van berichtobjecten - doorgegeven aan nodes verbonden met de overeenkomstige uitvoeren</li>
+    </ul>
+    <p>Let op: De setup-code wordt uitgevoerd tijdens de initialisatie van nodes. Als <code>node.send</code> in het setup-tabblad wordt aangeroepen, kunnen volgende nodes het bericht mogelijk niet ontvangen.</p>
+    <p>Als een element van de array zelf een array van berichten is, worden meerdere
+          berichten naar de overeenkomstige uitvoer verzonden.</p>
+    <p>Als null wordt geretourneerd, op zichzelf of als element van de array, wordt er geen
+          bericht doorgegeven.</p>
+    <h4>Loggen en foutafhandeling</h4>
+    <p>Om informatie te loggen of een fout te rapporteren zijn de volgende functies beschikbaar:</p>
+      <ul>
+          <li><code>node.log("Logbericht")</code></li>
+          <li><code>node.warn("Waarschuwing")</code></li>
+          <li><code>node.error("Fout")</code></li>
+      </ul>
+    </p>
+    <p>De Catch-node kan ook worden gebruikt om fouten af te handelen. Om een Catch-node aan te roepen,
+    geef <code>msg</code> door als tweede argument aan <code>node.error</code>:</p>
+    <pre>node.error("Fout",msg);</pre>
+    <h4>Toegang tot node-informatie</h4>
+    <p>De volgende eigenschappen zijn beschikbaar om informatie over de node te verkrijgen:</p>
+    <ul>
+        <li><code>node.id</code> - ID van de node</li>
+        <li><code>node.name</code> - naam van de node</li>
+        <li><code>node.outputCount</code> - aantal node-uitvoeren</li>
+    </ul>
+    <h4>Omgevingsvariabelen gebruiken</h4>
+    <p>Omgevingsvariabelen kunnen worden benaderd met <code>env.get("MY_ENV_VAR")</code>.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/function/10-switch.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/function/10-switch.html
@@ -1,0 +1,50 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="switch">
+    <p>Routeer berichten op basis van hun eigenschapswaarden of sequentiepositie.</p>
+    <h3>Details</h3>
+    <p>Wanneer een bericht aankomt, evalueert de node elk van de gedefinieerde regels
+    en stuurt het bericht door naar de overeenkomstige uitvoeren van alle overeenkomende regels.</p>
+    <p>Optioneel kan de node worden ingesteld om te stoppen met evalueren zodra er een
+    overeenkomende regel is gevonden.</p>
+    <p>De regels kunnen worden geëvalueerd tegen een individuele berichteigenschap, een flow- of global
+    context-eigenschap, omgevingsvariabele of het resultaat van een JSONata-expressie.</p>
+    <h4>Regels</h4>
+    <p>Er zijn vier soorten regels:</p>
+    <ol>
+        <li><b>Waarde</b>-regels worden geëvalueerd tegen de geconfigureerde eigenschap</li>
+        <li><b>Sequentie</b>-regels kunnen worden gebruikt op berichtsequenties, zoals die
+            gegenereerd door de Split-node</li>
+        <li>Een JSONata <b>Expressie</b> kan worden opgegeven die wordt geëvalueerd
+            tegen het hele bericht en overeenkomt als de expressie een
+            true-waarde retourneert.</li>
+        <li>Een <b>Anders</b>-regel kan worden gebruikt om overeen te komen als geen van de voorgaande
+            regels heeft gematcht.</li>
+    </ol>
+    <h4>Opmerkingen</h4>
+    <p>De <code>is waar/onwaar</code> en <code>is null</code> regels voeren strikte
+       vergelijkingen uit tegen die types. Ze converteren niet tussen types.</p>
+    <p>De <code>is leeg</code> en <code>is niet leeg</code> regels kunnen worden gebruikt om de lengte van Strings, Arrays en Buffers te testen, of het aantal eigenschappen dat een Object heeft. Geen van beide regels zal slagen als de geteste eigenschap een <code>boolean</code>, <code>null</code>
+       of <code>undefined</code> waarde heeft.</p>
+    <h4>Omgaan met berichtsequenties</h4>
+    <p>Standaard wijzigt de node de <code>msg.parts</code>-eigenschap niet van berichten
+       die deel uitmaken van een sequentie.</p>
+    <p>De <b>berichtsequenties herstellen</b>-optie kan worden ingeschakeld om nieuwe berichtsequenties te genereren
+       voor elke regel die overeenkomt. In deze modus buffert de node de volledige inkomende
+       sequentie voordat de nieuwe sequenties worden verzonden. De runtime-instelling <code>nodeMessageBufferMaxLength</code>
+       kan worden gebruikt om te beperken hoeveel berichten nodes zullen bufferen.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/function/15-change.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/function/15-change.html
@@ -1,0 +1,39 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="change">
+    <p>Stelt eigenschappen van een bericht, flow-context of globale context in, wijzigt, verwijdert of verplaatst deze.</p>
+    <p>De node kan meerdere regels specificeren die worden toegepast in de volgorde waarin ze zijn gedefinieerd.</p>
+    <h3>Details</h3>
+    <p>De beschikbare bewerkingen zijn:</p>
+    <dl class="message-properties">
+    <dt>Instellen</dt>
+    <dd>stel een eigenschap in. De waarde kan verschillende typen hebben, of
+            kan worden overgenomen van een bestaande bericht- of contexteigenschap.</dd>
+    <dt>Wijzigen</dt>
+    <dd>zoek &amp; vervang delen van de eigenschap. Als reguliere expressies
+        zijn ingeschakeld, kan de "vervangen door" eigenschap capture groups bevatten, bijvoorbeeld
+        <code>$1</code>. Vervangen wijzigt alleen het type als er een
+        volledige overeenkomst is.</dd>
+    <dt>Verwijderen</dt>
+    <dd>verwijder een eigenschap.</dd>
+    <dt>Verplaatsen</dt>
+    <dd>verplaats of hernoem een eigenschap.</dd>
+    </dl>
+    <p>Het "expressie" type gebruikt de <a href="http://jsonata.org/" target="_new">JSONata</a>
+    query- en expressietaal.
+    </p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/function/16-range.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/function/16-range.html
@@ -1,0 +1,47 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="range">
+    <p>Schaalt een numerieke waarde naar een ander bereik.</p>
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">number</span></dt>
+        <dd>De payload <i>moet</i> een getal zijn. Alles anders wordt geprobeerd
+        te converteren naar een getal en afgewezen als dat mislukt.</dd>
+    </dl>
+    <h3>Uitvoer</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">number</span></dt>
+        <dd>De waarde geschaald naar het nieuwe bereik.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>Deze node schaalt de ontvangen waarde lineair. Standaard wordt het resultaat
+    niet beperkt tot het bereik dat in de node is gedefinieerd.</p>
+    <p><i>Schaal en beperk tot doelbereik</i> betekent dat het resultaat nooit buiten
+    het opgegeven doelbereik zal vallen.</p>
+    <p><i>Schaal en laat rondgaan binnen het doelbereik</i> betekent dat het resultaat
+    zal rondgaan binnen het doelbereik.</p>
+    <p><i>Schaal, maar laat vallen als buiten invoerbereik</i> betekent dat het resultaat
+    wordt geschaald, maar invoer buiten het invoerbereik wordt genegeerd.</p>
+    <p>Bijvoorbeeld een invoer 0 - 10 geschaald naar 0 - 100.</p>
+    <table style="outline-width:#888 solid thin">
+        <tr><th width="80px">modus</th><th width="80px">invoer</th><th width="80px">uitvoer</th></tr>
+        <tr><td><center>schaal</center></td><td><center>12</center></td><td><center>120</center></td></tr>
+        <tr><td><center>beperk</center></td><td><center>12</center></td><td><center>100</center></td></tr>
+        <tr><td><center>rondgaan</center></td><td><center>12</center></td><td><center>20</center></td></tr>
+        <tr><td><center>laat vallen</center></td><td><center>12</center></td><td><center><i>(geen uitvoer)</i></center></td></tr>
+    </table>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/function/80-template.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/function/80-template.html
@@ -1,0 +1,58 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="template">
+    <p>Stelt een eigenschap in op basis van het opgegeven sjabloon.</p>
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt>msg <span class="property-type">object</span></dt>
+        <dd>Een msg-object met informatie om het sjabloon te vullen.</dd>
+        <dt class="optional">template <span class="property-type">string</span></dt>
+        <dd>Een sjabloon dat wordt gevuld vanuit <code>msg.payload</code>. Als dit niet is geconfigureerd in het bewerkingspaneel,
+         kan dit worden ingesteld als een eigenschap van msg.</dd>
+    </dl>
+    <h3>Uitvoer</h3>
+    <dl class="message-properties">
+        <dt>msg <span class="property-type">object</span></dt>
+        <dd>een msg met een eigenschap die is ingesteld door het geconfigureerde sjabloon te vullen met eigenschappen van het inkomende bericht.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>Standaard gebruikt dit het <i><a href="http://mustache.github.io/mustache.5.html" target="_blank">mustache</a></i>
+    formaat, maar dit kan indien nodig worden uitgeschakeld.</p>
+    <p>Bijvoorbeeld, wanneer een sjabloon van:
+    <pre>Hallo {{payload.name}}. Vandaag is het {{date}}</pre>
+    <p>een bericht ontvangt met:
+    <pre>{
+  date: "maandag",
+  payload: {
+    name: "Jan"
+  }
+}</pre>
+    <p>Het resulterende eigenschap zal zijn:
+    <pre>Hallo Jan. Vandaag is het maandag</pre>
+    <p>Het is mogelijk om een eigenschap van de flow-context of globale context te gebruiken. Gebruik gewoon <code>{{flow.name}}</code> of
+    <code>{{global.name}}</code>, of voor persistente opslag <code>store</code> gebruik <code>{{flow[store].name}}</code> of
+    <code>{{global[store].name}}</code>.
+    <p><b>Let op: </b>Standaard zal <i>mustache</i> alle niet-alfanumerieke tekens of HTML-entiteiten in de waarden die het vervangt escapen.
+       Om dit te voorkomen, gebruik <code>{{{driedubbele}}}</code> accolades.</p>
+    <p>Als je <code>{{ }}</code> binnen je inhoud moet gebruiken, kun je de tekens wijzigen
+       die worden gebruikt om de sjabloonsecties te markeren. Om bijvoorbeeld <code>[[ ]]</code>
+       te gebruiken, voeg je de volgende regel toe aan het begin van het sjabloon:</p>
+    <pre>{{=[[ ]]=}}</pre>
+    <h4>Omgevingsvariabelen gebruiken</h4>
+    <p>De template-node kan omgevingsvariabelen benaderen met de syntaxis:</p>
+    <pre>Mijn favoriete kleur is {{env.COLOUR}}.</pre>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/function/89-delay.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/function/89-delay.html
@@ -1,0 +1,64 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="delay">
+    <p>Vertraagt elk bericht dat door de node gaat of beperkt de snelheid waarmee ze kunnen passeren.</p>
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt class="optional">delay <span class="property-type">number</span></dt>
+        <dd>Stelt de vertraging in, in milliseconden, die op het bericht wordt toegepast. Deze
+            optie is alleen van toepassing als de node is geconfigureerd om het bericht toe te staan
+            het geconfigureerde standaard vertragingsinterval te overschrijven.</dd>
+        <dt class="optional">rate <span class="property-type">number</span></dt>
+        <dd>Stelt de snelheidswaarde in milliseconden in tussen berichten.
+            Deze node overschrijft de bestaande snelheidswaarde die in de nodeconfiguratie is gedefinieerd
+            wanneer het een bericht ontvangt dat een <code>msg.rate</code> waarde in milliseconden bevat.
+            Deze optie is alleen van toepassing als de node is geconfigureerd om het bericht toe te staan
+            het geconfigureerde standaard snelheidsinterval te overschrijven.</dd>
+        <dt class="optional">reset</dt>
+        <dd>Als het ontvangen bericht deze eigenschap heeft ingesteld op een willekeurige waarde, worden alle
+            uitstaande berichten die door de node worden vastgehouden gewist zonder te worden verzonden.</dd>
+        <dt class="optional">flush</dt>
+        <dd>Als het ontvangen bericht deze eigenschap heeft ingesteld op een numerieke waarde, dan worden dat aantal berichten
+            onmiddellijk vrijgegeven. Als het is ingesteld op een ander type (bijv. boolean), dan worden alle
+            uitstaande berichten die door de node worden vastgehouden onmiddellijk verzonden.</dd>
+        <dt class="optional">toFront</dt>
+        <dd>In snelheidsbeperkingsmodus, als het ontvangen bericht deze eigenschap heeft ingesteld op boolean <code>true</code>,
+            dan wordt het bericht naar de voorkant van de wachtrij geduwd en wordt het als volgende vrijgegeven.
+            Dit kan worden gecombineerd met <code>msg.flush=1</code> om onmiddellijk opnieuw te verzenden.
+        </dd>
+    </dl>
+    <h3>Details</h3>
+    <p>Wanneer geconfigureerd om berichten te vertragen, kan het vertragingsinterval een vaste waarde zijn,
+        een willekeurige waarde binnen een bereik of dynamisch worden ingesteld voor elk bericht.
+        Elk bericht wordt onafhankelijk van elk ander bericht vertraagd, op basis van
+        het tijdstip van aankomst.
+    </p>
+    <p>Wanneer geconfigureerd om de berichtsnelheid te beperken, wordt de levering verspreid over
+        de geconfigureerde tijdsperiode. De status toont het aantal berichten dat momenteel in de wachtrij staat.
+        Het kan optioneel tussenliggende berichten negeren wanneer ze aankomen.</p>
+    </p>
+    <p>Als ingesteld om overschrijving van de snelheid toe te staan, wordt de nieuwe snelheid onmiddellijk toegepast,
+        en blijft van kracht totdat deze opnieuw wordt gewijzigd, de node wordt gereset of de flow opnieuw wordt gestart.</p>
+    <p>De snelheidsbeperking kan worden toegepast op alle berichten, of ze groeperen op basis van
+        hun <code>msg.topic</code> waarde. Bij groeperen worden tussenliggende berichten
+        automatisch genegeerd. Bij elk tijdsinterval kan de node ofwel
+        het meest recente bericht voor alle topics vrijgeven, of het meest recente bericht
+        voor het volgende topic vrijgeven.
+    </p>
+    <p><b>Let op</b>: In snelheidsbeperkingsmodus kan de maximale wachtrijdiepte worden ingesteld door een eigenschap in je
+        <i>settings.js</i> bestand. Bijvoorbeeld <code>nodeMessageBufferMaxLength: 1000,</code></p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/function/89-trigger.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/function/89-trigger.html
@@ -1,0 +1,50 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="trigger">
+    <p>Wanneer geactiveerd, kan een bericht worden verzonden en vervolgens optioneel een tweede bericht, tenzij verlengd of gereset.</p>
+
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt class="optional">delay <span class="property-type">number</span></dt>
+        <dd>Stelt de vertraging in, in milliseconden, die op het bericht wordt toegepast. Deze optie is alleen van toepassing als de node is geconfigureerd om het bericht toe te staan het geconfigureerde standaard vertragingsinterval te overschrijven.</dd>
+        <dt class="optional">reset</dt>
+        <dd>Als een bericht met deze eigenschap wordt ontvangen, wordt elke lopende timeout of herhaling
+        gewist en wordt er geen bericht verzonden.</dd>
+    </dl>
+
+    <h3>Details</h3>
+    <p>Deze node kan worden gebruikt om een timeout binnen een flow te creeren. Standaard, wanneer
+    het een bericht ontvangt, verzendt het een bericht met een <code>payload</code> van <code>1</code>.
+    Vervolgens wacht het 250ms voordat het een tweede bericht verzendt met een <code>payload</code> van <code>0</code>.
+    Dit kan bijvoorbeeld worden gebruikt om een LED te laten knipperen die is aangesloten op een Raspberry Pi GPIO-pin.</p>
+    <p>De payloads van elk verzonden bericht kunnen worden geconfigureerd naar verschillende waarden, inclusief
+    de optie om niets te verzenden. Bijvoorbeeld, door het eerste bericht in te stellen op <i>niets</i> en
+    de optie te selecteren om de timer te verlengen bij elk ontvangen bericht, zal de node
+    fungeren als een watchdog-timer; er wordt alleen een bericht verzonden als er niets wordt ontvangen binnen het
+    ingestelde interval.</p>
+    <p>Als ingesteld op een <i>string</i> type, ondersteunt de node de mustache sjabloonsyntaxis.</p>
+    <p>De vertraging tussen het verzenden van berichten kan worden overschreven door <code>msg.delay</code> als die optie is ingeschakeld in de node. De waarde moet worden opgegeven in milliseconden.</p>
+    <p>Als de node een bericht ontvangt met een <code>reset</code> eigenschap, of een <code>payload</code>
+    die overeenkomt met de geconfigureerde waarde in de node, wordt elke lopende timeout of herhaling
+    gewist en wordt er geen bericht verzonden.</p>
+    <p>De node kan worden geconfigureerd om een bericht met regelmatige tussenpozen opnieuw te verzenden totdat het
+    wordt gereset door een ontvangen bericht.</p>
+    <p>Optioneel kan de node worden geconfigureerd om berichten te behandelen alsof ze afzonderlijke stromen zijn,
+    met behulp van een msg-eigenschap om elke stroom te identificeren. Standaard <code>msg.topic</code>.</p>
+    <p>De status geeft aan dat de node momenteel actief is. Als meerdere stromen worden gebruikt, geeft de status
+    het aantal stromen aan dat wordt vastgehouden.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/function/90-exec.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/function/90-exec.html
@@ -1,0 +1,84 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="exec">
+    <p>Voert een systeemcommando uit en retourneert de uitvoer.</p>
+    <p>De node kan worden geconfigureerd om te wachten tot het commando is voltooid, of om de
+    uitvoer te verzenden terwijl het commando deze genereert.</p>
+    <p>Het uit te voeren commando kan worden geconfigureerd in de node of worden geleverd door het ontvangen
+    bericht.</p>
+
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt class="optional">payload <span class="property-type">string</span></dt>
+        <dd>indien zo geconfigureerd, wordt dit toegevoegd aan het uitgevoerde commando.</dd>
+        <dt class="optional">kill <span class="property-type">string</span></dt>
+        <dd>het type kill-signaal om naar een bestaand exec-nodeproces te sturen.</dd>
+        <dt class="optional">pid <span class="property-type">number|string</span></dt>
+        <dd>de proces-ID van een bestaand exec-nodeproces om te beeindigen.</dd>
+    </dl>
+
+    <h3>Uitvoer</h3>
+    <ol class="node-ports">
+        <li>Standaarduitvoer
+            <dl class="message-properties">
+                <dt>payload <span class="property-type">string</span></dt>
+                <dd>de standaarduitvoer van het commando.</dd>
+            </dl>
+            <dl class="message-properties">
+                <dt>rc <span class="property-type">object</span></dt>
+                <dd>alleen exec-modus, een kopie van het retourcodeobject (ook beschikbaar op poort 3)</dd>
+            </dl>
+        </li>
+        <li>Standaardfout
+            <dl class="message-properties">
+                <dt>payload <span class="property-type">string</span></dt>
+                <dd>de standaardfout van het commando.</dd>
+            </dl>
+            <dl class="message-properties">
+                <dt>rc <span class="property-type">object</span></dt>
+                <dd>alleen exec-modus, een kopie van het retourcodeobject (ook beschikbaar op poort 3)</dd>
+            </dl>
+        </li>
+        <li>Retourcode
+            <dl class="message-properties">
+                <dt>payload <span class="property-type">object</span></dt>
+                <dd>een object met de retourcode, en mogelijk <code>message</code>, <code>signal</code> eigenschappen.</dd>
+            </dl>
+        </li>
+    </ol>
+    <h3>Details</h3>
+    <p>Standaard wordt de <code>exec</code> systeemaanroep gebruikt die het commando aanroept, wacht tot het voltooid is en vervolgens
+    de uitvoer retourneert. Bijvoorbeeld een succesvol commando zou een retourcode van <code>{ code: 0 }</code> moeten hebben.</p>
+    <p>Optioneel kan <code>spawn</code> worden gebruikt, dat de uitvoer van stdout en stderr retourneert
+    terwijl het commando wordt uitgevoerd, meestal een regel per keer. Na voltooiing retourneert het een object
+    op de 3e poort. Bijvoorbeeld, een succesvol commando zou <code>{ code: 0 }</code> moeten retourneren.</p>
+    <p>Fouten kunnen extra informatie retourneren op de 3e poort <code>msg.payload</code>, zoals een <code>message</code> string,
+    <code>signal</code> string.</p>
+    <p>Het uit te voeren commando wordt gedefinieerd in de node, met een optie om <code>msg.payload</code> toe te voegen en een verdere set parameters.</p>
+    <p>Commando's of parameters met spaties moeten tussen aanhalingstekens worden geplaatst - <code>"Dit is een enkele parameter"</code></p>
+    <p>De geretourneerde <code>payload</code> is meestal een <i>string</i>, tenzij niet-UTF8 tekens worden gedetecteerd, in welk
+    geval het een <i>buffer</i> is.</p>
+    <p>Het statuspictogram en PID van de node zijn zichtbaar terwijl de node actief is. Wijzigingen hierin kunnen worden gelezen door de <code>Status</code> node.</p>
+    <p>De optie <code>Verberg console</code> verbergt de procesconsole die normaal wordt weergegeven op Windows-systemen.</p>
+    <h4>Processen beeindigen</h4>
+    <p>Het verzenden van <code>msg.kill</code> zal een enkel actief proces beeindigen. <code>msg.kill</code> moet een string zijn met
+    het type signaal dat moet worden verzonden, bijvoorbeeld <code>SIGINT</code>, <code>SIGQUIT</code> of <code>SIGHUP</code>.
+    Standaard is <code>SIGTERM</code> als het is ingesteld op een lege string.</p>
+    <p>Als de node meer dan een proces draait, moet <code>msg.pid</code> ook worden ingesteld met de waarde van de PID die moet worden beeindigd.</p>
+    <p>Als een waarde is opgegeven in het <code>Timeout</code> veld en het proces niet is voltooid wanneer het opgegeven aantal seconden is verstreken, wordt het proces automatisch beeindigd</p>
+    <p>Tip: als je een Python-app uitvoert, moet je mogelijk de <code>-u</code> parameter gebruiken om te voorkomen dat de uitvoer wordt gebufferd.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/function/rbe.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/function/rbe.html
@@ -1,0 +1,41 @@
+<script type="text/html" data-help-name="rbe">
+    <p>Filternode - laat alleen gegevens door als de payload is gewijzigd.
+       Het kan ook blokkeren tenzij, of negeren als de waarde verandert met een bepaald bedrag (Deadband- en Narrowband-modus).</p>
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt>payload
+            <span class="property-type">number | string | (object)</span>
+        </dt>
+        <dd>RBE-modus accepteert getallen, strings en eenvoudige objecten.
+            Andere modi vereisen een te parsen getal.</dd>
+        <dt class="optional">topic <span class="property-type">string</span>
+        </dt>
+        <dd>indien gespecificeerd werkt de functie per topic. Deze eigenschap kan via configuratie worden ingesteld.</dd>
+        <dt class="optional">reset<span class="property-type">any</span></dt>
+        <dd>indien ingesteld wordt de opgeslagen waarde voor het gespecificeerde <code>msg.topic</code> gewist, of
+            alle topics als msg.topic niet is gespecificeerd.</dd>
+    </dl>
+    <h3>Uitvoer</h3>
+    <dl class="message-properties">
+        <dt>payload
+            <span class="property-type">zoals invoer</span>
+        </dt>
+        <dd>Als geactiveerd zal de uitvoer hetzelfde zijn als de invoer.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>In RBE-modus zal deze node blokkeren totdat de <code>msg.payload</code>,
+       (of geselecteerde eigenschap) waarde verschilt van de vorige waarde.
+       Indien gewenst kan het de initiele waarde negeren, zodat er bij de start niets wordt verzonden.</p>
+    <p>De <a href="https://en.wikipedia.org/wiki/Deadband" target="_blank">Deadband</a> modi zullen de inkomende waarde blokkeren
+       <i>tenzij</i> de verandering groter is dan of groter-of-gelijk aan &plusmn; de bandafstand van een vorige waarde.</p>
+    <p>De Narrowband modi zullen de inkomende waarde blokkeren,
+       <i>als</i> de verandering groter is dan of groter-of-gelijk aan &plusmn; de bandafstand van de vorige waarde.
+       Het is nuttig voor het negeren van uitschieters van een defecte sensor bijvoorbeeld.</p>
+    <p>Zowel in Deadband als Narrowband modus moet de inkomende waarde een te parsen getal bevatten en
+       beide ondersteunen ook % - verzendt alleen als/tenzij de invoer meer dan x% van de oorspronkelijke waarde verschilt.</p>
+    <p>Zowel Deadband als Narrowband maken vergelijking mogelijk met ofwel de vorige geldige uitvoerwaarde, waardoor
+    waarden buiten bereik worden genegeerd, of de vorige invoerwaarde, wat het instelpunt reset, waardoor
+    geleidelijke drift (deadband) of een stapverandering (narrowband) mogelijk is.</p>
+    <p><b>Let op:</b> Dit werkt per <code>msg.topic</code> basis, hoewel dit kan worden gewijzigd naar een andere eigenschap indien gewenst.
+       Dit betekent dat een enkele filternode meerdere verschillende topics tegelijkertijd kan verwerken.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/messages.json
@@ -1,0 +1,1162 @@
+{
+    "common": {
+        "label": {
+            "payload": "Payload",
+            "topic": "Onderwerp",
+            "name": "Naam",
+            "username": "Gebruikersnaam",
+            "password": "Wachtwoord",
+            "property": "Eigenschap",
+            "selectNodes": "Selecteer nodes...",
+            "expand": "Uitvouwen"
+        },
+        "status": {
+            "connected": "verbonden",
+            "not-connected": "niet verbonden",
+            "disconnected": "verbinding verbroken",
+            "connecting": "verbinden",
+            "error": "fout",
+            "ok": "OK"
+        },
+        "notification": {
+            "error": "<strong>Fout</strong>: __message__",
+            "errors": {
+                "not-deployed": "node niet geïmplementeerd",
+                "no-response": "geen reactie van server",
+                "unexpected": "onverwachte fout (__status__) __message__"
+            }
+        },
+        "errors": {
+            "nooverride": "Waarschuwing: msg-eigenschappen kunnen niet langer ingestelde node-eigenschappen overschrijven. Zie bit.ly/nr-override-msg-props"
+        }
+    },
+    "inject": {
+        "inject": "injecteren",
+        "injectNow": "nu injecteren",
+        "repeat": "herhaal = __repeat__",
+        "crontab": "crontab = __crontab__",
+        "stopped": "gestopt",
+        "failed": "Injectie mislukt: __error__",
+        "label": {
+            "properties": "Eigenschappen",
+            "repeat": "Herhalen",
+            "flow": "flow context",
+            "global": "global context",
+            "str": "tekst",
+            "num": "getal",
+            "bool": "boolean",
+            "json": "object",
+            "bin": "buffer",
+            "date": "tijdstempel",
+            "env": "omgevingsvariabele",
+            "object": "object",
+            "string": "tekst",
+            "boolean": "boolean",
+            "number": "getal",
+            "Array": "array",
+            "invalid": "Ongeldig JSON-object"
+        },
+        "timestamp": "tijdstempel",
+        "none": "geen",
+        "interval": "interval",
+        "interval-time": "interval tussen tijdstippen",
+        "time": "op een specifiek tijdstip",
+        "seconds": "seconden",
+        "minutes": "minuten",
+        "hours": "uren",
+        "between": "tussen",
+        "previous": "vorige waarde",
+        "at": "om",
+        "and": "en",
+        "every": "elke",
+        "days": [
+            "Maandag",
+            "Dinsdag",
+            "Woensdag",
+            "Donderdag",
+            "Vrijdag",
+            "Zaterdag",
+            "Zondag"
+        ],
+        "on": "op",
+        "onstart": "Eenmaal injecteren na",
+        "onceDelay": "seconden, daarna",
+        "success": "Succesvol geïnjecteerd: __label__",
+        "errors": {
+            "failed": "injectie mislukt, zie log voor details",
+            "toolong": "Interval te groot",
+            "invalid-expr": "Ongeldige JSONata-expressie: __error__",
+            "invalid-jsonata": "__prop__: ongeldige eigenschapsexpressie: __error__",
+            "invalid-prop": "__prop__: ongeldige eigenschapsexpressie: __error__",
+            "invalid-json": "__prop__: ongeldige JSON-gegevens: __error__",
+            "invalid-repeat": "Ongeldige herhalingswaarde"
+        }
+    },
+    "catch": {
+        "catch": "opvangen: alles",
+        "catchGroup": "opvangen: groep",
+        "catchNodes": "opvangen: __number__",
+        "catchUncaught": "opvangen: niet-opgevangen",
+        "label": {
+            "source": "Vang fouten op van",
+            "selectAll": "alles selecteren",
+            "uncaught": "Negeer fouten die door andere Catch-nodes worden afgehandeld"
+        },
+        "scope": {
+            "all": "alle nodes",
+            "group": "in dezelfde groep",
+            "selected": "geselecteerde nodes"
+        }
+    },
+    "status": {
+        "status": "status: alles",
+        "statusGroup": "status: groep",
+        "statusNodes": "status: __number__",
+        "label": {
+            "source": "Rapporteer status van",
+            "sortByType": "sorteren op type"
+        },
+        "scope": {
+            "all": "alle nodes",
+            "group": "in dezelfde groep",
+            "selected": "geselecteerde nodes"
+        }
+    },
+    "complete": {
+        "completeNodes": "voltooid: __number__",
+        "errors": {
+            "scopeUndefined": "bereik niet gedefinieerd"
+        }
+    },
+    "debug": {
+        "output": "Uitvoer",
+        "status": "status",
+        "none": "Geen",
+        "invalid-exp": "Ongeldige JSONata-expressie: __error__",
+        "msgprop": "berichteigenschap",
+        "msgobj": "volledig msg-object",
+        "autostatus": "zelfde als debug-uitvoer",
+        "messageCount": "berichtenteller",
+        "to": "Naar",
+        "debtab": "debug-tabblad",
+        "tabcon": "debug-tabblad en console",
+        "toSidebar": "debug-venster",
+        "toConsole": "systeemconsole",
+        "toStatus": "node-status (32 tekens)",
+        "severity": "Niveau",
+        "node": "node",
+        "notification": {
+            "activated": "Succesvol geactiveerd: __label__",
+            "deactivated": "Succesvol gedeactiveerd: __label__"
+        },
+        "sidebar": {
+            "label": "debug",
+            "name": "Debug-berichten",
+            "filterAll": "alle nodes",
+            "filterSelected": "geselecteerde nodes",
+            "filterCurrent": "huidige flow",
+            "debugNodes": "Debug-nodes",
+            "clearLog": "Berichten wissen",
+            "clearFilteredLog": "Gefilterde berichten wissen",
+            "filterLog": "Berichten filteren",
+            "openWindow": "Openen in nieuw venster",
+            "copyPath": "Pad kopiëren",
+            "copyPayload": "Waarde kopiëren",
+            "pinPath": "Open vastzetten",
+            "selectAll": "alles selecteren",
+            "selectNone": "niets selecteren",
+            "all": "alle",
+            "filtered": "gefilterd"
+        },
+        "messageMenu": {
+            "collapseAll": "Alle paden inklappen",
+            "clearPinned": "Vastgezette paden wissen",
+            "filterNode": "Deze node filteren",
+            "clearFilter": "Filter wissen"
+        }
+    },
+    "link": {
+        "linkIn": "link in",
+        "linkOut": "link out",
+        "linkCall": "link call",
+        "linkOutReturn": "link return",
+        "outMode": "Modus",
+        "sendToAll": "Verzenden naar alle verbonden link-nodes",
+        "returnToCaller": "Terug naar aanroepende link-node",
+        "timeout": "timeout",
+        "linkCallType": "Link-type",
+        "staticLinkCall": "Vast doel",
+        "dynamicLinkCall": "Dynamisch doel (msg.target)",
+        "dynamicLinkLabel": "Dynamisch",
+        "errors": {
+            "missingReturn": "Ontbrekende return-node-informatie",
+            "linkUndefined": "link niet gedefinieerd"
+        }
+    },
+    "tls": {
+        "tls": "TLS-configuratie",
+        "label": {
+            "use-local-files": "Gebruik sleutel en certificaten van lokale bestanden",
+            "upload": "Uploaden",
+            "cert": "Certificaat",
+            "key": "Privésleutel",
+            "passphrase": "Wachtwoordzin",
+            "ca": "CA-certificaat",
+            "verify-server-cert": "Servercertificaat verifiëren",
+            "servername": "Servernaam",
+            "alpnprotocol": "ALPN-protocol"
+        },
+        "placeholder": {
+            "cert": "pad naar certificaat (PEM-formaat)",
+            "key": "pad naar privésleutel (PEM-formaat)",
+            "ca": "pad naar CA-certificaat (PEM-formaat)",
+            "passphrase": "wachtwoordzin privésleutel (optioneel)",
+            "servername": "voor gebruik met SNI",
+            "alpnprotocol": "voor gebruik met ALPN"
+        },
+        "error": {
+            "missing-file": "Geen certificaat/sleutelbestand opgegeven",
+            "invalid-cert": "Certificaat niet opgegeven",
+            "invalid-key": "Privésleutel niet opgegeven"
+        }
+    },
+    "exec": {
+        "exec": "exec",
+        "spawn": "spawn",
+        "label": {
+            "command": "Commando",
+            "append": "Toevoegen",
+            "timeout": "Timeout",
+            "timeoutplace": "optioneel",
+            "return": "Uitvoer",
+            "seconds": "seconden",
+            "stdout": "stdout",
+            "stderr": "stderr",
+            "retcode": "returncode",
+            "winHide": "Console verbergen"
+        },
+        "placeholder": {
+            "extraparams": "extra invoerparameters"
+        },
+        "opt": {
+            "exec": "wanneer het commando voltooid is - exec-modus",
+            "spawn": "terwijl het commando draait - spawn-modus"
+        },
+        "oldrc": "Gebruik oude stijl uitvoer (compatibiliteitsmodus)"
+    },
+    "function": {
+        "function": "",
+        "label": {
+            "setup": "Setup",
+            "function": "Bij bericht",
+            "initialize": "Bij start",
+            "finalize": "Bij stoppen",
+            "outputs": "Uitvoeren",
+            "modules": "Modules",
+            "timeout": "Timeout"
+        },
+        "text": {
+            "initialize": "// Code hier wordt eenmaal uitgevoerd\n// wanneer de node wordt gestart.\n",
+            "finalize": "// Code hier wordt uitgevoerd wanneer de\n// node wordt gestopt of opnieuw geïmplementeerd.\n"
+        },
+        "require": {
+            "var": "variabele",
+            "module": "module",
+            "moduleName": "Modulenaam",
+            "importAs": "Importeren als"
+        },
+        "error": {
+            "externalModuleNotAllowed": "Function-node mag geen externe modules laden",
+            "moduleNotAllowed": "Module __module__ niet toegestaan",
+            "externalModuleLoadError": "Function-node kon externe modules niet laden",
+            "moduleLoadError": "Kon module __module__ niet laden: __error__",
+            "moduleNameError": "Ongeldige module-variabelenaam: __name__",
+            "moduleNameReserved": "Gereserveerde variabelenaam: __name__",
+            "inputListener": "Kan geen listener toevoegen aan 'input'-event binnen Function",
+            "non-message-returned": "Function probeerde een bericht van type __type__ te verzenden",
+            "invalid-js": "Fout in JavaScript-code",
+            "missing-module": "Module __module__ ontbreekt"
+        }
+    },
+    "template": {
+        "template": "template",
+        "label": {
+            "template": "Sjabloon",
+            "property": "Eigenschap",
+            "format": "Syntaxismarkering",
+            "syntax": "Formaat",
+            "output": "Uitvoer als",
+            "mustache": "Mustache-sjabloon",
+            "plain": "Platte tekst",
+            "json": "Geparseerde JSON",
+            "yaml": "Geparseerde YAML",
+            "none": "geen"
+        },
+        "templatevalue": "Dit is de payload: {{payload}} !"
+    },
+    "delay": {
+        "action": "Actie",
+        "for": "Voor",
+        "delaymsg": "Elk bericht vertragen",
+        "delayfixed": "Vaste vertraging",
+        "delayvarmsg": "Vertraging overschrijven met msg.delay",
+        "randomdelay": "Willekeurige vertraging",
+        "limitrate": "Snelheidslimiet",
+        "limitall": "Alle berichten",
+        "limittopic": "Voor elk msg.topic",
+        "fairqueue": "Elk onderwerp om de beurt verzenden",
+        "timedqueue": "Alle onderwerpen verzenden",
+        "milisecs": "Milliseconden",
+        "secs": "Seconden",
+        "sec": "Seconde",
+        "mins": "Minuten",
+        "min": "Minuut",
+        "hours": "Uren",
+        "hour": "Uur",
+        "days": "Dagen",
+        "day": "Dag",
+        "between": "Tussen",
+        "and": "&",
+        "rate": "Snelheid",
+        "msgper": "bericht(en) per",
+        "queuemsg": "Tussenliggende berichten in wachtrij plaatsen",
+        "dropmsg": "Tussenliggende berichten laten vallen",
+        "sendmsg": "Tussenliggende berichten naar 2e uitvoer verzenden",
+        "allowrate": "sta msg.rate (in ms) toe om snelheid te overschrijven",
+        "label": {
+            "delay": "vertraging",
+            "variable": "variabel",
+            "limit": "limiet",
+            "limitTopic": "limiet onderwerp",
+            "random": "willekeurig",
+            "rate": "snelheid",
+            "random-first": "eerste willekeurige waarde",
+            "random-last": "laatste willekeurige waarde",
+            "units": {
+                "second": {
+                    "plural": "Seconden",
+                    "singular": "Seconde"
+                },
+                "minute": {
+                    "plural": "Minuten",
+                    "singular": "Minuut"
+                },
+                "hour": {
+                    "plural": "Uren",
+                    "singular": "Uur"
+                },
+                "day": {
+                    "plural": "Dagen",
+                    "singular": "Dag"
+                }
+            }
+        },
+        "errors": {
+            "too-many": "te veel wachtende berichten in delay-node",
+            "invalid-timeout": "Ongeldige vertragingswaarde",
+            "invalid-rate": "Ongeldige snelheidswaarde",
+            "invalid-rate-unit": "Ongeldige snelheidseenheidwaarde",
+            "invalid-random-first": "Ongeldige eerste willekeurige waarde",
+            "invalid-random-last": "Ongeldige laatste willekeurige waarde"
+        }
+    },
+    "trigger": {
+        "send": "Verzenden",
+        "then": "dan",
+        "then-send": "dan verzenden",
+        "output": {
+            "string": "de tekst",
+            "number": "het getal",
+            "existing": "het bestaande msg-object",
+            "original": "het originele msg-object",
+            "latest": "het laatste msg-object",
+            "nothing": "niets"
+        },
+        "wait-reset": "wachten op reset",
+        "wait-for": "wachten op",
+        "wait-loop": "opnieuw verzenden elke",
+        "for": "Afhandeling",
+        "bytopics": "elk",
+        "alltopics": "alle berichten",
+        "duration": {
+            "ms": "Milliseconden",
+            "s": "Seconden",
+            "m": "Minuten",
+            "h": "Uren"
+        },
+        "extend": " vertraging verlengen bij nieuw bericht",
+        "override": "vertraging overschrijven met msg.delay",
+        "second": " tweede bericht naar aparte uitvoer verzenden",
+        "label": {
+            "trigger": "trigger",
+            "trigger-block": "trigger & blokkeren",
+            "trigger-loop": "opnieuw verzenden elke",
+            "reset": "Reset de trigger als:",
+            "resetMessage": "msg.reset is ingesteld",
+            "resetPayload": "msg.payload is gelijk aan",
+            "resetprompt": "optioneel",
+            "duration": "duur",
+            "topic": "onderwerp"
+        }
+    },
+    "comment": {
+        "comment": "commentaar"
+    },
+    "unknown": {
+        "label": {
+            "unknown": "onbekend"
+        },
+        "manageModules": "Modules beheren",
+        "tip": "<p>Deze node is een type dat onbekend is in uw Node-RED-installatie.</p><p><i>Als u implementeert met de node in deze staat, wordt de configuratie behouden, maar de flow start niet totdat het ontbrekende type is geïnstalleerd.</i></p><p>Zie de Info-zijbalk voor meer hulp</p>"
+    },
+    "mqtt": {
+        "label": {
+            "broker": "Server",
+            "example": "bijv. localhost",
+            "output": "Uitvoer",
+            "qos": "QoS",
+            "retain": "Behouden",
+            "clientid": "Client-ID",
+            "port": "Poort",
+            "keepalive": "Keep Alive",
+            "cleansession": "Schone sessie gebruiken",
+            "autoUnsubscribe": "Automatisch afmelden bij verbreken verbinding",
+            "cleanstart": "Schone start gebruiken",
+            "use-tls": "TLS gebruiken",
+            "tls-config": "TLS-configuratie",
+            "verify-server-cert": "Servercertificaat verifiëren",
+            "compatmode": "Gebruik legacy MQTT 3.1-ondersteuning",
+            "userProperties": "Gebruikerseigenschappen",
+            "subscriptionIdentifier": "Abonnements-ID",
+            "flags": "Vlaggen",
+            "nl": "Ontvang geen berichten gepubliceerd door deze client",
+            "rap": "Behoud retain-vlag van originele publicatie",
+            "rh": "Afhandeling behouden berichten",
+            "rh0": "Behouden berichten verzenden",
+            "rh1": "Alleen verzenden voor nieuwe abonnementen",
+            "rh2": "Niet verzenden",
+            "responseTopic": "Antwoordonderwerp",
+            "contentType": "Inhoudstype",
+            "correlationData": "Correlatiegegevens",
+            "expiry": "Vervaltijd (sec)",
+            "sessionExpiry": "Sessievervaltijd (sec)",
+            "topicAlias": "Alias",
+            "payloadFormatIndicator": "Formaat",
+            "payloadFormatIndicatorFalse": "niet-gespecificeerde bytes (Standaard)",
+            "payloadFormatIndicatorTrue": "UTF-8 gecodeerde payload",
+            "protocolVersion": "Protocol",
+            "protocolVersion3": "MQTT V3.1 (legacy)",
+            "protocolVersion4": "MQTT V3.1.1",
+            "protocolVersion5": "MQTT V5",
+            "topicAliasMaximum": "Alias Max",
+            "maximumPacketSize": "Max pakketgrootte",
+            "receiveMaximum": "Ontvangst Max",
+            "session": "Sessie",
+            "delay": "Vertraging",
+            "action": "Actie",
+            "staticTopic": "Abonneren op enkel onderwerp",
+            "dynamicTopic": "Dynamisch abonnement",
+            "auto-connect": "Automatisch verbinden",
+            "auto-mode-depreciated": "Deze optie is verouderd. Gebruik de nieuwe automatische detectiemodus.",
+            "none": "geen",
+            "other": "anders"
+        },
+        "sections-label": {
+            "birth-message": "Bericht verzonden bij verbinding (birth-bericht)",
+            "will-message": "Bericht verzonden bij onverwachte verbreking (will-bericht)",
+            "close-message": "Bericht verzonden voor verbreken (close-bericht)"
+        },
+        "tabs-label": {
+            "connection": "Verbinding",
+            "security": "Beveiliging",
+            "messages": "Berichten"
+        },
+        "placeholder": {
+            "clientid": "Laat leeg voor automatisch gegenereerd",
+            "clientid-nonclean": "Moet ingesteld zijn voor niet-schone sessies",
+            "will-topic": "Laat leeg om will-bericht uit te schakelen",
+            "birth-topic": "Laat leeg om birth-bericht uit te schakelen",
+            "close-topic": "Laat leeg om close-bericht uit te schakelen"
+        },
+        "state": {
+            "connected": "Verbonden met broker: __broker__",
+            "disconnected": "Verbinding verbroken met broker: __broker__",
+            "connect-failed": "Verbinding mislukt met broker: __broker__",
+            "broker-disconnected": "Broker __broker__ heeft client verbroken: __reasonCode__ __reasonString__"
+        },
+        "retain": "Behouden",
+        "output": {
+            "buffer": "een Buffer",
+            "string": "een String",
+            "base64": "een Base64-gecodeerde string",
+            "auto": "automatisch detecteren (string of buffer)",
+            "auto-detect": "automatisch detecteren (geparseerd JSON-object, string of buffer)",
+            "json": "een geparseerd JSON-object"
+        },
+        "true": "waar",
+        "false": "onwaar",
+        "tip": "Tip: Laat onderwerp, qos of retain leeg als u ze via msg-eigenschappen wilt instellen.",
+        "errors": {
+            "not-defined": "onderwerp niet gedefinieerd",
+            "missing-config": "ontbrekende broker-configuratie",
+            "invalid-topic": "Ongeldig onderwerp opgegeven",
+            "nonclean-missingclientid": "Geen client-ID ingesteld, schone sessie gebruiken",
+            "invalid-json-string": "Ongeldige JSON-string",
+            "invalid-json-parse": "Kon JSON-string niet parseren",
+            "invalid-action-action": "Ongeldige actie opgegeven",
+            "invalid-action-alreadyconnected": "Verbreek verbinding met broker voordat u verbindt",
+            "invalid-action-badsubscription": "msg.topic ontbreekt of is ongeldig",
+            "invalid-client-id": "Ontbrekend Client-ID"
+        }
+    },
+    "httpin": {
+        "label": {
+            "method": "Methode",
+            "url": "URL",
+            "doc": "Docs",
+            "return": "Retourneren",
+            "upload": "Bestandsuploads accepteren",
+            "parsing": "Verzoekbody niet parseren",
+            "status": "Statuscode",
+            "headers": "Headers",
+            "other": "anders",
+            "paytoqs": {
+                "ignore": "Negeren",
+                "query": "Toevoegen aan query-string parameters",
+                "body": "Verzenden als verzoekbody"
+            },
+            "utf8String": "UTF8-string",
+            "binaryBuffer": "binaire buffer",
+            "jsonObject": "geparseerd JSON-object",
+            "authType": "Type",
+            "bearerToken": "Token"
+        },
+        "setby": "- ingesteld door msg.method -",
+        "basicauth": "Authenticatie gebruiken",
+        "use-tls": "Beveiligde (SSL/TLS) verbinding inschakelen",
+        "tls-config": "TLS-configuratie",
+        "basic": "basis-authenticatie",
+        "digest": "digest-authenticatie",
+        "bearer": "bearer-authenticatie",
+        "use-proxy": "Proxy gebruiken",
+        "persist": "Verbinding keep-alive inschakelen",
+        "proxy-config": "Proxyconfiguratie",
+        "use-proxyauth": "Proxy-authenticatie gebruiken",
+        "noproxy-hosts": "Hosts negeren",
+        "senderr": "Alleen niet-2xx-antwoorden naar Catch-node verzenden",
+        "utf8": "een UTF-8-string",
+        "binary": "een binaire buffer",
+        "json": "een geparseerd JSON-object",
+        "tip": {
+            "in": "De URL zal relatief zijn aan ",
+            "res": "De berichten verzonden naar deze node <b>moeten</b> afkomstig zijn van een <i>http input</i>-node",
+            "req": "Tip: Als het JSON parseren mislukt, wordt de opgehaalde string ongewijzigd geretourneerd."
+        },
+        "httpreq": "http-verzoek",
+        "errors": {
+            "not-created": "Kan http-in-node niet maken wanneer httpNodeRoot op false staat",
+            "missing-path": "ontbrekend pad",
+            "no-response": "Geen response-object",
+            "json-error": "JSON-parseerfout",
+            "no-url": "Geen URL opgegeven",
+            "deprecated-call": "Verouderde aanroep naar __method__",
+            "invalid-transport": "niet-http-transport gevraagd",
+            "timeout-isnan": "Timeout-waarde is geen geldig getal, wordt genegeerd",
+            "timeout-isnegative": "Timeout-waarde is negatief, wordt genegeerd",
+            "invalid-payload": "Ongeldige payload",
+            "invalid-url": "Ongeldige URL",
+            "rejectunauthorized-invalid": "msg.rejectUnauthorized moet een boolean zijn"
+        },
+        "status": {
+            "requesting": "aanvragen"
+        },
+        "insecureHTTPParser": "Strikte HTTP-parsing uitschakelen"
+    },
+    "websocket": {
+        "label": {
+            "type": "Type",
+            "path": "Pad",
+            "url": "URL",
+            "subprotocol": "Subprotocol"
+        },
+        "listenon": "Luisteren op",
+        "connectto": "Verbinden met",
+        "sendrec": "Verzenden/Ontvangen",
+        "payload": "payload",
+        "message": "volledig bericht",
+        "sendheartbeat": "Heartbeat verzenden",
+        "tip": {
+            "path1": "Standaard bevat <code>payload</code> de gegevens die via een websocket worden verzonden of ontvangen. De listener kan worden geconfigureerd om het volledige berichtobject als een JSON-geformatteerde string te verzenden of ontvangen.",
+            "path2": "Dit pad zal relatief zijn aan <code>__path__</code>.",
+            "url1": "URL moet ws:&#47;&#47; of wss:&#47;&#47; schema gebruiken en naar een bestaande websocket-listener wijzen.",
+            "url2": "Standaard bevat <code>payload</code> de gegevens die via een websocket worden verzonden of ontvangen. De client kan worden geconfigureerd om het volledige berichtobject als een JSON-geformatteerde string te verzenden of ontvangen.",
+            "headers": "Headers worden alleen ingediend tijdens het protocol-upgrademechanisme, van HTTP naar het WS/WSS-protocol."
+        },
+        "status": {
+            "connected": "verbonden __count__",
+            "connected_plural": "verbonden __count__"
+        },
+        "errors": {
+            "connect-error": "Er is een fout opgetreden bij de ws-verbinding: ",
+            "send-error": "Er is een fout opgetreden bij het verzenden: ",
+            "missing-conf": "Ontbrekende serverconfiguratie",
+            "duplicate-path": "Kan geen twee WebSocket-listeners op hetzelfde pad hebben: __path__",
+            "missing-server": "Ontbrekende serverconfiguratie",
+            "missing-client": "Ontbrekende clientconfiguratie"
+        }
+    },
+    "watch": {
+        "watch": "bewaken",
+        "label": {
+            "files": "Bestand(en)",
+            "recursive": "Submappen recursief bewaken"
+        },
+        "placeholder": {
+            "files": "Kommagescheiden lijst van bestanden en/of mappen"
+        },
+        "tip": "Op Windows moet u dubbele backslashes \\\\ gebruiken in mapnamen."
+    },
+    "tcpin": {
+        "label": {
+            "type": "Type",
+            "output": "Uitvoer",
+            "port": "poort",
+            "host": "op host",
+            "payload": "payload(s)",
+            "delimited": "gescheiden door",
+            "close-connection": "Verbinding sluiten na elk verzonden bericht?",
+            "decode-base64": "Base64-bericht decoderen?",
+            "server": "Server",
+            "return": "Retourneren",
+            "ms": "ms",
+            "chars": "tekens",
+            "close": "Sluiten",
+            "optional": "(optioneel)",
+            "reattach": "scheidingsteken opnieuw toevoegen"
+        },
+        "type": {
+            "listen": "Luisteren op",
+            "connect": "Verbinden met",
+            "reply": "Antwoorden naar TCP"
+        },
+        "output": {
+            "stream": "stream van",
+            "single": "enkel",
+            "buffer": "Buffer",
+            "string": "String",
+            "base64": "Base64-string"
+        },
+        "return": {
+            "timeout": "na een vaste timeout van",
+            "character": "wanneer ontvangen teken is",
+            "number": "na een vast aantal tekens",
+            "never": "nooit - verbinding open houden",
+            "immed": "onmiddellijk - niet wachten op antwoord"
+        },
+        "status": {
+            "connecting": "verbinden met __host__:__port__",
+            "connected": "verbonden met __host__:__port__",
+            "listening-port": "luisteren op poort __port__",
+            "stopped-listening": "gestopt met luisteren op poort",
+            "connection-from": "verbinding van __host__:__port__",
+            "connection-closed": "verbinding gesloten van __host__:__port__",
+            "connections": "__count__ verbinding",
+            "connections_plural": "__count__ verbindingen"
+        },
+        "errors": {
+            "connection-lost": "verbinding verloren met __host__:__port__",
+            "timeout": "timeout sloot socket poort __port__",
+            "cannot-listen": "kan niet luisteren op poort __port__, fout: __error__",
+            "error": "fout: __error__",
+            "socket-error": "socket-fout van __host__:__port__",
+            "no-host": "Host en/of poort niet ingesteld",
+            "connect-timeout": "verbindingstimeout",
+            "connect-fail": "verbinding mislukt",
+            "bad-string": "kon niet converteren naar string",
+            "invalid-host": "Ongeldige host",
+            "invalid-port": "Ongeldige poort"
+        }
+    },
+    "udp": {
+        "label": {
+            "listen": "Luisteren naar",
+            "onport": "op poort",
+            "using": "gebruikend",
+            "output": "Uitvoer",
+            "group": "Groep",
+            "interface": "Lokale IF",
+            "send": "Verzenden van",
+            "toport": "naar poort",
+            "address": "Adres",
+            "decode-base64": "Base64-gecodeerde payload decoderen?",
+            "port": "poort"
+        },
+        "placeholder": {
+            "interface": "(optioneel) lokale interface of adres om aan te binden",
+            "interfaceprompt": "(optioneel) lokale interface of adres om aan te binden",
+            "address": "bestemmings-IP"
+        },
+        "udpmsgs": "UDP-berichten",
+        "mcmsgs": "multicast-berichten",
+        "udpmsg": "UDP-bericht",
+        "bcmsg": "broadcast-bericht",
+        "mcmsg": "multicast-bericht",
+        "output": {
+            "buffer": "een Buffer",
+            "string": "een String",
+            "base64": "een Base64-gecodeerde string"
+        },
+        "bind": {
+            "random": "binden aan willekeurige lokale poort",
+            "local": "binden aan lokale poort",
+            "target": "binden aan doelpoort"
+        },
+        "tip": {
+            "in": "Tip: Zorg ervoor dat uw firewall de gegevens doorlaat.",
+            "out": "Tip: laat adres en poort leeg als u ze wilt instellen via <code>msg.ip</code> en <code>msg.port</code>.",
+            "port": "Poorten al in gebruik: "
+        },
+        "status": {
+            "listener-at": "UDP-listener op __host__:__port__",
+            "mc-group": "UDP-multicast-groep __group__",
+            "listener-stopped": "UDP-listener gestopt",
+            "output-stopped": "UDP-uitvoer gestopt",
+            "mc-ready": "UDP-multicast gereed: __iface__:__outport__ -> __host__:__port__",
+            "bc-ready": "UDP-broadcast gereed: __outport__ -> __host__:__port__",
+            "ready": "UDP gereed: __outport__ -> __host__:__port__",
+            "ready-nolocal": "UDP gereed: __host__:__port__",
+            "re-use": "UDP hergebruik socket: __outport__ -> __host__:__port__"
+        },
+        "errors": {
+            "access-error": "UDP-toegangsfout, u hebt mogelijk root-toegang nodig voor poorten onder 1024",
+            "error": "fout: __error__",
+            "bad-mcaddress": "Ongeldig multicast-adres",
+            "interface": "Moet IP-adres zijn van de vereiste interface",
+            "ip-notset": "UDP: IP-adres niet ingesteld",
+            "port-notset": "UDP: poort niet ingesteld",
+            "port-invalid": "UDP: poortnummer niet geldig",
+            "alreadyused": "UDP: poort __port__ al in gebruik",
+            "ifnotfound": "UDP: interface __iface__ niet gevonden",
+            "invalid-group": "ongeldige multicast-groep"
+        }
+    },
+    "switch": {
+        "switch": "switch",
+        "label": {
+            "property": "Eigenschap",
+            "rule": "regel",
+            "repair": "berichtsequenties herstellen",
+            "value-rules": "waarde-regels",
+            "sequence-rules": "sequentie-regels"
+        },
+        "previous": "vorige waarde",
+        "and": "en",
+        "checkall": "alle regels controleren",
+        "stopfirst": "stoppen na eerste match",
+        "ignorecase": "hoofdletters negeren",
+        "rules": {
+            "btwn": "is tussen",
+            "cont": "bevat",
+            "regex": "komt overeen met regex",
+            "true": "is waar",
+            "false": "is onwaar",
+            "null": "is null",
+            "nnull": "is niet null",
+            "istype": "is van type",
+            "empty": "is leeg",
+            "nempty": "is niet leeg",
+            "head": "kop",
+            "tail": "staart",
+            "index": "index tussen",
+            "exp": "JSONata-exp",
+            "else": "anders",
+            "hask": "heeft sleutel"
+        },
+        "errors": {
+            "invalid-expr": "Ongeldige JSONata-expressie: __error__",
+            "too-many": "te veel wachtende berichten in switch-node"
+        }
+    },
+    "change": {
+        "label": {
+            "rules": "Regels",
+            "rule": "regel",
+            "set": "stel __property__ in",
+            "change": "wijzig __property__",
+            "delete": "verwijder __property__",
+            "move": "verplaats __property__",
+            "changeCount": "wijzigen: __count__ regels",
+            "regex": "Reguliere expressies gebruiken",
+            "deepCopy": "Diepe kopie van waarde"
+        },
+        "action": {
+            "set": "Instellen",
+            "change": "Wijzigen",
+            "delete": "Verwijderen",
+            "move": "Verplaatsen",
+            "toValue": "naar de waarde",
+            "to": "naar",
+            "search": "Zoeken naar",
+            "replace": "Vervangen door"
+        },
+        "errors": {
+            "invalid-from": "Ongeldige 'from'-eigenschap: __error__",
+            "invalid-json": "Ongeldige 'to' JSON-eigenschap",
+            "invalid-expr": "Ongeldige JSONata-expressie: __error__",
+            "no-override": "Kan eigenschap van niet-objecttype niet instellen: __property__",
+            "invalid-prop": "Ongeldige eigenschapsexpressie: __property__",
+            "invalid-json-data": "Ongeldige JSON-gegevens: __error__"
+        }
+    },
+    "range": {
+        "range": "bereik",
+        "label": {
+            "action": "Actie",
+            "inputrange": "Het invoerbereik mappen",
+            "resultrange": "naar het doelbereik",
+            "from": "van",
+            "to": "naar",
+            "roundresult": "Resultaat afronden naar dichtstbijzijnde geheel getal?",
+            "minin": "invoer van",
+            "maxin": "invoer naar",
+            "minout": "doel van",
+            "maxout": "doel naar"
+        },
+        "placeholder": {
+            "min": "bijv. 0",
+            "maxin": "bijv. 99",
+            "maxout": "bijv. 255"
+        },
+        "scale": {
+            "payload": "Schaal de berichteigenschap",
+            "limit": "Schalen en beperken tot het doelbereik",
+            "wrap": "Schalen en wrappen binnen het doelbereik",
+            "drop": "Schalen, maar bericht laten vallen als buiten invoerbereik"
+        },
+        "tip": "Tip: Deze node werkt ALLEEN met getallen.",
+        "errors": {
+            "notnumber": "Geen getal"
+        }
+    },
+    "csv": {
+        "label": {
+            "columns": "Kolommen",
+            "separator": "Scheidingsteken",
+            "c2o": "CSV naar Object opties",
+            "o2c": "Object naar CSV opties",
+            "input": "Invoer",
+            "skip-s": "Eerste",
+            "skip-e": "regels overslaan",
+            "firstrow": "eerste rij bevat kolomnamen",
+            "output": "Uitvoer",
+            "includerow": "kolomnamenrij opnemen",
+            "newline": "Nieuwe regel",
+            "usestrings": "numerieke waarden parseren",
+            "include_empty_strings": "lege strings opnemen",
+            "include_null_values": "null-waarden opnemen",
+            "spec": "Parser"
+        },
+        "spec": {
+            "rfc": "RFC4180",
+            "legacy": "Legacy",
+            "legacy_warning": "Legacy-modus wordt in een toekomstige release verwijderd."
+        },
+        "placeholder": {
+            "columns": "kommagescheiden kolomnamen"
+        },
+        "separator": {
+            "comma": "komma",
+            "tab": "tab",
+            "space": "spatie",
+            "semicolon": "puntkomma",
+            "colon": "dubbele punt",
+            "hashtag": "hashtag",
+            "other": "anders..."
+        },
+        "output": {
+            "row": "een bericht per rij",
+            "array": "een enkel bericht [array]"
+        },
+        "newline": {
+            "linux": "Linux (\\n)",
+            "mac": "Mac (\\r)",
+            "windows": "Windows (\\r\\n)"
+        },
+        "hdrout": {
+            "none": "nooit kolomheaders verzenden",
+            "all": "altijd kolomheaders verzenden",
+            "once": "headers eenmaal verzenden, tot msg.reset"
+        },
+        "errors": {
+            "bad_template": "Onjuiste kolomsjabloon.",
+            "csv_js": "Deze node verwerkt alleen CSV-strings of JS-objecten.",
+            "obj_csv": "Geen kolomsjabloon opgegeven voor object -> CSV.",
+            "bad_csv": "Onjuiste CSV-gegevens - uitvoer waarschijnlijk corrupt."
+        }
+    },
+    "html": {
+        "label": {
+            "select": "Selector",
+            "output": "Uitvoer",
+            "in": "in",
+            "prefix": "Eigenschapsnaam voor HTML-inhoud"
+        },
+        "output": {
+            "html": "de HTML-inhoud van de elementen",
+            "text": "alleen de tekstinhoud van de elementen",
+            "attr": "een object van alle attributen van de elementen",
+            "compl": "een object van alle attributen van de elementen en HTML-inhoud"
+        },
+        "format": {
+            "single": "als een enkel bericht met een array",
+            "multi": "als meerdere berichten, één voor elk element"
+        }
+    },
+    "json": {
+        "errors": {
+            "dropped-object": "Niet-object payload genegeerd",
+            "dropped": "Niet-ondersteund payloadtype genegeerd",
+            "dropped-error": "Kon payload niet converteren",
+            "schema-error": "JSON Schema-fout",
+            "schema-error-compile": "JSON Schema-fout: kon schema niet compileren"
+        },
+        "label": {
+            "o2j": "Object naar JSON opties",
+            "pretty": "JSON-string formatteren",
+            "action": "Actie",
+            "property": "Eigenschap",
+            "actions": {
+                "toggle": "Converteren tussen JSON-string en object",
+                "str": "Altijd converteren naar JSON-string",
+                "obj": "Altijd converteren naar JavaScript-object"
+            }
+        }
+    },
+    "yaml": {
+        "errors": {
+            "dropped-object": "Niet-object payload genegeerd",
+            "dropped": "Niet-ondersteund payloadtype genegeerd",
+            "dropped-error": "Kon payload niet converteren"
+        }
+    },
+    "xml": {
+        "label": {
+            "represent": "Eigenschapsnaam voor XML-tagattributen",
+            "prefix": "Eigenschapsnaam voor tagtekstinhoud",
+            "advanced": "Geavanceerde opties",
+            "x2o": "XML naar Object opties"
+        },
+        "errors": {
+            "xml_js": "Deze node verwerkt alleen XML-strings of JS-objecten."
+        }
+    },
+    "file": {
+        "label": {
+            "write": "bestand schrijven",
+            "read": "bestand lezen",
+            "filename": "Bestandsnaam",
+            "path": "pad",
+            "action": "Actie",
+            "addnewline": "Nieuwe regel (\\n) toevoegen aan elke payload?",
+            "createdir": "Map aanmaken als deze niet bestaat?",
+            "outputas": "Uitvoer",
+            "breakchunks": "Opdelen in chunks",
+            "breaklines": "Opdelen in regels",
+            "sendError": "Bericht verzenden bij fout (legacy-modus)",
+            "encoding": "Codering",
+            "deletelabel": "verwijder __file__",
+            "utf8String": "UTF8-string",
+            "utf8String_plural": "UTF8-strings",
+            "binaryBuffer": "binaire buffer",
+            "binaryBuffer_plural": "binaire buffers",
+            "allProps": "alle bestaande eigenschappen opnemen in elk bericht"
+        },
+        "action": {
+            "append": "toevoegen aan bestand",
+            "overwrite": "bestand overschrijven",
+            "delete": "bestand verwijderen"
+        },
+        "output": {
+            "utf8": "een enkele UTF8-string",
+            "buffer": "een enkel Buffer-object",
+            "lines": "een bericht per regel",
+            "stream": "een stream van Buffers"
+        },
+        "status": {
+            "wrotefile": "geschreven naar bestand: __file__",
+            "deletedfile": "bestand verwijderd: __file__",
+            "appendedfile": "toegevoegd aan bestand: __file__"
+        },
+        "encoding": {
+            "none": "standaard",
+            "setbymsg": "ingesteld door msg.encoding",
+            "native": "Native",
+            "unicode": "Unicode",
+            "japanese": "Japans",
+            "chinese": "Chinees",
+            "korean": "Koreaans",
+            "taiwan": "Taiwan/Hong Kong",
+            "windows": "Windows-codepagina's",
+            "iso": "ISO-codepagina's",
+            "ibm": "IBM-codepagina's",
+            "mac": "Mac-codepagina's",
+            "koi8": "KOI8-codepagina's",
+            "misc": "Overig"
+        },
+        "errors": {
+            "nofilename": "Geen bestandsnaam opgegeven",
+            "invaliddelete": "Waarschuwing: Ongeldige verwijdering. Gebruik de specifieke verwijderoptie in het configuratiedialoogvenster.",
+            "deletefail": "kon bestand niet verwijderen: __error__",
+            "writefail": "kon niet naar bestand schrijven: __error__",
+            "appendfail": "kon niet aan bestand toevoegen: __error__",
+            "createfail": "kon bestand niet aanmaken: __error__"
+        },
+        "tip": "Tip: De bestandsnaam moet een absoluut pad zijn, anders is het relatief aan de werkmap van het Node-RED-proces."
+    },
+    "split": {
+        "split": "splitsen",
+        "intro": "Splits <code>msg.payload</code> gebaseerd op type:",
+        "object": "<b>Object</b>",
+        "objectSend": "Verzend een bericht voor elk sleutel/waarde-paar",
+        "strBuff": "<b>String</b> / <b>Buffer</b>",
+        "array": "<b>Array</b>",
+        "splitThe": "Splits eigenschap",
+        "splitUsing": "Splitsen met",
+        "splitLength": "Vaste lengte van",
+        "stream": "Behandelen als een stream van berichten",
+        "addname": " Kopieer sleutel naar "
+    },
+    "join": {
+        "join": "samenvoegen",
+        "mode": {
+            "mode": "Modus",
+            "auto": "automatisch",
+            "merge": "sequenties samenvoegen",
+            "reduce": "sequentie reduceren",
+            "custom": "handmatig"
+        },
+        "combine": "Combineer elk",
+        "completeMessage": "volledig bericht",
+        "create": "om te maken",
+        "type": {
+            "string": "een String",
+            "array": "een Array",
+            "buffer": "een Buffer",
+            "object": "een sleutel/waarde-object",
+            "merged": "een samengevoegd object"
+        },
+        "using": "gebruikend de waarde van",
+        "key": "als de sleutel",
+        "joinedUsing": "samengevoegd met",
+        "send": "Verzend het bericht:",
+        "afterCount": "Na een aantal berichtdelen",
+        "useparts": "Bestaande msg.parts-eigenschap gebruiken",
+        "count": "aantal",
+        "subsequent": "en elk volgend bericht.",
+        "afterTimeout": "Na een timeout volgend op het eerste bericht",
+        "seconds": "seconden",
+        "complete": "Na een bericht met de <code>msg.complete</code>-eigenschap ingesteld",
+        "tip": "Deze modus gaat ervan uit dat deze node ofwel gekoppeld is aan een <i>split</i>-node of dat de ontvangen berichten een correct geconfigureerde <code>msg.parts</code>-eigenschap hebben.",
+        "too-many": "te veel wachtende berichten in join-node",
+        "message-prop": "berichteigenschap",
+        "merge": {
+            "topics-label": "Samengevoegde onderwerpen",
+            "topics": "onderwerpen",
+            "topic": "onderwerp",
+            "on-change": "Samengevoegd bericht verzenden bij aankomst van nieuw onderwerp"
+        },
+        "reduce": {
+            "exp": "Reduceer-exp",
+            "exp-value": "exp",
+            "init": "Initiële waarde",
+            "right": "Evalueren in omgekeerde volgorde (laatste naar eerste)",
+            "fixup": "Herstel-exp"
+        },
+        "errors": {
+            "invalid-expr": "Ongeldige JSONata-expressie: __error__",
+            "invalid-type": "Kan __error__ niet samenvoegen naar buffer"
+        }
+    },
+    "sort": {
+        "sort": "sorteren",
+        "target": "Sorteren",
+        "seq": "berichtsequentie",
+        "key": "Sleutel",
+        "elem": "elementwaarde",
+        "order": "Volgorde",
+        "ascending": "oplopend",
+        "descending": "aflopend",
+        "as-number": "als getal",
+        "invalid-exp": "Ongeldige JSONata-expressie in sort-node: __message__",
+        "too-many": "Te veel wachtende berichten in sort-node",
+        "clear": "wachtend bericht in sort-node wissen"
+    },
+    "batch": {
+        "batch": "batch",
+        "mode": {
+            "label": "Modus",
+            "num-msgs": "Groeperen op aantal berichten",
+            "interval": "Groeperen op tijdsinterval",
+            "concat": "Sequenties samenvoegen"
+        },
+        "count": {
+            "label": "Aantal berichten",
+            "overlap": "Overlap",
+            "count": "aantal",
+            "invalid": "Ongeldig aantal en overlap"
+        },
+        "interval": {
+            "label": "Interval",
+            "seconds": "seconden",
+            "empty": "leeg bericht verzenden wanneer geen bericht aankomt"
+        },
+        "concat": {
+            "topics-label": "Onderwerpen",
+            "topic": "onderwerp"
+        },
+        "too-many": "te veel wachtende berichten in batch-node",
+        "unexpected": "onverwachte modus",
+        "no-parts": "geen parts-eigenschap in bericht",
+        "honourParts": "Sta msg.parts toe om ook batch-operatie te voltooien.",
+        "error": {
+            "invalid-count": "Ongeldig aantal",
+            "invalid-overlap": "Ongeldige overlap",
+            "invalid-interval": "Ongeldig interval"
+        }
+    },
+    "rbe": {
+        "rbe": "filter",
+        "label": {
+            "func": "Modus",
+            "init": "Initiële waarde verzenden",
+            "start": "Startwaarde",
+            "name": "Naam",
+            "septopics": "Modus apart toepassen voor elk ",
+            "gap": "waardeverandering",
+            "property": "eigenschap",
+            "topic": "onderwerp"
+        },
+        "placeholder": {
+            "bandgap": "bijv. 10 of 5%",
+            "start": "laat leeg om eerste ontvangen gegevens te gebruiken"
+        },
+        "opts": {
+            "rbe": "blokkeren tenzij waarde verandert",
+            "rbei": "blokkeren tenzij waarde verandert (initiële waarde negeren)",
+            "deadband": "blokkeren tenzij waardeverandering groter is dan",
+            "deadbandEq": "blokkeren tenzij waardeverandering groter of gelijk is aan",
+            "narrowband": "blokkeren als waardeverandering groter is dan",
+            "narrowbandEq": "blokkeren als waardeverandering groter of gelijk is aan",
+            "in": "vergeleken met laatste invoerwaarde",
+            "out": "vergeleken met laatste geldige uitvoerwaarde"
+        },
+        "warn": {
+            "nonumber": "geen getal gevonden in payload"
+        }
+    },
+    "global-config": {
+        "label": {
+            "open-conf": "Configuratie openen"
+        }
+    }
+}

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/network/05-tls.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/network/05-tls.html
@@ -1,0 +1,19 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="tls-config">
+    <p>Configuratieopties voor TLS-verbindingen.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/network/06-httpproxy.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/network/06-httpproxy.html
@@ -1,0 +1,22 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="http proxy">
+    <p>Configuratieopties voor HTTP-proxy.</p>
+
+    <h3>Details</h3>
+    <p>Bij toegang tot hosts in de genegeerde hostlijst wordt geen proxy gebruikt.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/network/10-mqtt.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/network/10-mqtt.html
@@ -1,0 +1,161 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="mqtt in">
+<p>Maakt verbinding met een MQTT-broker en abonneert zich op berichten van het opgegeven topic.</p>
+    <h3>Uitvoer</h3>
+    <dl class="message-properties">
+       <dt>payload <span class="property-type">string | buffer</span></dt>
+       <dd>een string tenzij gedetecteerd als een binaire buffer.</dd>
+       <dt>topic <span class="property-type">string</span></dt>
+       <dd>het MQTT-topic, gebruikt / als hierarchiescheidingsteken.</dd>
+       <dt>qos <span class="property-type">number</span> </dt>
+       <dd>0, fire and forget - 1, minimaal eenmaal - 2, eenmaal en slechts eenmaal.</dd>
+       <dt>retain <span class="property-type">boolean</span></dt>
+       <dd>true geeft aan dat het bericht werd vastgehouden en mogelijk oud is.</dd>
+
+       <dt class="optional">responseTopic <span class="property-type">string</span></dt>
+       <dd><b>MQTTv5</b>: het MQTT-antwoordtopic voor het bericht</dd>
+       <dt class="optional">correlationData <span class="property-type">Buffer</span></dt>
+       <dd><b>MQTTv5</b>: de correlatiegegevens voor het bericht</dd>
+       <dt class="optional">contentType <span class="property-type">string</span></dt>
+       <dd><b>MQTTv5</b>: het content-type van de payload</dd>
+       <dt class="optional">userProperties <span class="property-type">object</span></dt>
+       <dd><b>MQTTv5</b>: eventuele gebruikerseigenschappen van het bericht</dd>
+       <dt class="optional">messageExpiryInterval <span class="property-type">number</span></dt>
+       <dd><b>MQTTv5</b>: de vervaltijd, in seconden, van het bericht</dd>
+    </dl>
+    <h3>Details</h3>
+    Het abonnementstopic kan MQTT-wildcards bevatten, + voor een niveau, # voor meerdere niveaus.</p>
+    <p>Deze node vereist een verbinding met een MQTT-broker die geconfigureerd moet worden. Dit wordt geconfigureerd door op
+    het potloodpictogram te klikken.</p>
+    <p>Meerdere MQTT-nodes (in of out) kunnen indien nodig dezelfde brokerverbinding delen.</p>
+    <h4>Dynamisch abonnement</h4>
+    De node kan worden geconfigureerd om de MQTT-verbinding en zijn abonnementen dynamisch te beheren. Wanneer
+    ingeschakeld, heeft de node een invoer en kan worden bestuurd door berichten te verzenden.
+    <h3>Invoer</h3>
+    <p>Deze zijn alleen van toepassing wanneer de node is geconfigureerd voor dynamische abonnementen.</p>
+    <dl class="message-properties">
+       <dt>action <span class="property-type">string</span></dt>
+       <dd>de naam van de actie die de node moet uitvoeren. Beschikbare acties zijn: <code>"connect"</code>,
+       <code>"disconnect"</code>, <code>"getSubscriptions"</code>, <code>"subscribe"</code> en
+       <code>"unsubscribe"</code>.</dd>
+       <dt class="optional">topic <span class="property-type">string|object|array</span></dt>
+       <dd>Voor de <code>"subscribe"</code> en <code>"unsubscribe"</code> acties levert deze eigenschap
+           het topic. Het kan worden ingesteld als:<ul>
+           <li>een String met het topicfilter</li>
+           <li>een Object met <code>topic</code> en <code>qos</code> eigenschappen</li>
+           <li>een array van strings of objecten om meerdere topics in een keer te verwerken</li>
+            </ul>
+        </dd>
+       <dt class="optional">broker <span class="property-type">broker</span> </dt>
+       <dd>Voor de <code>"connect"</code> actie kan deze eigenschap individuele
+           brokerconfiguratie-instellingen overschrijven, inclusief: <ul>
+               <li><code>broker</code></li>
+               <li><code>port</code></li>
+               <li><code>url</code> - overschrijft broker/port om een volledige verbindings-url te leveren</li>
+               <li><code>username</code></li>
+               <li><code>password</code></li>
+           </ul>
+           <p>Als deze eigenschap is ingesteld en de broker al is verbonden, wordt een fout
+              gelogd tenzij het de <code>force</code> eigenschap heeft ingesteld - in dat geval wordt de
+              verbinding met de broker verbroken, de nieuwe instellingen toegepast en opnieuw verbonden.</p>
+       </dd>
+    </dl>
+
+</script>
+
+<script type="text/html" data-help-name="mqtt out">
+    <p>Maakt verbinding met een MQTT-broker en publiceert berichten.</p>
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+       <dt>payload <span class="property-type">string | buffer</span></dt>
+       <dd> de payload om te publiceren. Als deze eigenschap niet is ingesteld, wordt er geen bericht verzonden. Om een leeg bericht te verzenden, stel deze eigenschap in op een lege String.</dd>
+       <dt class="optional">topic <span class="property-type">string</span></dt>
+       <dd> het MQTT-topic om naar te publiceren.</dd>
+       <dt class="optional">qos <span class="property-type">number</span></dt>
+       <dd>0, fire and forget - 1, minimaal eenmaal - 2, eenmaal en slechts eenmaal. Standaard 0.</dd>
+       <dt class="optional">retain <span class="property-type">boolean</span></dt>
+       <dd>stel in op true om het bericht vast te houden op de broker. Standaard false.</dd>
+       <dt class="optional">responseTopic <span class="property-type">string</span></dt>
+       <dd><b>MQTTv5</b>: het MQTT-antwoordtopic voor het bericht</dd>
+       <dt class="optional">correlationData <span class="property-type">Buffer</span></dt>
+       <dd><b>MQTTv5</b>: de correlatiegegevens voor het bericht</dd>
+       <dt class="optional">contentType <span class="property-type">string</span></dt>
+       <dd><b>MQTTv5</b>: het content-type van de payload</dd>
+       <dt class="optional">userProperties <span class="property-type">object</span></dt>
+       <dd><b>MQTTv5</b>: eventuele gebruikerseigenschappen van het bericht</dd>
+       <dt class="optional">messageExpiryInterval <span class="property-type">number</span></dt>
+       <dd><b>MQTTv5</b>: de vervaltijd, in seconden, van het bericht</dd>
+       <dt class="optional">topicAlias <span class="property-type">number</span></dt>
+       <dd><b>MQTTv5</b>: de te gebruiken MQTT-topicalias</dd>
+    </dl>
+    <h3>Details</h3>
+    <code>msg.payload</code> wordt gebruikt als de payload van het gepubliceerde bericht.
+    Als het een Object bevat, wordt het geconverteerd naar een JSON-string voordat het wordt verzonden.
+    Als het een binaire Buffer bevat, wordt het bericht as-is gepubliceerd.</p>
+    <p>Het te gebruiken topic kan worden geconfigureerd in de node of, indien leeg gelaten, worden ingesteld door <code>msg.topic</code>.</p>
+    <p>Evenzo kunnen de QoS- en retain-waarden worden geconfigureerd in de node of, indien leeg gelaten,
+    worden ingesteld door respectievelijk <code>msg.qos</code> en <code>msg.retain</code>. Om een eerder
+    vastgehouden topic van de broker te wissen, stuur een leeg bericht naar dat topic met de retain-vlag ingesteld.</p>
+    <p>Deze node vereist een verbinding met een MQTT-broker die geconfigureerd moet worden. Dit wordt geconfigureerd door op
+    het potloodpictogram te klikken.</p>
+    <p>Meerdere MQTT-nodes (in of out) kunnen indien nodig dezelfde brokerverbinding delen.</p>
+
+    <h4>Dynamische besturing</h4>
+    De verbinding die door de node wordt gedeeld, kan dynamisch worden bestuurd. Als de node een van de
+    volgende besturingsberichten ontvangt, zal het de berichtpayload niet ook publiceren.
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+       <dt>action <span class="property-type">string</span></dt>
+       <dd>de naam van de actie die de node moet uitvoeren. Beschikbare acties zijn: <code>"connect"</code>,
+       en <code>"disconnect"</code>.</dd>
+       <dt class="optional">broker <span class="property-type">broker</span> </dt>
+       <dd>Voor de <code>"connect"</code> actie kan deze eigenschap individuele
+           brokerconfiguratie-instellingen overschrijven, inclusief: <ul>
+               <li><code>broker</code></li>
+               <li><code>port</code></li>
+               <li><code>url</code> - overschrijft broker/port om een volledige verbindings-url te leveren</li>
+               <li><code>username</code></li>
+               <li><code>password</code></li>
+           </ul>
+           <p>Als deze eigenschap is ingesteld en de broker al is verbonden, wordt een fout
+              gelogd tenzij het de <code>force</code> eigenschap heeft ingesteld - in dat geval wordt de
+              verbinding met de broker verbroken, de nieuwe instellingen toegepast en opnieuw verbonden.</p>
+       </dd>
+    </dl>
+
+</script>
+
+<script type="text/html" data-help-name="mqtt-broker">
+    <p>Configuratie voor een verbinding met een MQTT-broker.</p>
+    <p>Deze configuratie maakt een enkele verbinding met de broker die vervolgens
+       kan worden hergebruikt door <code>MQTT In</code> en <code>MQTT Out</code> nodes.</p>
+    <p>De node genereert een willekeurige Client-ID als er geen is ingesteld en de
+       node is geconfigureerd om een Clean Session-verbinding te gebruiken. Als een Client-ID is ingesteld,
+       moet deze uniek zijn voor de broker waarmee je verbinding maakt.</p>
+    <h4>Geboortebericht</h4>
+    <p>Dit is een bericht dat wordt gepubliceerd op het geconfigureerde topic wanneer de
+       verbinding tot stand is gebracht.</p>
+    <h4>Sluitbericht</h4>
+    <p>Dit is een bericht dat wordt gepubliceerd op het geconfigureerde topic voordat de
+       verbinding normaal wordt gesloten, hetzij door het opnieuw deployen van de node, of door afsluiten.</p>
+    <h4>Testamentbericht</h4>
+    <p>Dit is een bericht dat door de broker wordt gepubliceerd in het geval dat de node
+       onverwacht de verbinding verliest.</p>
+    <h4>WebSockets</h4>
+    <p>De node kan worden geconfigureerd om een WebSocket-verbinding te gebruiken. Hiervoor moet het Server-
+       veld worden geconfigureerd met een volledige URI voor de verbinding. Bijvoorbeeld:</p>
+    <pre>ws://example.com:4000/mqtt</pre>
+
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/network/21-httpin.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/network/21-httpin.html
@@ -1,0 +1,101 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="http in">
+    <p>Maakt een HTTP-eindpunt voor het creeren van webservices.</p>
+    <h3>Uitvoer</h3>
+    <dl class="message-properties">
+        <dt>payload</dt>
+        <dd>Voor een GET-verzoek bevat dit een object van eventuele querystring-parameters.
+            Anders bevat het de body van het HTTP-verzoek.</dd>
+        <dt>req<span class="property-type">object</span></dt>
+        <dd>Een HTTP-verzoekobject. Dit object bevat meerdere eigenschappen die
+            informatie over het verzoek verstrekken.
+            <ul>
+             <li><code>body</code> - de body van het inkomende verzoek. Het formaat
+                 hangt af van het verzoek.</li>
+             <li><code>headers</code> - een object met de HTTP-verzoekheaders.</li>
+             <li><code>query</code> - een object met eventuele querystring-parameters.</li>
+             <li><code>params</code> - een object met eventuele routeparameters.</li>
+             <li><code>cookies</code> - een object met de cookies voor het verzoek.</li>
+             <li><code>files</code> - indien ingeschakeld in de node, een object met
+                 eventuele bestanden die zijn geupload als onderdeel van een POST-verzoek.</li>
+            </ul>
+        </dd>
+        <dt>res<span class="property-type">object</span></dt>
+        <dd>Een HTTP-antwoordobject. Deze eigenschap mag niet direct worden gebruikt;
+            de <code>HTTP Response</code> node documenteert hoe te reageren op een verzoek.
+            Deze eigenschap moet aan het bericht blijven gekoppeld dat wordt doorgegeven aan de antwoordnode.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>De node luistert op het geconfigureerde pad voor verzoeken van een bepaald type.
+       Het pad kan volledig worden gespecificeerd, zoals <code>/user</code>, of benoemde
+       parameters bevatten die elke waarde accepteren, zoals <code>/user/:name</code>.
+       Wanneer benoemde parameters worden gebruikt, is hun werkelijke waarde in een verzoek toegankelijk onder <code>msg.req.params</code>.</p>
+    <p>Voor verzoeken die een body bevatten, zoals een POST of PUT, wordt de inhoud van
+       het verzoek beschikbaar gesteld als <code>msg.payload</code>.</p>
+    <p>Als het content-type van het verzoek kan worden bepaald, wordt de body geparseerd naar
+       elk geschikt type. Bijvoorbeeld, <code>application/json</code> wordt geparseerd naar
+       zijn JavaScript-objectweergave.</p>
+    <p>De node kan worden geconfigureerd om de body niet te parsen, in welk geval deze wordt geleverd als een Buffer-object.</p>
+    <p><b>Let op:</b> deze node verzendt geen antwoord op het verzoek. De flow
+       moet een HTTP Response node bevatten om het verzoek te voltooien.</p>
+</script>
+
+<script type="text/html" data-help-name="http response">
+    <p>Verzendt antwoorden terug naar verzoeken ontvangen van een HTTP Input node.</p>
+
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">string</span></dt>
+        <dd>De body van het antwoord.</dd>
+        <dt class="optional">statusCode <span class="property-type">number</span></dt>
+        <dd>Indien ingesteld, wordt dit gebruikt als de antwoordstatuscode. Standaard: 200.</dd>
+        <dt class="optional">headers <span class="property-type">object</span></dt>
+        <dd>Indien ingesteld, levert dit HTTP-headers om in het antwoord op te nemen.</dd>
+        <dt class="optional">cookies <span class="property-type">object</span></dt>
+        <dd>Indien ingesteld, kan dit worden gebruikt om cookies in te stellen of te verwijderen.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>De <code>statusCode</code> en <code>headers</code> kunnen ook worden ingesteld in
+    de node zelf. Als een eigenschap in de node is ingesteld, kan deze niet worden overschreven
+    door de corresponderende berichteigenschap.</p>
+    <h4>Cookie-afhandeling</h4>
+    <p>De <code>cookies</code> eigenschap moet een object van naam/waarde-paren zijn.
+    De waarde kan een string zijn om de waarde van de cookie met standaardopties in te stellen,
+    of het kan een object van opties zijn.</p>
+    <p>Het volgende voorbeeld stelt twee cookies in - een genaamd <code>name</code> met
+    een waarde van <code>nick</code>, de andere genaamd <code>session</code> met een
+    waarde van <code>1234</code> en een vervaltijd ingesteld op 15 minuten.</p>
+    <pre>
+msg.cookies = {
+    name: 'nick',
+    session: {
+        value: '1234',
+        maxAge: 900000
+    }
+}</pre>
+    <p>De geldige opties zijn:</p>
+    <ul>
+    <li><code>domain</code> - (String) domeinnaam voor de cookie</li>
+    <li><code>expires</code> - (Date) vervaldatum in GMT. Indien niet gespecificeerd of ingesteld op 0, wordt een sessiecookie gemaakt</li>
+    <li><code>maxAge</code> - (String) vervaldatum als relatief ten opzichte van de huidige tijd in milliseconden</li>
+    <li><code>path</code> - (String) pad voor de cookie. Standaard /</li>
+    <li><code>value</code> - (String) de te gebruiken waarde voor de cookie</li>
+    </ul>
+    <p>Om een cookie te verwijderen, stel de <code>value</code> in op <code>null</code>.</p>
+
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/network/21-httprequest.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/network/21-httprequest.html
@@ -1,0 +1,96 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="http request">
+    <p>Verzendt HTTP-verzoeken en retourneert het antwoord.</p>
+
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt class="optional">url <span class="property-type">string</span></dt>
+        <dd>Indien niet geconfigureerd in de node, stelt deze optionele eigenschap de url van het verzoek in.</dd>
+        <dt class="optional">method <span class="property-type">string</span></dt>
+        <dd>Indien niet geconfigureerd in de node, stelt deze optionele eigenschap de HTTP-methode van het verzoek in.
+            Moet een van <code>GET</code>, <code>PUT</code>, <code>POST</code>, <code>PATCH</code> of <code>DELETE</code> zijn.</dd>
+        <dt class="optional">headers <span class="property-type">object</span></dt>
+        <dd>Stelt de HTTP-headers van het verzoek in. LET OP: Eventuele headers die in de nodeconfiguratie zijn ingesteld, overschrijven overeenkomende headers in <code>msg.headers</code></dd>
+        <dt class="optional">cookies <span class="property-type">object</span></dt>
+        <dd>Indien ingesteld, kan dit worden gebruikt om cookies met het verzoek mee te sturen.</dd>
+        <dt class="optional">payload</dt>
+        <dd>Verzonden als de body van het verzoek.</dd>
+        <dt class="optional">rejectUnauthorized</dt>
+        <dd>Indien ingesteld op <code>false</code>, staat dit verzoeken toe naar https-sites die
+            zelfondertekende certificaten gebruiken.</dd>
+        <dt class="optional">followRedirects</dt>
+        <dd>Indien ingesteld op <code>false</code>, voorkomt dit het volgen van Redirect (HTTP 301). <code>true</code> standaard</dd>
+        <dt class="optional">requestTimeout</dt>
+        <dd>Indien ingesteld op een positief aantal milliseconden, overschrijft dit de globaal ingestelde <code>httpRequestTimeout</code> parameter.</dd>
+    </dl>
+    <h3>Uitvoer</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">string | object | buffer</span></dt>
+        <dd>De body van het antwoord. De node kan worden geconfigureerd om de body
+             als een string te retourneren, proberen deze als een JSON-string te parsen of als een
+             binaire buffer te laten.</dd>
+        <dt>statusCode <span class="property-type">number</span></dt>
+        <dd>De statuscode van het antwoord, of de foutcode als het verzoek niet kon worden voltooid.</dd>
+        <dt>headers <span class="property-type">object</span></dt>
+        <dd>Een object met de antwoordheaders.</dd>
+        <dt>responseUrl <span class="property-type">string</span></dt>
+        <dd>In het geval dat er omleidingen plaatsvonden tijdens de verwerking van het verzoek, is dit de uiteindelijke omgeleide url.
+            Anders de url van het oorspronkelijke verzoek.</dd>
+        <dt>responseCookies <span class="property-type">object</span></dt>
+        <dd>Als het antwoord cookies bevat, is deze eigenschap een object van naam/waarde-paren voor elke cookie.</dd>
+        <dt>redirectList <span class="property-type">array</span></dt>
+        <dd>Als het verzoek een of meer keer werd omgeleid, wordt de verzamelde informatie toegevoegd aan deze eigenschap. `location` is de volgende omleidingsbestemming. `cookies` zijn de cookies die door de omleidingsbron zijn geretourneerd.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>Wanneer geconfigureerd in de node, kan de URL-eigenschap <a href="http://mustache.github.io/mustache.5.html" target="_blank">mustache-achtige</a> tags bevatten. Deze maken het
+    mogelijk de url te construeren met waarden van het inkomende bericht. Bijvoorbeeld, als de url is ingesteld op
+    <code>example.com/{{{topic}}}</code>, wordt de waarde van <code>msg.topic</code> automatisch ingevoegd.
+    Door {{{...}}} te gebruiken, voorkomt men dat mustache tekens zoals / & etc. escapet.</p>
+    <p>De node kan optioneel automatisch <code>msg.payload</code> coderen als querystring-parameters voor een GET-verzoek, in welk geval <code>msg.payload</code> een object moet zijn.</p>
+    <p><b>Let op</b>: Als je achter een proxy draait, moet de standaard <code>http_proxy=...</code> omgevingsvariabele zijn ingesteld en Node-RED opnieuw worden gestart, of gebruik de Proxy-configuratie. Als Proxy-configuratie is ingesteld, heeft de configuratie voorrang op de omgevingsvariabele.</p>
+    <h4>Meerdere HTTP Request nodes gebruiken</h4>
+    <p>Om meer dan een van deze nodes in dezelfde flow te gebruiken, moet voorzichtig worden omgegaan met
+    de <code>msg.headers</code> eigenschap. De eerste node zal deze eigenschap instellen met
+    de antwoordheaders. De volgende node zal die headers dan gebruiken voor zijn verzoek - dit
+    is meestal niet het juiste gedrag. Als de <code>msg.headers</code> eigenschap ongewijzigd blijft
+    tussen nodes, wordt deze door de tweede node genegeerd. Om aangepaste headers in te stellen, moet <code>msg.headers</code>
+    eerst worden verwijderd of gereset naar een leeg object: <code>{}</code>.
+    <h4>Cookie-afhandeling</h4>
+    <p>De <code>cookies</code> eigenschap die aan de node wordt doorgegeven, moet een object van naam/waarde-paren zijn.
+    De waarde kan een string zijn om de waarde van de cookie in te stellen of het kan een
+    object zijn met een enkele <code>value</code> eigenschap.</p>
+    <p>Eventuele cookies die door het verzoek worden geretourneerd, worden teruggegeven onder de <code>responseCookies</code> eigenschap.</p>
+    <h4>Content-type afhandeling</h4>
+    <p>Als <code>msg.payload</code> een Object is, zal de node automatisch het content-type
+    van het verzoek instellen op <code>application/json</code> en de body als zodanig coderen.</p>
+    <p>Om het verzoek als formuliergegevens te coderen, moet <code>msg.headers["content-type"]</code> worden ingesteld op <code>application/x-www-form-urlencoded</code>.</p>
+    <h4>Bestand uploaden</h4>
+    <p>Om een bestand te uploaden, moet <code>msg.headers["content-type"]</code> worden ingesteld op <code>multipart/form-data</code>
+        en de <code>msg.payload</code> die aan de node wordt doorgegeven moet een object zijn met de volgende structuur:</p>
+    <pre><code>{
+    "KEY": {
+        "value": FILE_CONTENTS,
+        "options": {
+            "filename": "FILENAME"
+        }
+    }
+}</code></pre>
+    <p>De waarden van <code>KEY</code>, <code>FILE_CONTENTS</code> en <code>FILENAME</code>
+    moeten worden ingesteld op de juiste waarden.</p>
+
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/network/22-websocket.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/network/22-websocket.html
@@ -1,0 +1,43 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="websocket in">
+    <p>WebSocket-invoernode.</p>
+    <p>Standaard bevinden de gegevens ontvangen van de WebSocket zich in <code>msg.payload</code>.
+    De socket kan worden geconfigureerd om een correct gevormde JSON-string te verwachten, in welk
+    geval het de JSON parseert en het resulterende object als het volledige bericht verzendt.</p>
+</script>
+
+<script type="text/html" data-help-name="websocket out">
+    <p>WebSocket-uitvoernode.</p>
+    <p>Standaard wordt <code>msg.payload</code> via de WebSocket verzonden. De socket
+    kan worden geconfigureerd om het volledige <code>msg</code> object als een JSON-string te coderen en die
+    via de WebSocket te verzenden.</p>
+
+    <p>Als het bericht dat bij deze node aankomt begon bij een WebSocket In node, wordt het bericht
+    teruggestuurd naar de client die de flow heeft geactiveerd. Anders wordt het bericht
+    naar alle verbonden clients uitgezonden.</p>
+    <p>Als je een bericht wilt uitzenden dat begon bij een WebSocket In node, moet je
+    de <code>msg._session</code> eigenschap binnen de flow verwijderen.</p>
+</script>
+
+<script type="text/html" data-help-name="websocket-listener">
+   <p>Deze configuratienode maakt een WebSocket Server-eindpunt aan met het opgegeven pad.</p>
+</script>
+
+<script type="text/html" data-help-name="websocket-client">
+   <p>Deze configuratienode verbindt een WebSocket-client met de opgegeven URL.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/network/31-tcpin.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/network/31-tcpin.html
@@ -1,0 +1,49 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="tcp in">
+    <p>Biedt een keuze aan TCP-invoer. Kan verbinden met een externe TCP-poort,
+       of inkomende verbindingen accepteren.</p>
+    <p><b>Let op: </b>Op sommige systemen heb je mogelijk root- of beheerderstoegang nodig
+    om poorten onder 1024 te benaderen.</p>
+</script>
+
+<script type="text/html" data-help-name="tcp out">
+    <p>Biedt een keuze aan TCP-uitvoer. Kan verbinden met een externe TCP-poort,
+    inkomende verbindingen accepteren, of antwoorden op berichten ontvangen van een TCP In node.</p>
+    <p>Alleen de <code>msg.payload</code> wordt verzonden.</p>
+    <p>Als <code>msg.payload</code> een string bevat met een Base64-codering van binaire
+    gegevens, zorgt de Base64-decoderingsoptie ervoor dat deze wordt geconverteerd naar binair
+    voordat deze wordt verzonden.</p>
+    <p>Als <code>msg._session</code> niet aanwezig is, wordt de payload
+    naar <b>alle</b> verbonden clients verzonden.</p>
+    <p>In Antwoord-op modus zal het instellen van <code>msg.reset = true</code> de verbinding
+        resetten die is gespecificeerd door _session.id, of alle verbindingen als er geen _session.id is gespecificeerd.</p>
+    <p><b>Let op: </b>Op sommige systemen heb je mogelijk root- of beheerderstoegang nodig
+    om poorten onder 1024 te benaderen.</p>
+</script>
+
+<script type="text/html" data-help-name="tcp request">
+    <p>Een eenvoudige TCP-verzoeknode - verzendt de <code>msg.payload</code> naar een server TCP-poort en verwacht een antwoord.</p>
+    <p>Maakt verbinding, verzendt het "verzoek" en leest het "antwoord". Het kan ofwel een aantal
+    geretourneerde tekens tellen in een vaste buffer, overeenkomen met een opgegeven teken voordat het terugkeert,
+    een vaste timeout wachten vanaf het eerste antwoord en dan terugkeren, blijven wachten op gegevens, of verzenden en dan de verbinding onmiddellijk sluiten
+    zonder op een antwoord te wachten.</p>
+    <p>In blijf wachten modus (verbonden blijven) kun je <code>msg.reset = true</code> of <code>msg.reset = "host:port"</code> sturen om een onderbreking te forceren in
+    de verbinding en een automatische herverbinding.</p>
+    <p>Het antwoord wordt uitgevoerd in <code>msg.payload</code> als een buffer, dus je wilt het misschien .toString() aanroepen.</p>
+    <p>Als je de tcp-host of -poort leeg laat, moeten ze worden ingesteld met behulp van de <code>msg.host</code> en <code>msg.port</code> eigenschappen in elk bericht dat naar de node wordt verzonden.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/network/32-udp.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/network/32-udp.html
@@ -1,0 +1,31 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="udp in">
+    <p>Een UDP-invoernode, die een <code>msg.payload</code> produceert met een
+    Buffer, string of base64-gecodeerde string. Ondersteunt multicast.</p>
+    <p>Het biedt ook <code>msg.ip</code> en <code>msg.port</code> ingesteld op het
+    IP-adres en de poort van waaruit het bericht is ontvangen.</p>
+    <p><b>Let op</b>: Op sommige systemen heb je mogelijk root- of beheerderstoegang nodig om
+    poorten onder 1024 en/of broadcast te gebruiken.</p>
+</script>
+
+<script type="text/html" data-help-name="udp out">
+    <p>Deze node verzendt <code>msg.payload</code> naar de aangewezen UDP-host en -poort. Ondersteunt multicast.</p>
+    <p>Je kunt ook <code>msg.ip</code> en <code>msg.port</code> gebruiken om de bestemmingswaarden in te stellen, maar de statisch geconfigureerde waarden hebben voorrang.</p>
+    <p>Als je broadcast selecteert, stel het adres dan in op het lokale broadcast-IP-adres, of probeer misschien 255.255.255.255, wat het globale broadcast-adres is.</p>
+    <p><b>Let op</b>: Op sommige systemen moet je mogelijk root zijn om poorten onder 1024 en/of broadcast te gebruiken.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/parsers/70-CSV.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/parsers/70-CSV.html
@@ -1,0 +1,55 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="csv">
+    <p>Converteert tussen een CSV-geformatteerde string en zijn JavaScript-objectweergave, in beide richtingen.</p>
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">object | array | string</span></dt>
+        <dd>Een JavaScript-object, array of CSV-string.</dd>
+    </dl>
+    <h3>Uitvoer</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">object | array | string</span></dt>
+        <dd>
+        <ul>
+            <li>Als de invoer een string is, probeert het deze als CSV te parsen en maakt een JavaScript-object van sleutel/waarde-paren voor elke regel.
+                De node verzendt dan ofwel een bericht voor elke regel, of een enkel bericht met een array van objecten.</li>
+            <li>Als de invoer een JavaScript-object is, probeert het een CSV-string te bouwen.</li>
+            <li>Als de invoer een array van eenvoudige waarden is, bouwt het een CSV-string van een enkele regel.</li>
+            <li>Als de invoer een array van arrays is, of een array van objecten, wordt een CSV-string met meerdere regels gemaakt.</li>
+        </ul>
+        </dd>
+    </dl>
+    <h3>Details</h3>
+    <p>Het kolomsjabloon kan een geordende lijst van kolomnamen bevatten. Bij het converteren van CSV naar een object worden de kolomnamen
+    gebruikt als de eigenschapsnamen. Als alternatief kunnen de kolomnamen worden overgenomen van de eerste rij van de CSV.
+        <p>Wanneer de RFC-parser is geselecteerd, moet het kolomsjabloon voldoen aan RFC4180.</p>
+    </p>
+    <p>Bij het converteren naar CSV wordt het kolomsjabloon gebruikt om te identificeren welke eigenschappen uit het object moeten worden gehaald en in welke volgorde.</p>
+    <p>Als het kolomsjabloon leeg is, kun je een eenvoudige door komma's gescheiden lijst van eigenschappen opgeven in <code>msg.columns</code> om
+    te bepalen wat moet worden gehaald en in welke volgorde. Als geen van beide aanwezig is, worden alle objecteigenschappen uitgevoerd in de volgorde
+    waarin de eigenschappen in de eerste rij worden gevonden.</p>
+    <p>Als de invoer een array is, wordt het kolomsjabloon alleen gebruikt om optioneel een rij kolomtitels te genereren.</p>
+    <p>Als de optie 'parseer numerieke waarden' is aangevinkt, worden numerieke stringwaarden als getallen geretourneerd, bijv. middelste waarde '1,"1.5",2'.</p>
+    <p>Als de optie 'inclusief lege strings' is aangevinkt, worden lege strings in het resultaat opgenomen, bijv. middelste waarde '"1","",3'.</p>
+    <p>Als de optie 'inclusief null-waarden' is aangevinkt, worden null-waarden in het resultaat opgenomen, bijv. middelste waarde '"1",,3'.</p>
+    <p>De node kan een meerdelige invoer accepteren zolang de <code>parts</code> eigenschap correct is ingesteld, bijvoorbeeld van een file-in node of split node.</p>
+    <p>Als er meerdere berichten worden uitgevoerd, hebben ze hun <code>parts</code> eigenschap ingesteld en vormen ze een volledige berichtenreeks.</p>
+    <p>Als de node is ingesteld om kolomheaders slechts eenmaal te verzenden, zal het instellen van <code>msg.reset</code> op een willekeurige waarde ervoor zorgen dat de node de headers opnieuw verzendt.</p>
+    <p><b>Let op:</b> het kolomsjabloon moet door komma's gescheiden zijn - zelfs als een ander scheidingsteken is gekozen voor de gegevens.</p>
+    <p><b>Let op:</b> in RFC-modus worden afvangbare fouten gegenereerd voor misvormde CSV-headers en ongeldige invoerpayload-gegevens</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/parsers/70-HTML.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/parsers/70-HTML.html
@@ -1,0 +1,36 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="html">
+    <p>Extraheert elementen uit een html-document dat zich in <code>msg.payload</code> bevindt met behulp van een CSS-selector.</p>
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+    <dt>payload <span class="property-type">string</span></dt>
+    <dd>de html-string waaruit elementen moeten worden gehaald.</dd>
+    <dt class="optional">select <span class="property-type">string</span></dt>
+    <dd>als niet geconfigureerd in het bewerkingspaneel, kan de selector worden ingesteld als een eigenschap van msg.</dd>
+</dl>
+    <h3>Uitvoer</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">array | string</span></dt>
+        <dd>het resultaat kan ofwel een enkel bericht zijn met een payload met een array van de overeenkomende elementen, of meerdere
+           berichten die elk een overeenkomend element bevatten. Als meerdere berichten worden verzonden, hebben ze ook <code>parts</code> ingesteld.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>Deze node ondersteunt een combinatie van CSS- en jQuery-selectors. Zie de
+    <a href="https://github.com/fb55/CSSselect#user-content-supported-selectors" target="_blank">css-select documentatie</a> voor meer informatie
+    over de ondersteunde syntaxis.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/parsers/70-JSON.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/parsers/70-JSON.html
@@ -1,0 +1,53 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="json">
+    <p>Converteert tussen een JSON-string en zijn JavaScript-objectweergave, in beide richtingen.</p>
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">object | string</span></dt>
+        <dd>Een JavaScript-object of JSON-string.</dd>
+        <dt>schema<span class="property-type">object</span></dt>
+        <dd>Een optioneel JSON Schema-object om de payload tegen te valideren.
+        De eigenschap wordt verwijderd voordat het <code>msg</code> naar de volgende node wordt verzonden.</dd>
+    </dl>
+    <h3>Uitvoer</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">object | string</span></dt>
+        <dd>
+            <ul>
+                <li>Als de invoer een JSON-string is, probeert het deze te parsen naar een JavaScript-object.</li>
+                <li>Als de invoer een JavaScript-object is, maakt het een JSON-string. De string kan optioneel netjes worden geformatteerd.</li>
+            </ul>
+        </dd>
+        <dt>schemaError<span class="property-type">array</span></dt>
+        <dd>Als JSON-schemavalidatie mislukt, heeft de catch-node een <code>schemaError</code> eigenschap
+            met een array van fouten.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>Standaard werkt de node op <code>msg.payload</code>, maar kan worden geconfigureerd
+       om elke berichteigenschap te converteren.</p>
+    <p>De node kan ook worden geconfigureerd om een bepaalde codering te garanderen in plaats van te wisselen
+       tussen de twee. Dit kan bijvoorbeeld worden gebruikt met de <code>HTTP In</code>
+       node om te garanderen dat de payload een geparseerd object is, zelfs als een inkomend verzoek
+       het content-type niet correct heeft ingesteld voor de HTTP In node om de conversie uit te voeren.</p>
+    <p>Als de node is geconfigureerd om te garanderen dat de eigenschap als een String is gecodeerd en het
+       ontvangt een String, worden er geen verdere controles van de eigenschap uitgevoerd. Het zal
+       niet controleren of de String geldige JSON is, noch zal het opnieuw formatteren als de formatteringsoptie
+       is geselecteerd.</p>
+    <p>Voor meer details over JSON Schema kun je de specificatie
+    <a href="http://json-schema.org/latest/json-schema-validation.html">hier</a> raadplegen.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/parsers/70-XML.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/parsers/70-XML.html
@@ -1,0 +1,51 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="xml">
+    <p>Converteert tussen een XML-string en zijn JavaScript-objectweergave, in beide richtingen.</p>
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">object | string</span></dt>
+        <dd>Een JavaScript-object of XML-string.</dd>
+        <dt class="optional">options <span class="property-type">object</span></dt>
+        <dd>Deze optionele eigenschap kan worden gebruikt om opties door te geven die worden ondersteund door de onderliggende
+            bibliotheek die wordt gebruikt voor conversie van en naar XML. Zie <a href="https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/README.md#options" target="_blank">de xml2js docs</a>
+            voor meer informatie.</dd>
+    </dl>
+    <h3>Uitvoer</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">object | string</span></dt>
+        <dd>
+            <ul>
+                <li>Als de invoer een string is, probeert het deze als XML te parsen en maakt een JavaScript-object.</li>
+                <li>Als de invoer een JavaScript-object is, probeert het een XML-string te bouwen.</li>
+            </ul>
+        </dd>
+    </dl>
+    <h3>Details</h3>
+    <p>Bij het converteren tussen XML en een object worden standaard alle XML-attributen toegevoegd als een eigenschap genaamd <code>$</code>.
+    Alle tekstinhoud wordt toegevoegd als een eigenschap genaamd <code>_</code>. Deze eigenschapsnamen kunnen worden gespecificeerd in de nodeconfiguratie.</p>
+    <p>Bijvoorbeeld, de volgende XML wordt als volgt geconverteerd:</p>
+    <pre>&lt;p class="tag"&gt;Hallo Wereld&lt;/p&gt;</pre>
+    <pre>{
+  "p": {
+    "$": {
+      "class": "tag"
+    },
+    "_": "Hallo Wereld"
+  }
+}</pre>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/parsers/70-YAML.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/parsers/70-YAML.html
@@ -1,0 +1,34 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="yaml">
+    <p>Converteert tussen een YAML-geformatteerde string en zijn JavaScript-objectweergave, in beide richtingen.</p>
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">object | string</span></dt>
+        <dd>Een JavaScript-object of YAML-string.</dd>
+    </dl>
+    <h3>Uitvoer</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">object | string</span></dt>
+        <dd>
+            <ul>
+                <li>Als de invoer een YAML-string is, probeert het deze te parsen naar een JavaScript-object.</li>
+                <li>Als de invoer een JavaScript-object is, maakt het een YAML-string.</li>
+            </ul>
+        </dd>
+    </dl>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/sequence/17-split.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/sequence/17-split.html
@@ -1,0 +1,172 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="split">
+    <p>Splitst een bericht in een reeks berichten.</p>
+
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">object | string | array | buffer</span></dt>
+        <dd>Het gedrag van de node wordt bepaald door het type van <code>msg.payload</code>:
+            <ul>
+                <li><b>string</b>/<b>buffer</b> - het bericht wordt gesplitst met het opgegeven teken (standaard: <code>\n</code>), bufferreeks of in vaste lengtes.</li>
+                <li><b>array</b> - het bericht wordt gesplitst in individuele array-elementen, of arrays met een vaste lengte.</li>
+                <li><b>object</b> - er wordt een bericht verzonden voor elk sleutel/waarde-paar van het object.</li>
+            </ul>
+        </dd>
+    </dl>
+    <h3>Uitvoer</h3>
+    <dl class="message-properties">
+        <dt>parts<span class="property-type">object</span></dt>
+        <dd>Deze eigenschap bevat informatie over hoe het bericht is gesplitst van
+        het oorspronkelijke bericht. Als het aan de <b>join</b> node wordt doorgegeven, kan de reeks worden
+        samengesteld tot een enkel bericht. De eigenschap heeft de volgende eigenschappen:
+        <ul>
+            <li><code>id</code> - een identificatie voor de groep berichten</li>
+            <li><code>index</code> - de positie binnen de groep</li>
+            <li><code>count</code> - indien bekend, het totale aantal berichten in de groep. Zie 'streaming modus' hieronder.</li>
+            <li><code>type</code> - het type bericht - string/array/object/buffer</li>
+            <li><code>ch</code> - voor een string of buffer, de gegevens gebruikt om het bericht te splitsen als string of een array van bytes</li>
+            <li><code>key</code> - voor een object, de sleutel van de eigenschap waaruit dit bericht is gemaakt. De node kan worden geconfigureerd om deze waarde ook naar andere berichteigenschappen te kopieren, zoals <code>msg.topic</code>.</li>
+            <li><code>len</code> - de lengte van elk bericht bij splitsen met een vaste lengtewaarde</li>
+        </ul>
+        </dd>
+    </dl>
+    <h3>Details</h3>
+    <p>Deze node maakt het gemakkelijk om een flow te maken die algemene acties uitvoert over
+    een reeks berichten voordat, met behulp van de <b>join</b> node, de
+    reeks wordt samengevoegd tot een enkel bericht.</p>
+    <p>Het gebruikt de <code>msg.parts</code> eigenschap om de individuele delen
+    van een reeks bij te houden.</p>
+    <h4>Streaming modus</h4>
+    <p>De node kan ook worden gebruikt om een stroom berichten te herordenen. Bijvoorbeeld, een
+    serieel apparaat dat newline-getermineerde commando's verzendt, kan een enkel bericht
+    met een gedeeltelijk commando aan het einde leveren. In 'streaming modus' zal deze node
+    een bericht splitsen en elk volledig segment verzenden. Als er een gedeeltelijk segment aan het einde is,
+    houdt de node dit vast en voegt het toe aan het volgende bericht dat wordt ontvangen.
+    </p>
+    <p>Bij gebruik in deze modus stelt de node de <code>msg.parts.count</code>
+    eigenschap niet in omdat het niet weet hoeveel berichten in de stroom te verwachten zijn. Dit
+    betekent dat het niet kan worden gebruikt met de <b>join</b> node in zijn automatische modus.</p>
+</script>
+
+<script type="text/html" data-help-name="join">
+    <p>Voegt reeksen berichten samen tot een enkel bericht.</p>
+    <p>Er zijn drie modi beschikbaar:</p>
+    <dl>
+        <dt>automatisch</dt>
+        <dd>Wanneer gekoppeld aan de <b>split</b> node, zal het automatisch de berichten samenvoegen om de splitsing die werd uitgevoerd ongedaan te maken.</dd>
+        <dt>handmatig</dt>
+        <dd>Voeg reeksen berichten samen op verschillende manieren.</dd>
+        <dt>reduceer reeks</dt>
+        <dd>Pas een expressie toe op alle berichten in een reeks om deze te reduceren tot een enkel bericht.</dd>
+    </dl>
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt class="optional">parts<span class="property-type">object</span></dt>
+        <dd>Om automatisch een reeks berichten samen te voegen, moeten ze allemaal
+        deze eigenschap hebben ingesteld. De <b>split</b> node genereert deze eigenschap, maar het
+        kan handmatig worden gemaakt. Het heeft de volgende eigenschappen:
+        <ul>
+            <li><code>id</code> - een identificatie voor de groep berichten</li>
+            <li><code>index</code> - de positie binnen de groep</li>
+            <li><code>count</code> - het totale aantal berichten in de groep</li>
+            <li><code>type</code> - het type bericht - string/array/object/buffer</li>
+            <li><code>ch</code> - voor een string of buffer, de gegevens gebruikt om het bericht te splitsen als string of een array van bytes</li>
+            <li><code>key</code> - voor een object, de sleutel van de eigenschap waaruit dit bericht is gemaakt</li>
+            <li><code>len</code> - de lengte van elk bericht bij splitsen met een vaste lengtewaarde</li>
+        </ul>
+        </dd>
+        <dt class="optional">complete</dt>
+        <dd>Indien ingesteld, voegt de node de payload toe en verzendt vervolgens het uitvoerbericht in zijn huidige staat.
+            Als je de payload niet wilt toevoegen, verwijder deze dan uit de msg.</dd>
+        <dt class="optional">reset</dt>
+        <dd>Indien ingesteld, wist de node elk gedeeltelijk volledig bericht en verzendt het niet.</dd>
+        <dt class="optional">restartTimeout</dt>
+        <dd>Indien ingesteld, en de node heeft een timeout geconfigureerd, wordt die timeout herstart.</dd>
+    </dl>
+    <h3>Details</h3>
+
+    <h4>Automatische modus</h4>
+    <p>Automatische modus gebruikt de <code>parts</code> eigenschap van inkomende berichten om
+       te bepalen hoe de reeks moet worden samengevoegd. Hierdoor kan het automatisch
+       de actie van een <b>split</b> node ongedaan maken.</p>
+
+    <h4>Handmatige modus</h4>
+    <p>Wanneer geconfigureerd om in handmatige modus samen te voegen, kan de node reeksen
+     van berichten samenvoegen tot verschillende resultaten:</p>
+    <ul>
+        <li>een <b>string</b> of <b>buffer</b> - gemaakt door de geselecteerde eigenschap van elk bericht samen te voegen met de opgegeven tekens of buffer.</li>
+        <li>een <b>array</b> - gemaakt door elke geselecteerde eigenschap, of volledig bericht, aan de uitvoerarray toe te voegen.</li>
+        <li>een <b>sleutel/waarde object</b> - gemaakt door een eigenschap van elk bericht te gebruiken om de sleutel te bepalen waaronder
+        de vereiste waarde wordt opgeslagen.</li>
+        <li>een <b>samengevoegd object</b> - gemaakt door de eigenschap van elk bericht samen te voegen onder een enkel object.</li>
+    </ul>
+    <p>De andere eigenschappen van het uitvoerbericht worden overgenomen van het laatst ontvangen bericht voordat het resultaat wordt verzonden.</p>
+    <p>Een <i>telling</i> kan worden ingesteld voor hoeveel berichten moeten worden ontvangen voordat het uitvoerbericht wordt gegenereerd.
+    Voor objectuitvoer kan de node, zodra deze telling is bereikt, worden geconfigureerd om een bericht te verzenden voor elk volgend bericht
+    dat wordt ontvangen.</p>
+    <p>Een <i>timeout</i> kan worden ingesteld om het verzenden van het nieuwe bericht te activeren met wat tot nu toe is ontvangen.
+     Deze timeout kan worden herstart door een bericht te verzenden met de <code>msg.restartTimeout</code> eigenschap ingesteld.</p>
+    <p>Als een bericht wordt ontvangen met de <code>msg.complete</code> eigenschap ingesteld, wordt het uitvoerbericht gefinaliseerd en verzonden.
+    Dit reset alle deeltellingen.</p>
+    <p>Als een bericht wordt ontvangen met de <code>msg.reset</code> eigenschap ingesteld, wordt het gedeeltelijk voltooide bericht verwijderd en niet verzonden.
+    Dit reset alle deeltellingen.</p>
+
+    <h4>Reduceer Reeks modus</h4>
+    <p>Wanneer geconfigureerd om in reduceermodus samen te voegen, wordt een expressie toegepast op elk
+       bericht in een reeks en het resultaat geaccumuleerd om een enkel bericht te produceren.</p>
+
+    <dl class="message-properties">
+        <dt>Beginwaarde</dt>
+        <dd>De beginwaarde van de geaccumuleerde waarde (<code>$A</code>).</dd>
+        <dt>Reduceer-expressie</dt>
+        <dd>Een JSONata-expressie die wordt aangeroepen voor elk bericht in de reeks.
+            Het resultaat wordt doorgegeven aan de volgende aanroep van de expressie als de geaccumuleerde waarde.
+            In de expressie kunnen de volgende speciale variabelen worden gebruikt:
+            <ul>
+                <li><code>$A</code>: de geaccumuleerde waarde, </li>
+                <li><code>$I</code>: index van het bericht in de reeks, </li>
+                <li><code>$N</code>: aantal berichten in de reeks.</li>
+            </ul>
+        </dd>
+        <dt>Herstel-expressie</dt>
+        <dd>Een optionele JSONata-expressie die wordt toegepast nadat de reduceer-expressie
+            is toegepast op alle berichten in de reeks.
+            In de expressie kunnen de volgende speciale variabelen worden gebruikt:
+            <ul>
+                <li><code>$A</code>: de geaccumuleerde waarde, </li>
+                <li><code>$N</code>: aantal berichten in de reeks.</li>
+            </ul>
+        </dd>
+        <p>Standaard wordt de reduceer-expressie in volgorde toegepast, van het eerste
+           tot het laatste bericht van de reeks. Het kan optioneel in omgekeerde
+           volgorde worden toegepast.</p>
+        <p>$N is het aantal berichten dat aankomt - zelfs als ze identiek zijn.</p>
+    </dl>
+    <p><b>Voorbeeld:</b> de volgende instellingen, gegeven een reeks numerieke waarden,
+       berekent de gemiddelde waarde:
+        <ul>
+            <li><b>Reduceer-expressie</b>: <code>$A+payload</code></li>
+            <li><b>Beginwaarde</b>: <code>0</code></li>
+            <li><b>Herstel-expressie</b>: <code>$A/$N</code></li>
+        </ul>
+    </p>
+    <h4>Berichten opslaan</h4>
+    <p>Deze node buffert intern berichten om over reeksen te werken. De
+       runtime-instelling <code>nodeMessageBufferMaxLength</code> kan worden gebruikt om te beperken hoeveel berichten nodes
+       zullen bufferen.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/sequence/18-sort.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/sequence/18-sort.html
@@ -1,0 +1,41 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="sort">
+    <p>Een functie die berichteigenschappen of een reeks berichten sorteert.</p>
+    <p>Wanneer geconfigureerd om berichteigenschappen te sorteren, sorteert de node arraygegevens waarnaar de opgegeven berichteigenschap verwijst.</p>
+    <p>Wanneer geconfigureerd om een reeks berichten te sorteren, worden de berichten opnieuw geordend.</p>
+    <p>De sorteervolgorde kan zijn:</p>
+    <ul>
+        <li><b>oplopend</b>,</li>
+        <li><b>aflopend</b>.</li>
+    </ul>
+    <p>Voor getallen kan numerieke volgorde worden gespecificeerd via een selectievakje.</p>
+    <p>Sorteersleutel kan elementwaarde of JSONata-expressie zijn voor het sorteren van eigenschapswaarden, of berichteigenschap of JSONata-expressie voor het sorteren van een berichtenreeks.<p>
+    <p>Bij het sorteren van een berichtenreeks vertrouwt de sort-node erop dat de ontvangen berichten <code>msg.parts</code> hebben ingesteld. De split-node genereert deze eigenschap, maar kan handmatig worden gemaakt. Het heeft de volgende eigenschappen:</p>
+    <p>
+        <ul>
+            <li><code>id</code> - een identificatie voor de groep berichten</li>
+            <li><code>index</code> - de positie binnen de groep</li>
+            <li><code>count</code> - het totale aantal berichten in de groep</li>
+        </ul>
+    </p>
+    <p><b>Let op:</b> Deze node houdt intern berichten vast voor zijn werking. Om onverwacht geheugengebruik te voorkomen, kan het maximale aantal vastgehouden berichten worden gespecificeerd. Standaard is er geen limiet op het aantal berichten.
+        <ul>
+            <li><code>nodeMessageBufferMaxLength</code> eigenschap ingesteld in <b>settings.js</b>.</li>
+        </ul>
+    </p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/sequence/19-batch.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/sequence/19-batch.html
@@ -1,0 +1,43 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="batch">
+    <p>Maakt reeksen berichten op basis van verschillende regels.</p>
+    <h3>Details</h3>
+    <p>Er zijn drie modi voor het maken van berichtenreeksen:</p>
+    <dl>
+        <dt>Aantal berichten</dt>
+        <dd>groepeert berichten in reeksen van een bepaalde lengte. De <b>overlap</b>
+        optie specificeert hoeveel berichten aan het einde van een reeks moeten worden
+        herhaald aan het begin van de volgende reeks.</dd>
+
+        <dt>Tijdsinterval</dt>
+        <dd>groepeert berichten die binnen het opgegeven interval aankomen. Als er geen berichten
+            binnen het interval aankomen, kan de node optioneel een leeg bericht verzenden.</dd>
+
+        <dt>Reeksen samenvoegen</dt>
+        <dd>maakt een berichtenreeks door inkomende reeksen samen te voegen. Elk bericht
+            moet een <code>msg.topic</code> eigenschap en een <code>msg.parts</code> eigenschap
+            hebben die zijn reeks identificeert. De node wordt geconfigureerd met een lijst van <code>topic</code>
+            waarden om de volgorde te identificeren waarin reeksen worden samengevoegd.
+        </dd>
+    </dl>
+    <h4>Berichten opslaan</h4>
+    <p>Deze node buffert intern berichten om over reeksen te werken. De
+       runtime-instelling <code>nodeMessageBufferMaxLength</code> kan worden gebruikt om te beperken hoeveel berichten nodes
+       zullen bufferen.</p>
+    <p>Als een bericht wordt ontvangen met de <code>msg.reset</code> eigenschap ingesteld, worden de gebufferde berichten verwijderd en niet verzonden.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/storage/10-file.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/storage/10-file.html
@@ -1,0 +1,69 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="file">
+    <p>Schrijft <code>msg.payload</code> naar een bestand, ofwel toevoegend aan het einde of de bestaande inhoud vervangend.
+       Als alternatief kan het bestand worden verwijderd.</p>
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt class="optional">filename <span class="property-type">string</span></dt>
+        <dd>De naam van het te updaten bestand kan worden opgegeven in de nodeconfiguratie, of als een berichteigenschap.
+            Standaard gebruikt het <code>msg.filename</code> maar dit kan worden aangepast in de node.
+        </dd>
+        <dt class="optional">encoding <span class="property-type">string</span></dt>
+        <dd>Als codering is ingesteld om via msg te worden ingesteld, kan deze optionele eigenschap de codering instellen.</dt>
+    </dl>
+    <h3>Uitvoer</h3>
+    <p>Na voltooiing van schrijven wordt het invoerbericht naar de uitvoerpoort verzonden.</p>
+    <h3>Details</h3>
+    <p>Elke berichtpayload wordt aan het einde van het bestand toegevoegd, optioneel met een
+    newline (\n) teken tussen elk bericht.</p>
+    <p>Als <code>msg.filename</code> wordt gebruikt, wordt het bestand na elke schrijfactie gesloten.
+    Voor de beste prestaties gebruik een vaste bestandsnaam.</p>
+    <p>Het kan worden geconfigureerd om het volledige bestand te overschrijven in plaats van toe te voegen. Bijvoorbeeld,
+    bij het schrijven van binaire gegevens naar een bestand, zoals een afbeelding, moet deze optie worden gebruikt
+    en de optie om een newline toe te voegen moet worden uitgeschakeld.</p>
+    <p>Codering van gegevens die naar een bestand worden geschreven kan worden gespecificeerd uit een lijst van coderingen.</p>
+    <p>Als alternatief kan deze node worden geconfigureerd om het bestand te verwijderen.</p>
+</script>
+
+<script type="text/html" data-help-name="file in">
+    <p>Leest de inhoud van een bestand als een string of binaire buffer.</p>
+    <h3>Invoer</h3>
+    <dl class="message-properties">
+        <dt class="optional">filename <span class="property-type">string</span></dt>
+        <dd>De naam van het te lezen bestand kan worden opgegeven in de nodeconfiguratie, of als een berichteigenschap.
+            Standaard gebruikt het <code>msg.filename</code> maar dit kan worden aangepast in de node.
+        </dd>
+    </dl>
+    <h3>Uitvoer</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">string | buffer</span></dt>
+        <dd>De inhoud van het bestand als een string of binaire buffer.</dd>
+        <dt class="optional">filename <span class="property-type">string</span></dt>
+        <dd>Als niet geconfigureerd in de node, stelt deze optionele eigenschap de naam in van het te lezen bestand.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>De bestandsnaam moet een absoluut pad zijn, anders is het relatief ten opzichte van
+    de werkdirectory van het Node-RED proces.</p>
+    <p>Op Windows moeten padscheidingstekens mogelijk worden ge-escapet, bijvoorbeeld: <code>\\Users\\myUser</code>.</p>
+    <p>Optioneel kan een tekstbestand worden gesplitst in regels, met een bericht per regel als uitvoer, of een binair bestand
+    gesplitst in kleinere bufferchunks - de chunkgrootte is afhankelijk van het besturingssysteem, maar typisch 64k (Linux/Mac) of 41k (Windows).</p>
+    <p>Wanneer gesplitst in meerdere berichten, heeft elk bericht een <code>parts</code>
+    eigenschap ingesteld, wat een volledige berichtenreeks vormt.</p>
+    <p>Codering van invoergegevens kan worden gespecificeerd uit een lijst van coderingen als het uitvoerformaat string is.</p>
+    <p>Fouten moeten worden opgevangen en afgehandeld met een Catch-node.</p>
+</script>

--- a/packages/node_modules/@node-red/nodes/locales/nl-NL/storage/23-watch.html
+++ b/packages/node_modules/@node-red/nodes/locales/nl-NL/storage/23-watch.html
@@ -1,0 +1,30 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/html" data-help-name="watch">
+    <p>Bewaakt een directory of bestand op wijzigingen.</p>
+    <p>Je kunt een lijst van door komma's gescheiden directory's en/of bestanden invoeren. Je moet
+    aanhalingstekens "..." plaatsen rond items die spaties bevatten.</p>
+    <p>Op Windows moet je dubbele backslashes \\ gebruiken in directorynamen.</p>
+    <p>De volledige bestandsnaam van het bestand dat daadwerkelijk is gewijzigd wordt in <code>msg.payload</code> en <code>msg.filename</code> geplaatst,
+    terwijl een stringversie van de bewakingslijst wordt geretourneerd in <code>msg.topic</code>.</p>
+    <p><code>msg.file</code> bevat alleen de korte bestandsnaam van het gewijzigde bestand.
+    <code>msg.type</code> bevat het type van wat is gewijzigd, meestal <i>file</i> of <i>directory</i>,
+    terwijl <code>msg.size</code> de bestandsgrootte in bytes bevat.</p>
+    <p>Natuurlijk is in Linux <i>alles</i> een bestand en kan dus worden bewaakt...</p>
+    <p><b>Let op: </b>De directory of het bestand moet bestaan om te kunnen worden bewaakt. Als het bestand
+    of de directory wordt verwijderd, wordt het mogelijk niet meer bewaakt, zelfs als het opnieuw wordt aangemaakt.</p>
+</script>

--- a/packages/node_modules/@node-red/runtime/locales/nl-NL/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/nl-NL/runtime.json
@@ -1,0 +1,195 @@
+{
+    "runtime": {
+        "welcome": "Welkom bij Node-RED",
+        "version": "__component__ versie: __version__",
+        "unsupported_version": "Niet-ondersteunde versie van __component__. Vereist: __requires__ Gevonden: __version__",
+        "paths": {
+            "settings": "Instellingenbestand: __path__",
+            "httpStatic": "HTTP Static    : __path__"
+        }
+    },
+    "server": {
+        "loading": "Palet-nodes laden",
+        "palette-editor": {
+            "disabled": "Paleteditor uitgeschakeld: gebruikersinstellingen",
+            "npm-not-found": "Paleteditor uitgeschakeld: npm-commando niet gevonden",
+            "npm-too-old": "Paleteditor uitgeschakeld: npm-versie te oud. Vereist npm >= 3.x"
+        },
+        "errors": "Kon __count__ node-type niet registreren",
+        "errors_plural": "Kon __count__ node-types niet registreren",
+        "errors-help": "Voer uit met -v voor details",
+        "missing-modules": "Ontbrekende node-modules:",
+        "node-version-mismatch": "Node-module kan niet worden geladen op deze versie. Vereist: __version__",
+        "set-has-no-types": "Set heeft geen types. naam: '__name__', module: '__module__', bestand: '__file__'",
+        "type-already-registered": "'__type__' al geregistreerd door module __module__",
+        "removing-modules": "Modules verwijderen uit configuratie",
+        "added-types": "Toegevoegde node-types:",
+        "removed-types": "Verwijderde node-types:",
+        "removed-plugins": "Verwijderde plugins:",
+        "install": {
+            "invalid": "Ongeldige modulenaam",
+            "installing": "Module installeren: __name__, versie: __version__",
+            "installed": "Module geïnstalleerd: __name__",
+            "install-failed": "Installatie mislukt",
+            "install-failed-long": "Installatie van module __name__ mislukt:",
+            "install-failed-not-found": "$t(server.install.install-failed-long) module niet gevonden",
+            "install-failed-name": "$t(server.install.install-failed-long) ongeldige modulenaam: __name__",
+            "install-failed-url": "$t(server.install.install-failed-long) ongeldige URL: __url__",
+            "post-install-error": "Fout bij uitvoeren 'postInstall' hook:",
+            "upgrading": "Module upgraden: __name__ naar versie: __version__",
+            "upgraded": "Module geüpgraded: __name__. Herstart Node-RED om de nieuwe versie te gebruiken",
+            "upgrade-failed-not-found": "$t(server.install.install-failed-long) versie niet gevonden",
+            "uninstalling": "Module verwijderen: __name__",
+            "uninstall-failed": "Verwijdering mislukt",
+            "uninstall-failed-long": "Verwijdering van module __name__ mislukt:",
+            "uninstalled": "Module verwijderd: __name__",
+            "old-ext-mod-dir-warning": "\n\n---------------------------------------------------------------------\nNode-RED 1.3 externe modules-map gedetecteerd:\n    __oldDir__\nDeze map wordt niet meer gebruikt. Externe modules worden\nopnieuw geïnstalleerd in uw Node-RED-gebruikersmap:\n   __newDir__\nVerwijder de oude externalModules-map om dit bericht te stoppen.\n---------------------------------------------------------------------\n"
+        },
+        "deprecatedOption": "Gebruik van __old__ is VEROUDERD. Gebruik in plaats daarvan __new__",
+        "unable-to-listen": "Kan niet luisteren op __listenpath__",
+        "port-in-use": "Fout: poort in gebruik",
+        "uncaught-exception": "Niet-opgevangen uitzondering:",
+        "admin-ui-disabled": "Admin-UI uitgeschakeld",
+        "now-running": "Server draait nu op __listenpath__",
+        "failed-to-start": "Server starten mislukt:",
+        "headless-mode": "Draait in headless-modus",
+        "httpadminauth-deprecated": "Gebruik van httpAdminAuth is VEROUDERD. Gebruik in plaats daarvan adminAuth",
+        "https": {
+            "refresh-interval": "HTTPS-instellingen verversen elke __interval__ uur",
+            "settings-refreshed": "Server HTTPS-instellingen zijn vernieuwd",
+            "refresh-failed": "Vernieuwen van HTTPS-instellingen mislukt: __message__",
+            "function-required": "httpsRefreshInterval vereist dat de https-eigenschap een functie is"
+        }
+    },
+    "api": {
+        "flows": {
+            "error-save": "Fout bij opslaan van flows: __message__",
+            "error-reload": "Fout bij herladen van flows: __message__"
+        },
+        "library": {
+            "error-load-entry": "Fout bij laden van bibliotheekitem '__path__': __message__",
+            "error-save-entry": "Fout bij opslaan van bibliotheekitem '__path__': __message__",
+            "error-load-flow": "Fout bij laden van flow '__path__': __message__",
+            "error-save-flow": "Fout bij opslaan van flow '__path__': __message__"
+        },
+        "nodes": {
+            "enabled": "Ingeschakelde node-types:",
+            "disabled": "Uitgeschakelde node-types:",
+            "error-enable": "Inschakelen van node mislukt:"
+        }
+    },
+    "comms": {
+        "error": "Communicatiekanalfout: __message__",
+        "error-server": "Communicatieserverfout: __message__",
+        "error-send": "Communicatieverzendfout: __message__"
+    },
+    "settings": {
+        "user-not-available": "Kan gebruikersinstellingen niet opslaan: __message__",
+        "not-available": "Instellingen niet beschikbaar",
+        "property-read-only": "Eigenschap '__prop__' is alleen-lezen",
+        "readonly-mode": "Runtime in alleen-lezen modus. Wijzigingen worden niet opgeslagen."
+    },
+    "library": {
+        "unknownLibrary": "Onbekende bibliotheek: __library__",
+        "unknownType": "Onbekend bibliotheektype: __type__",
+        "readOnly": "Bibliotheek __library__ is alleen-lezen",
+        "failedToInit": "Initialiseren van bibliotheek __library__ mislukt: __error__",
+        "invalidProperty": "Ongeldige eigenschap __prop__: '__value__'"
+    },
+    "nodes": {
+        "credentials": {
+            "error": "Fout bij laden van referenties: __message__",
+            "error-saving": "Fout bij opslaan van referenties: __message__",
+            "not-registered": "Referentietype '__type__' is niet geregistreerd",
+            "system-key-warning": "\n\n---------------------------------------------------------------------\nUw flow-referentiebestand is versleuteld met een systeemgegenereerde sleutel.\n\nAls de systeemgegenereerde sleutel om welke reden dan ook verloren gaat,\nkan uw referentiebestand niet worden hersteld. U moet het verwijderen\nen uw referenties opnieuw invoeren.\n\nU zou uw eigen sleutel moeten instellen met de 'credentialSecret'-optie\nin uw instellingenbestand. Node-RED zal dan uw referentiebestand\nopnieuw versleutelen met uw gekozen sleutel bij de volgende implementatie.\n---------------------------------------------------------------------\n",
+            "unencrypted": "Onversleutelde referenties gebruiken",
+            "encryptedNotFound": "Versleutelde referenties niet gevonden"
+        },
+        "flows": {
+            "safe-mode": "Flows gestopt in veilige modus. Implementeer om te starten.",
+            "registered-missing": "Ontbrekend type geregistreerd: __type__",
+            "error": "Fout bij laden van flows: __message__",
+            "starting-modified-nodes": "Gewijzigde nodes starten",
+            "starting-modified-flows": "Gewijzigde flows starten",
+            "starting-flows": "Flows starten",
+            "started-modified-nodes": "Gewijzigde nodes gestart",
+            "started-modified-flows": "Gewijzigde flows gestart",
+            "started-flows": "Flows gestart",
+            "stopping-modified-nodes": "Gewijzigde nodes stoppen",
+            "stopping-modified-flows": "Gewijzigde flows stoppen",
+            "stopping-flows": "Flows stoppen",
+            "stopped-modified-nodes": "Gewijzigde nodes gestopt",
+            "stopped-modified-flows": "Gewijzigde flows gestopt",
+            "stopped-flows": "Flows gestopt",
+            "stopped": "Gestopt",
+            "stopping-error": "Fout bij stoppen van node: __message__",
+            "updated-flows": "Flows bijgewerkt",
+            "added-flow": "Flow toevoegen: __label__",
+            "updated-flow": "Flow bijgewerkt: __label__",
+            "removed-flow": "Flow verwijderd: __label__",
+            "missing-types": "Wachten op registratie van ontbrekende types:",
+            "missing-type-provided": " - __type__ (geleverd door npm-module __module__)",
+            "missing-type-install-1": "Om een van deze ontbrekende modules te installeren, voer uit:",
+            "missing-type-install-2": "in de map:"
+        },
+        "flow": {
+            "unknown-type": "Onbekend type: __type__",
+            "missing-types": "ontbrekende types",
+            "error-loop": "Bericht heeft maximum aantal catches overschreden",
+            "non-message-returned": "Node probeerde een bericht van type __type__ te verzenden"
+        },
+        "index": {
+            "unrecognised-id": "Onbekend ID: __id__",
+            "type-in-use": "Type in gebruik: __msg__",
+            "unrecognised-module": "Onbekende module: __module__"
+        },
+        "registry": {
+            "localfilesystem": {
+                "module-not-found": "Kan module '__module__' niet vinden"
+            }
+        }
+    },
+    "storage": {
+        "index": {
+            "forbidden-flow-name": "verboden flow-naam"
+        },
+        "localfilesystem": {
+            "user-dir": "Gebruikersmap  : __path__",
+            "flows-file": "Flows-bestand  : __path__",
+            "create": "Nieuw __type__-bestand aanmaken",
+            "empty": "Bestaand __type__-bestand is leeg",
+            "invalid": "Bestaand __type__-bestand is geen geldige JSON",
+            "restore": "__type__-bestandsback-up herstellen: __path__",
+            "restore-fail": "Herstellen van __type__-bestandsback-up mislukt: __message__",
+            "fsync-fail": "Bestand __path__ naar schijf schrijven mislukt: __message__",
+            "warn_name": "Flows-bestandsnaam niet ingesteld. Naam genereren met hostnaam.",
+            "projects": {
+                "changing-project": "Actief project instellen: __project__",
+                "active-project": "Actief project: __project__",
+                "projects-directory": "Projectenmap: __projectsDirectory__",
+                "project-not-found": "Project niet gevonden: __project__",
+                "no-active-project": "Geen actief project: standaard flows-bestand gebruiken",
+                "disabled": "Projecten uitgeschakeld: editorTheme.projects.enabled=false",
+                "disabledNoFlag": "Projecten uitgeschakeld: stel editorTheme.projects.enabled=true in om in te schakelen",
+                "git-not-found": "Projecten uitgeschakeld: git-commando niet gevonden",
+                "git-version-old": "Projecten uitgeschakeld: git __version__ niet ondersteund. Vereist 2.x",
+                "summary": "Een Node-RED-project",
+                "readme": "### Over\n\nDit is het README.md-bestand van uw project. Het helpt gebruikers te begrijpen wat uw\nproject doet, hoe het te gebruiken en al het andere dat ze mogelijk moeten weten."
+            }
+        }
+    },
+    "context": {
+        "log-store-init": "Context store  : '__name__' [__info__]",
+        "error-loading-module": "Fout bij laden van context store: __message__",
+        "error-loading-module2": "Fout bij laden van context store '__module__': __message__",
+        "error-module-not-defined": "Context store '__storage__' mist 'module'-optie",
+        "error-invalid-module-name": "Ongeldige context store naam: '__name__'",
+        "error-invalid-default-module": "Standaard context store onbekend: '__storage__'",
+        "unknown-store": "Onbekende context store '__name__' opgegeven. Standaard store gebruiken.",
+        "localfilesystem": {
+            "invalid-json": "Ongeldige JSON in contextbestand '__file__'",
+            "error-circular": "Context __scope__ bevat een circulaire referentie die niet kan worden opgeslagen",
+            "error-write": "Fout bij schrijven van context: __message__"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add Dutch (nl-NL) translations for all 36 HTML help files that appear in the Info sidebar when a node is selected.

### Files translated:
- **common/** (9 files): inject, debug, catch, status, complete, link, comment, global-config, unknown
- **function/** (9 files): function, switch, change, range, template, delay, trigger, exec, rbe
- **network/** (8 files): mqtt, http-in/response/request, websocket, tcp, udp, tls, httpproxy
- **parsers/** (5 files): csv, html, json, xml, yaml
- **sequence/** (3 files): split/join, sort, batch
- **storage/** (2 files): file, watch

Follow-up to #5440 (editor-client) and #5442 (nodes/runtime messages).

## Test plan

- [x] Set language to Dutch (nl-NL) in Node-RED settings
- [x] Select various nodes and verify help text appears in Dutch in the Info sidebar