### PR TITLE
Ensure custom subflow colors override theme overrides

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -1331,8 +1331,12 @@ RED.utils = (function() {
 
     function getNodeColor(type, def) {
         def = def || {};
-        if (type === 'subflow') {
+        // Allow a subflow instance colour to take precedence over theme if not the default color
+        if (/^subflow($|:)/.test(type) && def.hasOwnProperty('color') && def.color !== "#DDAA99") {
             return def.color
+        }
+        if (type === 'subflow') {
+            type = def.type 
         }
         if (!nodeColorCache.hasOwnProperty(type)) {
             const paletteTheme = RED.settings.theme('palette.theme') || [];


### PR DESCRIPTION
Fixes #5589

Better fix for #5512 - this ensures a subflow's custom colour is applied properly, whilst allowing a theme to override the default subflow colour.

The hardcoded default colour check is not nice, but a quick solution. Not going to pull on that thread here.