### PR TITLE
Ensure active tab is fully visible

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -254,10 +254,12 @@ var RED = (function() {
                             const hashParts = currentHash.split('/')
                             const showEditDialog = hashParts.length > 2 && hashParts[2] === 'edit'
                             if (hashParts[0] === '#flow') {
-                                RED.workspaces.show(hashParts[1], true);
-                                if (showEditDialog) {
-                                    RED.workspaces.edit()
-                                }
+                                setTimeout(() => {
+                                    RED.workspaces.show(hashParts[1], true);
+                                    if (showEditDialog) {
+                                        RED.workspaces.edit()
+                                    }
+                                }, 10);
                             } else if (hashParts[0] === '#node') {
                                 const nodeToShow = RED.nodes.node(hashParts[1])
                                 if (nodeToShow) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
@@ -450,23 +450,24 @@ RED.tabs = (function() {
             if (!link.parent().hasClass("active")) {
                 updateTabWidths();
                 ul.children().removeClass("active");
-                ul.children().css({"transition": "width 100ms"});
                 link.parent().addClass("active");
                 var parentId = link.parent().attr('id');
                 wrapper.find(".red-ui-tab-link-button").removeClass("active selected");
                 $("#"+parentId+"-link-button").addClass("active selected");
-                if (options.scrollable) {
-                    window.sc = scrollContainer;
-                    window.at = link
-                    var pos = link.parent().position().left;
-                    if (pos-21 < 0) {
-                        scrollContainer.animate( { scrollLeft: '+='+(pos-50) }, 300);
-                    } else if (pos + 120 > scrollContainer.width()) {
-                        scrollContainer.animate( { scrollLeft: '+='+(pos + 140-scrollContainer.width()) }, 300);
-                    }
-                }
                 if (options.onchange) {
                     options.onchange(tabs[link.attr('href').slice(1)]);
+                }
+            }
+
+            if (options.scrollable) {
+                ul.children().css({"transition": "width 100ms"});
+                window.sc = scrollContainer;
+                window.at = link
+                const pos = link.parent().position().left;
+                if (pos - 21 < 0) {
+                    scrollContainer.animate( { scrollLeft: '+=' + (pos - 50) }, 300);
+                } else if (pos + link.parent().width() + 10 > scrollContainer.width()) {
+                    scrollContainer.animate( { scrollLeft: '+=' + (pos + link.parent().width() + 40 - scrollContainer.width()) }, 300);
                 }
                 setTimeout(function() {
                     ul.children().css({"transition": ""});


### PR DESCRIPTION
I noticed the active tab was not always scrolling into view properly - either when switching active flows, or reloading the editor.

A couple of issues:
 - the scroll position calculation didn't take the true tab width into account
 - repeated calls to show the tab would no-op the scroll if it was already active - losing the ability to get it into view without toggling tabs
 - the scroll position calculation was failing on load of the editor as the container was still zero-width

This fixes all of that.