### PR TITLE
registry: fix importModule base dir for exports subpaths

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/externalModules.js
+++ b/packages/node_modules/@node-red/registry/lib/externalModules.js
@@ -122,7 +122,7 @@ function importModule(module) {
         throw e;
     }
     const externalModuleDir = getInstallDir();
-    const moduleDir = path.join(externalModuleDir,"node_modules",module);
+    const moduleDir = path.join(externalModuleDir,"node_modules",parsedModule.module);
     // To handle both CJS and ESM we need to resolve the module to the
     // specific file that is loaded when the module is required/imported
     // As this won't be on the natural module search path, we use createRequire


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? --> 
- Fix `importModule` to resolve exports-mapped subpaths by anchoring the resolver at the package root. Fixes #5434.
- Add a hermetic unit test that creates a fake package with `exports` remapping and verifies `externalModules.import("fake-pkg/M.js")` resolves correctly.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality

**Tests:**
- `npx mocha test/unit/@node-red/registry/lib/externalModules_spec.js`
- `npm test`: 2799 passing, 61 pending, 1 failing (unrelated: `test/nodes/core/storage/23-watch_spec.js` watch-node assertion)
