### PR TITLE
Remove unslightly gap in the debug sidebar

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/debug.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/debug.scss
@@ -23,18 +23,20 @@
         font-size: 14px;
     }
 }
+.red-ui-debug-container {
+    position: relative;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
 
 .red-ui-debug-content {
-    position: absolute;
-    top: 43px;
-    bottom: 0px;
-    left:0px;
-    right: 0px;
     overflow-y: auto;
+    flex: 1 1 auto;
 }
 .red-ui-debug-filter-box {
     position:absolute;
-    top: 42px;
+    top: 28px;
     left: 0px;
     right: 0px;
     z-index: 20;

--- a/packages/node_modules/@node-red/nodes/core/common/lib/debug/debug-utils.js
+++ b/packages/node_modules/@node-red/nodes/core/common/lib/debug/debug-utils.js
@@ -39,7 +39,7 @@ RED.debug = (function() {
     function init(_config) {
         config = _config;
 
-        var content = $("<div>").css({"position":"relative","height":"100%"});
+        var content = $('<div class="red-ui-debug-container"></div>');
         var toolbar = $('<div class="red-ui-sidebar-header">'+
             '<span class="button-group">'+
                 '<a id="red-ui-sidebar-debug-pause" class="red-ui-sidebar-header-button" href="#"><i class="fa fa-pause"></i></a>'+


### PR DESCRIPTION
An unsightly gap had appeared in the debug sidebar panel between the messages and the panel toolbar. 

This fixes it by moving to flex layout for positioning the container rather than relying on absolute px positioning.

The 'selected nodes' filter dropdown is still absolute px positioned because I'm imperfect.