### PR TITLE
Update config sidebar id handling

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-config.js
@@ -160,10 +160,9 @@ RED.sidebar.config = (function() {
                     $('<li class="red-ui-palette-node-config-type">'+node.type+'</li>').appendTo(list);
                     currentType = node.type;
                 }
-                var entry = $('<li class="red-ui-palette-node_id_'+node.id.replace(/\./g,"-")+'"></li>').appendTo(list);
+                var entry = $('<li></li>').appendTo(list);
                 var nodeDiv = $('<div class="red-ui-palette-node-config red-ui-palette-node"></div>').appendTo(entry);
-                entry.data('node',node.id);
-                nodeDiv.data('node',node.id);
+                entry.data('data-node-id',node.id);
                 var label = $('<div class="red-ui-palette-label"></div>').text(labelText).appendTo(nodeDiv);
 
                 if (node.d) {
@@ -316,7 +315,7 @@ RED.sidebar.config = (function() {
         RED.actions.add("core:delete-config-selection", function() {
             var selectedNodes = [];
             $(content).find(".red-ui-palette-node.selected").each(function() {
-                selectedNodes.push($(this).parent().data('node'));
+                selectedNodes.push($(this).parent().data('data-node-id'));
             });
             if (selectedNodes.length > 0) {
                 var historyEvent = {
@@ -454,19 +453,23 @@ RED.sidebar.config = (function() {
             $('#red-ui-sidebar-config-filter-all').trigger("click");
             id = id.replace(/\./g,"-");
             setTimeout(function() {
-                var node = $(".red-ui-palette-node_id_"+id);
-                var y = node.position().top;
-                var h = node.height();
-                var scrollWindow = $(".red-ui-sidebar-node-config");
-                var scrollHeight = scrollWindow.height();
+                const node = $(content).find(".red-ui-sidebar-node-config-list li").filter(function() {
+                    return $(this).data('data-node-id') === id;
+                })
+                if (node.length) {
+                    var y = node.position().top;
+                    var h = node.height();
+                    var scrollWindow = $(".red-ui-sidebar-node-config");
+                    var scrollHeight = scrollWindow.height();
 
-                if (y+h > scrollHeight) {
-                    scrollWindow.animate({scrollTop: '-='+(scrollHeight-(y+h)-30)},150);
-                } else if (y<0) {
-                    scrollWindow.animate({scrollTop: '+='+(y-10)},150);
+                    if (y+h > scrollHeight) {
+                        scrollWindow.animate({scrollTop: '-='+(scrollHeight-(y+h)-30)},150);
+                    } else if (y<0) {
+                        scrollWindow.animate({scrollTop: '+='+(y-10)},150);
+                    }
+                    flashConfigNode(node);
                 }
-                flashConfigNode(node, id);
-            },100);
+            }, 100);
         }
         RED.sidebar.show("config");
     }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -1246,9 +1246,11 @@ RED.utils = (function() {
             try {
                 l = (typeof l === "function" ? l.call(node) : l)||defaultLabel;
             } catch(err) {
-                console.log("Definition error: "+node.type+".label",err);
                 l = defaultLabel;
             }
+        }
+        if (typeof l !== 'string') {
+            l = defaultLabel
         }
         return RED.text.bidi.enforceTextDirectionWithUCC(l);
     }


### PR DESCRIPTION
The config node sidebar was setting a css class on the node `li` elements that contained the node id. This fix removes that in favour of the existing `data` attributes for looking up the node id.