### PR TITLE
Fix multiplayer icon appearance

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/multiplayer.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/multiplayer.js
@@ -159,7 +159,7 @@ RED.multiplayer = (function () {
             userCountSpan.text('')
             userCountIcon.appendTo(tray)
             const userCountTooltip = RED.popover.tooltip(userCountIcon, function () {
-                    const content = $('<div>')
+                    const content = $('<div style="min-width:50px"></div>')
                     users.forEach(sessionId => {
                         $('<div>').append($('<a href="#">').text(sessions[sessionId].user.username).on('click', function (evt) {
                             evt.preventDefault()
@@ -174,20 +174,17 @@ RED.multiplayer = (function () {
             )
 
             const updateUserCount = function () {
-                const maxShown = 2
+                // If one user - show their icon
+                // If >1 - show the count
                 const children = tray.children()
-                children.each(function (index, element) {
-                    const i = users.length - index
-                    if (i > maxShown) {
-                        $(this).hide()
-                    } else if (i >= 0) {
-                        $(this).show()
-                    }
-                })
-                if (users.length < maxShown + 1) { 
+                if (users.length === 0) {
+                    children.hide()
+                } else if (users.length === 1) {
+                    children.eq(0).show()
                     userCountIcon.hide()
                 } else {
-                    userCountSpan.text('+'+(users.length - maxShown))
+                    children.hide()
+                    userCountSpan.text(users.length)
                     userCountIcon.show()
                 }
             }

--- a/packages/node_modules/@node-red/editor-client/src/sass/header.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/header.scss
@@ -403,10 +403,10 @@
     }
 }
 
-#red-ui-header-button-user {
+a#red-ui-header-button-user.button {
     background-color: var(--red-ui-header-background);
     border: 1px solid var(--red-ui-header-button-border);
-    border-radius: 4px;
+    border-radius: 20px;
 }
 
 .red-ui-user-profile {

--- a/packages/node_modules/@node-red/editor-client/src/sass/multiplayer.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/multiplayer.scss
@@ -42,8 +42,8 @@
 }
 .red-ui-multiplayer-users-tray {
     position: absolute;
-    top: 5px;
-    right: 20px;
+    top: 2px;
+    right: 15px;
     line-height: normal;
     cursor: pointer;
     // &:hover {
@@ -51,6 +51,9 @@
     //         margin-left: 1px;
     //     }
     // }
+    .red-ui-multiplayer-user-location .red-ui-user-profile {
+        border-color: var(--red-ui-primary-border-color);
+    }
 }
 $multiplayer-user-icon-background: var(--red-ui-primary-background);
 $multiplayer-user-icon-border: var(--red-ui-view-background);


### PR DESCRIPTION
Before:

 - Vertically mis-aligned
 - Takes up too much of the tab width - obscuring the title now the text is centrally aligned
<img width="192" height="63" alt="image" src="https://github.com/user-attachments/assets/30b0d730-c91c-4f11-859b-61c30aec2c00" />


After:

<img width="320" height="64" alt="image" src="https://github.com/user-attachments/assets/b5b0aad0-6a06-4f69-a13e-4401d58ad8ef" />

 - Vertically aligned
 - Nudged a bit more to the right. In the case of subflows, we don't want to cover the close icon. We *could* do a bit more conditional positioning... but not today.
 - Only shows _one_ user icon. If there is a single user, you see their icon. If there are more, it shows just the count (previously it would show up to 2 user icons *and* a `+1` count).