### PR TITLE
Use req.hostname in https redirect to ensure proxy trust is maintained

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/index.js
@@ -59,7 +59,7 @@ module.exports = {
                     if (req.secure) {
                         next();
                     } else {
-                        res.redirect('https://' + req.headers.host + req.originalUrl);
+                        res.redirect('https://' + req.hostname + req.originalUrl);
                     }
                 });
             }


### PR DESCRIPTION
The https redirect logic uses `req.headers.host` to rebuild the url to redirect to. It is safer to use `req.hostname` as that will honour any `x-forwarded-host` header if proxy trust is enabled.

Ref: https://expressjs.com/en/api.html#req.hostname