### PR TITLE
Ensure tcp-request doesn't reuse uncloned msg objects

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
@@ -689,7 +689,7 @@ module.exports = function(RED) {
                     try {
                         if (node.out === "sit") { // if we are staying connected just send the buffer
                             if (clients[connection_id]) {
-                                const msg = clients[connection_id].lastMsg || {};
+                                const msg = RED.util.cloneMessage(clients[connection_id].lastMsg || {});
                                 msg.payload = RED.util.cloneMessage(data);
                                 if (node.ret === "string") {
                                     try {

--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
@@ -731,7 +731,7 @@ module.exports = function(RED) {
                                             clients[connection_id].timeout = setTimeout(function () {
                                                 if (clients[connection_id]) {
                                                     clients[connection_id].timeout = null;
-                                                    const msg = clients[connection_id].lastMsg || {};
+                                                    const msg = RED.util.cloneMessage(clients[connection_id].lastMsg || {});
                                                     msg.payload = Buffer.alloc(i+1);
                                                     buf.copy(msg.payload,0,0,i+1);
                                                     if (node.ret === "string") {
@@ -757,7 +757,7 @@ module.exports = function(RED) {
                                     i += 1;
                                     if ( i >= node.splitc) {
                                         if (clients[connection_id]) {
-                                            const msg = clients[connection_id].lastMsg || {};
+                                            const msg = RED.util.cloneMessage(clients[connection_id].lastMsg || {});
                                             msg.payload = Buffer.alloc(i);
                                             buf.copy(msg.payload,0,0,i);
                                             if (node.ret === "string") {
@@ -780,7 +780,7 @@ module.exports = function(RED) {
                                     i += 1;
                                     if (data[j] == node.splitc) {
                                         if (clients[connection_id]) {
-                                            const msg = clients[connection_id].lastMsg || {};
+                                            const msg = RED.util.cloneMessage(clients[connection_id].lastMsg || {});
                                             msg.payload = Buffer.alloc(i);
                                             buf.copy(msg.payload,0,0,i);
                                             if (node.ret === "string") {


### PR DESCRIPTION
fixes #5609
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Clones the input message before using it for the response, so if more than one response message is received then it doesn't override the first message.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
