### PR TITLE
Ensure edit dialog fills the tray

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1205,8 +1205,8 @@ RED.editor = (function() {
             ],
             resize: function(dimensions) {
                 editTrayWidthCache[type] = dimensions.width;
-                $(".red-ui-tray-content").height(dimensions.height - 50);
-                var form = $(".red-ui-tray-content form").height(dimensions.height - 50 - 40);
+                $(".red-ui-tray-content").height(dimensions.height - 35);
+                var form = $(".red-ui-tray-content form").height(dimensions.height - 35 - 40);
                 var size = {width:form.width(),height:form.height()};
                 activeEditPanes.forEach(function(pane) {
                     if (pane.resize) {
@@ -1364,7 +1364,7 @@ RED.editor = (function() {
         var trayOptions = {
             title: getEditStackTitle(), //(adding?RED._("editor.addNewConfig", {type:type}):RED._("editor.editConfig", {type:type})),
             resize: function(dimensions) {
-                $(".red-ui-tray-content").height(dimensions.height - 50);
+                $(".red-ui-tray-content").height(dimensions.height - 35);
                 var form = $("#node-config-dialog-edit-form");
                 var size = {width:form.width(),height:form.height()};
                 activeEditPanes.forEach(function(pane) {
@@ -1934,9 +1934,9 @@ RED.editor = (function() {
                 }
             ],
             resize: function (dimensions) {
-                $(".red-ui-tray-content").height(dimensions.height - 50);
+                $(".red-ui-tray-content").height(dimensions.height - 35);
 
-                const form = $(".red-ui-tray-content form").height(dimensions.height - 50 - 40);
+                const form = $(".red-ui-tray-content form").height(dimensions.height - 35 - 40);
                 const size = { width: form.width(), height: form.height() };
                 activeEditPanes.forEach(function (pane) {
                     if (pane.resize) {
@@ -2056,8 +2056,8 @@ RED.editor = (function() {
             ],
             resize: function(dimensions) {
                 editTrayWidthCache['group'] = dimensions.width;
-                $(".red-ui-tray-content").height(dimensions.height - 50);
-                var form = $(".red-ui-tray-content form").height(dimensions.height - 50 - 40);
+                $(".red-ui-tray-content").height(dimensions.height - 35);
+                var form = $(".red-ui-tray-content form").height(dimensions.height - 35 - 40);
                 var size = {width:form.width(),height:form.height()};
                 activeEditPanes.forEach(function(pane) {
                     if (pane.resize) {
@@ -2194,8 +2194,8 @@ RED.editor = (function() {
                 }
             ],
             resize: function(dimensions) {
-                $(".red-ui-tray-content").height(dimensions.height - 50);
-                var form = $(".red-ui-tray-content form").height(dimensions.height - 50 - 40);
+                $(".red-ui-tray-content").height(dimensions.height - 35);
+                var form = $(".red-ui-tray-content form").height(dimensions.height - 35 - 40);
                 var size = {width:form.width(),height:form.height()};
                 activeEditPanes.forEach(function(pane) {
                     if (pane.resize) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tray.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tray.js
@@ -194,7 +194,7 @@
 
     function handleWindowResize() {
         let sidebarWidth = $("#red-ui-sidebar").is(":visible") ? $("#red-ui-sidebar").outerWidth() : 0;
-        $("#red-ui-editor-stack").css('right', sidebarWidth + 4);
+        $("#red-ui-editor-stack").css('right', sidebarWidth + 9);
         if (stack.length > 0) {
             var tray = stack[stack.length-1];
             if (tray.options.maximized || tray.width > $("#red-ui-editor-stack").position().left-8) {


### PR DESCRIPTION
Fixes #5573 

I spent a lot of time trying to rework the edit dialog structure to use `flex`, to remove the need for all of the absolute sizing the code does. But it ended up being a whack-a-mole of issues with the various uses of the edit tray and a much bigger task. I decided I couldn't reliably make those changes without risking breaking a 3rd party node's edit dialog, so I chickened out and updated the absolute sizing calculations. 