### PR TITLE
Set showSupportNotice option on i18n

### DIFF
--- a/packages/node_modules/@node-red/util/lib/i18n.js
+++ b/packages/node_modules/@node-red/util/lib/i18n.js
@@ -160,6 +160,7 @@ function init(settings) {
         initPromise = new Promise((resolve,reject) => {
             i18n.use(MessageFileLoader);
             var opt = {
+                showSupportNotice: false,
                 // debug: true,
                 defaultNS: "runtime",
                 ns: [],


### PR DESCRIPTION
Latest i18next logs a support message each time it is initialised. This option suppresses that.