### PR TITLE
Add badges to func node tabs with code in

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.html
@@ -351,6 +351,27 @@
         return _libs;
     }
 
+    function getEditorValue(editor, defaultValue) {
+        var val = editor.getValue();
+        if (defaultValue && val.trim() === defaultValue.trim()) {
+            return "";
+        } else {
+            return val;
+        }
+    }
+
+    function getEditorErrorCount(editor) {
+        const annot = editor.getSession().getAnnotations();
+        let count = 0
+        for (var k=0; k < annot.length; k++) {
+            if (annot[k].type === "error") {
+                count += annot.length;
+                break;
+            }
+        }
+        return count
+    }
+
     RED.nodes.registerType('function',{
         color:"#fdd0a2",
         category: 'function',
@@ -427,6 +448,7 @@
                         } else if (that.finalizeEditor.getDomNode() == editor[0]) {
                             that.finalizeEditor.focus();
                         }
+                        updateTabBadges();
                     }
                 }
             });
@@ -451,6 +473,28 @@
 
             tabs.activateTab("func-tab-body");
 
+
+            const updateTabBadge = (tabId, editorName, defaultValue) => {
+                const editor = this[editorName]
+                const hasContent = getEditorValue(editor, defaultValue) !== ''
+                // This doesn't work as the annotations appear to be cleared when the editor isn't active
+                // TODO: add a badge for tabs with errors
+                // const hasErrors = getEditorErrorCount(editor) > 0
+                const badgeSpan = $(`#red-ui-tab-${tabId} .red-ui-tabs-badges`)
+                badgeSpan.find('i').remove()
+                $(`#red-ui-tab-${tabId} .red-ui-tabs-badges i`).remove()
+                if (hasContent) {
+                    $('<i style="display: inline" class="fa fa-file-code-o"></i>').appendTo(badgeSpan)
+                }
+                                
+            }
+            
+            const updateTabBadges = function () {
+                updateTabBadge("func-tab-body", "editor", "")
+                updateTabBadge("func-tab-init", "initEditor", RED._("node-red:function.text.initialize"))
+                updateTabBadge("func-tab-finalize", "finalizeEditor", RED._("node-red:function.text.finalize"))
+            }
+            
             $( "#node-input-outputs" ).spinner({
                 min: 0,
                 max: 500,
@@ -593,27 +637,18 @@
             if (RED.settings.functionExternalModules !== false) {
                 prepareLibraryConfig(that);
             }
+
+            updateTabBadges();
         },
         oneditsave: function() {
-            var node = this;
-            var noerr = 0;
+            const node = this;
+            let noerr = 0;
             $("#node-input-noerr").val(0);
 
-            var disposeEditor = function(editorName,targetName,defaultValue) {
-                var editor = node[editorName];
-                var annot = editor.getSession().getAnnotations();
-                for (var k=0; k < annot.length; k++) {
-                    if (annot[k].type === "error") {
-                        noerr += annot.length;
-                        break;
-                    }
-                }
-                var val = editor.getValue();
-                if (defaultValue) {
-                    if (val.trim() == defaultValue.trim()) {
-                        val = "";
-                    }
-                }
+            const disposeEditor = function(editorName,targetName,defaultValue) {
+                const editor = node[editorName];
+                noerr += getEditorErrorCount(editor)
+                const val = getEditorValue(editor, defaultValue)
                 editor.destroy();
                 delete node[editorName];
                 $("#"+targetName).val(val);


### PR DESCRIPTION
Closes #5436 

Adds a badge to the Function node tabs that contain code. Helps highlight if the start/stop tabs have any content hidden on them.

I idid also look at adding a badge to indicate if there are errors on the tabs.. but the editor api wasn't consistently returning error information, so marked as a todo

<img width="620" height="129" alt="image" src="https://github.com/user-attachments/assets/5c7d8e69-6165-4a74-bce8-6ea606042f9d" />
