### PR TITLE
fix: prevent double resolve in node close callback

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/Node.js
@@ -322,6 +322,7 @@ Node.prototype.close = function(removed) {
             // The callback takes a 'done' callback and (maybe) the removed flag
             promises.push(
                 new Promise((resolve) => {
+                    var resolved = false;
                     try {
                         var args = [];
                         if (callback.length === 2) {
@@ -329,13 +330,19 @@ Node.prototype.close = function(removed) {
                             args.push(!!removed);
                         }
                         args.push(() => {
-                            resolve();
+                            if (!resolved) {
+                                resolved = true;
+                                resolve();
+                            }
                         });
                         callback.apply(node, args);
                     } catch(err) {
                         // TODO: error thrown in node async close callback
                         // We've never logged this properly.
-                        resolve();
+                        if (!resolved) {
+                            resolved = true;
+                            resolve();
+                        }
                     }
                 })
             );


### PR DESCRIPTION
## Summary

Fixes #5455 - Node close callback wrapper could call resolve() twice if handler both calls done() and throws.

## Changes

Added a `resolved` flag to ensure resolve is only called once.

## Test Plan

- [x] All node tests pass