### PR TITLE
Fix node halo height calculation when status is shown

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -5789,10 +5789,8 @@ RED.view = (function() {
                         this.classList.toggle("red-ui-flow-node-disabled", d.d === true);
                         this.__mainRect__.setAttribute("width", d.w)
                         this.__mainRect__.setAttribute("height", d.h)
-
                         this.__halo__.setAttribute("width", d.w + 16)
-                        this.__halo__.setAttribute("height", d.h + 10)
-
+                        this.__halo__.setAttribute("height", d.h + (d.statusHeight || 0) + 10)
 
                         if (labelParts) {
                             // The label has changed
@@ -6013,7 +6011,8 @@ RED.view = (function() {
                         });
 
                         if (d._def.button) {
-                            let buttonVisible = true
+                            let buttonVisible = false
+                            buttonVisible = true
                             var buttonEnabled = isButtonEnabled(d);
                             this.__buttonGroup__.classList.toggle("red-ui-flow-node-button-disabled", !buttonEnabled);
                             if (RED.runtime && RED.runtime.started !== undefined) {
@@ -6039,7 +6038,6 @@ RED.view = (function() {
                                     this.__buttonGroup__.style.display = "inherit";
                                 }
                             }
-                            // Need to adjust the halo to encompass the button
                             if (buttonVisible) {
                                 this.__halo__.setAttribute("width", d.w + 40)
                                 if (d._def.align !== 'right') {
@@ -6066,8 +6064,13 @@ RED.view = (function() {
                     }
 
                     if (d.dirtyStatus) {
-                        redrawStatus(d,this);
+                        const currentStatusHeight = d.statusHeight || 0
+                        redrawStatus(d,this)
+                        if (currentStatusHeight !== d.statusHeight) {
+                            this.__halo__.setAttribute("height", d.h + (d.statusHeight || 0) + 10)
+                        }
                     }
+
                     d.dirty = false;
                     if (d.g) {
                         if (!dirtyGroups[d.g]) {


### PR DESCRIPTION
Somewhere along the way, the node status height was dropped from the halo size calculation. This restores is with a bit more robustness.

<img width="170" height="94" alt="image" src="https://github.com/user-attachments/assets/8a177a63-35f0-4502-848d-1d08c4bc2879" />
