### PR TITLE
Ensure disabled tab has fully dashed border

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/workspace.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/workspace.scss
@@ -96,9 +96,9 @@
 }
 .red-ui-workspace-disabled {
     &.red-ui-tab {
-        border-top-style: dashed;
-        border-left-style: dashed;
-        border-right-style: dashed;
+        &.active {
+            border-style: dashed;
+        }
 
         a {
             font-style: italic;


### PR DESCRIPTION
Fixes #5558 - ensures a disabled flow has a fully dashed border when active