### PR TITLE
Only connect websocket client if need to

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
@@ -67,7 +67,7 @@ module.exports = function(RED) {
             }
         }
 
-        function startconn() {    // Connect to remote endpoint
+        node.startconn = function() {    // Connect to remote endpoint
             node.tout = null;
             const prox = getProxyForUrl(node.brokerurl, RED.settings.proxyOptions);
             let agent = undefined;
@@ -96,15 +96,15 @@ module.exports = function(RED) {
                     const keyValue = header.keyValue;
                     const valueType = header.valueType;
                     const valueValue = header.valueValue;
-                    
+
                     const headerName = keyType === 'other' ? keyValue : keyType;
                     let headerValue;
-                    
+
                     switch(valueType){
                         case 'other':
                             headerValue = valueValue;
                             break;
-                            
+
                         case 'env':
                             headerValue = RED.util.evaluateNodeProperty(valueValue,valueType,node);
                             break;
@@ -165,7 +165,7 @@ module.exports = function(RED) {
                 }
                 if (!node.closing && !node.isServer) {
                     clearTimeout(node.tout);
-                    node.tout = setTimeout(function() { startconn(); }, 3000); // try to reconnect every 3 secs... bit fast ?
+                    node.tout = setTimeout(function() { node.startconn(); }, 3000); // try to reconnect every 3 secs... bit fast ?
                 }
             });
             socket.on('message',function(data,flags) {
@@ -176,7 +176,7 @@ module.exports = function(RED) {
                 node.emit('erro',{err:err,id:id});
                 if (!node.closing && !node.isServer) {
                     clearTimeout(node.tout);
-                    node.tout = setTimeout(function() { startconn(); }, 3000); // try to reconnect every 3 secs... bit fast ?
+                    node.tout = setTimeout(function() { node.startconn(); }, 3000); // try to reconnect every 3 secs... bit fast ?
                 }
             }
             socket.on('error',socket.nrErrorHandler);
@@ -229,7 +229,7 @@ module.exports = function(RED) {
         }
         else {
             node.closing = false;
-            startconn(); // start outbound connection
+            // node.startconn(); // start outbound connection
         }
 
         node.on("close", function(done) {
@@ -245,7 +245,7 @@ module.exports = function(RED) {
             else {
                 node.closing = true;
                 node.server.close();
-                //wait 20*50 (1000ms max) for ws to close. 
+                //wait 20*50 (1000ms max) for ws to close.
                 //call done when readyState === ws.CLOSED (or 1000ms, whichever comes fist)
                 const closeMonitorInterval = 20;
                 let closeMonitorCount = 50;
@@ -268,6 +268,10 @@ module.exports = function(RED) {
 
     WebSocketListenerNode.prototype.registerInputNode = function(/*Node*/handler) {
         this._inputNodes.push(handler);
+        // start connection if we are the first and we are a client
+        if (!this.isServer && this._inputNodes.length === 1) {
+            this.startconn();
+        }
     }
 
     WebSocketListenerNode.prototype.removeInputNode = function(/*Node*/handler) {
@@ -417,6 +421,10 @@ module.exports = function(RED) {
                 status._session = {type:"websocket",id:event.id}
                 node.status(status);
             });
+            // start connection if we are the first and we are a client
+            if (!this.serverConfig.isServer && this.serverConfig._inputNodes.length === 0) {
+                this.serverConfig.startconn();
+            }
         }
         this.on("input", function(msg, nodeSend, nodeDone) {
             var payload;

--- a/test/nodes/core/network/22-websocket_spec.js
+++ b/test/nodes/core/network/22-websocket_spec.js
@@ -381,7 +381,9 @@ describe('websocket Node', function() {
         it('should connect to server', function(done) {
             var flow = [
                 { id: "server", type: "websocket-listener", path: "/ws" },
-                { id: "n2", type: "websocket-client", path: getWsUrl("/ws") }];
+                { id: "n2", type: "websocket-client", path: getWsUrl("/ws") },
+                { id: "n3", type: "websocket out", client: "n2" }
+            ];
             helper.load(websocketNode, flow, function() {
                 getSocket('server').on('connection', function(sock) {
                     done();
@@ -393,7 +395,8 @@ describe('websocket Node', function() {
         it('should initiate with subprotocol', function(done) {
             var flow = [
                 { id: "server", type: "websocket-listener", path: "/ws" },
-                { id: "n2", type: "websocket-client", path: getWsUrl("/ws"), subprotocol: "testprotocol" }];
+                { id: "n2", type: "websocket-client", path: getWsUrl("/ws"), subprotocol: "testprotocol" },
+                { id: "n3", type: "websocket out", client: "n2" }];
             helper.load(websocketNode, flow, function() {
                 getSocket('server').on('connection', function (sock) {
                     sock.should.have.property("protocol", "testprotocol")
@@ -405,7 +408,8 @@ describe('websocket Node', function() {
         it('should close on delete', function(done) {
             var flow = [
                 { id: "server", type: "websocket-listener", path: "/ws" },
-                { id: "n2", type: "websocket-client", path: getWsUrl("/ws") }];
+                { id: "n2", type: "websocket-client", path: getWsUrl("/ws") },
+                { id: "n3", type: "websocket out", client: "n2" }];
             helper.load(websocketNode, flow, function() {
                 getSocket('server').on('connection', function(sock) {
                     sock.on('close', function() {


### PR DESCRIPTION
to address Issue #5506

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

This PR enhances the web socket node to only connect (when in client mode) the underlying connection if there is actually a node that demands it. IE If you disable all the client nodes on the desktop the underlying config node will not create a connection.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
