### PR TITLE
Remove IE7 CSS hacks

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/forms.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/forms.scss
@@ -38,7 +38,6 @@
     button,
     div[contenteditable="true"],
     input {
-        *overflow: visible;
         line-height: normal;
     }
 
@@ -452,7 +451,6 @@
     .input-prepend .uneditable-input {
         position: relative;
         margin-bottom: 0;
-        *margin-left: 0;
         vertical-align: top;
         border-radius: 0 4px 4px 0;
     }
@@ -612,10 +610,8 @@
     .form-inline .input-append,
     .form-horizontal .input-append {
         display: inline-block;
-        *display: inline;
         margin-bottom: 0;
         vertical-align: middle;
-        *zoom: 1;
     }
 
     .form-search .hide,
@@ -667,7 +663,6 @@
 
     .form-horizontal .control-group {
         margin-bottom: 20px;
-        *zoom: 1;
     }
 
     .form-horizontal .control-group:before,
@@ -689,14 +684,7 @@
     }
 
     .form-horizontal .controls {
-        *display: inline-block;
-        *padding-left: 20px;
         margin-left: 180px;
-        *margin-left: 0;
-    }
-
-    .form-horizontal .controls:first-child {
-        *padding-left: 180px;
     }
 
     .form-horizontal .help-block {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Since Internet Explorer is no longer supported, these hacks are no longer needed.

They should've been removed in #5142.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
