### PR TITLE
Indicate that "use-tls" label is using a custom config

### DIFF
--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -533,7 +533,7 @@
         },
         "setby": "- set by msg.method -",
         "basicauth": "Use authentication",
-        "use-tls": "Enable secure (SSL/TLS) connection",
+        "use-tls": "Use custom SSL/TLS configuration",
         "tls-config": "TLS Configuration",
         "basic": "basic authentication",
         "digest": "digest authentication",


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Currently the label in the http-request node is "Enable secure (SSL/TLS) connection". I think this is confusing, because TLS is used by default for https requests. I think "Use custom SSL/TLS configuration" is a better label.

<img width="620" height="301" alt="image" src="https://github.com/user-attachments/assets/3531f116-fb66-45cd-af35-8b47a41c5adc" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
