### PR TITLE
Ensure config sidebar tooltip handles html content

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
@@ -210,7 +210,7 @@ RED.sidebar.config = (function() {
                     nodeDiv.addClass("red-ui-palette-node-config-invalid");
                     RED.popover.tooltip(nodeDivAnnotations, function () {
                         if (node.validationErrors && node.validationErrors.length > 0) {
-                            return RED._("editor.errors.invalidProperties") + "<br>  - " + node.validationErrors.join("<br>  - ");
+                            return $('<span>' + RED._("editor.errors.invalidProperties") + "<br>  - " + node.validationErrors.join("<br>  - ") + '</span>');
                         }
                     })
                 }


### PR DESCRIPTION
Fixes #5497 

The tooltip content api will treat strings as raw text, so to ensure `<br>` are rendered, we need to pass in a pre-built dom element.