### PR TITLE
Allow palette.categories to be set via theme plugin

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -198,6 +198,10 @@ async function loadThemePlugin () {
                     }
                 })
             }
+            if (Array.isArray(themePlugin.palette?.categories)) {
+                themeSettings.palette = themeSettings.palette || {};
+                themeSettings.palette.categories = themePlugin.palette.categories;
+            }
 
             // These settings are not exposed under `editorTheme`, so we don't have a merge strategy for them
             // If they're defined in the theme plugin, they replace any settings.js values.


### PR DESCRIPTION
The order of palette categories can already be set via `editorTheme.palette.categories` in the settings file.

This PR allows that to also be set via a theme plugin. This is a continuation of #5500 

```
RED.plugins.registerPlugin('test-theme-plugin', {
        type: 'node-red-theme',
        // scripts: [],
        css: [
            'theme.css',
        ],
        palette: {
            theme: [ ... ]
            categories: ['network', 'function', 'subflow', 'common']
        }
    }) 
```

If not set, the default order is: `['subflows', 'common', 'function', 'network', 'sequence', 'parser', 'storage']` - with any unknown categories being appended to the palette in the order they are loaded.