### PR TITLE
Handle shift-scroll more robustly

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -907,10 +907,19 @@ RED.view = (function() {
                 // Regular scroll - prevent default and manually handle both axes
                 evt.preventDefault();
                 evt.stopPropagation();
-
                 // Apply scroll deltas directly to both axes
                 var deltaX = evt.originalEvent.deltaX;
                 var deltaY = evt.originalEvent.deltaY;
+
+                if (evt.shiftKey) {
+                    // Shift key pressed - this should cause a scroll on the X-axis
+                    // But - some OS/browser combinations don't flip them, so we'll do it ourselves.
+                    if (deltaX === 0 && deltaY !== 0) {
+                        // swap the deltas
+                        deltaX = deltaY
+                        deltaY = 0
+                    }
+                }
 
                 chart.scrollLeft(chart.scrollLeft() + deltaX);
                 chart.scrollTop(chart.scrollTop() + deltaY);


### PR DESCRIPTION
Fixes #5557 

On Mac, shift-scroll works as expected - it scrolls horzontally.

For other OS/browser combinations, it appears not to work as expected - so we have to do it ourselves.

This checks for the shift-key in the wheel event handler. The expectation is to have `deltaY=0` and `deltaX` to be the scroll amount. If, however, we see `deltaX=0` and `deltaY` is not `0`, then flip the values to apply the scroll on the other axis.

