### PR TITLE
Renable click to close for edit dialog

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tray.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tray.js
@@ -231,6 +231,14 @@
             editorStack = $("#red-ui-editor-stack");
             $(window).on("resize", handleWindowResize);
             RED.events.on("sidebar:resize",handleWindowResize);
+            $("#red-ui-editor-shade").on("click", function() {
+                if (!openingTray) {
+                    var tray = stack[stack.length-1];
+                    if (tray && tray.primaryButton) {
+                        tray.primaryButton.click();
+                    }
+                }
+            });
         },
         show: function show(options) {
             lowerTrayZ();


### PR DESCRIPTION
This restores the long-held behaviour of closing the edit dialog when clicking on the workspace outside the dialog. We've only had negative feedback on the change - which is somewhat self-selecting (why comment on something you like).

The alternative is to give the user a choice of behaviours. I'm very keen to avoid adding config options for small bits of UI behaviour - they set an expectation that anything and everything should be customisable, and become hard to maintain.

I've going to merge this for the next beta to gauge feedback on reverting. We can still go with #5385 if we really must.