### PR TITLE
Remove aria label application from popover

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
@@ -483,7 +483,6 @@ RED.popover = (function() {
                 }
                 return label;
             }
-            applyAriaLabel(typeof content === 'function' ? content() : content);
             var popover = RED.popover.create({
                 tooltip: true,
                 target:target,


### PR DESCRIPTION
Missed this when reviewing the original PR; but this call to `applyAriaLabel` is triggering an error when the Debug sidebar is added - specifically for its Pause button.

On inspection, I think this is a redundant call to `applyAriaLabel` as the one in `label` function just above will ensure the right aria label is applied.

Removing this call has fixed the error and I can see the aria attributes being set (and updated) as expected.