### PR TITLE
Better touch handling for submenus

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/menu.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/menu.js
@@ -133,6 +133,14 @@ RED.menu = (function() {
                 link.on("click", function(event) {
                     event.preventDefault();
                 });
+            } else {
+                // This is an item with a submenu. Clicking on it should not trigger the
+                // document level click handler that closes the submenu.
+                // This allows touch screen users to reliably open the submenu
+                link.on("click", function (event) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                })
             }
             if (opt.options) {
                 item.addClass("red-ui-menu-dropdown-submenu"+(opt.direction!=='right'?" pull-left":""));


### PR DESCRIPTION
The document level click handler on menus is used to close the menu when clicking away.

On touchscreens, this was preventing the natural UX of clicking on a menu item to open its submenu.

This fixes that by preventing the click on the menu item from propagating up to the document level handler.