### PR TITLE
Rework sidebars to be draggable

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 RED.sidebar = (function() {
-    const sidebarLayoutVersion = 3
+    const sidebarLayoutVersion = 4
     const sidebars = {
         primary: {
             id: 'primary',
@@ -48,7 +48,16 @@ RED.sidebar = (function() {
 
     let sidebarsInitialised = false
 
+    const globalTabBar = {
+        container: null,
+        tabOverflowButton: null
+    }
+
+
     function exportSidebarState () {
+        // TODO: fix all of this
+        // console.log('TODO: exportSidebarState', sidebars.primary.sections.top.tabs, sidebars.primary.sections.bottom.tabs, sidebars.secondary.sections.top.tabs, sidebars.secondary.sections.bottom.tabs)
+        return
         if (!sidebars.secondary?.tabBars?.bottom?.container) {
             // This has been called whilst setting up the sidebars
             // We don't have all the state yet, so not nothing to export
@@ -106,8 +115,6 @@ RED.sidebar = (function() {
             console.warn('wiped the floor')
         }
     }
-
-
 
     function addTab(title,content,closeable,visible) {
         var options;
@@ -187,7 +194,6 @@ RED.sidebar = (function() {
             }
             $(options.toolbar).hide();
         }
-        var id = options.id;
 
         // console.log('menu', options.id, options.name)
         RED.menu.addItem("menu-item-view-menu",{
@@ -204,13 +210,18 @@ RED.sidebar = (function() {
         knownTabs[options.id] = options;
         options.tabButton = $('<button></button>')
         // Insert the tab button at the correct index
-        if (targetTabButtonIndex === -1) {
-            // Append to end
-            targetSidebar.tabBars[targetSection].addButton(options.tabButton)
-        } else {
-            // Insert before the item at targetTabButtonIndex
-            targetSidebar.tabBars[targetSection].addButton(options.tabButton, targetTabButtonIndex)
-        }
+        // if (targetTabButtonIndex === -1) {
+        //     // Append to end
+        //     console.log('add to end')
+        //     options.tabButton.appendTo(globalTabBar.container);
+        // } else {
+        //     console.log('insert before index', targetTabButtonIndex)
+        //     options.tabButton.insertBefore(globalTabBar.container.children().eq(targetTabButtonIndex));
+        // }
+        // TODO: get them in the right order
+        options.tabButton.appendTo(globalTabBar.container);
+        targetSidebar.sections[targetSection].tabs.push(options.id)
+
         options.tabButton.attr('data-tab-id', options.id)
 
         options.tabButtonTooltip = RED.popover.tooltip(options.tabButton, options.name, options.action);
@@ -225,19 +236,9 @@ RED.sidebar = (function() {
                 return
             }
             const targetSidebar = options.target === 'secondary' ? sidebars.secondary : sidebars.primary;
-            if (targetSidebar.tabBars[options.targetSection].active === options.id && RED.menu.isSelected(targetSidebar.menuToggle)) {
+            if (targetSidebar.sections[options.targetSection].active === options.id && RED.menu.isSelected(targetSidebar.menuToggle)) {
                 if (!targetSidebar.sections[options.targetSection].hidden) {
-                    const otherSectionHidden = targetSidebar.sections[options.targetSection === 'top' ? 'bottom' : 'top'].hidden
-                    if (otherSectionHidden) {
-                        // Both sections are going to be hidden, so hide the sidebar first.
-                        // We do this *before* hiding the last section so that we remember which the 'last' section was and it can be
-                        // restored when the sidebar is shown again.
-                        RED.menu.setSelected(targetSidebar.menuToggle, false);
-                    } else {
-                        // Hiding just one section, clear its active setting
-                        targetSidebar.tabBars[targetSection].active = null
-                    }
-                    targetSidebar.hideSection(options.targetSection)
+                    hideTab(options.id)
                 } else {
                     targetSidebar.showSection(options.targetSection)
                 }
@@ -248,6 +249,24 @@ RED.sidebar = (function() {
         })
     }
 
+    function hideTab(id) {
+        const options = knownTabs[id]
+        if (options) {
+            const targetSidebar = options.target === 'secondary' ? sidebars.secondary : sidebars.primary;
+            const otherSectionHidden = targetSidebar.sections[options.targetSection === 'top' ? 'bottom' : 'top'].hidden
+            if (otherSectionHidden) {
+                // Both sections are going to be hidden, so hide the sidebar first.
+                // We do this *before* hiding the last section so that we remember which the 'last' section was and it can be
+                // restored when the sidebar is shown again.
+                RED.menu.setSelected(targetSidebar.menuToggle, false);
+            } else {
+                // Hiding just one section, clear its active setting
+                targetSidebar.sections[options.targetSection].active = null
+            }
+            targetSidebar.hideSection(options.targetSection)
+        }
+    }
+
     function removeTab(id) {
         if (knownTabs[id]) {
             const targetSidebar = knownTabs[id].target === 'secondary' ? sidebars.secondary : sidebars.primary;
@@ -255,23 +274,33 @@ RED.sidebar = (function() {
             if (knownTabs[id].footer) {
                 knownTabs[id].footer.remove();
             }
-            targetSidebar.tabBar.find('button[data-tab-id="'+id+'"]').remove()
+            globalTabBar.container.find('button[data-tab-id="'+id+'"]').remove();
             RED.menu.removeItem("menu-item-view-menu-"+id);
             if (knownTabs[id].onremove) {
                 knownTabs[id].onremove.call(knownTabs[id]);
             }
             delete knownTabs[id];
-            const firstTab = targetSidebar.tabBar.find('button').first().attr('data-tab-id');
-            if (firstTab) {
-                RED.sidebar.show(firstTab);
-            }
+            // TODO: reselect next tab for the section
+            // const firstTab = targetSidebar.tabBar.find('button').first().attr('data-tab-id');
+            // if (firstTab) {
+            //     RED.sidebar.show(firstTab);
+            // }
         }
     }
 
     function moveTab(id, srcSidebar, srcPosition, targetSidebar, targetPosition) {
+        // console.log('MOVE', id, srcSidebar.id, srcPosition, '->', targetSidebar.id, targetPosition, srcSidebar.sections[srcPosition].tabs, targetSidebar.sections[targetPosition].tabs)
+
         const options = knownTabs[id];
+
+        const currentIndex = srcSidebar.sections[srcPosition].tabs.indexOf(options.id)
+        srcSidebar.sections[srcPosition].tabs.splice(currentIndex, 1);
+
+
         options.target = targetSidebar.id;
         options.targetSection = targetPosition;
+
+        targetSidebar.sections[targetPosition].tabs.push(options.id);
 
         $(options.wrapper).appendTo(targetSidebar.sections[targetPosition].content);
         if (options.toolbar) {
@@ -280,239 +309,113 @@ RED.sidebar = (function() {
         // Reset the tooltip so its left/right direction is recalculated
         options.tabButtonTooltip.delete()
         options.tabButtonTooltip = RED.popover.tooltip(options.tabButton, options.name, options.action);
+        RED.sidebar.show(options.id)
 
-        if (targetSidebar.sections[targetPosition].content.children().length === 1) {
-            RED.sidebar.show(options.id)
+        if (srcSidebar.sections[srcPosition].tabs.length === 0) {
+            // src has been emptied. If this is the top section and there is content in the bottom section, then move the bottom connect to the top
+            if (srcPosition === 'top' && srcSidebar.sections.bottom.tabs.length > 0) {
+                const tabsToMove = [...srcSidebar.sections.bottom.tabs]
+                tabsToMove.forEach(function(tabId) {
+                    moveTab(tabId, srcSidebar, 'bottom', srcSidebar, 'top')
+                })
+                srcSidebar.hideSection('bottom')
+                targetPosition = 'top'
+            } else {
+                srcSidebar.hideSection(srcPosition)
+            }
+        } else {
+            RED.sidebar.show(srcSidebar.sections[srcPosition].tabs[0])    
         }
-        if (srcSidebar.sections[srcPosition].content.children().length === 0) {
-            // src has been emptied
-            srcSidebar.hideSection(srcPosition)
-            srcSidebar.tabBars[srcPosition].container.addClass('red-ui-sidebar-tab-bar-empty')
-        }
-        if (targetSidebar.sections[targetPosition].content.children().length > 0) {
-            targetSidebar.tabBars[targetPosition].container.removeClass('red-ui-sidebar-tab-bar-empty')
-        }
-        
         if (targetSidebar.sections[targetPosition].hidden) {
             targetSidebar.showSection(targetPosition)
         }
+        exportSidebarState();
     }
 
     let draggingTabButton = false
 
-
     function getSidebarOptions(sidebar, targetSection) {
         const menuOptions = []
-        const active = sidebar.tabBars[targetSection].active
-        sidebar.tabBars[targetSection].container.find('button:not(.red-ui-sidebar-tab-bar-overflow-button)').each(function () {
-            const tabId = $(this).attr('data-tab-id')
+        sidebar.sections[targetSection].tabs.forEach(function (tabId) {
             const tabOptions = knownTabs[tabId]
             let initialStateSet = false
             menuOptions.push({
                 label: tabOptions.name,
-                selected: tabId === active,
-                toggle: true,
                 onselect: function(state) {
-                    if (!initialStateSet) {
-                        // This is called when showing the menu to initialise the state properly. This made
-                        // sense for other menus, but is inconvenient here. So we swallow the first call to onselect
-                        // without taking any action.
-                        initialStateSet = true
-                        return
-                    }
-                    if (state) {
-                        RED.sidebar.show(tabId)
-                    } else {
-                        // DRY: overlapping logic with the mouseup handler on the inidividual tab buttons
-                        if (!sidebar.sections[targetSection].hidden) {
-                            const otherSectionHidden = sidebar.sections[targetSection === 'top' ? 'bottom' : 'top'].hidden
-                            if (otherSectionHidden) {
-                                // Both sections are going to be hidden, so hide the sidebar first.
-                                // We do this *before* hiding the last section so that we remember which the 'last' section was and it can be
-                                // restored when the sidebar is shown again.
-                                RED.menu.setSelected(sidebar.menuToggle, false);
-                            } else {
-                                // Hiding just one section, clear its active setting
-                                sidebar.tabBars[targetSection].active = null
-                            }
-                            sidebar.hideSection(targetSection)
-                        } else {
-                            sidebar.showSection(targetSection)
-                        }
-                        exportSidebarState()
-                    }
-
+                    RED.sidebar.show(tabId)
                 }
             })
         })
         return menuOptions
     }
 
-    function setupSidebarTabs(sidebar) {
-        const tabBar = $('<div class="red-ui-sidebar-tab-bar"></div>').addClass('red-ui-sidebar-' + sidebar.direction);
-        if (sidebar.direction === 'right') {
-            tabBar.appendTo("#red-ui-workspace-footer");
-        } else if (sidebar.direction === 'left') {
-            tabBar.prependTo("#red-ui-workspace-footer");
-        }
+    function setupSidebarTabs() {
+        const tabBar = $('<div class="red-ui-sidebar-tab-bar"></div>').addClass('red-ui-sidebar-right');
+        globalTabBar.container = tabBar
+        tabBar.appendTo("#red-ui-workspace-footer");
 
         // TODO: consider an explicit toggle button for the sidebars...
         // const toggleSidebarButton = $('<button class="red-ui-sidebar-toggle-button"><i class="fa fa-columns"></i></button>')
         // toggleSidebarButton.on('click', function() {
         //     RED.menu.toggleSelected(sidebar.menuToggle);
         // })
-        sidebar.tabBars = {
-            top: setupTabSection(sidebar, tabBar, 'top'),
-            bottom: setupTabSection(sidebar, tabBar, 'bottom')
-        }
+        // sidebar.tabBars = {
+        //     top: setupTabSection(sidebar, tabBar, 'top'),
+        //     bottom: setupTabSection(sidebar, tabBar, 'bottom')
+        // }
         // if (sidebar.direction === 'right') {
         //     toggleSidebarButton.appendTo(tabBar);
         // } else if (sidebar.direction === 'left') {
         //     toggleSidebarButton.prependTo(tabBar);
         // }
 
-        sidebar.tabOverflowButton = $('<button class="red-ui-sidebar-tab-bar-overflow-button"><i class="fa fa-ellipsis-h"></i></button>');
-        sidebar.tabOverflowButton.hide()
-        sidebar.tabOverflowButton.on('click', function(evt) {
-            try {
-                const menuOptions = getSidebarOptions(sidebar, 'top')
-                const bottomMenuOptions = getSidebarOptions(sidebar, 'bottom')
-                if (menuOptions.length > 0 && bottomMenuOptions.length > 0) {
-                    menuOptions.push(null) // separator
-                }
-                menuOptions.push(...bottomMenuOptions)
-                if (menuOptions.length === 0) {
-                    return
-                }
-                const menu = RED.menu.init({ options: menuOptions });
-                menu.attr("id",sidebar.container.attr('id')+"-menu");
-                menu.css({
-                    position: "absolute"
-                })
-                menu.appendTo("body");
-                var elementPos = sidebar.tabOverflowButton.offset();
-                menu.css({
-                    top: (elementPos.top+sidebar.tabOverflowButton.height()- menu.height() - 10)+"px",
-                    left: sidebar.direction === 'left' ?  ((elementPos.left + sidebar.tabOverflowButton.width() + 3)+"px") : ((elementPos.left - menu.width() - 3)+"px")
-                })
-                $(".red-ui-menu.red-ui-menu-dropdown").hide();
-                setTimeout(() => {
-                    $(document).on("click.red-ui-sidebar-tabmenu", function(evt) {
-                        $(document).off("click.red-ui-sidebar-tabmenu");
-                        menu.remove();
-                    });
-                }, 0)
-                menu.show();
-            } catch (err) {
-                console.log(err)
-            }
-        })
+        // sidebar.tabOverflowButton = $('<button class="red-ui-sidebar-tab-bar-overflow-button"><i class="fa fa-ellipsis-h"></i></button>');
+        // sidebar.tabOverflowButton.hide()
+        // sidebar.tabOverflowButton.on('click', function(evt) {
+        //     try {
+        //         const menuOptions = getSidebarOptions(sidebar, 'top')
+        //         const bottomMenuOptions = getSidebarOptions(sidebar, 'bottom')
+        //         if (menuOptions.length > 0 && bottomMenuOptions.length > 0) {
+        //             menuOptions.push(null) // separator
+        //         }
+        //         menuOptions.push(...bottomMenuOptions)
+        //         if (menuOptions.length === 0) {
+        //             return
+        //         }
+        //         const menu = RED.menu.init({ options: menuOptions });
+        //         menu.attr("id",sidebar.container.attr('id')+"-menu");
+        //         menu.css({
+        //             position: "absolute"
+        //         })
+        //         menu.appendTo("body");
+        //         var elementPos = sidebar.tabOverflowButton.offset();
+        //         menu.css({
+        //             top: (elementPos.top+sidebar.tabOverflowButton.height()- menu.height() - 10)+"px",
+        //             left: sidebar.direction === 'left' ?  ((elementPos.left + sidebar.tabOverflowButton.width() + 3)+"px") : ((elementPos.left - menu.width() - 3)+"px")
+        //         })
+        //         $(".red-ui-menu.red-ui-menu-dropdown").hide();
+        //         setTimeout(() => {
+        //             $(document).on("click.red-ui-sidebar-tabmenu", function(evt) {
+        //                 $(document).off("click.red-ui-sidebar-tabmenu");
+        //                 menu.remove();
+        //             });
+        //         }, 0)
+        //         menu.show();
+        //     } catch (err) {
+        //         console.log(err)
+        //     }
+        // })
 
-        if (sidebar.direction === 'right') {
-            sidebar.tabOverflowButton.appendTo(tabBar);
-        } else if (sidebar.direction === 'left') {
-            sidebar.tabOverflowButton.prependTo(tabBar);
-        }
+        // if (sidebar.direction === 'right') {
+        //     sidebar.tabOverflowButton.appendTo(tabBar);
+        // } else if (sidebar.direction === 'left') {
+        //     sidebar.tabOverflowButton.prependTo(tabBar);
+        // }
 
 
-        sidebar.tabBar = tabBar // sidebar.tabBars.top.container;
-        sidebar.hideSection = function (position) {
-            // Track the height of the top section as that is the one that will determine the layout - but only if the other section is visible.
-            const otherPosition = position === 'top' ? 'bottom' : 'top'
-            if (!sidebar.sections[otherPosition].hidden) {
-                sidebar.sections.top.height = sidebar.sections.top.container.height() || 300
-            }
-            sidebar.sections[position].container.hide()
-            sidebar.sections[position].hidden = true
-
-            sidebar.sections[otherPosition].container.css('flex-grow', '1')
-            if (otherPosition === 'bottom') {
-                sidebar.sections[otherPosition].container.css('margin-top', sidebar.direction === 'left' ? '0' : '4px')
-            }
-            sidebar.tabBars[position].clearSelected()
-
-            sidebar.resizeSidebar()
-        }
-        sidebar.showSection = function (position) {
-            sidebar.sections[position].container.show()
-            sidebar.sections[position].hidden = false
-            const otherPosition = position === 'top' ? 'bottom' : 'top'
-            sidebar.sections[otherPosition].container.css('flex-grow', '0')
-            sidebar.sections.top.container.css('height', sidebar.sections.top.height + 'px')
-            sidebar.sections.bottom.container.css('height', '100%')
-            if (otherPosition === 'bottom') {
-                sidebar.sections[otherPosition].container.css('margin-top', '')
-            }
-            sidebar.tabBars[position].container.find('button[data-tab-id="'+sidebar.tabBars[position].active+'"]').addClass('selected')
-            sidebar.resizeSidebar()
-        }
-        sidebar.hideSection('top')
-        sidebar.hideSection('bottom')
+        // sidebar.tabBar = tabBar // sidebar.tabBars.top.container;
     }
 
-    function setupTabSection(sidebar, tabBar, position) {
-        const tabBarButtonsContainer = $('<div class="red-ui-sidebar-tab-bar-buttons red-ui-sidebar-tab-bar-empty"></div>').appendTo(tabBar);
-        tabBarButtonsContainer.data('sidebar', sidebar.id)
-        tabBarButtonsContainer.data('sidebar-position', position)
-        tabBarButtonsContainer.sortable({
-            axis: 'x',
-            distance: 10,
-            cancel: false,
-            items: "button:not(.red-ui-sidebar-tab-bar-overflow-button)",
-            placeholder: "red-ui-sidebar-tab-bar-button-placeholder",
-            connectWith: ".red-ui-sidebar-tab-bar-buttons",
-            start: function(event, ui) {
-                const tabId = ui.item.attr('data-tab-id');
-                const options = knownTabs[tabId];
-                options.tabButtonTooltip.delete()
-                draggingTabButton = true
-                tabBar.css('z-index','inherit')
-                $(".red-ui-sidebar-tab-bar").addClass("red-ui-sidebar-dragging-tab");
-            },
-            stop: function(event, ui) {
-                // Restore the tooltip
-                const tabId = ui.item.attr('data-tab-id');
-                const options = knownTabs[tabId];
-                options.tabButtonTooltip.delete()
-                options.tabButtonTooltip = RED.popover.tooltip(options.tabButton, options.name, options.action);
-                // Save the sidebar state
-                exportSidebarState()
-                tabBar.css('z-index','')
-                $(".red-ui-sidebar-tab-bar").removeClass("red-ui-sidebar-dragging-tab");
-            },
-            receive: function(event, ui) {
-                // Tab has been moved from one sidebar to another
-                const src = sidebars[ui.sender.data('sidebar')]
-                const dest = sidebars[$(this).data('sidebar')]
-                const srcPosition = ui.sender.data('sidebar-position')
-                const destPosition = $(this).data('sidebar-position')
-                const tabId = ui.item.attr('data-tab-id');
-                moveTab(tabId, src, srcPosition, dest, destPosition);
-                if (ui.item.hasClass('selected')) {
-                    const firstTab = src.tabBars[srcPosition].container.find('button').first().attr('data-tab-id');
-                    if (firstTab) {
-                        RED.sidebar.show(firstTab);
-                    }
-                }
-                RED.sidebar.show(tabId)
-            }
-        })
-
-        return {
-            container: tabBarButtonsContainer,
-            addButton: function(button, position) {
-                tabBarButtonsContainer.removeClass('red-ui-sidebar-tab-bar-empty');
-                if (position === undefined || position >= tabBarButtonsContainer.children().length) {
-                    button.appendTo(tabBarButtonsContainer);
-                } else {
-                    button.insertBefore(tabBarButtonsContainer.children().eq(position));
-                }
-            },
-            clearSelected: function() {
-                tabBarButtonsContainer.children('button').removeClass('selected')
-            }
-        }
-    }
     function setupSidebarSeparator(sidebar) {
         const separator = $('<div class="red-ui-sidebar-separator"></div>');
         separator.attr('id', sidebar.container.attr('id') + '-separator')
@@ -576,9 +479,6 @@ RED.sidebar = (function() {
                 }
                 sidebar.container.width(newSidebarWidth);
                 ui.position.left -= scaleFactor * d
-                if (sidebar.direction === 'left') {
-                    sidebar.tabBar.css('min-width', sidebar.container.width() - 5)
-                }
                 RED.events.emit("sidebar:resize");
             },
             stop:function(event,ui) {
@@ -593,9 +493,6 @@ RED.sidebar = (function() {
                     sidebar.separator.hide()
                 } else {
                     sidebar.width = sidebar.container.width();
-                }
-                if (sidebar.direction === 'left') {
-                    sidebar.tabBar.css('min-width', sidebar.container.width() - 5)
                 }
                 RED.events.emit("sidebar:resize");
                 exportSidebarState();
@@ -633,25 +530,17 @@ RED.sidebar = (function() {
                     // Nothing to show - keep the sidebar hidden
                     return
                 }
-                if (sidebar.tabBars.top.active) {
-                    showSidebar(sidebar.tabBars.top.active)
+                if (sidebar.sections.top.active) {
+                    showSidebar(sidebar.sections.top.active)
                 }
-                if (sidebar.tabBars.bottom.active) {
-                    showSidebar(sidebar.tabBars.bottom.active)
+                if (sidebar.sections.bottom.active) {
+                    showSidebar(sidebar.sections.bottom.active)
                 }
             }
             sidebar.container.width(sidebar.width || sidebar.defaultWidth)
-            if (sidebar.direction === 'left') {
-                sidebar.tabBar.css('min-width', sidebar.container.width() - 5)
-            }
             sidebar.separator.show()
-            if (sidebar.tabBars.top.active && !sidebar.sections.top.hidden) {
-                sidebar.tabBars.top.container.find('button[data-tab-id="'+sidebar.tabBars.top.active+'"]').addClass('selected')
-            }
-            if (sidebar.tabBars.bottom.active && !sidebar.sections.bottom.hidden) {
-                sidebar.tabBars.bottom.container.find('button[data-tab-id="'+sidebar.tabBars.bottom.active+'"]').addClass('selected')
-            }
         }
+        resyncSidebarButtonStates()
         RED.events.emit("sidebar:resize");
     }
 
@@ -660,8 +549,8 @@ RED.sidebar = (function() {
             sidebarsInitialised = true
             // Show the last selected tab for each sidebar
             Object.keys(sidebars).forEach(function(sidebarKey) {
-                const sidebar = sidebars[sidebarKey];
-                ['top','bottom'].forEach(function(position) {
+                const sidebar = sidebars[sidebarKey]
+                ;['top','bottom'].forEach(function(position) {
                     if (lastSessionSelectedTabs[sidebarKey]?.[position]?.hidden !== true) {
                         let lastTabId = lastSessionSelectedTabs[sidebarKey]?.[position]?.active;
                         if (lastTabId) {
@@ -689,25 +578,125 @@ RED.sidebar = (function() {
                 } else {
                     targetSidebar.sections[targetSection].footer.hide();
                 }
-                targetSidebar.tabBars[targetSection].active = id
+                targetSidebar.sections[targetSection].active = id
+                targetSidebar.sections[targetSection].banner.label.text(tabOptions.name)
+
+                targetSidebar.sections[targetSection].banner.icon.empty()
+                if (tabOptions.icon) {
+                    $('<i>',{class: 'red-ui-sidebar-tab-icon', style:"mask-image: url("+tabOptions.icon+"); -webkit-mask-image: url("+tabOptions.icon+");"}).appendTo(targetSidebar.sections[targetSection].banner.icon);
+                } else if (tabOptions.iconClass) {
+                    $('<i>',{class:tabOptions.iconClass}).appendTo(targetSidebar.sections[targetSection].banner.icon);
+                }
+
                 if (!skipShowSidebar && targetSidebar.sections[targetSection].hidden) {
                     targetSidebar.showSection(targetSection)
                 }
                 if (!skipShowSidebar && !RED.menu.isSelected(targetSidebar.menuToggle)) {
                     RED.menu.setSelected(targetSidebar.menuToggle,true);
                 }
-                if (!targetSidebar.sections[targetSection].hidden) {
-                    targetSidebar.tabBars[targetSection].clearSelected()
-                    targetSidebar.tabBars[targetSection].container.find('button[data-tab-id="'+id+'"]').addClass('selected')
-                }
+                resyncSidebarButtonStates()
                 exportSidebarState()
             }
         }
     }
 
+    function resyncSidebarButtonStates() {
+        if (globalTabBar.container === null) {
+            return
+        }
+        globalTabBar.container.find('button').removeClass('selected')
+        Object.keys(sidebars).forEach(function(sidebarKey) {
+            const sidebar = sidebars[sidebarKey]
+            ;['top','bottom'].forEach(function(position) {
+                if (!sidebar.sections[position].hidden && sidebar.sections[position].active) {
+                    globalTabBar.container.find('button[data-tab-id="'+sidebar.sections[position].active+'"]').addClass('selected')
+                }
+            })
+        })
+    }
+
     function containsTab(id) {
         return sidebars.primary.tabs.contains(id);
     }
+
+    // function showSectionMenu(sidebar, section, button) {
+    //     const menuId = `${sidebar.container.attr('id')}-${section}-menu`
+    //     if ($("#"+menuId).length) {
+    //         // Menu is already open. The click handler will close it - take no further action here
+    //         return
+    //     }
+    //     const menuOptions = []
+    //     const moveHereOptions = []
+    //     Object.keys(sidebars).forEach(function(sidebarKey) {
+    //         const targetSidebar = sidebars[sidebarKey]
+    //         ;['top','bottom'].forEach(function(targetSection) {
+    //             if (targetSidebar.id === sidebar.id && targetSection === section) {
+    //                 targetSidebar.sections[targetSection].tabs.forEach(function(tabId) {
+    //                     const tabOptions = knownTabs[tabId]
+    //                     menuOptions.push({
+    //                         label: tabOptions.name,
+    //                         onselect: function(state) {
+    //                             RED.sidebar.show(tabId)
+    //                         }
+    //                     })
+    //                 })
+    //             } else {
+    //                 if (moveHereOptions.length > 0 && targetSidebar.sections[targetSection].tabs.length > 0) {
+    //                     moveHereOptions.push(null) // separator
+    //                 }
+    //                 targetSidebar.sections[targetSection].tabs.forEach(function(tabId) {
+    //                     const tabOptions = knownTabs[tabId]
+    //                     moveHereOptions.push({
+    //                         label: tabOptions.name,
+    //                         onselect: function(state) {
+    //                             console.log('MOVE HERE', tabId, targetSidebar.id, targetSection, sidebar.id, section)
+    //                             moveTab(tabId, targetSidebar, targetSection, sidebar, section)
+    //                         }
+    //                     })
+    //                 })
+    //             }
+    //         })
+    //     })
+
+    //     if (moveHereOptions.length > 0) {
+    //         menuOptions.push(null) // separator
+    //         menuOptions.push({
+    //             label: 'Move panel here...',
+    //             options: moveHereOptions
+    //         })
+    //         menuOptions.push({
+    //             label: 'Hide section',
+    //             onselect: function () {
+    //                 hideTab(sidebar.sections[section].active)
+    //             }
+    //         })
+    //     }
+
+    //     const menu = RED.menu.init({ direction: 'right',  options: menuOptions });
+    //     menu.attr("id",menuId);
+    //     menu.css({
+    //         position: "absolute"
+    //     })
+    //     menu.appendTo("body");
+    //     const elementPos = button.offset();
+    //     const menuPosition = {
+    //         top: (elementPos.top + button.height())+"px",
+    //         left: sidebar.direction === 'left' ?  (elementPos.left + "px") : ((elementPos.left + button.width() - menu.width() - 3)+"px")
+    //     }
+    //     if (menu.height() + elementPos.top > $(window).height()) {
+    //         menuPosition.top = (elementPos.top - menu.height()) + "px"
+    //     }
+    //     menu.css(menuPosition);
+    //     $(".red-ui-menu.red-ui-menu-dropdown").hide();
+    //     setTimeout(() => {
+    //         $(document).on("click.red-ui-sidebar-tabmenu", function(evt) {
+    //             $(document).off("click.red-ui-sidebar-tabmenu");
+    //             menu.next('.red-ui-menu-dropdown-portaled').remove()
+    //             menu.remove();
+    //         });
+    //     }, 0)
+    //     menu.show();
+    // }
 
     function setupSidebar(sidebar) {
         // Get the appropriate height for the sidebar - as the sidebar will be hidden at this point in time, we need to use
@@ -715,25 +704,141 @@ RED.sidebar = (function() {
         const sidebarHeight = $("#red-ui-main-container").height();
         sidebar.container.addClass("red-ui-sidebar").addClass('red-ui-sidebar-' + sidebar.direction);
         sidebar.container.width(sidebar.defaultWidth);
-        if (sidebar.direction === 'left') {
-            // $('<div>',{class:"red-ui-sidebar-shade hide"}).css("z-index", 0).appendTo(sidebar.container);
-        }
         sidebar.sections = {};
-        sidebar.sections.top = {}
+        sidebar.sections.top = { tabs: [] }
         sidebar.sections.top.container = $('<div class="red-ui-sidebar-section red-ui-sidebar-section-top"></div>').appendTo(sidebar.container);
-        // sidebar.sections.top.banner = $('<div class="red-ui-sidebar-banner">Head</div>').appendTo(sidebar.sections.top.container);
+        sidebar.sections.top.banner = {
+            container: $('<div class="red-ui-sidebar-banner"></div>').appendTo(sidebar.sections.top.container)
+            
+        };
+        sidebar.sections.top.banner.icon = $('<div class="red-ui-sidebar-banner-icon"></div>').appendTo(sidebar.sections.top.banner.container)
+        sidebar.sections.top.banner.label = $('<div class="red-ui-sidebar-banner-label"></div>').appendTo(sidebar.sections.top.banner.container)
+        sidebar.sections.top.banner.tools = $('<div class="red-ui-sidebar-banner-tools"></div>').appendTo(sidebar.sections.top.banner.container)
+        // $('<button class="red-ui-button red-ui-button-small"><i class="fa fa-close"></i></button>').appendTo(sidebar.sections.top.banner.tools).on('click', function() {
+        //     hideTab(sidebar.sections.top.active)
+        // })
+        // $('<button class="red-ui-button red-ui-button-small"><i class="fa fa-caret-down"></i></button>').appendTo(sidebar.sections.top.banner.tools).on('click', function() {
+        //     showSectionMenu(sidebar, 'top', $(this))
+        // })
+
         sidebar.sections.top.content = $('<div class="red-ui-sidebar-content"></div>').appendTo(sidebar.sections.top.container);
         sidebar.sections.top.footer =  $('<div class="red-ui-sidebar-footer"></div>').appendTo(sidebar.sections.top.container);
-        sidebar.sectionsSeparator = $('<div class="red-ui-sidebar-tab-bar-separator"><div class="red-ui-sidebar-separator-handle"></div></div>').appendTo(sidebar.container);
-        sidebar.sections.bottom = {}
+        sidebar.sectionsSeparator = $('<div class="red-ui-sidebar-section-separator"><div class="red-ui-sidebar-separator-handle"></div></div>').appendTo(sidebar.container);
+        sidebar.sections.bottom = { tabs: [] }
         sidebar.sections.bottom.container = $('<div class="red-ui-sidebar-section red-ui-sidebar-section-bottom"></div>').appendTo(sidebar.container);
-        // sidebar.sections.bottom.banner = $('<div class="red-ui-sidebar-banner">Head</div>').appendTo(sidebar.sections.bottom.container);
+        sidebar.sections.bottom.banner = {
+            container: $('<div class="red-ui-sidebar-banner"></div>').appendTo(sidebar.sections.bottom.container)
+        };
+        sidebar.sections.bottom.banner.icon = $('<div class="red-ui-sidebar-banner-icon"></div>').appendTo(sidebar.sections.bottom.banner.container)
+        sidebar.sections.bottom.banner.label = $('<div class="red-ui-sidebar-banner-label"></div>').appendTo(sidebar.sections.bottom.banner.container)
+        sidebar.sections.bottom.banner.tools = $('<div class="red-ui-sidebar-banner-tools"></div>').appendTo(sidebar.sections.bottom.banner.container)
+        // $('<button class="red-ui-button red-ui-button-small"><i class="fa fa-close"></i></button>').appendTo(sidebar.sections.bottom.banner.tools).on('click', function() {
+        //     hideTab(sidebar.sections.bottom.active)
+        // })
+        // $('<button class="red-ui-button red-ui-button-small"><i class="fa fa-caret-down"></i></button>').appendTo(sidebar.sections.bottom.banner.tools).on('click', function() {
+        //     showSectionMenu(sidebar, 'bottom', $(this))
+        // })
+
         sidebar.sections.bottom.content = $('<div class="red-ui-sidebar-content"></div>').appendTo(sidebar.sections.bottom.container);
         sidebar.sections.bottom.footer =  $('<div class="red-ui-sidebar-footer"></div>').appendTo(sidebar.sections.bottom.container);
 
+        const makeSectionDraggable = function (position) {
+            const section = sidebar.sections[position];
+            section.container.draggable({
+                handle: ".red-ui-sidebar-banner",
+                containment: 'window',
+                helper: function() {
+                    const helper = $('<div style="z-index:1000; border-radius: 6px; border: 1px solid red; background: rgba(155, 170, 219, 0.82)"></div>');
+                    helper.height(80);
+                    helper.width(section.container.outerWidth());
+                    return helper
+                },
+                appendTo: 'body',
+                start: function (event, ui) {
+                    const overlay = $('<div class="red-ui-sidebar-drop-background"></div>').appendTo('body');
+                    // Add dropTargets for the top and bottom sections of both sidebars
+                    Object.keys(sidebars).forEach(function(sidebarKey) {
+                        const targetSidebar = sidebars[sidebarKey];
+                        // Handle the permutations of hidden sections
+                        // Both visible - align drop targets to sections
+                        // Both hidden - show drop targets for both sections
+                        ;['top','bottom'].forEach(function(targetPosition) {
+                            const otherPosition = targetPosition === 'top' ? 'bottom' : 'top'
+                            const dropTarget = $('<div class="red-ui-sidebar-drop-target"></div>').appendTo(overlay)
+                            const sectionContainer = targetSidebar.sections[targetPosition].container
+                            const selfHidden = targetSidebar.sections[targetPosition].hidden
+                            const otherHidden = targetSidebar.sections[otherPosition].hidden
+                            const offset = sectionContainer.offset()
+                            const dropTargetPos = {
+                                top: offset.top,
+                                left: offset.left,
+                                width: sectionContainer.outerWidth(),
+                                height: sectionContainer.outerHeight()
+                            }
+                            if (selfHidden && otherHidden) {
+                                dropTargetPos.height = (targetSidebar.container.height() - 10) / 2
+                                dropTargetPos.width = 160
+
+                                if (targetPosition === 'top') {
+                                    dropTargetPos.top = 40
+                                } else {
+                                    dropTargetPos.top = dropTargetPos.height + 50
+                                }
+                                if (targetSidebar.direction === 'left') {
+                                    dropTargetPos.left = 5
+                                } else {
+                                    delete dropTargetPos.left
+                                    dropTargetPos.right = 5
+                                }
+                            } else if (selfHidden) {
+                                // Self hidden, but other is not. Need to manually align
+                                dropTargetPos.left = targetSidebar.sections[otherPosition].container.offset().left
+                                if (targetPosition === 'bottom') {
+                                    dropTargetPos.top = targetSidebar.sections[otherPosition].container.offset().top + targetSidebar.sections[otherPosition].container.outerHeight() - 140
+                                } else {
+                                    dropTargetPos.top = sidebarKey === 'primary' ? 48 : 40;
+                                }
+                                dropTargetPos.width = targetSidebar.sections[otherPosition].container.outerWidth()
+                                dropTargetPos.height = 140
+                            } else if (otherHidden) {
+                                // Other hidden but self is not. Make room for it
+                                dropTargetPos.height -= 150
+                                if (targetPosition === 'bottom') {
+                                    dropTargetPos.top += 150
+                                }
+                            }
+                            dropTarget.css(dropTargetPos)
+                            dropTarget.droppable({
+                                accept: ".red-ui-sidebar-section",
+                                classes: {
+                                    "ui-droppable-hover": "red-ui-sidebar-drop-target-hover",
+                                },
+                                tolerance: "pointer",
+                                drop: function(event, ui) {
+                                    if (sidebar === targetSidebar && position === targetPosition) {
+                                        // Nothing to move
+                                        return
+                                    }
+                                    moveTab(
+                                        sidebar.sections[position].active,
+                                        sidebar, position,
+                                        targetSidebar, targetPosition
+                                    )
+                                }
+                            });
+                        })
+                    })
+                },
+                stop: function (event, ui) {
+                    $('.red-ui-sidebar-drop-background').remove();
+                }
+            })
+        }
+        makeSectionDraggable('top')
+        makeSectionDraggable('bottom')
+
         let startPosition
         let startTopSectionHeight
-        let startTopTabSectionHeight
         let startSidebarHeight
         let lastSeparatorPosition
         sidebar.sectionsSeparator.draggable({
@@ -744,7 +849,6 @@ RED.sidebar = (function() {
                 startPosition = ui.position.top
                 lastSeparatorPosition = ui.position.top
                 startTopSectionHeight = sidebar.sections.top.container.outerHeight()
-                startTopTabSectionHeight = sidebar.tabBars.top.container.outerHeight()
                 startSidebarHeight = sidebar.container.height()
             },
             drag: function(event,ui) {
@@ -756,7 +860,6 @@ RED.sidebar = (function() {
                     return
                 }
                 sidebar.sections.top.container.outerHeight(startTopSectionHeight + delta)
-                // sidebar.tabBars.top.container.outerHeight(startTopTabSectionHeight + delta)
                 ui.position.top -= delta
                 lastSeparatorPosition = ui.position.top
                 sidebar.resizeSidebar()
@@ -765,58 +868,90 @@ RED.sidebar = (function() {
                 exportSidebarState();
             }
         });
-
-        // sidebar.shade = $('<div class="red-ui-sidebar-shade hide"></div>').appendTo(sidebar.container);
-        
+       
         sidebar.separator = setupSidebarSeparator(sidebar);
+
         sidebar.resizeSidebar = function () {
             // Resize sidebar sections as needed
             const topSectionHeight = sidebar.sections.top.container.outerHeight()
             if (!sidebar.sections.bottom.hidden) {
                 const bottomSectionHeight = sidebar.sections.bottom.container.outerHeight()
-
                 // Shrink the top section if the bottom section is too small
                 if (bottomSectionHeight < 90 && topSectionHeight > 90) {
                     sidebar.sections.top.container.outerHeight(topSectionHeight - (90 - bottomSectionHeight));
                 }
             }
-            // Trigger a resize of the tab bars to handle overflow
-            if (sidebar.direction === 'left') {
-                sidebar.tabBar.css('min-width', sidebar.container.width() - 5)
-            }
             RED.events.emit("sidebar:resize");
 
             if (sidebar.direction === 'right') {
                 const windowWidth = $("#red-ui-editor").width();
-                if (sidebar.tabOverflowButtonShown) {
-                    // Check if there's space to show the tab bar again
-                    if ($(window).width() - (sidebars.secondary.tabBar.width() + sidebar.tabOverflowButtonStatusBarWidth + sidebar.tabOverflowButtonSpace) > 0) {
-                        sidebar.tabOverflowButtonShown = false
-                        sidebar.tabOverflowButton.hide()
-                        sidebar.tabBars.top.container.show()
-                        sidebar.tabBars.bottom.container.show()
+                // if (sidebar.tabOverflowButtonShown) {
+                //     // Check if there's space to show the tab bar again
+                //     if ($(window).width() - (sidebars.secondary.tabBar.width() + sidebar.tabOverflowButtonStatusBarWidth + sidebar.tabOverflowButtonSpace) > 0) {
+                //         sidebar.tabOverflowButtonShown = false
+                //         sidebar.tabOverflowButton.hide()
+                //         sidebar.tabBars.top.container.show()
+                //         sidebar.tabBars.bottom.container.show()
 
-                    }
-                }
-                if (!sidebar.tabOverflowButtonShown) {
-                    const tabBarWidth = sidebar.tabBar.width()
-                    const tabBarPosition = sidebar.tabBar.position()
-                    if (tabBarWidth + tabBarPosition.left > windowWidth) {
-                        sidebar.tabOverflowButtonStatusBarWidth = $("#red-ui-statusbar").width()
-                        sidebar.tabOverflowButtonSpace = tabBarWidth
-                        sidebar.tabOverflowButtonShown = true
-                        sidebar.tabOverflowButton.show()
-                        sidebar.tabBars.top.container.hide()
-                        sidebar.tabBars.bottom.container.hide()
-                    }
-                }
+                //     }
+                // }
+                // if (!sidebar.tabOverflowButtonShown) {
+                //     const tabBarWidth = sidebar.tabBar.width()
+                //     const tabBarPosition = sidebar.tabBar.position()
+                //     if (tabBarWidth + tabBarPosition.left > windowWidth) {
+                //         sidebar.tabOverflowButtonStatusBarWidth = $("#red-ui-statusbar").width()
+                //         sidebar.tabOverflowButtonSpace = tabBarWidth
+                //         sidebar.tabOverflowButtonShown = true
+                //         sidebar.tabOverflowButton.show()
+                //         sidebar.tabBars.top.container.hide()
+                //         sidebar.tabBars.bottom.container.hide()
+                //     }
+                // }
             }
 
         }
         $(window).on("resize", sidebar.resizeSidebar)
 
-        setupSidebarTabs(sidebar)
         sidebar.resizeSidebar()
+
+        sidebar.hideSection = function (position) {
+            if (sidebar.sections[position].hidden) {
+                return
+            }
+            // Track the height of the top section as that is the one that will determine the layout - but only if the other section is visible.
+            const otherPosition = position === 'top' ? 'bottom' : 'top'
+            if (!sidebar.sections[otherPosition].hidden) {
+                sidebar.sections.top.height = sidebar.sections.top.container.height() || 300
+            }
+            sidebar.sections[position].container.hide()
+            sidebar.sections[position].hidden = true
+
+            sidebar.sections[otherPosition].container.css('flex-grow', '1')
+            if (otherPosition === 'bottom') {
+                sidebar.sections[otherPosition].container.css('margin-top', sidebar.direction === 'left' ? '0' : '4px')
+            }
+            resyncSidebarButtonStates()
+            sidebar.resizeSidebar()
+        }
+        sidebar.showSection = function (position) {
+            if (!sidebar.sections[position].hidden) {
+                return
+            }
+
+            sidebar.sections[position].container.show()
+            sidebar.sections[position].hidden = false
+            const otherPosition = position === 'top' ? 'bottom' : 'top'
+            sidebar.sections[otherPosition].container.css('flex-grow', '0')
+            sidebar.sections.top.container.css('height', sidebar.sections.top.height + 'px')
+            sidebar.sections.bottom.container.css('height', '100%')
+            if (otherPosition === 'bottom') {
+                sidebar.sections[otherPosition].container.css('margin-top', '')
+            }
+            resyncSidebarButtonStates()
+            sidebar.resizeSidebar()
+        }
+        sidebar.hideSection('top')
+        sidebar.hideSection('bottom')
 
     }
     function init () {
@@ -824,6 +959,9 @@ RED.sidebar = (function() {
         setupSidebar(sidebars.primary)
         sidebars.secondary.container = $("#red-ui-sidebar-left");
         setupSidebar(sidebars.secondary)
+
+        setupSidebarTabs()
+
 
         RED.actions.add("core:toggle-sidebar",function(state){
             if (state === undefined) {
@@ -852,10 +990,10 @@ RED.sidebar = (function() {
         }
 
         // Restore the active flags so we know which sidebars to show when the :first option is used
-        sidebars.primary.tabBars.top.active = lastSessionSelectedTabs?.primary?.top?.active
-        sidebars.primary.tabBars.bottom.active = lastSessionSelectedTabs?.primary?.bottom?.active
-        sidebars.secondary.tabBars.top.active = lastSessionSelectedTabs?.secondary?.top?.active
-        sidebars.secondary.tabBars.bottom.active = lastSessionSelectedTabs?.secondary?.bottom?.active
+        // sidebars.primary.tabBars.top.active = lastSessionSelectedTabs?.primary?.top?.active
+        // sidebars.primary.tabBars.bottom.active = lastSessionSelectedTabs?.primary?.bottom?.active
+        // sidebars.secondary.tabBars.top.active = lastSessionSelectedTabs?.secondary?.top?.active
+        // sidebars.secondary.tabBars.bottom.active = lastSessionSelectedTabs?.secondary?.bottom?.active
 
         // Restore sidebar widths and splitPx if present
         if (lastSessionSelectedTabs?.dimensions) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
@@ -50,7 +50,7 @@ RED.sidebar = (function() {
 
     const globalTabBar = {
         container: null,
-        tabOverflowButton: null
+        overflowButton: null
     }
 
 
@@ -87,7 +87,7 @@ RED.sidebar = (function() {
                 }
             }
         }
-        globalTabBar.container.children('button').each(function() {
+        globalTabBar.container.children('button:not(.red-ui-sidebar-tab-bar-overflow-button)').each(function() {
             const tabId = $(this).attr('data-tab-id');
             state.tabs.push(tabId)
         })
@@ -161,7 +161,7 @@ RED.sidebar = (function() {
                     showSection = false
                 }
                 // This tab was found in the saved sidebar state. Now find the target position for the tab button
-                targetTabButtonIndex = sidebarState.tabs.indexOf(options.id)
+                targetTabButtonIndex = lastSessionState.tabs.indexOf(options.id)
             }
         }
 
@@ -203,18 +203,14 @@ RED.sidebar = (function() {
         knownTabs[options.id] = options;
         options.tabButton = $('<button></button>')
         // Insert the tab button at the correct index
-        // if (targetTabButtonIndex === -1) {
-        //     // Append to end
-        //     console.log('add to end')
-        //     options.tabButton.appendTo(globalTabBar.container);
-        // } else {
-        //     console.log('insert before index', targetTabButtonIndex)
-        //     options.tabButton.insertBefore(globalTabBar.container.children().eq(targetTabButtonIndex));
-        // }
-        // TODO: get them in the right order
-        options.tabButton.appendTo(globalTabBar.container);
-        targetSidebar.sections[targetSection].tabs.push(options.id)
+        if (targetTabButtonIndex === -1) {
+            // Append to end
+            options.tabButton.insertBefore(globalTabBar.overflowButton);
+        } else {
+            options.tabButton.insertBefore(globalTabBar.container.children().eq(targetTabButtonIndex));
+        }   
 
+        targetSidebar.sections[targetSection].tabs.push(options.id)
         options.tabButton.attr('data-tab-id', options.id)
 
         options.tabButtonTooltip = RED.popover.tooltip(options.tabButton, options.name, options.action);
@@ -289,7 +285,6 @@ RED.sidebar = (function() {
         const currentIndex = srcSidebar.sections[srcPosition].tabs.indexOf(options.id)
         srcSidebar.sections[srcPosition].tabs.splice(currentIndex, 1);
 
-
         options.target = targetSidebar.id;
         options.targetSection = targetPosition;
 
@@ -345,68 +340,83 @@ RED.sidebar = (function() {
     function setupSidebarTabs() {
         const tabBar = $('<div class="red-ui-sidebar-tab-bar"></div>').addClass('red-ui-sidebar-right');
         globalTabBar.container = tabBar
+
+
+        globalTabBar.overflowButton = $('<button class="red-ui-sidebar-tab-bar-overflow-button"><i class="fa fa-ellipsis-h"></i></button>').appendTo(tabBar);
+        globalTabBar.overflowButton.hide()
+        globalTabBar.overflowButton.on('click', function(evt) {
+            try {
+                const menuOptions = []
+                globalTabBar.container.children('button:not(.red-ui-sidebar-tab-bar-overflow-button)').each(function() {
+                    const tabId = $(this).attr('data-tab-id');
+                    const tabOptions = knownTabs[tabId];
+                    let initialStateSet = false
+                    let active = true
+                    menuOptions.push({
+                        label: tabOptions.name,
+                        selected: $(this).hasClass('selected'),
+                        toggle: true,
+                        onselect: function(state) {
+                            if (!initialStateSet) {
+                                // This is called when showing the menu to initialise the state properly. This made
+                                // sense for other menus, but is inconvenient here. So we swallow the first call to onselect
+                                // without taking any action.
+                                initialStateSet = true
+                                return
+                            }
+                            globalTabBar.container.find('button[data-tab-id="'+tabId+'"]').trigger('mouseup')
+                        }
+                    })
+                })
+                const menu = RED.menu.init({ options: menuOptions });
+                menu.attr("id","red-ui-sidebar-tab-bar-menu");
+                menu.css({
+                    position: "absolute"
+                })
+                menu.appendTo("body");
+                var elementPos = globalTabBar.overflowButton.offset();
+                menu.css({
+                    top: (elementPos.top+globalTabBar.overflowButton.height()- menu.height() - 10)+"px",
+                    left: ((elementPos.left - menu.width() - 3)+"px")
+                })
+                $(".red-ui-menu.red-ui-menu-dropdown").hide();
+                setTimeout(() => {
+                    $(document).on("click.red-ui-sidebar-tabmenu", function(evt) {
+                        $(document).off("click.red-ui-sidebar-tabmenu");
+                        menu.remove();
+                    });
+                }, 0)
+                menu.show();
+            } catch (err) {
+                console.log(err)
+            }
+        })
+
+        // globalTabBar.spacer = $('<div style="flex:1 1 auto; width: 100%; height: 100%; background: yellow"></div>').appendTo("#red-ui-workspace-footer");
         tabBar.appendTo("#red-ui-workspace-footer");
 
-        // TODO: consider an explicit toggle button for the sidebars...
-        // const toggleSidebarButton = $('<button class="red-ui-sidebar-toggle-button"><i class="fa fa-columns"></i></button>')
-        // toggleSidebarButton.on('click', function() {
-        //     RED.menu.toggleSelected(sidebar.menuToggle);
-        // })
-        // sidebar.tabBars = {
-        //     top: setupTabSection(sidebar, tabBar, 'top'),
-        //     bottom: setupTabSection(sidebar, tabBar, 'bottom')
-        // }
-        // if (sidebar.direction === 'right') {
-        //     toggleSidebarButton.appendTo(tabBar);
-        // } else if (sidebar.direction === 'left') {
-        //     toggleSidebarButton.prependTo(tabBar);
-        // }
+        $(window).on('resize', function () {
+            resizeTabBar();
+        })
+    }
 
-        // sidebar.tabOverflowButton = $('<button class="red-ui-sidebar-tab-bar-overflow-button"><i class="fa fa-ellipsis-h"></i></button>');
-        // sidebar.tabOverflowButton.hide()
-        // sidebar.tabOverflowButton.on('click', function(evt) {
-        //     try {
-        //         const menuOptions = getSidebarOptions(sidebar, 'top')
-        //         const bottomMenuOptions = getSidebarOptions(sidebar, 'bottom')
-        //         if (menuOptions.length > 0 && bottomMenuOptions.length > 0) {
-        //             menuOptions.push(null) // separator
-        //         }
-        //         menuOptions.push(...bottomMenuOptions)
-        //         if (menuOptions.length === 0) {
-        //             return
-        //         }
-        //         const menu = RED.menu.init({ options: menuOptions });
-        //         menu.attr("id",sidebar.container.attr('id')+"-menu");
-        //         menu.css({
-        //             position: "absolute"
-        //         })
-        //         menu.appendTo("body");
-        //         var elementPos = sidebar.tabOverflowButton.offset();
-        //         menu.css({
-        //             top: (elementPos.top+sidebar.tabOverflowButton.height()- menu.height() - 10)+"px",
-        //             left: sidebar.direction === 'left' ?  ((elementPos.left + sidebar.tabOverflowButton.width() + 3)+"px") : ((elementPos.left - menu.width() - 3)+"px")
-        //         })
-        //         $(".red-ui-menu.red-ui-menu-dropdown").hide();
-        //         setTimeout(() => {
-        //             $(document).on("click.red-ui-sidebar-tabmenu", function(evt) {
-        //                 $(document).off("click.red-ui-sidebar-tabmenu");
-        //                 menu.remove();
-        //             });
-        //         }, 0)
-        //         menu.show();
-        //     } catch (err) {
-        //         console.log(err)
-        //     }
-        // })
-
-        // if (sidebar.direction === 'right') {
-        //     sidebar.tabOverflowButton.appendTo(tabBar);
-        // } else if (sidebar.direction === 'left') {
-        //     sidebar.tabOverflowButton.prependTo(tabBar);
-        // }
-
-
-        // sidebar.tabBar = tabBar // sidebar.tabBars.top.container;
+    function resizeTabBar() {
+        const windowWidth = $("#red-ui-editor").width();
+        const globalTabBarWidth = globalTabBar.container.outerWidth();
+        if (!globalTabBar.overflowShown) {
+            if (windowWidth + 5 < globalTabBarWidth + globalTabBar.container.offset().left) {
+                globalTabBar.container.children('button:not(.red-ui-sidebar-tab-bar-overflow-button)').hide()
+                globalTabBar.overflowButton.show()
+                globalTabBar.overflowShown = true
+                globalTabBar.tabBarWidth = globalTabBarWidth
+            }
+        } else if (globalTabBar.overflowShown) {
+            if (globalTabBarWidth > globalTabBar.tabBarWidth + 5) {
+                globalTabBar.container.children('button:not(.red-ui-sidebar-tab-bar-overflow-button)').show()
+                globalTabBar.overflowButton.hide()
+                globalTabBar.overflowShown = false
+            }
+        }
     }
 
     function setupSidebarSeparator(sidebar) {
@@ -877,33 +887,6 @@ RED.sidebar = (function() {
                 }
             }
             RED.events.emit("sidebar:resize");
-
-            if (sidebar.direction === 'right') {
-                const windowWidth = $("#red-ui-editor").width();
-                // if (sidebar.tabOverflowButtonShown) {
-                //     // Check if there's space to show the tab bar again
-                //     if ($(window).width() - (sidebars.secondary.tabBar.width() + sidebar.tabOverflowButtonStatusBarWidth + sidebar.tabOverflowButtonSpace) > 0) {
-                //         sidebar.tabOverflowButtonShown = false
-                //         sidebar.tabOverflowButton.hide()
-                //         sidebar.tabBars.top.container.show()
-                //         sidebar.tabBars.bottom.container.show()
-
-                //     }
-                // }
-                // if (!sidebar.tabOverflowButtonShown) {
-                //     const tabBarWidth = sidebar.tabBar.width()
-                //     const tabBarPosition = sidebar.tabBar.position()
-                //     if (tabBarWidth + tabBarPosition.left > windowWidth) {
-                //         sidebar.tabOverflowButtonStatusBarWidth = $("#red-ui-statusbar").width()
-                //         sidebar.tabOverflowButtonSpace = tabBarWidth
-                //         sidebar.tabOverflowButtonShown = true
-                //         sidebar.tabOverflowButton.show()
-                //         sidebar.tabBars.top.container.hide()
-                //         sidebar.tabBars.bottom.container.hide()
-                //     }
-                // }
-            }
-
         }
         $(window).on("resize", sidebar.resizeSidebar)
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
@@ -42,7 +42,7 @@ RED.sidebar = (function() {
         secondary: { top: { tabs: ['explorer'], active: 'explorer' }, bottom: { tabs: ['palette'], active: 'palette' } }
     }
 
-    let lastSessionSelectedTabs = {}
+    let lastSessionState = {}
 
     const knownTabs = {};
 
@@ -57,62 +57,55 @@ RED.sidebar = (function() {
     function exportSidebarState () {
         // TODO: fix all of this
         // console.log('TODO: exportSidebarState', sidebars.primary.sections.top.tabs, sidebars.primary.sections.bottom.tabs, sidebars.secondary.sections.top.tabs, sidebars.secondary.sections.bottom.tabs)
-        return
-        if (!sidebars.secondary?.tabBars?.bottom?.container) {
-            // This has been called whilst setting up the sidebars
-            // We don't have all the state yet, so not nothing to export
-            return
-        }
         const state = {
-            primary: { top: { tabs: [] }, bottom: { tabs: [] } },
-            secondary: { top: { tabs: [] }, bottom: { tabs: [] } },
+            // Version of state format - to make it easier to modify
             v: sidebarLayoutVersion,
-            dimensions: {
-                // Store split as px for reliable restore before render in init() 
-                // since container height may not be available until after render
-                primary: {
-                    width: sidebars.primary.container ? sidebars.primary.container.width() : sidebars.primary.defaultWidth,
-                    splitPx: sidebars.primary.sections.top.container.outerHeight() || (sidebars.primary.container ? sidebars.primary.container.height() * sidebars.primary.defaultTopHeight : 300)
+            // The order of the tabs in the globalTab bar
+            tabs: [],
+            // The right-hand sidebar, with the tabs in each section in the order they appear in the sidebar
+            primary: {
+                width: sidebars.primary.container ? sidebars.primary.container.width() : sidebars.primary.defaultWidth,
+                top: {
+                    height: sidebars.primary.sections.top.container.outerHeight(),
+                    tabs: sidebars.primary.sections.top.tabs
                 },
-                secondary: {
-                    width: sidebars.secondary.container ? sidebars.secondary.container.width() : sidebars.secondary.defaultWidth,
-                    splitPx: sidebars.secondary.sections.top.container.outerHeight() || (sidebars.secondary.container ? sidebars.secondary.container.height() * sidebars.secondary.defaultTopHeight : 300)
+                bottom: {
+                    height: sidebars.primary.sections.bottom.container.outerHeight(),
+                    tabs: sidebars.primary.sections.bottom.tabs
+                }
+            },
+            // The left-hand sidebar, with the tabs in each section in the order they appear in the sidebar
+            secondary: {
+                width: sidebars.secondary.container ? sidebars.secondary.container.width() : sidebars.secondary.defaultWidth,
+                top: {
+                    height: sidebars.secondary.sections.top.container.outerHeight(),
+                    tabs: sidebars.secondary.sections.top.tabs
+                },
+                bottom: {
+                    height: sidebars.secondary.sections.bottom.container.outerHeight(),
+                    tabs: sidebars.secondary.sections.bottom.tabs
                 }
             }
         }
-
-        function getTabButtons(tabBar) {
-            const result = []
-            tabBar.children('button').each(function() {
-                const tabId = $(this).attr('data-tab-id');
-                if (tabId) {
-                    result.push(tabId);
-                }
-            })
-            return result
-        }
-        state.primary.top.tabs = getTabButtons(sidebars.primary.tabBars.top.container);
-        state.primary.bottom.tabs = getTabButtons(sidebars.primary.tabBars.bottom.container);
-        state.secondary.top.tabs = getTabButtons(sidebars.secondary.tabBars.top.container);
-        state.secondary.bottom.tabs = getTabButtons(sidebars.secondary.tabBars.bottom.container);
+        globalTabBar.container.children('button').each(function() {
+            const tabId = $(this).attr('data-tab-id');
+            state.tabs.push(tabId)
+        })
 
         state.primary.top.hidden = !!sidebars.primary.sections.top.hidden
         state.primary.bottom.hidden = !!sidebars.primary.sections.bottom.hidden
         state.secondary.top.hidden = !!sidebars.secondary.sections.top.hidden
         state.secondary.bottom.hidden = !!sidebars.secondary.sections.bottom.hidden
 
-        state.primary.top.active = sidebars.primary.tabBars.top.active
-        state.primary.bottom.active = sidebars.primary.tabBars.bottom.active
-        state.secondary.top.active = sidebars.secondary.tabBars.top.active
-        state.secondary.bottom.active = sidebars.secondary.tabBars.bottom.active
+        state.primary.top.active = sidebars.primary.sections.top.active
+        state.primary.bottom.active = sidebars.primary.sections.bottom.active
+        state.secondary.top.active = sidebars.secondary.sections.top.active
+        state.secondary.bottom.active = sidebars.secondary.sections.bottom.active
 
         const newState = JSON.stringify(state)
         const existingState = JSON.stringify(RED.settings.get('editor.sidebar.state'))
         if (newState !== existingState) {
             RED.settings.set('editor.sidebar.state', state)
-        }
-        if (state.secondary.top.tabs.length === 0) {
-            console.warn('wiped the floor')
         }
     }
 
@@ -546,19 +539,19 @@ RED.sidebar = (function() {
 
     function showSidebar(id, skipShowSidebar) {
         if (id === ":first") {
-            sidebarsInitialised = true
             // Show the last selected tab for each sidebar
             Object.keys(sidebars).forEach(function(sidebarKey) {
                 const sidebar = sidebars[sidebarKey]
                 ;['top','bottom'].forEach(function(position) {
-                    if (lastSessionSelectedTabs[sidebarKey]?.[position]?.hidden !== true) {
-                        let lastTabId = lastSessionSelectedTabs[sidebarKey]?.[position]?.active;
+                    if (lastSessionState[sidebarKey]?.[position]?.hidden !== true) {
+                        let lastTabId = lastSessionState[sidebarKey]?.[position]?.active;
                         if (lastTabId) {
                             showSidebar(lastTabId)
                         }
                     }
                 })
             })
+            sidebarsInitialised = true
             return
         }
         if (id) {
@@ -595,7 +588,9 @@ RED.sidebar = (function() {
                     RED.menu.setSelected(targetSidebar.menuToggle,true);
                 }
                 resyncSidebarButtonStates()
-                exportSidebarState()
+                if (sidebarsInitialised) {
+                    exportSidebarState()
+                }
             }
         }
     }
@@ -979,39 +974,40 @@ RED.sidebar = (function() {
         });
 
         // Load any saved sidebar state
-        lastSessionSelectedTabs = RED.settings.get('editor.sidebar.state', defaultSidebarConfiguration)
-        if (typeof lastSessionSelectedTabs.primary[0] === 'string' || typeof lastSessionSelectedTabs.secondary[0] === 'string' || lastSessionSelectedTabs.v === undefined || lastSessionSelectedTabs.v !== sidebarLayoutVersion) {
-            // This is a beta.0/1 format. Reset it for beta.2
-            lastSessionSelectedTabs = defaultSidebarConfiguration
+        lastSessionState = RED.settings.get('editor.sidebar.state', defaultSidebarConfiguration)
+        if (typeof lastSessionState.primary[0] === 'string' || typeof lastSessionState.secondary[0] === 'string' || lastSessionState.v === undefined || lastSessionState.v !== sidebarLayoutVersion) {
+            lastSessionState = defaultSidebarConfiguration
             // To migrate state format, we have to delete the old entry rather than try to merge settings
             // RED.settings.set debounces calls made within 300ms - we need the above call to get flushed before setting the new state value.
             RED.settings.set('editor.sidebar.state', null, true)
-            RED.settings.set('editor.sidebar.state', lastSessionSelectedTabs)
+            RED.settings.set('editor.sidebar.state', lastSessionState)
         }
 
         // Restore the active flags so we know which sidebars to show when the :first option is used
-        // sidebars.primary.tabBars.top.active = lastSessionSelectedTabs?.primary?.top?.active
-        // sidebars.primary.tabBars.bottom.active = lastSessionSelectedTabs?.primary?.bottom?.active
-        // sidebars.secondary.tabBars.top.active = lastSessionSelectedTabs?.secondary?.top?.active
-        // sidebars.secondary.tabBars.bottom.active = lastSessionSelectedTabs?.secondary?.bottom?.active
+        sidebars.primary.sections.top.active = lastSessionState?.primary?.top?.active
+        sidebars.primary.sections.bottom.active = lastSessionState?.primary?.bottom?.active
+        sidebars.secondary.sections.top.active = lastSessionState?.secondary?.top?.active
+        sidebars.secondary.sections.bottom.active = lastSessionState?.secondary?.bottom?.active
 
-        // Restore sidebar widths and splitPx if present
-        if (lastSessionSelectedTabs?.dimensions) {
-            if (lastSessionSelectedTabs.dimensions.primary?.width) {
-                sidebars.primary.container.width(lastSessionSelectedTabs.dimensions.primary.width)
-            }
-            if (lastSessionSelectedTabs.dimensions.secondary?.width) {
-                sidebars.secondary.container.width(lastSessionSelectedTabs.dimensions.secondary.width)
-            }
-
-            if (lastSessionSelectedTabs.dimensions.primary?.splitPx) {
-                sidebars.primary.sections.top.container.outerHeight(lastSessionSelectedTabs.dimensions.primary.splitPx);
-                sidebars.primary.sections.top.height = lastSessionSelectedTabs.dimensions.primary.splitPx;
-            }
-            if (lastSessionSelectedTabs.dimensions.secondary?.splitPx) {
-                sidebars.secondary.sections.top.container.outerHeight(lastSessionSelectedTabs.dimensions.secondary.splitPx);
-                sidebars.secondary.sections.top.height = lastSessionSelectedTabs.dimensions.secondary.splitPx;
-            }
+        if (lastSessionState.primary.width) {
+            sidebars.primary.container.width(lastSessionState.primary.width)
+        }
+        if (lastSessionState.secondary.width) {
+            sidebars.secondary.container.width(lastSessionState.secondary.width)
+        }
+        if (lastSessionState.primary.top.height) {
+            sidebars.primary.sections.top.container.outerHeight(lastSessionState.primary.top.height)
+            sidebars.primary.sections.top.height = lastSessionState.primary.top.height
+        }
+        if (lastSessionState.primary.bottom.height) {
+            sidebars.primary.sections.bottom.height = lastSessionState.primary.bottom.height
+        }
+        if (lastSessionState.secondary.top.height) {
+            sidebars.secondary.sections.top.container.outerHeight(lastSessionState.secondary.top.height)
+            sidebars.secondary.sections.top.height = lastSessionState.secondary.top.height
+        }
+        if (lastSessionState.secondary.bottom.height) {
+            sidebars.secondary.sections.bottom.height = lastSessionState.secondary.bottom.height
         }
     }
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
@@ -38,6 +38,7 @@ RED.sidebar = (function() {
     }
     const defaultSidebarConfiguration = {
         v: sidebarLayoutVersion,
+        tabs: ['palette','explorer','info','debug','help','config','context'],
         primary: { top: { tabs: ['info','help','config','context'], active: 'info' }, bottom: { tabs: ['debug'], active: 'debug' } },
         secondary: { top: { tabs: ['explorer'], active: 'explorer' }, bottom: { tabs: ['palette'], active: 'palette' } }
     }
@@ -165,7 +166,6 @@ RED.sidebar = (function() {
             }
         }
 
-
         targetSidebar = targetSidebar || (options.target === 'secondary' ? sidebars.secondary : sidebars.primary);
         targetSection = targetSection || 'top'
         options.targetSection = targetSection;
@@ -202,12 +202,27 @@ RED.sidebar = (function() {
 
         knownTabs[options.id] = options;
         options.tabButton = $('<button></button>')
+        options.tabButton.data('initial-tab-index', targetTabButtonIndex)
         // Insert the tab button at the correct index
-        if (targetTabButtonIndex === -1) {
+        const existingButtons = globalTabBar.container.children('button:not(.red-ui-sidebar-tab-bar-overflow-button)')
+        if (existingButtons.length === 0 || targetTabButtonIndex === -1) {
             // Append to end
             options.tabButton.insertBefore(globalTabBar.overflowButton);
         } else {
-            options.tabButton.insertBefore(globalTabBar.container.children().eq(targetTabButtonIndex));
+            // Find the right place to insert the button given not all buttons will have been added yet so
+            // cannot simply insert into a particular position based on index
+            let inserted = false
+            globalTabBar.container.children('button:not(.red-ui-sidebar-tab-bar-overflow-button)').each(function() {
+                const currentIndex = $(this).data('initial-tab-index')
+                if (currentIndex > targetTabButtonIndex) {
+                    options.tabButton.insertBefore($(this));
+                    inserted = true
+                    return false;
+                }
+            })
+            if (!inserted) {
+                options.tabButton.insertBefore(globalTabBar.overflowButton);
+            }
         }   
 
         targetSidebar.sections[targetSection].tabs.push(options.id)
@@ -878,6 +893,9 @@ RED.sidebar = (function() {
 
         sidebar.resizeSidebar = function () {
             // Resize sidebar sections as needed
+
+            const bottomSectionHeight = sidebar.sections.bottom.container.outerHeight()
+
             const topSectionHeight = sidebar.sections.top.container.outerHeight()
             if (!sidebar.sections.bottom.hidden) {
                 const bottomSectionHeight = sidebar.sections.bottom.container.outerHeight()
@@ -885,6 +903,8 @@ RED.sidebar = (function() {
                 if (bottomSectionHeight < 90 && topSectionHeight > 90) {
                     sidebar.sections.top.container.outerHeight(topSectionHeight - (90 - bottomSectionHeight));
                 }
+            } else {
+                sidebar.sections.top.container.css({ height: '' })
             }
             RED.events.emit("sidebar:resize");
         }
@@ -920,7 +940,7 @@ RED.sidebar = (function() {
             sidebar.sections[position].hidden = false
             const otherPosition = position === 'top' ? 'bottom' : 'top'
             sidebar.sections[otherPosition].container.css('flex-grow', '0')
-            sidebar.sections.top.container.css('height', sidebar.sections.top.height + 'px')
+            sidebar.sections.top.container.css('height', (sidebar.sections.top.height || 300) + 'px')
             sidebar.sections.bottom.container.css('height', '100%')
             if (otherPosition === 'bottom') {
                 sidebar.sections[otherPosition].container.css('margin-top', '')
@@ -980,14 +1000,12 @@ RED.sidebar = (function() {
         }
         if (lastSessionState.primary.top.height) {
             sidebars.primary.sections.top.container.outerHeight(lastSessionState.primary.top.height)
-            sidebars.primary.sections.top.height = lastSessionState.primary.top.height
         }
         if (lastSessionState.primary.bottom.height) {
             sidebars.primary.sections.bottom.height = lastSessionState.primary.bottom.height
         }
         if (lastSessionState.secondary.top.height) {
             sidebars.secondary.sections.top.container.outerHeight(lastSessionState.secondary.top.height)
-            sidebars.secondary.sections.top.height = lastSessionState.secondary.top.height
         }
         if (lastSessionState.secondary.bottom.height) {
             sidebars.secondary.sections.bottom.height = lastSessionState.secondary.bottom.height

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
@@ -356,6 +356,28 @@ RED.sidebar = (function() {
         const tabBar = $('<div class="red-ui-sidebar-tab-bar"></div>').addClass('red-ui-sidebar-right');
         globalTabBar.container = tabBar
 
+        globalTabBar.container.sortable({
+            axis: 'x',
+            distance: 10,
+            cancel: false,
+            items: "button:not(.red-ui-sidebar-tab-bar-overflow-button)",
+            start: function(event, ui) {
+                const tabId = ui.item.attr('data-tab-id');
+                const options = knownTabs[tabId];
+                options.tabButtonTooltip.delete()
+                draggingTabButton = true
+            },
+            stop: function(event, ui) {
+                // Restore the tooltip
+                const tabId = ui.item.attr('data-tab-id');
+                const options = knownTabs[tabId];
+                options.tabButtonTooltip.delete()
+                options.tabButtonTooltip = RED.popover.tooltip(options.tabButton, options.name, options.action);
+                // Save the sidebar state
+                exportSidebarState()
+            }
+        })
+
 
         globalTabBar.overflowButton = $('<button class="red-ui-sidebar-tab-bar-overflow-button"><i class="fa fa-ellipsis-h"></i></button>').appendTo(tabBar);
         globalTabBar.overflowButton.hide()
@@ -366,7 +388,6 @@ RED.sidebar = (function() {
                     const tabId = $(this).attr('data-tab-id');
                     const tabOptions = knownTabs[tabId];
                     let initialStateSet = false
-                    let active = true
                     menuOptions.push({
                         label: tabOptions.name,
                         selected: $(this).hasClass('selected'),

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
@@ -56,8 +56,6 @@ RED.sidebar = (function() {
 
 
     function exportSidebarState () {
-        // TODO: fix all of this
-        // console.log('TODO: exportSidebarState', sidebars.primary.sections.top.tabs, sidebars.primary.sections.bottom.tabs, sidebars.secondary.sections.top.tabs, sidebars.secondary.sections.bottom.tabs)
         const state = {
             // Version of state format - to make it easier to modify
             v: sidebarLayoutVersion,
@@ -67,11 +65,9 @@ RED.sidebar = (function() {
             primary: {
                 width: sidebars.primary.container ? sidebars.primary.container.width() : sidebars.primary.defaultWidth,
                 top: {
-                    height: sidebars.primary.sections.top.container.outerHeight(),
                     tabs: sidebars.primary.sections.top.tabs
                 },
                 bottom: {
-                    height: sidebars.primary.sections.bottom.container.outerHeight(),
                     tabs: sidebars.primary.sections.bottom.tabs
                 }
             },
@@ -79,11 +75,9 @@ RED.sidebar = (function() {
             secondary: {
                 width: sidebars.secondary.container ? sidebars.secondary.container.width() : sidebars.secondary.defaultWidth,
                 top: {
-                    height: sidebars.secondary.sections.top.container.outerHeight(),
                     tabs: sidebars.secondary.sections.top.tabs
                 },
                 bottom: {
-                    height: sidebars.secondary.sections.bottom.container.outerHeight(),
                     tabs: sidebars.secondary.sections.bottom.tabs
                 }
             }
@@ -92,6 +86,15 @@ RED.sidebar = (function() {
             const tabId = $(this).attr('data-tab-id');
             state.tabs.push(tabId)
         })
+
+        if (!sidebars.primary.sections.top.hidden && !sidebars.primary.sections.bottom.hidden) {
+            // Both sections are visible - store the height of the top section so it can be restored later
+            state.primary.top.height = sidebars.primary.sections.top.container.outerHeight()
+        }
+        if (!sidebars.secondary.sections.top.hidden && !sidebars.secondary.sections.bottom.hidden) {
+            // Both sections are visible - store the height of the top section so it can be restored later
+            state.secondary.top.height = sidebars.secondary.sections.top.container.outerHeight()
+        }
 
         state.primary.top.hidden = !!sidebars.primary.sections.top.hidden
         state.primary.bottom.hidden = !!sidebars.primary.sections.bottom.hidden
@@ -1021,12 +1024,14 @@ RED.sidebar = (function() {
         }
         if (lastSessionState.primary.top.height) {
             sidebars.primary.sections.top.container.outerHeight(lastSessionState.primary.top.height)
+            sidebars.primary.sections.top.height = lastSessionState.primary.top.height
         }
         if (lastSessionState.primary.bottom.height) {
             sidebars.primary.sections.bottom.height = lastSessionState.primary.bottom.height
         }
         if (lastSessionState.secondary.top.height) {
             sidebars.secondary.sections.top.container.outerHeight(lastSessionState.secondary.top.height)
+            sidebars.secondary.sections.top.height = lastSessionState.secondary.top.height
         }
         if (lastSessionState.secondary.bottom.height) {
             sidebars.secondary.sections.bottom.height = lastSessionState.secondary.bottom.height

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/statusBar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/statusBar.js
@@ -39,6 +39,7 @@ RED.statusBar = (function() {
         } else if (options.align === 'right') {
             rightBucket.prepend(el);
         }
+        $(window).trigger("resize");
     }
 
     function hideWidget(id) {
@@ -46,6 +47,7 @@ RED.statusBar = (function() {
 
         if (widget && widget.elementDiv) {
             widget.elementDiv.hide();
+            $(window).trigger("resize");
         }
     }
 
@@ -54,6 +56,7 @@ RED.statusBar = (function() {
 
         if (widget && widget.elementDiv) {
             widget.elementDiv.show();
+            $(window).trigger("resize");
         }
     }
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -576,7 +576,7 @@ RED.workspaces = (function() {
         $('<div id="red-ui-workspace-tabs-shade" class="hide"></div>').appendTo("#red-ui-header-tabs");
         $('<div id="red-ui-workspace-chart" tabindex="1"></div>').appendTo("#red-ui-workspace");
         $('<div id="red-ui-workspace-toolbar"></div>').appendTo("#red-ui-workspace");
-        $('<div id="red-ui-workspace-footer" class="red-ui-component-footer"></div>').insertAfter("#red-ui-workspace");
+        $('<div id="red-ui-workspace-footer" class="red-ui-component-footer"></div>').appendTo("#red-ui-workspace");
 
         scrollbars.v = { bar: $('<div id="red-ui-workspace-scroll-v" class="red-ui-workspace-scrollbar"><div class="red-ui-workspace-scrollbar-handle"><div class="red-ui-workspace-scrollbar-handle-target"></div></div></div>').appendTo("#red-ui-workspace") }
         scrollbars.v.handle = scrollbars.v.bar.children().first();

--- a/packages/node_modules/@node-red/editor-client/src/sass/sidebar.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/sidebar.scss
@@ -40,6 +40,7 @@
     background: var(--red-ui-primary-background);
     margin-top: 0px;
     margin-left: 5px;
+    margin-bottom: 5px;
     border: none;
     z-index: 10;
 }
@@ -56,6 +57,7 @@
 }
 
 .red-ui-sidebar-section {
+    position: relative;
     margin: 8px 4px 0 4px;
     display: flex;
     flex-direction: column;
@@ -82,7 +84,6 @@
 .red-ui-sidebar-right .red-ui-sidebar-section {
     margin-right: 0;
 }
-
 
 .red-ui-sidebar-content-wrapper {
     display: flex;
@@ -117,7 +118,7 @@
     }
 }
 
-.red-ui-sidebar-tab-bar-separator {
+.red-ui-sidebar-section-separator {
     height: 0;
     flex: 0 0 auto;
     overflow: visible;
@@ -136,31 +137,23 @@
 }
 
 .red-ui-sidebar-tab-bar {
+    flex: 0 0 auto;
     display: flex;
     flex-direction: row;
-    flex: 0 0 auto;
     align-items: center;
+    justify-content: flex-end;
     flex-wrap: nowrap;
     margin: 0;
+    margin-right: 5px;
+    // height: 28px;
+    padding: 0 6px;
     z-index: 12;
-    overflow: hidden;
     pointer-events: auto;
+    border-bottom: none;
+    gap: 8px;
+    flex-grow: 0;
+    box-sizing: border-box;
     // background: rgba(243, 160, 204, 0.617);
-
-    &.red-ui-sidebar-left {
-        margin-left: 5px;
-        z-index: 10;
-        background: none;
-    }
-    &.red-ui-sidebar-right {
-        margin-right: 5px;
-        border-bottom: none;
-        justify-content: flex-end;
-
-        .red-ui-sidebar-tab-bar-buttons:not(:first-child) {
-            padding-right: 0px;
-        }
-    }
 
     button {
         @include mixins.workspace-button;
@@ -173,70 +166,68 @@
         height: 28px;
         width: 28px;
         &:not(.selected):not(:hover) {
+            background-color: var(--red-ui-view-background);
             i {
-                opacity: 1;
+                opacity: 0.7;
             }
         }
         i {
             font-size: 13px;
         }
-        border-color: var(--red-ui-secondary-border-color);
         &.selected {
             background-color: var(--red-ui-secondary-color);
             border-color: var(--red-ui-primary-border-color);
         }
     }
-    .red-ui-sidebar-tab-bar-button-placeholder {      
-        border: 1px dashed var(--red-ui-form-input-border-color) !important;
-    }
+    // .red-ui-sidebar-tab-bar-button-placeholder {      
+    //     border: 1px dashed var(--red-ui-form-input-border-color) !important;
+    // }
 
-    .red-ui-sidebar-tab-bar-buttons {
-        display: flex;
-        // background-color: var(--red-ui-primary-background);
-        // background: rgba(233, 255, 91, 0.555);
+    // .red-ui-sidebar-tab-bar-buttons {
+    //     display: flex;
+    //     // background-color: var(--red-ui-primary-background);
+    //     // background: rgba(233, 255, 91, 0.555);
         
-        height: 28px;
-        padding: 0 6px;
-        box-sizing: border-box;
-        flex-direction: row;
-        align-items: center;
-        gap: 8px;
-        flex-grow: 0;
-        // height: 50%;
-        // &:first-child {
-        //     // background: rgba(255,0,0,0.1);
-        //     flex-grow: 0;
-        //     flex-shrink: 0;
-        // }
-        // &:last-child {
-        //     // background: rgba(255,255,0,0.1);
-        //     flex-grow: 1;
-        //     flex-shrink: 1;
-        // }
-    }
-    .red-ui-sidebar-tab-bar-buttons.red-ui-sidebar-tab-bar-empty {
-        display: none;
-        // background: rgba(255,0,0,0.3);
-    }
-    &.red-ui-sidebar-dragging-tab .red-ui-sidebar-tab-bar-empty {
-        display: flex;
-    }
-    &.red-ui-sidebar-dragging-tab .red-ui-sidebar-tab-bar-buttons:last-child {
-            // margin-left: -2px;
-            width: 42px;
-            height: 28px;
-    }
-    .red-ui-sidebar-tab-bar-buttons:last-child {
-        min-width: 28px;
-    }
-    &.red-ui-sidebar-left .red-ui-sidebar-tab-bar-buttons:last-child,
-    &.red-ui-sidebar-right .red-ui-sidebar-tab-bar-buttons:not(:first-child) {
-        border-left: 2px solid var(--red-ui-secondary-border-color);
-    }
+    //     box-sizing: border-box;
+    //     flex-direction: row;
+    //     align-items: center;
+    //     gap: 8px;
+    //     flex-grow: 0;
+    //     // height: 50%;
+    //     // &:first-child {
+    //     //     // background: rgba(255,0,0,0.1);
+    //     //     flex-grow: 0;
+    //     //     flex-shrink: 0;
+    //     // }
+    //     // &:last-child {
+    //     //     // background: rgba(255,255,0,0.1);
+    //     //     flex-grow: 1;
+    //     //     flex-shrink: 1;
+    //     // }
+    // }
+    // .red-ui-sidebar-tab-bar-buttons.red-ui-sidebar-tab-bar-empty {
+    //     display: none;
+    //     // background: rgba(255,0,0,0.3);
+    // }
+    // &.red-ui-sidebar-dragging-tab .red-ui-sidebar-tab-bar-empty {
+    //     display: flex;
+    // }
+    // &.red-ui-sidebar-dragging-tab .red-ui-sidebar-tab-bar-buttons:last-child {
+    //         // margin-left: -2px;
+    //         width: 42px;
+    //         height: 28px;
+    // }
+    // .red-ui-sidebar-tab-bar-buttons:last-child {
+    //     min-width: 28px;
+    // }
+    // &.red-ui-sidebar-left .red-ui-sidebar-tab-bar-buttons:last-child,
+    // &.red-ui-sidebar-right .red-ui-sidebar-tab-bar-buttons:not(:first-child) {
+    //     border-left: 2px solid var(--red-ui-secondary-border-color);
+    // }
 
-    .red-ui-sidebar-right & {
-        justify-items: flex-end;
-    }
+    // .red-ui-sidebar-right & {
+    //     justify-items: flex-end;
+    // }
 }
 
 .red-ui-sidebar-right .red-ui-sidebar-tab-bar-buttons:first-child {
@@ -252,14 +243,70 @@
     padding: 2px 8px;
 }
 
-.red-ui-sidebar-banner { /* Currently unused... */
-    @include mixins.disable-selection;
+.red-ui-sidebar-banner {
+    flex: 0 0 auto;
     background: var(--red-ui-primary-background);
-    color: var(--red-ui-primary-text-color);
-    font-size: 8px;
-    padding: 0 3px;
-    text-align: right;
+    border-bottom: 1px solid var(--red-ui-secondary-border-color);
+    height: 18px;
+    font-size: 9px;
+    line-height: 9px;
     cursor: grab;
+    z-index: 12;
+    display: flex;
+    align-items: center;
+    justify-content: left;
+    padding: 0 0 0 6px;
+    gap: 4px;
+    user-select: none;
+}
+.red-ui-sidebar-banner-label {
+    flex: 1 1 auto;
+    color: var(--red-ui-primary-text-color);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+}
+.red-ui-sidebar-banner-tools {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-right: 3px;
+    // .red-ui-sidebar-banner-collapse-button {}
+    .red-ui-editor & button {
+        width: 16px;
+        height: 16px;
+        padding: 0;
+        line-height: 16px;
+        border: none;
+        background-color: transparent;
+    }
+}
+.red-ui-sidebar-banner-icon {
+    flex: 0 0 auto;
+    .red-ui-sidebar-tab-icon {
+        width: 10px;
+        height: 10px;
+    }
+}
+.red-ui-sidebar-drop-background {
+    z-index: 999;
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.3);
+}
+.red-ui-sidebar-drop-target {
+    border-radius: 6px;
+    position: absolute;
+    background: rgba(255,255,255,0.4);
+    border: 1px dashed white;
+    box-sizing: border-box;
+}
+.red-ui-sidebar-drop-target-hover {
+    background: var(--red-ui-shade-color);
 }
 .sidebar-header, /* Deprecated -> red-ui-sidebar-header */
 .red-ui-sidebar-header {

--- a/packages/node_modules/@node-red/editor-client/src/sass/sidebar.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/sidebar.scss
@@ -137,15 +137,13 @@
 }
 
 .red-ui-sidebar-tab-bar {
-    flex: 0 0 auto;
+    flex: 1 1 100%;
     display: flex;
     flex-direction: row;
     align-items: center;
     justify-content: flex-end;
     flex-wrap: nowrap;
     margin: 0;
-    margin-right: 5px;
-    // height: 28px;
     padding: 0 6px;
     z-index: 12;
     pointer-events: auto;

--- a/packages/node_modules/@node-red/editor-client/src/sass/workspace.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/workspace.scss
@@ -217,7 +217,7 @@ button.red-ui-footer-button-toggle {
     // background: rgba(62, 236, 53, 0.8);
     flex: 1 1 100%;
     height: 100%;
-    padding-left: 5px;
+    padding-left: 7px;
 
 }
 .red-ui-statusbar-widget {

--- a/packages/node_modules/@node-red/editor-client/src/sass/workspace.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/workspace.scss
@@ -215,7 +215,7 @@ button.red-ui-footer-button-toggle {
     align-items: center;
     gap: 4px;
     // background: rgba(62, 236, 53, 0.8);
-    flex: 1 1 100%;
+    flex: 0 0 auto;
     height: 100%;
     padding-left: 7px;
 


### PR DESCRIPTION
Fixes #5604 

This changes the sidebar UX to support drag and drop positioning.

 - Sidebar tab buttons are now all located in bottom right
 - Sidebar panels have a small header - easier to identify which panel is which
 - Panels can be dragged between the left/right top/bottom sidebar positions

The following items are knowingly broken in this branch currently:

 - ~Saving/restoring sidebar panel state - currently disabled whilst doing this rework. Need to revisit the format of the data.~
 - ~Collapsing sidebar tab buttons to a menu on narrow screens~

