### PR TITLE
fix: prevent incorrect array modification in delay node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/89-delay.js
+++ b/packages/node_modules/@node-red/nodes/core/function/89-delay.js
@@ -159,7 +159,8 @@ module.exports = function(RED) {
         if (node.pauseType === "delay") {
             node.on("input", function(msg, send, done) {
                 var id = ourTimeout(function() {
-                    node.idList.splice(node.idList.indexOf(id),1);
+                    var idx = node.idList.indexOf(id);
+                    if (idx !== -1) { node.idList.splice(idx, 1); }
                     if (node.timeout > 1000) {
                         node.status({fill:"blue",shape:"dot",text:node.idList.length});
                     }
@@ -184,7 +185,8 @@ module.exports = function(RED) {
                 }
                 if (delayvar < 0) { delayvar = 0; }
                 var id = ourTimeout(function() {
-                    node.idList.splice(node.idList.indexOf(id),1);
+                    var idx = node.idList.indexOf(id);
+                    if (idx !== -1) { node.idList.splice(idx, 1); }
                     if (node.idList.length === 0) { node.status({}); }
                     send(msg);
                     if (delayvar >= 0) {
@@ -207,7 +209,8 @@ module.exports = function(RED) {
             node.on("input", function(msg, send, done) {
                 var wait = node.randomFirst + (node.diff * Math.random());
                 var id = ourTimeout(function() {
-                    node.idList.splice(node.idList.indexOf(id),1);
+                    var idx = node.idList.indexOf(id);
+                    if (idx !== -1) { node.idList.splice(idx, 1); }
                     send(msg);
                     if (node.timeout >= 1000) {
                         node.status({fill:"blue",shape:"dot",text:node.idList.length});


### PR DESCRIPTION
## Summary

Fixes #5451 - The delay node could incorrectly remove the last element from `idList` when `indexOf()` returns -1.

## Changes

Check indexOf result before splicing at three locations:
```javascript
var idx = node.idList.indexOf(id);
if (idx !== -1) { node.idList.splice(idx, 1); }
```

## Test Plan

- [x] All 54 delay node tests pass
- [x] Manual testing with flush during various delay modes