### PR TITLE
fix: prevent stale activeFlowConfig reference in type-registered handler

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/index.js
@@ -55,12 +55,14 @@ function init(runtime) {
     state = 'stop';
     if (!typeEventRegistered) {
         events.on('type-registered',function(type) {
-            if (activeFlowConfig && activeFlowConfig.missingTypes.length > 0) {
-                var i = activeFlowConfig.missingTypes.indexOf(type);
+            var config = activeFlowConfig;
+            if (config && config.missingTypes.length > 0) {
+                var i = config.missingTypes.indexOf(type);
                 if (i != -1) {
                     log.info(log._("nodes.flows.registered-missing", {type:type}));
-                    activeFlowConfig.missingTypes.splice(i,1);
-                    if (activeFlowConfig.missingTypes.length === 0 && started) {
+                    config.missingTypes.splice(i,1);
+                    // Only start if config is still the active one
+                    if (config === activeFlowConfig && config.missingTypes.length === 0 && started) {
                         events.emit("runtime-event",{id:"runtime-state",retain: true});
                         start();
                     }


### PR DESCRIPTION
## Summary

Fixes #5454 - The type-registered event handler could operate on a stale activeFlowConfig reference.

## Changes

Cache the `activeFlowConfig` reference at handler start and verify it hasn't changed before calling `start()`.

## Test Plan

- [x] All flow tests pass
- [x] Manual testing with rapid type registration