### PR TITLE
Fix: allow middle-click panning over links and ports

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -3226,7 +3226,7 @@ RED.view = (function() {
         clearSuggestedFlow();
         RED.contextMenu.hide();
         evt = evt || d3.event;
-        if (evt === 1) {
+        if (evt.button !== 0) {
             return;
         }
         if (mouse_mode === RED.state.SELECTING_NODE) {
@@ -4082,7 +4082,7 @@ RED.view = (function() {
             d3.event.stopPropagation();
             return;
         }
-        if (d3.event.button === 2) {
+        if (d3.event.button !== 0) {
             return
         }
         mousedown_link = d;


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #5492 

#### Incorrect Mouse Button Check in `portMouseDown`
Only left-click is handled.
Middle/right clicks return early.

#### Incomplete Filtering in `linkMouseDown`
Only left-click is handled.
Middle-click ignored.
Canvas receives event.
Pan activates.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
