### PR TITLE
Set minimum node.js version to 22.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22, 24]
+        node-version: [22, 24]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}

--- a/packages/node_modules/node-red/lib/red.js
+++ b/packages/node_modules/node-red/lib/red.js
@@ -31,7 +31,7 @@ dns.setDefaultResultOrder('ipv4first');
 
 function checkVersion(userSettings) {
     var semver = require('semver');
-    if (!semver.satisfies(process.version,">=18.0.0")) {
+    if (!semver.satisfies(process.version,">=22.9.0")) {
         // var e = new Error("Unsupported version of Node.js");
         // e.code = "unsupported_version";
         // throw e;

--- a/packages/node_modules/node-red/package.json
+++ b/packages/node_modules/node-red/package.json
@@ -48,6 +48,6 @@
         "@node-rs/bcrypt": "1.10.7"
     },
     "engines": {
-        "node": ">=18.5"
+        "node": ">=22.9"
     }
 }

--- a/packages/node_modules/node-red/red.js
+++ b/packages/node_modules/node-red/red.js
@@ -27,9 +27,9 @@ if (process.argv[2] === 'admin') {
 }
 
 var semver = require('semver');
-if (!semver.satisfies(process.version, ">=18.0.0")) {
+if (!semver.satisfies(process.version, ">=22.9.0")) {
     console.log("Unsupported version of Node.js:", process.version);
-    console.log("Node-RED requires Node.js v18 or later");
+    console.log("Node-RED requires Node.js v22.9 or later");
     process.exit(1)
 }
 
@@ -360,7 +360,7 @@ httpsPromise.then(function(startupHttps) {
     } catch(err) {
         if (err.code == "unsupported_version") {
             console.log("Unsupported version of Node.js:",process.version);
-            console.log("Node-RED requires Node.js v18 or later");
+            console.log("Node-RED requires Node.js v22.9 or later");
         } else {
             console.log("Failed to start server:");
             if (err.stack) {


### PR DESCRIPTION
This sets the minimum supported Node.js version to Node 22.9. We will recommend `24` - and only provide `24` in the docker images initially.

Node-RED v5 will refuse to run on anything earlier than 22.9.