### PR TITLE
Add error handling for markdown parser

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -121,9 +121,14 @@ RED.utils = (function() {
     window._marked.use({extensions: [descriptionList, description] } );
 
     function renderMarkdown(txt) {
-        var rendered = _marked.parse(txt);
-        const cleaned = DOMPurify.sanitize(rendered);
-        return cleaned;
+        try {
+            var rendered = _marked.parse(txt);
+            const cleaned = DOMPurify.sanitize(rendered);
+            return cleaned;
+        } catch (err) {
+            console.warn(err);
+            return txt
+        }
     }
 
     function formatString(str) {


### PR DESCRIPTION
I imported markdown into a flow description tab that included a mermaid block that itself included the character `…`. This caused an unexpected error in the marked parser. Not seen this code throw in this way before.

Before investigating properly, getting a simple try/catch in place to avoid the breakage this caused.