### PR TITLE
Include sidebar width in position calculation for reveal function

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -7761,7 +7761,7 @@ RED.view = (function() {
                         if (node.type === "group" && !node.w && !node.h) {
                             _redraw();
                         }
-                        var screenSize = [chart[0].clientWidth/scaleFactor,chart[0].clientHeight/scaleFactor];
+                        var screenSize = [(chart[0].clientWidth - $("#red-ui-sidebar").width())/scaleFactor,chart[0].clientHeight/scaleFactor];
                         var scrollPos = [chart.scrollLeft()/scaleFactor,chart.scrollTop()/scaleFactor];
                         var cx = node.x;
                         var cy = node.y;


### PR DESCRIPTION
If the sidebar is shown, this ensures the reveal function brings the node into the visible space.