### PR TITLE
Use a token exchange pattern for OAuth logins

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/auth/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/index.js
@@ -154,7 +154,7 @@ function revoke(req,res) {
 function completeVerify(profile,done) {
     Users.authenticate(profile).then(function(user) {
         if (user) {
-            Tokens.create(user.username,"node-red-editor",user.permissions).then(function(tokens) {
+            Tokens.create(user.username, "node-red-editor", user.permissions, true).then(function(tokens) {
                 log.audit({event: "auth.login",user,username:user.username,scope:user.permissions});
                 user.tokens = tokens;
                 done(null,user);
@@ -255,7 +255,7 @@ function completeGenericStrategyAuth(req,res) {
     var tokens = req.user.tokens;
     delete req.user.tokens;
     // Successful authentication, redirect home.
-    res.redirect(settings.httpAdminRoot + '?access_token='+tokens.accessToken);
+    res.redirect(settings.httpAdminRoot + '?code='+tokens.exchangeCode);
 }
 function handleStrategyError(err, req, res, next) {
     if (res.headersSent) {
@@ -265,6 +265,22 @@ function handleStrategyError(err, req, res, next) {
     res.removeHeader('WWW-Authenticate')
     log.audit({event: "auth.login.fail.oauth",error:err.toString()});
     res.redirect(settings.httpAdminRoot + '?session_message='+err.toString());
+}
+
+/**
+ * As part of the generic auth strategy flow, this endpoint will exchange an access code for
+ * an access token.
+ * This can only be called once per access code and must be done within 20 seconds of the code being issued.
+ * @param {*} req 
+ * @param {*} res 
+ */
+function exchangeCodeForToken(req, res) {
+    const exchangeCode = req.body.code;
+    return Tokens.exchangeCodeForToken(exchangeCode).then(function(tokenResponse) {
+        res.json(tokenResponse);
+    }).catch(function(err) {
+        res.status(400).json({error: err.toString()});
+    })
 }
 
 module.exports = {
@@ -281,5 +297,6 @@ module.exports = {
     },
     login: login,
     revoke: revoke,
-    genericStrategy: genericStrategy
+    genericStrategy: genericStrategy,
+    exchangeCodeForToken: exchangeCodeForToken
 }

--- a/packages/node_modules/@node-red/editor-api/lib/auth/strategies.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/strategies.js
@@ -96,7 +96,7 @@ var passwordTokenExchange = function(client, username, password, scope, done) {
                 if(user.token){
                     done(null,user.token,null,null);
                 } else {
-                    Tokens.create(username,client.id,scope).then(function(tokens) {
+                    Tokens.create(username,client.id,scope,false).then(function(tokens) {
                         log.audit({event: "auth.login",user,username:username,client:client.id,scope:scope});
                         done(null,tokens.accessToken,null,{expires_in:tokens.expires_in});
                     });

--- a/packages/node_modules/@node-red/editor-api/lib/auth/tokens.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/tokens.js
@@ -19,6 +19,8 @@ const crypto = require("crypto");
 var storage;
 var sessionExpiryTime
 var sessions = {};
+const pendingSessions = {};
+let exchangeCodeExpiryTime
 var loadedSessions = null;
 var apiAccessTokens;
 var sessionExpiryListeners = [];
@@ -73,6 +75,7 @@ module.exports = {
         sessionExpiryListeners = [];
 
         sessionExpiryTime = adminAuthSettings.sessionExpiryTime || 604800; // 1 week in seconds
+        exchangeCodeExpiryTime = adminAuthSettings.exchangeCodeExpiryTime || 20; // 20 seconds
         // At this point, storage will not have been initialised, so defer loading
         // the sessions until there's a request for them.
         loadedSessions = null;
@@ -105,32 +108,67 @@ module.exports = {
             }
         });
     },
-    create: function(user,client,scope) {
+    create: function(user, client, scope, useExchangeCode) {
         return loadSessions().then(function() {
-            var accessToken = crypto.randomBytes(128).toString('base64');
+            const accessToken = crypto.randomBytes(128).toString('base64');
+            const accessTokenExpiresAt = Date.now() + (sessionExpiryTime*1000);
 
-            var accessTokenExpiresAt = Date.now() + (sessionExpiryTime*1000);
-
-            var session = {
+            const session = {
                 user:user,
                 client:client,
                 scope:scope,
                 accessToken: accessToken,
-                expires: accessTokenExpiresAt
+                expires: accessTokenExpiresAt,
             };
-            sessions[accessToken] = session;
 
             if (!expiryTimeout) {
                 expiryTimeout = setTimeout(expireSessions,Math.min(2147483647,(accessTokenExpiresAt - Date.now()) + 5000))
             }
 
-            return storage.saveSessions(sessions).then(function() {
-                return {
-                    accessToken: accessToken,
-                    expires_in: sessionExpiryTime
-                }
-            });
+            if (useExchangeCode) {
+                // This is a short-lived token used to exchange for a longer lived token.
+                // Do not save the session to the store until the token is exchanged.
+                const exchangeCode = crypto.randomBytes(32).toString('base64');
+                session.exchangeCode = exchangeCode;
+                session.exchangeCodeExpires = Date.now() + (exchangeCodeExpiryTime * 1000);
+                pendingSessions[exchangeCode] = session;
+                return Promise.resolve({
+                    exchangeCode
+                });
+            } else {
+                sessions[accessToken] = session;
+                return storage.saveSessions(sessions).then(function() {
+                    return {
+                        accessToken,
+                        expires_in: sessionExpiryTime
+                    }
+                })
+            }
         });
+    },
+    // Swap a short-lived exchange code for a long-lived access token
+    // This can only happen once per exchange code and must be done within 20 seconds of the code being issued.
+    exchangeCodeForToken: function(exchangeCode) {
+        return loadSessions().then(function () {
+            const session = pendingSessions[exchangeCode];
+            if (session && session.exchangeCodeExpires > Date.now()) {
+                delete pendingSessions[exchangeCode];
+                delete session.exchangeCode;
+                delete session.exchangeCodeExpires;
+                // Save the session to the store now we have validated the exchange code
+                sessions[session.accessToken] = session;
+                return storage.saveSessions(sessions).then(function() {
+                    return {
+                        accessToken: session.accessToken,
+                        expires_in: sessionExpiryTime
+                    }
+                })
+            } else {
+                delete pendingSessions[exchangeCode];
+                return Promise.reject(new Error("Invalid exchange code"));
+            }
+        })
+
     },
     revoke: function(token) {
         return loadSessions().then(function() {

--- a/packages/node_modules/@node-red/editor-api/lib/auth/tokens.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/tokens.js
@@ -25,6 +25,7 @@ var loadedSessions = null;
 var apiAccessTokens;
 var sessionExpiryListeners = [];
 var expiryTimeout;
+let pendingSessionTimeout
 
 function expireSessions() {
     if (expiryTimeout) {
@@ -56,6 +57,28 @@ function expireSessions() {
         return storage.saveSessions(sessions);
     } else {
         return Promise.resolve();
+    }
+}
+function expirePendingSessions() {
+    // Pending sessions are short-lived and do not get persisted to storage.
+    // We can simply iterate over them in memory to remove expired entries.
+    const now = Date.now();
+    let activeCount = 0
+    for (let code in pendingSessions) {
+        if (pendingSessions.hasOwnProperty(code)) {
+            const session = pendingSessions[code];
+            if (session.exchangeCodeExpires < now) {
+                delete pendingSessions[code];
+            } else {
+                activeCount++
+            }
+        }
+    }
+    if (activeCount > 0) {
+        // There are still some active pending sessions - so schedule the next check.
+        pendingSessionTimeout = setTimeout(expirePendingSessions, 30000);
+    } else {
+        pendingSessionTimeout = null;
     }
 }
 function loadSessions() {
@@ -132,6 +155,9 @@ module.exports = {
                 session.exchangeCode = exchangeCode;
                 session.exchangeCodeExpires = Date.now() + (exchangeCodeExpiryTime * 1000);
                 pendingSessions[exchangeCode] = session;
+                if (!pendingSessionTimeout) {
+                    pendingSessionTimeout = setTimeout(expirePendingSessions, 30000);
+                }
                 return Promise.resolve({
                     exchangeCode
                 });

--- a/packages/node_modules/@node-red/editor-api/lib/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/index.js
@@ -84,6 +84,8 @@ function init(settings,_server,storage,runtimeAPI) {
             adminApp.post("/auth/revoke",auth.needsPermission(""),auth.revoke,apiUtil.errorHandler);
         }
 
+        adminApp.post("/auth/token", auth.exchangeCodeForToken, apiUtil.errorHandler);
+
         // Editor
         if (!settings.disableEditor) {
             editor = require("./editor");

--- a/packages/node_modules/@node-red/editor-client/src/js/settings.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/settings.js
@@ -107,22 +107,47 @@ RED.settings = (function () {
     }
 
     var init = function (options, done) {
-        var accessTokenMatch = /[?&]access_token=(.*?)(?:$|&)/.exec(window.location.search);
-        var path=window.location.pathname.slice(0,-1);
-        RED.settings.authTokensSuffix=path.replace(/\//g, '-');
+        RED.settings.apiRootUrl = options.apiRootUrl;
+        const path = window.location.pathname.slice(0,-1);
+        RED.settings.authTokensSuffix = path.replace(/\//g, '-');
+
+        const accessTokenMatch = /[?&]access_token=(.*?)(?:$|&)/.exec(window.location.search);
+
         if (accessTokenMatch) {
-            var accessToken = accessTokenMatch[1];
+            // This is deprecated behaviour, but kept for backward compatibility with 3rd party embedders
+            const accessToken = accessTokenMatch[1];
             RED.settings.set("auth-tokens",{access_token: accessToken});
             window.location.search = "";
         }
-        RED.settings.apiRootUrl = options.apiRootUrl;
 
+        const exchangeCodeMatch = /[?&]code=(.*?)(?:$|&)/.exec(window.location.search);
+        if (exchangeCodeMatch) {
+            const code = exchangeCodeMatch[1];
+            $.ajax({
+                url: 'auth/token',
+                type: "POST",
+                data: { code }
+            }).done(function(tokenResponse) {
+                RED.settings.set("auth-tokens", {access_token: tokenResponse.accessToken});
+                window.location.search = "";
+                postAuthInit(done);
+            }).fail(function(jqXHR, textStatus, errorThrown) {
+                console.log("Error exchanging code for token:", jqXHR.status, textStatus, errorThrown);
+                window.location.search = "";
+                postAuthInit(done);
+            });
+        } else {
+            postAuthInit(done)
+        }
+    }
+
+    const postAuthInit = function (done) {
         $.ajaxSetup({
             beforeSend: function(jqXHR,settings) {
                 // Only attach auth header for requests to relative paths
                 if (!/^\s*(https?:|\/|\.)/.test(settings.url)) {
-                    if (options.apiRootUrl) {
-                        settings.url = options.apiRootUrl+settings.url;
+                    if (RED.settings.apiRootUrl) {
+                        settings.url = RED.settings.apiRootUrl+settings.url;
                     }
                     var auth_tokens = RED.settings.get("auth-tokens");
                     if (auth_tokens) {
@@ -132,7 +157,6 @@ RED.settings = (function () {
                 }
             }
         });
-
         load(done);
     }
 

--- a/test/unit/@node-red/editor-api/lib/auth/tokens_spec.js
+++ b/test/unit/@node-red/editor-api/lib/auth/tokens_spec.js
@@ -153,6 +153,120 @@ describe("api/auth/tokens", function() {
         });
     });
 
+    describe('Exchange code for token', function () {
+        it('creates a token with an exchange code', function (done) {
+            let savedSession;
+            Tokens.init({sessionExpiryTime: 10, exchangeCodeExpiryTime: 0.5},{
+                getSessions:function() {
+                    return Promise.resolve({});
+                },
+                saveSessions:function(sess) {
+                    savedSession = sess;
+                    return Promise.resolve();
+                }
+            });
+            Tokens.create("user", "client", "scope", true).then(function(token) {
+                // When created with an exchange code, the session should not be saved until the code is exchanged
+                should.not.exist(savedSession);
+                token.should.have.a.property('exchangeCode');
+
+                return Tokens.exchangeCodeForToken(token.exchangeCode).then(function(tokenResponse) {
+                    tokenResponse.should.have.a.property('accessToken');
+                    tokenResponse.should.have.a.property('expires_in');
+                    should.exist(savedSession);
+                    var sessionKeys = Object.keys(savedSession);
+                    sessionKeys.should.have.lengthOf(1);
+                    savedSession[sessionKeys[0]].should.have.a.property('user','user');
+                    savedSession[sessionKeys[0]].should.have.a.property('client','client');
+                    savedSession[sessionKeys[0]].should.have.a.property('scope','scope');
+                    savedSession[sessionKeys[0]].should.have.a.property('expires');
+                })
+            }).then(done).catch(err => {
+                done(err)
+            })
+        })
+        it('cannot exchange an invalid code', function (done) {
+            let savedSession;
+            Tokens.init({sessionExpiryTime: 10, exchangeCodeExpiryTime: 0.5},{
+                getSessions:function() {
+                    return Promise.resolve({});
+                },
+                saveSessions:function(sess) {
+                    savedSession = sess;
+                    return Promise.resolve();
+                }
+            });
+            Tokens.create("user", "client", "scope", true).then(function(token) {
+                // When created with an exchange code, the session should not be saved until the code is exchanged
+                should.not.exist(savedSession);
+                token.should.have.a.property('exchangeCode');
+                return Tokens.exchangeCodeForToken('invalid').then(function(tokenResponse) {
+                    throw new Error("Should not have exchanged an invalid code");
+                }).catch(err => {
+                    err.toString().should.match(/Invalid exchange code/);
+                })
+            }).then(done).catch(err => {
+                done(err)
+            })
+        })
+        it('cannot exchange an expired code', function (done) {
+            let savedSession;
+            Tokens.init({sessionExpiryTime: 10, exchangeCodeExpiryTime: 0.1},{
+                getSessions:function() {
+                    return Promise.resolve({});
+                },
+                saveSessions:function(sess) {
+                    savedSession = sess;
+                    return Promise.resolve();
+                }
+            });
+            Tokens.create("user", "client", "scope", true).then(function(token) {
+                // When created with an exchange code, the session should not be saved until the code is exchanged
+                should.not.exist(savedSession);
+                token.should.have.a.property('exchangeCode');
+                return new Promise(resolve => setTimeout(resolve, 200)).then(() => {
+                    return Tokens.exchangeCodeForToken(token.exchangeCode).then(function(tokenResponse) {
+                        throw new Error("Should not have exchanged an invalid code");
+                    }).catch(err => {
+                        err.toString().should.match(/Invalid exchange code/);
+                    })
+                })
+            }).then(done).catch(err => {
+                done(err)
+            })
+        })
+        it('cannot exchange a code twice', function (done) {
+            let savedSession;
+            Tokens.init({sessionExpiryTime: 10, exchangeCodeExpiryTime: 0.1},{
+                getSessions:function() {
+                    return Promise.resolve({});
+                },
+                saveSessions:function(sess) {
+                    savedSession = sess;
+                    return Promise.resolve();
+                }
+            });
+            Tokens.create("user", "client", "scope", true).then(function(token) {
+                // When created with an exchange code, the session should not be saved until the code is exchanged
+                should.not.exist(savedSession);
+                token.should.have.a.property('exchangeCode');
+                return Tokens.exchangeCodeForToken(token.exchangeCode).then(function(tokenResponse) {
+                    tokenResponse.should.have.a.property('accessToken');
+                    tokenResponse.should.have.a.property('expires_in');
+                    return Tokens.exchangeCodeForToken(token.exchangeCode).then(function(tokenResponse) {
+                        throw new Error("Should not have been able to exchange the same code twice");
+                    }).catch(err => {
+                        err.toString().should.match(/Invalid exchange code/);
+                    })
+                }).catch(err => {
+                    err.toString().should.match(/Invalid exchange code/);
+                })
+            }).then(done).catch(err => {
+                done(err)
+            })
+        })
+    })
+
     describe("#revoke", function() {
         it('revokes a token', function(done) {
             var savedSession;


### PR DESCRIPTION
This updates the SAML login flow to use a code exchange at the final step. This avoids including the access token in a redirect uri. Instead, the uri includes a code that can be exchanged for the true access token via a second API call. The exchange code is only valid for 20 seconds and can only be used once. This prevents any session replay issues.