### PR TITLE
Minor change to treeList select/expand behaviour

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
@@ -632,12 +632,12 @@
                     });
                 // $('<span class="red-ui-treeList-icon"><i class="fa fa-folder-o" /></span>').appendTo(label);
                 label.on("click.red-ui-treeList-expand", function(e) {
-                    if (that.options.expandOnLabel !== false || item.expandOnLabel === true) {
-                        if (container.hasClass("expanded")) {
-                            if (item.hasOwnProperty('selected') || label.hasClass("selected")) {
-                                item.treeList.collapse();
-                            }
-                        } else {
+                    if (container.hasClass("expanded")) {
+                        if (label.hasClass("selected")) {
+                            item.treeList.collapse();
+                        }
+                    } else {
+                        if (item.expandOnLabel === true || label.hasClass("selected")) {
                             item.treeList.expand();
                         }
                     }


### PR DESCRIPTION
<img width="211" height="248" alt="image" src="https://github.com/user-attachments/assets/a46c46c8-19f7-47a8-9792-491f8e7db898" />


In NR 4, clicking on an item in the outliner would automatically expand it. This got annoying if you just wanted to click on a flow to switch to it.

In an earlier beta, the behaviour was changed so that for Flows, clicking the label would only select it. To expand/collapse you had to click the chevron. The section headers `Flows`/`Subflows` etc would still expand/collapse on first click.

Having spent time with this change, this PR makes a further refinement.

Now, clicking on a Flow that is *not* selected, will just select it. Clicking on it again (ie, once selected) will then expand/collapse it - so you don't have to hit the chevron.

I *think* this is better.