### PR TITLE
Remove obsolete vendor-prefixed CSS properties

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/notifications.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/notifications.scss
@@ -79,20 +79,17 @@
 @keyframes red-ui-notification-shake-horizontal {
     0%,
     100% {
-        -webkit-transform: translateX(0);
         transform: translateX(0);
     }
     10%,
     30%,
     50%,
     70% {
-        -webkit-transform: translateX(-1px);
         transform: translateX(-1px);
     }
     20%,
     40%,
     60% {
-        -webkit-transform: translateX(1px);
         transform: translateX(1px);
     }
 }

--- a/packages/node_modules/@node-red/editor-client/src/sass/palette.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/palette.scss
@@ -112,17 +112,11 @@
     position: absolute;
     left: 11px;
     top: 12px;
-    -webkit-transition: all 0.2s ease-in-out;
-    -moz-transition: all 0.2s ease-in-out;
-    -o-transition: all 0.2s ease-in-out;
-    -webkit-transform: rotate(-90deg);
-    -moz-transform: rotate(-90deg);
-    -o-transform: rotate(-90deg);
+    transition: all 0.2s ease-in-out;
+    transform: rotate(-90deg);
 }
 .red-ui-palette-header i.expanded {
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
 }
 .red-ui-palette-header span {
     clear: both;
@@ -170,7 +164,6 @@
     top:8px;
     left: -5px;
     box-sizing: border-box;
-    -moz-box-sizing: border-box;
     background: var(--red-ui-node-port-background);
     border-radius: 3px;
     width: 10px;

--- a/packages/node_modules/@node-red/editor-client/src/sass/tourGuide.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tourGuide.scss
@@ -110,15 +110,12 @@
 //     0%,
 //     10%,
 //     100% {
-//         -webkit-transform: translateY(0);
 //         transform: translateY(0);
 //     }
 //     2%,8% {
-//         -webkit-transform: translateY(-5px);
 //         transform: translateY(-5px);
 //     }
 //     5% {
-//         -webkit-transform: translateY(5px);
 //         transform: translateY(5px);
 //     }
 // }

--- a/packages/node_modules/@node-red/editor-client/src/sass/ui/common/searchBox.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/ui/common/searchBox.scss
@@ -49,7 +49,6 @@
         border: none;
         width: 100%;
         box-shadow: none;
-        -webkit-box-shadow: none;
         padding: 3px 17px 3px 22px;
         margin: 0px;
         height: 30px;
@@ -58,7 +57,6 @@
         &:focus {
             border: none;
             box-shadow: none;
-            -webkit-box-shadow: none;
         }
     }
     a {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Remove obsolete vendor-prefixed 'transition', 'transform', 'box-sizing', and 'box-shadow' CSS properties.

The versions of these properties without a prefix have been supported by the major browsers for years.

https://caniuse.com/?search=transition

https://caniuse.com/?search=transform

https://caniuse.com/css3-boxsizing

https://caniuse.com/css-boxshadow

I tested this on a Mac using Chrome, Safari, and Firefox and found no issues. Please test it in other browsers and operating systems before considering merging this PR.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
