### PR TITLE
Add § as shortcut meta-key

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/keyboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/keyboard.js
@@ -43,6 +43,7 @@ RED.keyboard = (function() {
         "-":189,
         ".":190,
         "/":191,
+        "§":192, // <- top left key MacOS
         "\\":220,
         "'":222,
         "?":191, // <- QWERTY specific


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

[Forum Discussion](https://discourse.nodered.org/t/support-as-shortcut-key/99722)

This adds the '§' char as a shortcut prefix key. I use this to map zoom out as Cmd-§, zoom reset to Cmd-1 and zoom-in to Cmd-2 - allows using left had for zoom and right hand for mouse movements.

Tested with Firefox on MacOS 15.6, this might well work on other versions, I didn't test on older Macs.

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
