### PR TITLE
Encode branch name in delete request

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/projects/projectSettings.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/projects/projectSettings.js
@@ -1259,7 +1259,7 @@ RED.projects.settings = (function() {
                                         text: RED._("sidebar.project.projectSettings.deleteBranch"),
                                         click: function() {
                                             notification.close();
-                                            var url = "projects/"+activeProject.name+"/branches/"+entry.name;
+                                            var url = "projects/"+activeProject.name+"/branches/"+encodeURIComponent(entry.name);
                                             var options = {
                                                 url: url,
                                                 type: "DELETE",


### PR DESCRIPTION
Fixes #5477

Encodes the branch name in the delete url to allow for names with uri-specific characters.