### PR TITLE
Handle invalid theme regex

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -1285,19 +1285,39 @@ RED.utils = (function() {
             for (let i = 0; i < paletteTheme.length; i++ ){
                 const themeRule = paletteTheme[i];
                 if (themeRule.hasOwnProperty('category')) {
-                    if (!themeRule.hasOwnProperty('_category')) {
-                        themeRule._category = new RegExp(themeRule.category);
-                    }
-                    if (!themeRule._category.test(def.category)) {
-                        continue;
+                    try {
+                        if (!themeRule.hasOwnProperty('_category')) {
+                            if (themeRule.category === '*') {
+                                themeRule._category = /.*/;
+                            } else {
+                                themeRule._category = new RegExp(themeRule.category);
+                            }
+                        }
+                        if (!themeRule._category.test(def.category)) {
+                            continue;
+                        }
+                    } catch (err) {
+                        console.warn(`Invalid theme category rule: ${themeRule.category}`);
+                        // Delete the category so we don't try to evaluate it again
+                        delete themeRule.category
                     }
                 }
                 if (themeRule.hasOwnProperty('type')) {
-                    if (!themeRule.hasOwnProperty('_type')) {
-                        themeRule._type = new RegExp(themeRule.type);
-                    }
-                    if (!themeRule._type.test(def.type)) {
-                        continue;
+                    try {
+                        if (!themeRule.hasOwnProperty('_type')) {
+                            if (themeRule.type === '*') {
+                                themeRule._type = /.*/;
+                            } else {
+                                themeRule._type = new RegExp(themeRule.type);
+                            }
+                        }
+                        if (!themeRule._type.test(def.type)) {
+                            continue;
+                        }
+                    } catch (err) {
+                        console.warn(`Invalid theme type rule: ${themeRule.type}`);
+                        // Delete the type so we don't try to evaluate it again
+                        delete themeRule.type
                     }
                 }
                 // We have found a rule that matches - now see if it provides the requested property


### PR DESCRIPTION
Fixes #5588 

If a palette theme has an invalid regex, it was breaking the palette. This PR adds proper error handling and handling for `*` as we know the user meant `.*` really.