### PR TITLE
Allow theme plugin to override settings and add menu options

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -175,14 +175,16 @@ async function loadThemePlugin () {
                         // update themeContext header image
                         themeContext.header.image = result[0]
                     }
+                } else if (themePlugin.header.image === false) {
+                    themeContext.header.image = false
                 }
                 // if the plugin has a title
-                if (themePlugin.header.title) {
-                    themeContext.header.title = themePlugin.header.title || themeContext.header.title
+                if (themePlugin.header.hasOwnProperty('title')) {
+                    themeContext.header.title = themePlugin.header.title
                 }
                 // if the plugin has a header url
-                if (themePlugin.header.url) {
-                    themeContext.header.url = themePlugin.header.url || themeContext.header.url
+                if (themePlugin.header.hasOwnProperty('url')) {
+                    themeContext.header.url = themePlugin.header.url
                 }
             }
 


### PR DESCRIPTION
Closes #5577

This allows a theme plugin to override settings for certain properties. It also adds the existing `menu` options to what is supported in Theme Plugins.

Here is an example of how the plugin to set a custom favicon, page title etc.

A couple of notes:

 - the `favicon`/`header.image` settings must be full paths to the image relative to the root of the package.
 - for `header.title/image/url` - set to `false` to remove the title/image/link as desired
- The example shows how to hide the `Node-RED Help` menu item and the version number menu item (that links to the help sidebar changelog).

```
module.exports = function (RED) {

    RED.plugins.registerPlugin('test-theme-plugin', {
        type: 'node-red-theme',
        // scripts: [],
        css: [
            'theme.css',
        ],
        page: {
            favicon: 'resources/favicon.png',
            title: 'Banana Theme'
        },
        header: {
            title: 'Flow Editor',
            image: 'resources/header-image.png',
            url: false,
        },
        menu: {
            'menu-item-help': false,
            'menu-item-node-red-version': false
        }

    })
}
```


For `menu-item-help`, the text/url of the menu item can be customised by setting it to an object with `label` and `url` properties:
```
        menu: {
            'menu-item-help': {
                label: 'Get Help',
                url: 'https://example.com'
            },
            'menu-item-node-red-version': false
        }
```