### PR TITLE
Do not cache subflow colors as each subflow can have its own

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -1309,6 +1309,9 @@ RED.utils = (function() {
 
     function getNodeColor(type, def) {
         def = def || {};
+        if (type === 'subflow') {
+            return def.color
+        }
         if (!nodeColorCache.hasOwnProperty(type)) {
             const paletteTheme = RED.settings.theme('palette.theme') || [];
             if (paletteTheme.length > 0) {


### PR DESCRIPTION
Fixes #5512

The changes made in #5500 included a change to the caching around what color individual nodes are based on their type.

In the case of subflows, each subflow can have its own color - so caching against the key 'subflow' is inappropriate.
