### PR TITLE
Introduce `show-first-tab` and `show-last-tab` actions

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/fr/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/fr/editor.json
@@ -1288,6 +1288,8 @@
     "toggle-show-tips": "Basculer l'affichage des astuces",
     "show-about": "Afficher la description de Node-RED",
     "show-welcome-tour": "Afficher la visite de bienvenue",
+    "show-first-tab": "Afficher le premier onglet",
+    "show-last-tab": "Afficher le dernier onglet",
     "show-next-tab": "Afficher l'onglet suivant",
     "show-previous-tab": "Afficher l'onglet précédent",
     "add-flow": "Ajouter un flux",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
@@ -605,6 +605,20 @@ RED.tabs = (function() {
             }
         }
 
+        function activateFirstTab() {
+            const first = ul.find("li.red-ui-tab:not(.hide-tab)").first();
+            if (first.length > 0) {
+                activateTab(first.find("a"));
+            }
+        }
+
+        function activateLastTab() {
+            const last = ul.find("li.red-ui-tab:not(.hide-tab)").last();
+            if (last.length > 0) {
+                activateTab(last.find("a"));
+            }
+        }
+
         function findPreviousVisibleTab(li) {
             if (!li) {
                 li = ul.find("li.active");
@@ -963,6 +977,8 @@ RED.tabs = (function() {
             },
             removeTab: removeTab,
             activateTab: activateTab,
+            firstTab: activateFirstTab,
+            lastTab: activateLastTab,
             nextTab: activateNextTab,
             previousTab: activatePreviousTab,
             resize: updateTabWidths,

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -514,6 +514,20 @@ RED.workspaces = (function() {
             workspaceIndex = 0
         })
 
+        RED.actions.add("core:show-first-tab", function () {
+            const oldActive = activeWorkspace;
+            workspace_tabs.firstTab();
+            if (oldActive !== activeWorkspace) {
+                addToViewStack(oldActive);
+            }
+        });
+        RED.actions.add("core:show-last-tab", function () {
+            const oldActive = activeWorkspace;
+            workspace_tabs.lastTab();
+            if (oldActive !== activeWorkspace) {
+                addToViewStack(oldActive);
+            }
+        });
         RED.actions.add("core:show-next-tab",function() {
             var oldActive = activeWorkspace;
             workspace_tabs.nextTab();


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Second part of #5355.

Add `show-first-tab` and `show-last-tab` actions.

TODO: a default key (`keymap`) should be added.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
