### PR TITLE
fix: prevent race condition in localfilesystem context store during shutdown

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/nodes/context/localfilesystem.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/context/localfilesystem.js
@@ -155,6 +155,7 @@ function LocalFileSystem(config){
     }
     this.pendingWrites = {};
     this.knownCircularRefs = {};
+    this.closing = false;
 
     if (config.hasOwnProperty('flushInterval')) {
         this.flushInterval = Math.max(0,config.flushInterval) * 1000;
@@ -233,16 +234,19 @@ LocalFileSystem.prototype.open = function(){
 
 LocalFileSystem.prototype.close = function(){
     var self = this;
-    if (this.cache && this._pendingWriteTimeout) {
-        clearTimeout(this._pendingWriteTimeout);
-        delete this._pendingWriteTimeout;
+    this.closing = true;
+    if (this.cache) {
+        if (this._pendingWriteTimeout) {
+            clearTimeout(this._pendingWriteTimeout);
+            delete this._pendingWriteTimeout;
+        }
         this.flushInterval = 0;
+        // Always flush pending writes on close, even if no timeout was pending
         self.writePromise = self.writePromise.then(function(){
             return self._flushPendingWrites.call(self).catch(function(err) {
                 log.error(log._("context.localfilesystem.error-write",{message:err.toString()}));
             });
         });
-
     }
     return this.writePromise;
 }
@@ -298,8 +302,9 @@ LocalFileSystem.prototype.set = function(scope, key, value, callback) {
     if (this.cache) {
         this.cache.set(scope,key,value,callback);
         this.pendingWrites[scope] = true;
-        if (this._pendingWriteTimeout) {
-            // there's a pending write which will handle this
+        if (this._pendingWriteTimeout || this.closing) {
+            // there's a pending write which will handle this,
+            // or we're closing and the close() flush will handle it
             return;
         } else {
             this._pendingWriteTimeout = setTimeout(function() {


### PR DESCRIPTION
## Summary

Fixes #5450 - Race condition in localfilesystem context store that can cause data loss during shutdown.

May also help with #2723 (localFileSystem data cleared after power failure).

## Changes

1. Added `closing` flag that is set at the start of `close()`
2. Check this flag in `set()` to prevent scheduling new timeouts during shutdown
3. Always flush pending writes in `close()` regardless of timeout state

## Test Plan

- [x] All existing context store tests pass
- [x] Manual testing with rapid shutdown during writes