### PR TITLE
Bundle npm to enable cross-platform module management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
                 "node-red-admin": "^4.1.3",
                 "node-watch": "0.7.4",
                 "nopt": "5.0.0",
+                "npm": "10.9.8",
                 "oauth2orize": "1.12.0",
                 "on-headers": "1.1.0",
                 "passport": "0.7.0",
@@ -63,6 +64,7 @@
                 "tough-cookie": "5.1.2",
                 "uglify-js": "3.19.3",
                 "uuid": "9.0.1",
+                "validate-npm-package-name": "7.0.2",
                 "ws": "7.5.10",
                 "xml2js": "0.6.2"
             },
@@ -8303,6 +8305,2331 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/npm": {
+            "version": "10.9.8",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-10.9.8.tgz",
+            "integrity": "sha512-fYwb6ODSmHkqrJQQaCxY3M2lPf/mpgC7ik0HSzzIwG5CGtabRp4bNqikatvCoT42b5INQSqudVH0R7yVmC9hVg==",
+            "bundleDependencies": [
+                "@isaacs/string-locale-compare",
+                "@npmcli/arborist",
+                "@npmcli/config",
+                "@npmcli/fs",
+                "@npmcli/map-workspaces",
+                "@npmcli/package-json",
+                "@npmcli/promise-spawn",
+                "@npmcli/redact",
+                "@npmcli/run-script",
+                "@sigstore/tuf",
+                "abbrev",
+                "archy",
+                "cacache",
+                "chalk",
+                "ci-info",
+                "cli-columns",
+                "fastest-levenshtein",
+                "fs-minipass",
+                "glob",
+                "graceful-fs",
+                "hosted-git-info",
+                "ini",
+                "init-package-json",
+                "is-cidr",
+                "json-parse-even-better-errors",
+                "libnpmaccess",
+                "libnpmdiff",
+                "libnpmexec",
+                "libnpmfund",
+                "libnpmhook",
+                "libnpmorg",
+                "libnpmpack",
+                "libnpmpublish",
+                "libnpmsearch",
+                "libnpmteam",
+                "libnpmversion",
+                "make-fetch-happen",
+                "minimatch",
+                "minipass",
+                "minipass-pipeline",
+                "ms",
+                "node-gyp",
+                "nopt",
+                "normalize-package-data",
+                "npm-audit-report",
+                "npm-install-checks",
+                "npm-package-arg",
+                "npm-pick-manifest",
+                "npm-profile",
+                "npm-registry-fetch",
+                "npm-user-validate",
+                "p-map",
+                "pacote",
+                "parse-conflict-json",
+                "proc-log",
+                "qrcode-terminal",
+                "read",
+                "semver",
+                "spdx-expression-parse",
+                "ssri",
+                "supports-color",
+                "tar",
+                "text-table",
+                "tiny-relative-date",
+                "treeverse",
+                "validate-npm-package-name",
+                "which",
+                "write-file-atomic"
+            ],
+            "license": "Artistic-2.0",
+            "workspaces": [
+                "docs",
+                "smoke-tests",
+                "mock-globals",
+                "mock-registry",
+                "workspaces/*"
+            ],
+            "dependencies": {
+                "@isaacs/string-locale-compare": "^1.1.0",
+                "@npmcli/arborist": "^8.0.5",
+                "@npmcli/config": "^9.0.0",
+                "@npmcli/fs": "^4.0.0",
+                "@npmcli/map-workspaces": "^4.0.2",
+                "@npmcli/package-json": "^6.2.0",
+                "@npmcli/promise-spawn": "^8.0.3",
+                "@npmcli/redact": "^3.2.2",
+                "@npmcli/run-script": "^9.1.0",
+                "@sigstore/tuf": "^3.1.1",
+                "abbrev": "^3.0.1",
+                "archy": "~1.0.0",
+                "cacache": "^19.0.1",
+                "chalk": "^5.6.2",
+                "ci-info": "^4.4.0",
+                "cli-columns": "^4.0.0",
+                "fastest-levenshtein": "^1.0.16",
+                "fs-minipass": "^3.0.3",
+                "glob": "^10.5.0",
+                "graceful-fs": "^4.2.11",
+                "hosted-git-info": "^8.1.0",
+                "ini": "^5.0.0",
+                "init-package-json": "^7.0.2",
+                "is-cidr": "^5.1.1",
+                "json-parse-even-better-errors": "^4.0.0",
+                "libnpmaccess": "^9.0.0",
+                "libnpmdiff": "^7.0.5",
+                "libnpmexec": "^9.0.5",
+                "libnpmfund": "^6.0.5",
+                "libnpmhook": "^11.0.0",
+                "libnpmorg": "^7.0.0",
+                "libnpmpack": "^8.0.5",
+                "libnpmpublish": "^10.0.2",
+                "libnpmsearch": "^8.0.0",
+                "libnpmteam": "^7.0.0",
+                "libnpmversion": "^7.0.0",
+                "make-fetch-happen": "^14.0.3",
+                "minimatch": "^9.0.9",
+                "minipass": "^7.1.3",
+                "minipass-pipeline": "^1.2.4",
+                "ms": "^2.1.2",
+                "node-gyp": "^11.5.0",
+                "nopt": "^8.1.0",
+                "normalize-package-data": "^7.0.1",
+                "npm-audit-report": "^6.0.0",
+                "npm-install-checks": "^7.1.2",
+                "npm-package-arg": "^12.0.2",
+                "npm-pick-manifest": "^10.0.0",
+                "npm-profile": "^11.0.1",
+                "npm-registry-fetch": "^18.0.2",
+                "npm-user-validate": "^3.0.0",
+                "p-map": "^7.0.4",
+                "pacote": "^19.0.1",
+                "parse-conflict-json": "^4.0.0",
+                "proc-log": "^5.0.0",
+                "qrcode-terminal": "^0.12.0",
+                "read": "^4.1.0",
+                "semver": "^7.7.4",
+                "spdx-expression-parse": "^4.0.0",
+                "ssri": "^12.0.0",
+                "supports-color": "^9.4.0",
+                "tar": "^7.5.11",
+                "text-table": "~0.2.0",
+                "tiny-relative-date": "^1.3.0",
+                "treeverse": "^3.0.0",
+                "validate-npm-package-name": "^6.0.2",
+                "which": "^5.0.0",
+                "write-file-atomic": "^6.0.0"
+            },
+            "bin": {
+                "npm": "bin/npm-cli.js",
+                "npx": "bin/npx-cli.js"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
+            "version": "1.1.0",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/@npmcli/agent": {
+            "version": "3.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.1",
+                "lru-cache": "^10.0.1",
+                "socks-proxy-agent": "^8.0.3"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/arborist": {
+            "version": "8.0.5",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@isaacs/string-locale-compare": "^1.1.0",
+                "@npmcli/fs": "^4.0.0",
+                "@npmcli/installed-package-contents": "^3.0.0",
+                "@npmcli/map-workspaces": "^4.0.1",
+                "@npmcli/metavuln-calculator": "^8.0.0",
+                "@npmcli/name-from-folder": "^3.0.0",
+                "@npmcli/node-gyp": "^4.0.0",
+                "@npmcli/package-json": "^6.0.1",
+                "@npmcli/query": "^4.0.0",
+                "@npmcli/redact": "^3.0.0",
+                "@npmcli/run-script": "^9.0.1",
+                "bin-links": "^5.0.0",
+                "cacache": "^19.0.1",
+                "common-ancestor-path": "^1.0.1",
+                "hosted-git-info": "^8.0.0",
+                "json-parse-even-better-errors": "^4.0.0",
+                "json-stringify-nice": "^1.1.4",
+                "lru-cache": "^10.2.2",
+                "minimatch": "^9.0.4",
+                "nopt": "^8.0.0",
+                "npm-install-checks": "^7.1.0",
+                "npm-package-arg": "^12.0.0",
+                "npm-pick-manifest": "^10.0.0",
+                "npm-registry-fetch": "^18.0.1",
+                "pacote": "^19.0.0",
+                "parse-conflict-json": "^4.0.0",
+                "proc-log": "^5.0.0",
+                "proggy": "^3.0.0",
+                "promise-all-reject-late": "^1.0.0",
+                "promise-call-limit": "^3.0.1",
+                "promise-retry": "^2.0.1",
+                "read-package-json-fast": "^4.0.0",
+                "semver": "^7.3.7",
+                "ssri": "^12.0.0",
+                "treeverse": "^3.0.0",
+                "walk-up-path": "^3.0.1"
+            },
+            "bin": {
+                "arborist": "bin/index.js"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/config": {
+            "version": "9.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/map-workspaces": "^4.0.1",
+                "@npmcli/package-json": "^6.0.1",
+                "ci-info": "^4.0.0",
+                "ini": "^5.0.0",
+                "nopt": "^8.0.0",
+                "proc-log": "^5.0.0",
+                "semver": "^7.3.5",
+                "walk-up-path": "^3.0.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/fs": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/git": {
+            "version": "6.0.3",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/promise-spawn": "^8.0.0",
+                "ini": "^5.0.0",
+                "lru-cache": "^10.0.1",
+                "npm-pick-manifest": "^10.0.0",
+                "proc-log": "^5.0.0",
+                "promise-retry": "^2.0.1",
+                "semver": "^7.3.5",
+                "which": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
+            "version": "3.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-bundled": "^4.0.0",
+                "npm-normalize-package-bin": "^4.0.0"
+            },
+            "bin": {
+                "installed-package-contents": "bin/index.js"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/map-workspaces": {
+            "version": "4.0.2",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/name-from-folder": "^3.0.0",
+                "@npmcli/package-json": "^6.0.0",
+                "glob": "^10.2.2",
+                "minimatch": "^9.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
+            "version": "8.0.1",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "cacache": "^19.0.0",
+                "json-parse-even-better-errors": "^4.0.0",
+                "pacote": "^20.0.0",
+                "proc-log": "^5.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
+            "version": "20.0.1",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/git": "^6.0.0",
+                "@npmcli/installed-package-contents": "^3.0.0",
+                "@npmcli/package-json": "^6.0.0",
+                "@npmcli/promise-spawn": "^8.0.0",
+                "@npmcli/run-script": "^9.0.0",
+                "cacache": "^19.0.0",
+                "fs-minipass": "^3.0.0",
+                "minipass": "^7.0.2",
+                "npm-package-arg": "^12.0.0",
+                "npm-packlist": "^9.0.0",
+                "npm-pick-manifest": "^10.0.0",
+                "npm-registry-fetch": "^18.0.0",
+                "proc-log": "^5.0.0",
+                "promise-retry": "^2.0.1",
+                "sigstore": "^3.0.0",
+                "ssri": "^12.0.0",
+                "tar": "^7.5.10"
+            },
+            "bin": {
+                "pacote": "bin/index.js"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/name-from-folder": {
+            "version": "3.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/node-gyp": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/package-json": {
+            "version": "6.2.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/git": "^6.0.0",
+                "glob": "^10.2.2",
+                "hosted-git-info": "^8.0.0",
+                "json-parse-even-better-errors": "^4.0.0",
+                "proc-log": "^5.0.0",
+                "semver": "^7.5.3",
+                "validate-npm-package-license": "^3.0.4"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/promise-spawn": {
+            "version": "8.0.3",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "which": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/query": {
+            "version": "4.0.1",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "postcss-selector-parser": "^7.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/redact": {
+            "version": "3.2.2",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/run-script": {
+            "version": "9.1.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/node-gyp": "^4.0.0",
+                "@npmcli/package-json": "^6.0.0",
+                "@npmcli/promise-spawn": "^8.0.0",
+                "node-gyp": "^11.0.0",
+                "proc-log": "^5.0.0",
+                "which": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/bundle": {
+            "version": "3.1.0",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/protobuf-specs": "^0.4.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/core": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+            "version": "0.4.3",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/sign": {
+            "version": "3.1.0",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/bundle": "^3.1.0",
+                "@sigstore/core": "^2.0.0",
+                "@sigstore/protobuf-specs": "^0.4.0",
+                "make-fetch-happen": "^14.0.2",
+                "proc-log": "^5.0.0",
+                "promise-retry": "^2.0.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/tuf": {
+            "version": "3.1.1",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/protobuf-specs": "^0.4.1",
+                "tuf-js": "^3.0.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/verify": {
+            "version": "2.1.1",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/bundle": "^3.1.0",
+                "@sigstore/core": "^2.0.0",
+                "@sigstore/protobuf-specs": "^0.4.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@tufjs/canonical-json": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/abbrev": {
+            "version": "3.0.1",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/agent-base": {
+            "version": "7.1.4",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/npm/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/aproba": {
+            "version": "2.1.0",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/archy": {
+            "version": "1.0.0",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/bin-links": {
+            "version": "5.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "cmd-shim": "^7.0.0",
+                "npm-normalize-package-bin": "^4.0.0",
+                "proc-log": "^5.0.0",
+                "read-cmd-shim": "^5.0.0",
+                "write-file-atomic": "^6.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/binary-extensions": {
+            "version": "2.3.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/cacache": {
+            "version": "19.0.1",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/fs": "^4.0.0",
+                "fs-minipass": "^3.0.0",
+                "glob": "^10.2.2",
+                "lru-cache": "^10.0.1",
+                "minipass": "^7.0.3",
+                "minipass-collect": "^2.0.1",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "p-map": "^7.0.2",
+                "ssri": "^12.0.0",
+                "tar": "^7.4.3",
+                "unique-filename": "^4.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/chalk": {
+            "version": "5.6.2",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/chownr": {
+            "version": "3.0.0",
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/npm/node_modules/ci-info": {
+            "version": "4.4.0",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/cidr-regex": {
+            "version": "4.1.3",
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "ip-regex": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/npm/node_modules/cli-columns": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/npm/node_modules/cmd-shim": {
+            "version": "7.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/color-convert": {
+            "version": "2.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/color-name": {
+            "version": "1.1.4",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/common-ancestor-path": {
+            "version": "1.0.1",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
+            "version": "2.0.2",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/npm/node_modules/cssesc": {
+            "version": "3.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "bin": {
+                "cssesc": "bin/cssesc"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/debug": {
+            "version": "4.4.3",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/npm/node_modules/diff": {
+            "version": "5.2.2",
+            "inBundle": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/npm/node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/encoding": {
+            "version": "0.1.13",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "iconv-lite": "^0.6.2"
+            }
+        },
+        "node_modules/npm/node_modules/env-paths": {
+            "version": "2.2.1",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/npm/node_modules/err-code": {
+            "version": "2.0.3",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/exponential-backoff": {
+            "version": "3.1.3",
+            "inBundle": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/npm/node_modules/fastest-levenshtein": {
+            "version": "1.0.16",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.9.1"
+            }
+        },
+        "node_modules/npm/node_modules/fdir": {
+            "version": "6.5.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/npm/node_modules/foreground-child": {
+            "version": "3.3.1",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/fs-minipass": {
+            "version": "3.0.3",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/glob": {
+            "version": "10.5.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/hosted-git-info": {
+            "version": "8.1.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^10.0.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/http-cache-semantics": {
+            "version": "4.2.0",
+            "inBundle": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/npm/node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/npm/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/npm/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/ignore-walk": {
+            "version": "7.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minimatch": "^9.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/imurmurhash": {
+            "version": "0.1.4",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.19"
+            }
+        },
+        "node_modules/npm/node_modules/ini": {
+            "version": "5.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/init-package-json": {
+            "version": "7.0.2",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/package-json": "^6.0.0",
+                "npm-package-arg": "^12.0.0",
+                "promzard": "^2.0.0",
+                "read": "^4.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-license": "^3.0.4",
+                "validate-npm-package-name": "^6.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/ip-address": {
+            "version": "10.1.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/npm/node_modules/ip-regex": {
+            "version": "5.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm/node_modules/is-cidr": {
+            "version": "5.1.1",
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "cidr-regex": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/npm/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/isexe": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/jackspeak": {
+            "version": "3.4.3",
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/npm/node_modules/json-parse-even-better-errors": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/json-stringify-nice": {
+            "version": "1.1.4",
+            "inBundle": true,
+            "license": "ISC",
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/jsonparse": {
+            "version": "1.3.1",
+            "engines": [
+                "node >= 0.2.0"
+            ],
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/just-diff": {
+            "version": "6.0.2",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/just-diff-apply": {
+            "version": "5.5.0",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/libnpmaccess": {
+            "version": "9.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-package-arg": "^12.0.0",
+                "npm-registry-fetch": "^18.0.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmdiff": {
+            "version": "7.0.5",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/arborist": "^8.0.5",
+                "@npmcli/installed-package-contents": "^3.0.0",
+                "binary-extensions": "^2.3.0",
+                "diff": "^5.1.0",
+                "minimatch": "^9.0.4",
+                "npm-package-arg": "^12.0.0",
+                "pacote": "^19.0.0",
+                "tar": "^7.5.11"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmexec": {
+            "version": "9.0.5",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/arborist": "^8.0.5",
+                "@npmcli/run-script": "^9.0.1",
+                "ci-info": "^4.0.0",
+                "npm-package-arg": "^12.0.0",
+                "pacote": "^19.0.0",
+                "proc-log": "^5.0.0",
+                "read": "^4.0.0",
+                "read-package-json-fast": "^4.0.0",
+                "semver": "^7.3.7",
+                "walk-up-path": "^3.0.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmfund": {
+            "version": "6.0.5",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/arborist": "^8.0.5"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmhook": {
+            "version": "11.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^2.0.0",
+                "npm-registry-fetch": "^18.0.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmorg": {
+            "version": "7.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^2.0.0",
+                "npm-registry-fetch": "^18.0.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmpack": {
+            "version": "8.0.5",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/arborist": "^8.0.5",
+                "@npmcli/run-script": "^9.0.1",
+                "npm-package-arg": "^12.0.0",
+                "pacote": "^19.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmpublish": {
+            "version": "10.0.2",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "ci-info": "^4.0.0",
+                "normalize-package-data": "^7.0.0",
+                "npm-package-arg": "^12.0.0",
+                "npm-registry-fetch": "^18.0.1",
+                "proc-log": "^5.0.0",
+                "semver": "^7.3.7",
+                "sigstore": "^3.0.0",
+                "ssri": "^12.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmsearch": {
+            "version": "8.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-registry-fetch": "^18.0.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmteam": {
+            "version": "7.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^2.0.0",
+                "npm-registry-fetch": "^18.0.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmversion": {
+            "version": "7.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/git": "^6.0.1",
+                "@npmcli/run-script": "^9.0.1",
+                "json-parse-even-better-errors": "^4.0.0",
+                "proc-log": "^5.0.0",
+                "semver": "^7.3.7"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/make-fetch-happen": {
+            "version": "14.0.3",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/agent": "^3.0.0",
+                "cacache": "^19.0.1",
+                "http-cache-semantics": "^4.1.1",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^4.0.0",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^1.0.0",
+                "proc-log": "^5.0.0",
+                "promise-retry": "^2.0.1",
+                "ssri": "^12.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/minimatch": {
+            "version": "9.0.9",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/minipass": {
+            "version": "7.1.3",
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-collect": {
+            "version": "2.0.1",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-fetch": {
+            "version": "4.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.0.3",
+                "minipass-sized": "^1.0.3",
+                "minizlib": "^3.0.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            },
+            "optionalDependencies": {
+                "encoding": "^0.1.13"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-flush": {
+            "version": "1.0.5",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
+            "version": "3.3.6",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/minipass-pipeline": {
+            "version": "1.2.4",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
+            "version": "3.3.6",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/minipass-sized": {
+            "version": "1.0.3",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
+            "version": "3.3.6",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-sized/node_modules/yallist": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/minizlib": {
+            "version": "3.1.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/npm/node_modules/ms": {
+            "version": "2.1.3",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/mute-stream": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/negotiator": {
+            "version": "1.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/npm/node_modules/node-gyp": {
+            "version": "11.5.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "env-paths": "^2.2.0",
+                "exponential-backoff": "^3.1.1",
+                "graceful-fs": "^4.2.6",
+                "make-fetch-happen": "^14.0.3",
+                "nopt": "^8.0.0",
+                "proc-log": "^5.0.0",
+                "semver": "^7.3.5",
+                "tar": "^7.4.3",
+                "tinyglobby": "^0.2.12",
+                "which": "^5.0.0"
+            },
+            "bin": {
+                "node-gyp": "bin/node-gyp.js"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/nopt": {
+            "version": "8.1.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^3.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/normalize-package-data": {
+            "version": "7.0.1",
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^8.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-license": "^3.0.4"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-audit-report": {
+            "version": "6.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-bundled": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-normalize-package-bin": "^4.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-install-checks": {
+            "version": "7.1.2",
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "semver": "^7.1.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-normalize-package-bin": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-package-arg": {
+            "version": "12.0.2",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "hosted-git-info": "^8.0.0",
+                "proc-log": "^5.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-name": "^6.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-packlist": {
+            "version": "9.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "ignore-walk": "^7.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-pick-manifest": {
+            "version": "10.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-install-checks": "^7.1.0",
+                "npm-normalize-package-bin": "^4.0.0",
+                "npm-package-arg": "^12.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-profile": {
+            "version": "11.0.1",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-registry-fetch": "^18.0.0",
+                "proc-log": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-registry-fetch": {
+            "version": "18.0.2",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/redact": "^3.0.0",
+                "jsonparse": "^1.3.1",
+                "make-fetch-happen": "^14.0.0",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^4.0.0",
+                "minizlib": "^3.0.1",
+                "npm-package-arg": "^12.0.0",
+                "proc-log": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-user-validate": {
+            "version": "3.0.0",
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/p-map": {
+            "version": "7.0.4",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm/node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "inBundle": true,
+            "license": "BlueOak-1.0.0"
+        },
+        "node_modules/npm/node_modules/pacote": {
+            "version": "19.0.2",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/git": "^6.0.0",
+                "@npmcli/installed-package-contents": "^3.0.0",
+                "@npmcli/package-json": "^6.0.0",
+                "@npmcli/promise-spawn": "^8.0.0",
+                "@npmcli/run-script": "^9.0.0",
+                "cacache": "^19.0.0",
+                "fs-minipass": "^3.0.0",
+                "minipass": "^7.0.2",
+                "npm-package-arg": "^12.0.0",
+                "npm-packlist": "^9.0.0",
+                "npm-pick-manifest": "^10.0.0",
+                "npm-registry-fetch": "^18.0.0",
+                "proc-log": "^5.0.0",
+                "promise-retry": "^2.0.1",
+                "sigstore": "^3.0.0",
+                "ssri": "^12.0.0",
+                "tar": "^7.5.10"
+            },
+            "bin": {
+                "pacote": "bin/index.js"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/parse-conflict-json": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "json-parse-even-better-errors": "^4.0.0",
+                "just-diff": "^6.0.0",
+                "just-diff-apply": "^5.2.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/path-key": {
+            "version": "3.1.1",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/path-scurry": {
+            "version": "1.11.1",
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/picomatch": {
+            "version": "4.0.3",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/npm/node_modules/postcss-selector-parser": {
+            "version": "7.1.1",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/proc-log": {
+            "version": "5.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/proggy": {
+            "version": "3.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/promise-all-reject-late": {
+            "version": "1.0.1",
+            "inBundle": true,
+            "license": "ISC",
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/promise-call-limit": {
+            "version": "3.0.2",
+            "inBundle": true,
+            "license": "ISC",
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/promise-retry": {
+            "version": "2.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "err-code": "^2.0.2",
+                "retry": "^0.12.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/npm/node_modules/promzard": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "read": "^4.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/qrcode-terminal": {
+            "version": "0.12.0",
+            "inBundle": true,
+            "bin": {
+                "qrcode-terminal": "bin/qrcode-terminal.js"
+            }
+        },
+        "node_modules/npm/node_modules/read": {
+            "version": "4.1.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "mute-stream": "^2.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/read-cmd-shim": {
+            "version": "5.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/read-package-json-fast": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "json-parse-even-better-errors": "^4.0.0",
+                "npm-normalize-package-bin": "^4.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/retry": {
+            "version": "0.12.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/npm/node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/npm/node_modules/semver": {
+            "version": "7.7.4",
+            "inBundle": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/npm/node_modules/shebang-command": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/sigstore": {
+            "version": "3.1.0",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/bundle": "^3.1.0",
+                "@sigstore/core": "^2.0.0",
+                "@sigstore/protobuf-specs": "^0.4.0",
+                "@sigstore/sign": "^3.1.0",
+                "@sigstore/tuf": "^3.1.0",
+                "@sigstore/verify": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/smart-buffer": {
+            "version": "4.2.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/socks": {
+            "version": "2.8.7",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ip-address": "^10.0.1",
+                "smart-buffer": "^4.2.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/socks-proxy-agent": {
+            "version": "8.0.5",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/npm/node_modules/spdx-correct": {
+            "version": "3.2.0",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/spdx-exceptions": {
+            "version": "2.5.0",
+            "inBundle": true,
+            "license": "CC-BY-3.0"
+        },
+        "node_modules/npm/node_modules/spdx-expression-parse": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/spdx-license-ids": {
+            "version": "3.0.23",
+            "inBundle": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/npm/node_modules/ssri": {
+            "version": "12.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/string-width": {
+            "version": "4.2.3",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/supports-color": {
+            "version": "9.4.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/tar": {
+            "version": "7.5.11",
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.1.0",
+                "yallist": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/npm/node_modules/text-table": {
+            "version": "0.2.0",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/tiny-relative-date": {
+            "version": "1.3.0",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/tinyglobby": {
+            "version": "0.2.15",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/npm/node_modules/treeverse": {
+            "version": "3.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/tuf-js": {
+            "version": "3.1.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tufjs/models": "3.0.1",
+                "debug": "^4.4.1",
+                "make-fetch-happen": "^14.0.3"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
+            "version": "3.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tufjs/canonical-json": "2.0.0",
+                "minimatch": "^9.0.5"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/unique-filename": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "unique-slug": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/unique-slug": {
+            "version": "5.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "imurmurhash": "^0.1.4"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/validate-npm-package-license": {
+            "version": "3.0.4",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/validate-npm-package-name": {
+            "version": "6.0.2",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/walk-up-path": {
+            "version": "3.0.1",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/which": {
+            "version": "5.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^3.1.1"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/which/node_modules/isexe": {
+            "version": "3.1.5",
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "5.1.2",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/write-file-atomic": {
+            "version": "6.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/yallist": {
+            "version": "5.0.0",
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/nth-check": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -11417,6 +13744,15 @@
             "dependencies": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "node_modules/validate-npm-package-name": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+            "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "node-red-admin": "^4.1.3",
         "node-watch": "0.7.4",
         "nopt": "5.0.0",
+        "npm": "10.9.8",
         "oauth2orize": "1.12.0",
         "on-headers": "1.1.0",
         "passport": "0.7.0",
@@ -80,6 +81,7 @@
         "tough-cookie": "5.1.2",
         "uglify-js": "3.19.3",
         "uuid": "9.0.1",
+        "validate-npm-package-name": "7.0.2",
         "ws": "7.5.10",
         "xml2js": "0.6.2"
     },

--- a/packages/node_modules/@node-red/registry/lib/externalModules.js
+++ b/packages/node_modules/@node-red/registry/lib/externalModules.js
@@ -12,11 +12,13 @@ const log = require("@node-red/util").log;
 const hooks = require("@node-red/util").hooks;
 const url = require("url");
 const { createRequire } = require("module");
+const validateNpmPackageName = require("validate-npm-package-name");
 
 const BUILTIN_MODULES = require('module').builtinModules;
 
-// TODO: outsource running npm to a plugin
-const NPM_COMMAND = (process.platform === "win32") ? "npm.cmd" : "npm";
+const npmPackageJson = require.resolve('npm/package.json')
+const npmRoot = path.dirname(npmPackageJson);
+const npmCli = path.join(npmRoot, 'bin', 'npm-cli.js');
 
 let registeredTypes = {};
 let subflowTypes = {};
@@ -246,6 +248,11 @@ async function installModule(moduleDetails) {
             e.code = "install_not_allowed";
             throw e;
         }
+        if (!validateNpmPackageName(moduleDetails.module).validForOldPackages) {
+            const e = new Error("Invalid module name");
+            e.code = "install_not_allowed";
+            throw e;
+        }
         if (moduleDetails.version) {
             installSpec = installSpec+"@"+moduleDetails.version;
         }
@@ -265,9 +272,10 @@ async function installModule(moduleDetails) {
             // - run install
             if (result !== false) {
                 let extraArgs = triggerPayload.args || [];
-                let args = ['install', ...extraArgs, installSpec]
-                log.trace(NPM_COMMAND + JSON.stringify(args));
-                return exec.run(NPM_COMMAND, args, { cwd: installDir, shell: true },true)
+                let args = [npmCli, 'install', ...extraArgs, '--', installSpec]
+                log.trace(`${process.execPath} ${npmCli} ${JSON.stringify(args)}`);
+                console.log('HIT EM ONE')
+                return exec.run(process.execPath, args, { cwd: installDir },true)
             } else {
                 log.trace("skipping npm install");
             }

--- a/packages/node_modules/@node-red/registry/lib/installer.js
+++ b/packages/node_modules/@node-red/registry/lib/installer.js
@@ -173,13 +173,15 @@ async function installModule(module,version,url) {
             e.code = "invalid_module_name";
             throw e;
         }
-        let installVersion = version;
-        if (isRegistryPackage) {
-            // For an registry module, this will validate the version exists before trying to install it
-            // It will throw an error if the version doesn't exist.
-            installVersion = await getModuleVersionFromNPM(module, version);
-        }
+
         if (!installAllAllowed) {
+            let installVersion = version;
+            if (isRegistryPackage) {
+                // For an registry module, this will validate the version exists before trying to install it
+                // It will throw an error if the version doesn't exist.
+                installVersion = await getModuleVersionFromNPM(module, version);
+            }
+
             if (!registryUtil.checkModuleAllowed(module,installVersion,installAllowList,installDenyList)) {
                 const e = new Error("Install not allowed");
                 e.code = "install_not_allowed";

--- a/packages/node_modules/@node-red/registry/lib/installer.js
+++ b/packages/node_modules/@node-red/registry/lib/installer.js
@@ -29,12 +29,16 @@ const child_process = require('child_process');
 const plugins = require("./plugins");
 
 const isWindows = process.platform === 'win32'
-const npmCommand =  isWindows ? 'npm.cmd' : 'npm';
+
+const npmPackageJson = require.resolve('npm/package.json')
+const npmRoot = path.dirname(npmPackageJson);
+const npmCli = path.join(npmRoot, 'bin', 'npm-cli.js');
+
+const validateNpmPackageName = require("validate-npm-package-name");
 
 let installerEnabled = false;
 let settings;
 
-const moduleRe = /^(@[^/@]+?[/])?[^/@]+?$/;
 const slashRe = isWindows ? /\\|[/]/ : /[/]/;
 const pkgurlRe = /^(https?|git(|\+https?|\+ssh|\+file)):\/\//;
 const localtgzRe = /^([a-zA-Z]:|\/).+tgz$/;
@@ -152,8 +156,8 @@ async function installModule(module,version,url) {
                 e.code = "invalid_module_url";
                 throw e;
             }
-        } else if (moduleRe.test(module)) {
-            // Simple module name - assume it can be npm installed
+        } else if (validateNpmPackageName(module).validForOldPackages) {
+            // A valid npm module name
             if (version) {
                 installName += "@"+version;
             }
@@ -169,12 +173,13 @@ async function installModule(module,version,url) {
             e.code = "invalid_module_name";
             throw e;
         }
+        let installVersion = version;
+        if (isRegistryPackage) {
+            // For an registry module, this will validate the version exists before trying to install it
+            // It will throw an error if the version doesn't exist.
+            installVersion = await getModuleVersionFromNPM(module, version);
+        }
         if (!installAllAllowed) {
-            let installVersion = version;
-            if (installVersionRestricted && isRegistryPackage) {
-                installVersion = await getModuleVersionFromNPM(module, version);
-            }
-
             if (!registryUtil.checkModuleAllowed(module,installVersion,installAllowList,installDenyList)) {
                 const e = new Error("Install not allowed");
                 e.code = "install_not_allowed";
@@ -228,9 +233,9 @@ async function installModule(module,version,url) {
             // - run install
             if (result !== false) {
                 let extraArgs = triggerPayload.args || [];
-                let args = ['install', ...extraArgs, installName]
-                log.trace(npmCommand + JSON.stringify(args));
-                return exec.run(npmCommand,args,{ cwd: installDir, shell: true }, true)
+                let args = [npmCli, 'install', ...extraArgs, '--', installName]
+                log.trace(`${process.execPath} ${npmCli} ${JSON.stringify(args)}`);
+                return exec.run(process.execPath, args, { cwd: installDir }, true)
             } else {
                 log.trace("skipping npm install");
             }
@@ -265,7 +270,7 @@ async function installModule(module,version,url) {
                 log.warn("------------------------------------------");
                 e = new Error(log._("server.install.install-failed")+": "+err.toString());
                 if (err.hook === "postInstall") {
-                    return exec.run(npmCommand,["remove",module],{ cwd: installDir, shell: true }, false).finally(() => {
+                    return exec.run(process.execPath, [npmCli, "remove", module],{ cwd: installDir }, false).finally(() => {
                         throw e;
                     })
                 }
@@ -370,7 +375,7 @@ async function getModuleVersionFromNPM(module, version) {
     
 
     return new Promise((resolve, reject) => {
-        child_process.execFile(`${npmCommand} info --json ${installName}`, { shell: true },function(err,stdout,stderr) {
+        child_process.execFile(process.execPath, [npmCli, 'info', '--json', '--', installName], function(err,stdout,stderr) {
             try {
                 if (!stdout) {
                     log.warn(log._("server.install.install-failed-not-found",{name:module}));
@@ -381,6 +386,7 @@ async function getModuleVersionFromNPM(module, version) {
                 }
                 const response = JSON.parse(stdout);
                 if (response.error) {
+                    console.log(response)
                     if (response.error.code === "E404") {
                         log.warn(log._("server.install.install-failed-not-found",{name:module}));
                         e = new Error("Module not found");
@@ -495,9 +501,13 @@ async function getTarballModuleInfo(tarball) {
 }
 
 function uninstallModule(module) {
+    // This function is called when the admin api is called to remove a module.
+    // A check in node.js#removeModule verifies the module being removed is already in the registry
+    // as a user module. As such, we can have confidence that the `module` passed here is 
+    // a valid and recognised module name.
     activePromise = activePromise.then(() => {
         return new Promise((resolve,reject) => {
-            if (/[\s;]/.test(module)) {
+            if (/[.\s;]/.test(module)) {
                 reject(new Error(log._("server.install.invalid")));
                 return;
             }
@@ -527,9 +537,9 @@ function uninstallModule(module) {
                 // - run uninstall
                 if (result !== false) {
                     let extraArgs = triggerPayload.args || [];
-                    let args = ['remove', ...extraArgs, module]
-                    log.trace(npmCommand + JSON.stringify(args));
-                    return exec.run(npmCommand,args,{ cwd: installDir, shell: true }, true)
+                    let args = [npmCli, 'remove', ...extraArgs, '--', module]
+                    log.trace(`${process.execPath} ${npmCli} ${JSON.stringify(args)}`);
+                    return exec.run(process.execPath, args, { cwd: installDir }, true)
                 } else {
                     log.trace("skipping npm uninstall");
                 }
@@ -596,7 +606,7 @@ async function checkPrereq() {
         installerEnabled = false;
     } else {
         return new Promise(resolve => {
-            child_process.execFile(`${npmCommand} -v`,{ shell: true },function(err,stdout) {
+            child_process.execFile(process.execPath, [npmCli, '-v'], function(err,stdout) {
                 if (err) {
                     log.info(log._("server.palette-editor.npm-not-found"));
                     installerEnabled = false;

--- a/packages/node_modules/@node-red/registry/package.json
+++ b/packages/node_modules/@node-red/registry/package.json
@@ -19,8 +19,10 @@
         "@node-red/util": "4.1.8",
         "clone": "2.1.2",
         "fs-extra": "11.3.0",
+        "npm": "10.9.8",
         "semver": "7.7.4",
         "tar": "7.5.12",
-        "uglify-js": "3.19.3"
+        "uglify-js": "3.19.3",
+        "validate-npm-package-name": "7.0.2"
     }
 }

--- a/test/unit/@node-red/registry/lib/installer_spec.js
+++ b/test/unit/@node-red/registry/lib/installer_spec.js
@@ -275,7 +275,10 @@ describe('nodes/registry/installer', function() {
             });
 
             installer.installModule("foo",null,"/example path/foo-0.1.1.tgz").then(function(info) {
-                exec.run.lastCall.args[1].should.eql([ 'install', '--no-audit', '--no-update-notifier', '--no-fund', '--save', '--save-prefix=~', '--omit=dev', '--engine-strict', '"/example path/foo-0.1.1.tgz"' ]);
+                const lastCallArgs = exec.run.lastCall.args[1];
+                lastCallArgs[0].should.match(/npm\/bin\/npm-cli\.js$/)
+                const remainingArgs = lastCallArgs.slice(1);
+                remainingArgs.should.eql([ 'install', '--no-audit', '--no-update-notifier', '--no-fund', '--save', '--save-prefix=~', '--omit=dev', '--engine-strict', '--', '"/example path/foo-0.1.1.tgz"' ]);
                 info.should.eql(nodeInfo);
                 done();
             }).catch(done);
@@ -297,7 +300,7 @@ describe('nodes/registry/installer', function() {
 
             installer.installModule("this_wont_exist","1.2.3").then(function(info) {
                 exec.run.called.should.be.true();
-                exec.run.lastCall.args[1].should.eql([ 'install', 'a', 'this_wont_exist@1.2.3' ]);
+                exec.run.lastCall.args[1].slice(1).should.eql([ 'install', 'a', '--', 'this_wont_exist@1.2.3' ]);
                 info.should.eql(nodeInfo);
                 should.exist(receivedPreEvent)
                 receivedPreEvent.should.have.property("module","this_wont_exist")


### PR DESCRIPTION
This changes our approach to handle `npm` within the palette manager.

Previously, we relied on it being installed and on the path. However, this had an unintended side-effect on Windows; as it is provided as a `.cmd` file, our means of calling it meant we needed comprehensive sanitising of user-provided values to ensure correct behaviour.

With this PR, we now have `npm` as an explicit dependency, meaning we can invoke it directly without going via the `.cmd` file. This allows us to apply proper argument handling and avoid any risk of unintended command execution.

I have tested this on Mac and Windows across the a number of scenarios, both golden and error paths.