### PR TITLE
Remove default admin cors rules

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/index.js
@@ -24,9 +24,9 @@
   * @namespace @node-red/editor-api
   */
 
-var bodyParser = require("body-parser");
-var passport = require('passport');
-
+const bodyParser = require("body-parser");
+const passport = require('passport');
+const cors = require('cors');
 var auth = require("./auth");
 var apiUtil = require("./util");
 

--- a/packages/node_modules/@node-red/editor-api/lib/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/index.js
@@ -47,13 +47,6 @@ function init(settings,_server,storage,runtimeAPI) {
     if (settings.httpAdminRoot !== false) {
         adminApp = apiUtil.createExpressApp(settings);
 
-        var cors = require('cors');
-        var corsHandler = cors({
-           origin: "*",
-           methods: "GET,PUT,POST,DELETE"
-        });
-        adminApp.use(corsHandler);
-
         if (settings.httpAdminMiddleware) {
             if (typeof settings.httpAdminMiddleware === "function" || Array.isArray(settings.httpAdminMiddleware)) {
                 adminApp.use(settings.httpAdminMiddleware);

--- a/test/unit/@node-red/editor-api/lib/index_spec.js
+++ b/test/unit/@node-red/editor-api/lib/index_spec.js
@@ -144,14 +144,14 @@ describe("api/index", function() {
         it('uses default cors middleware when user settings absent', function(done){
             api.init({ httpAdminRoot: true }, {}, {}, {});
             const middlewareFound = api.httpAdmin._router.stack.filter((layer) => layer.name === 'corsMiddleware')
-            should(middlewareFound).be.length(1);
+            should(middlewareFound).be.length(0);
             done();
         })
 
         it('enables custom cors middleware when settings present', function(done){
             api.init({ httpAdminRoot: true, httpAdminCors }, {}, {}, {});
             const middlewareFound = api.httpAdmin._router.stack.filter((layer) => layer.name === 'corsMiddleware')
-            should(middlewareFound).be.length(2);
+            should(middlewareFound).be.length(1);
             done();
         })
     });


### PR DESCRIPTION
Remove the default CORS settings for the admin route for a more secure default.

The admin cors setting can be still be set via the `httpAdminCors` setting.