### PR TITLE
[5634] Junctions and ports on hover disappear with light theme

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
@@ -235,7 +235,7 @@ $node-status-colors: (
 
 
 $node-selected-color: #0090ff;
-$port-selected-color: #ffffff;
+$port-selected-color: #0090ff;
 
 $link-color: #999;
 $link-link-color: #aaa;

--- a/packages/node_modules/@node-red/editor-client/src/sass/dark-theme.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/dark-theme.scss
@@ -242,7 +242,7 @@ html.nr-theme-dark {
     --red-ui-node-config-icon-container-disabled: #444444;
     --red-ui-node-link-port-background:     #1e1e1e;
     --red-ui-node-selected-color:           #e8334a; // accent red selection ✅
-    --red-ui-port-selected-color:           #f0f0f0;
+    --red-ui-port-selected-color:           #e8334a;
 
     // Node status pills
     --red-ui-node-status-error-border:       #CE2C31;


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Resolves https://github.com/node-red/node-red/issues/5634

<img width="500" height="197" alt="junction" src="https://github.com/user-attachments/assets/180b610a-5c99-4735-8ddb-68298b606728" />

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
