### PR TITLE
Rework selected/hightlighted node appearance

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -5278,7 +5278,18 @@ RED.view = (function() {
             .on("touchstart",nodeTouchStart)
             .on("touchend",nodeTouchEnd)
         nodeContents.appendChild(mainRect);
-        
+
+        const nodeHalo = document.createElementNS("http://www.w3.org/2000/svg","rect");
+        nodeHalo.setAttribute("class", "red-ui-flow-node-highlight");
+        nodeHalo.setAttribute("rx", 5);
+        nodeHalo.setAttribute("ry", 5);
+        nodeHalo.setAttribute("x", -8)
+        nodeHalo.setAttribute("y", -5)
+        nodeHalo.setAttribute("width", 40);
+        nodeHalo.setAttribute("height", 40);
+        node[0][0].__halo__ = nodeHalo;
+        nodeContents.appendChild(nodeHalo);
+
         const port_label_group = document.createElementNS("http://www.w3.org/2000/svg","g");
         port_label_group.setAttribute("x",0);
         port_label_group.setAttribute("y",0);
@@ -5388,6 +5399,8 @@ RED.view = (function() {
                 this.__mainRect__.setAttribute("width", d.w)
                 this.__mainRect__.setAttribute("height", d.h)
                 this.__mainRect__.classList.toggle("red-ui-flow-node-highlighted",!!d.highlighted );
+                this.__halo__.setAttribute("width", d.w + 16);
+                this.__halo__.setAttribute("height", d.h + 10);
 
                 if (labelParts) {
                     // The label has changed
@@ -5477,7 +5490,10 @@ RED.view = (function() {
                     .on("mousedown",nodeMouseDown)
                     .on("touchstart",nodeTouchStart)
                     .on("touchend", nodeTouchEnd);
-
+                statusGroup.append("rect")
+                    .attr("class", "red-ui-flow-node-highlight")
+                    .attr("x",-8).attr("y",-5).attr("width", 56).attr("height", 50)
+                    .attr("rx", 5).attr("ry", 5);
                 statusGroup.append("g").attr('transform','translate(-5,15)').append("rect").attr("class","red-ui-flow-port").attr("rx",3).attr("ry",3).attr("width",10).attr("height",10)
                     .on("mousedown", function(d,i){portMouseDown(d,PORT_TYPE_INPUT,0);} )
                     .on("touchstart", function(d,i){portMouseDown(d,PORT_TYPE_INPUT,0);d3.event.preventDefault();} )
@@ -5696,8 +5712,8 @@ RED.view = (function() {
                 nodeHalo.setAttribute("class", "red-ui-flow-node-highlight");
                 nodeHalo.setAttribute("rx", 5);
                 nodeHalo.setAttribute("ry", 5);
-                nodeHalo.setAttribute("x", -10)
-                nodeHalo.setAttribute("y", -10)
+                nodeHalo.setAttribute("x", -8)
+                nodeHalo.setAttribute("y", -5)
                 node[0][0].__halo__ = nodeHalo;
                 nodeContents.appendChild(nodeHalo);
 
@@ -5774,8 +5790,8 @@ RED.view = (function() {
                         this.__mainRect__.setAttribute("width", d.w)
                         this.__mainRect__.setAttribute("height", d.h)
 
-                        this.__halo__.setAttribute("width", d.w + 20)
-                        this.__halo__.setAttribute("height", d.h + 20 + (d.statusHeight || 0))
+                        this.__halo__.setAttribute("width", d.w + 16)
+                        this.__halo__.setAttribute("height", d.h + 10)
 
 
                         if (labelParts) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -369,7 +369,7 @@ RED.workspaces = (function() {
                 clearTabHighlight()
                 RED.events.emit("workspace:change",event);
                 RED.sidebar.config.refresh();
-                RED.view.focus();                
+                RED.view.focus();
             },
             onclick: function(tab, evt) {
                 if(evt.which === 2) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/workspaces.js
@@ -366,9 +366,10 @@ RED.workspaces = (function() {
                     document.title = documentTitle
                 }
                 event.workspace = activeWorkspace;
+                clearTabHighlight()
                 RED.events.emit("workspace:change",event);
                 RED.sidebar.config.refresh();
-                RED.view.focus();
+                RED.view.focus();                
             },
             onclick: function(tab, evt) {
                 if(evt.which === 2) {
@@ -474,7 +475,6 @@ RED.workspaces = (function() {
                 var hiddenTabs = JSON.parse(RED.settings.getLocal("hiddenTabs")||"{}");
                 delete hiddenTabs[tab.id];
                 RED.settings.setLocal("hiddenTabs",JSON.stringify(hiddenTabs));
-
                 RED.events.emit("workspace:show",{workspace: tab.id})
             },
             minimumActiveTabWidth: 150,
@@ -952,28 +952,22 @@ RED.workspaces = (function() {
         return newOrder
     }
 
-    function flashTab(tabId) {
-        if(flashingTab && flashingTab.length) {
+    function clearTabHighlight() {
+        if (flashingTab && flashingTab.length) {
             //cancel current flashing node before flashing new node
             clearInterval(flashingTabTimer);
             flashingTabTimer = null;
             flashingTab.removeClass('highlighted');
             flashingTab = null;
         }
+    }
+    function highlightTab(tabId) {
+        clearTabHighlight();
         let tab = $("#red-ui-tab-" + tabId);
-        if(!tab || !tab.length) { return; }
-
-        flashingTabTimer = setInterval(function(flashEndTime) {
-            if (flashEndTime >= Date.now()) {
-                const highlighted = tab.hasClass("highlighted");
-                tab.toggleClass('highlighted', !highlighted)
-            } else {
-                clearInterval(flashingTabTimer);
-                flashingTabTimer = null;
-                flashingTab = null;
-                tab.removeClass('highlighted');
-            }
-        }, 100, Date.now() + 2200);
+        if (!tab || !tab.length) { return; }
+        flashingTabTimer = setTimeout(function(tab) {
+            tab.removeClass('highlighted');
+        }, 8100, tab);
         flashingTab = tab;
         tab.addClass('highlighted');
     }
@@ -1037,7 +1031,7 @@ RED.workspaces = (function() {
                 workspace_tabs.activateTab(id);
             }
             if(flash) {
-                flashTab(id.replace(".","-"))
+                highlightTab(id.replace(".","-"))
             }
         },
         refresh: function() {

--- a/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
@@ -295,55 +295,50 @@ g.red-ui-flow-node-selected {
     .red-ui-workspace-select-mode & {
         opacity: 1;
     }
-    .red-ui-flow-node,.red-ui-flow-subflow-port {
-        stroke-width: 2;
-        stroke: var(--red-ui-node-selected-color) !important;
+    .red-ui-flow-node-highlight {
+        opacity: 1;
+        stroke-opacity: 1;
+        stroke: var(--red-ui-node-selected-color);
     }
 }
 
 .red-ui-flow-node-highlight {
     border-color: var(--red-ui-node-selected-color) !important;
-    border-style: dashed !important;
     stroke: var(--red-ui-node-selected-color);
-    stroke-width: 4;
+    stroke-width: 2;
     stroke-opacity: 0;
-    stroke-dasharray: 8, 4;
     fill: none;
     pointer-events: none;
     .red-ui-workspace-zoom-level-1 & {
-        stroke-width: 8;
-        stroke-dasharray: 16, 8;
+        stroke-width: 2;
+        // stroke-dasharray: 16, 8;
     }
     .red-ui-workspace-zoom-level-2 & {
-        stroke-width: 16;
-        stroke-dasharray: 16, 8;
+        stroke-width: 4;
+        // stroke-dasharray: 16, 8;
     }
     .red-ui-flow-node-highlighted & {
+        stroke-width: 4;
+        stroke-dasharray: 8, 4;
+        border-style: dashed !important;
         animation-duration: 8s;
         animation-name: node-reveal-highlight;
         animation-timing-function: ease-out;
         animation-iteration-count: 1;
     }
+    .red-ui-workspace-zoom-level-1 .red-ui-flow-node-highlighted & {
+        stroke-dasharray: 16, 8;
+    }
+    .red-ui-workspace-zoom-level-2 .red-ui-flow-node-highlighted & {
+        stroke-dasharray: 16, 8;
+    }
+
+
 }
 @keyframes node-reveal-highlight {
     from {
         stroke-opacity: 1;
     }
-    2% { stroke-opacity: 1;}
-    3% { stroke-opacity: 0 ;}
-    4% { stroke-opacity: 1 ;}
-    5% { stroke-opacity: 0 ;}
-    6% { stroke-opacity: 1 ;}
-    7% { stroke-opacity: 0 ;}
-    8% { stroke-opacity: 1 ;}
-    9% { stroke-opacity: 0 ;}
-    10% { stroke-opacity: 1 ;}
-    11% { stroke-opacity: 0 ;}
-    12% { stroke-opacity: 1;}
-    13% { stroke-opacity: 0 ;}
-    14% { stroke-opacity: 1 ;}
-    15% { stroke-opacity: 0 ;}
-    16% { stroke-opacity: 1 ;}
     80% {
         stroke-opacity: 1;
     }

--- a/packages/node_modules/@node-red/editor-client/src/sass/tabs.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tabs.scss
@@ -91,8 +91,8 @@ body .red-ui-tabs {
                 background: var(--red-ui-tab-background-hover);
             }
             &.highlighted {
-                box-shadow: 0px 0px 4px 2px var(--red-ui-node-selected-color);
-                border: dashed 1px var(--red-ui-node-selected-color);
+                border: 1px solid var(--red-ui-node-selected-color) !important;
+                box-shadow: 0 0 0 1px var(--red-ui-node-selected-color) !important;
             }
             &.active {
                 background: var(--red-ui-tab-background-active);


### PR DESCRIPTION
This reworks the appearance of selected nodes to use a halo effect around the node body:

<img width="637" height="430" alt="image" src="https://github.com/user-attachments/assets/37397ea7-a069-46dd-9c6a-5fbb7ad73ca9" />

Using a halo means there is better contrast between the selection colour and the node body colour and it stands out more.

The halo was originally added in a previous beta as part of the 'reveal' node behaviour. The flash effect was very distracting when triggered by simply mousing over the debug sidebar (for example). I have turned off the flash behaviour as I think this halo effect is easier to spot. I expect the community to Have Opinions on this as it is one of the topics that triggers a lot of debate without conclusion. I'm being opinionated here.