### PR TITLE
Invert selected tab button border color to improve contrast

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
@@ -128,6 +128,7 @@ $workspace-button-background-hover: $secondary-background-hover;
 $workspace-button-background-active: $secondary-background-selected;
 $workspace-button-background-selected: #838383;
 $workspace-button-border-selected: #838383;
+$workspace-button-border-selected-inverse: $secondary-background-hover;
 
 $workspace-button-color: $secondary-text-color;
 $workspace-button-color-disabled: $secondary-text-color-disabled;

--- a/packages/node_modules/@node-red/editor-client/src/sass/dark-theme.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/dark-theme.scss
@@ -146,6 +146,7 @@ html.nr-theme-dark {
     --red-ui-workspace-button-background-active:        #22222c;
     --red-ui-workspace-button-background-selected:      #22222c;
     --red-ui-workspace-button-border-selected:          #444444;
+    --red-ui-workspace-button-border-selected-inverse:  #444444;
     --red-ui-workspace-button-color:                    #aaaaaa;
     --red-ui-workspace-button-color-disabled:           #7a7a7b;
     --red-ui-workspace-button-color-focus:              #e84a4a;

--- a/packages/node_modules/@node-red/editor-client/src/sass/sidebar.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/sidebar.scss
@@ -178,6 +178,9 @@
                 opacity: 0.7;
             }
         }
+        &.selected:not(.disabled):not(:disabled) {
+            border-color: var(--red-ui-workspace-button-border-selected-inverse);
+        }
     }
     .button-group {
         display: flex;

--- a/packages/node_modules/@node-red/editor-client/src/sass/variables.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/variables.scss
@@ -121,6 +121,7 @@
     --red-ui-workspace-button-background-active: #{colors.$workspace-button-background-active};
     --red-ui-workspace-button-background-selected: #{colors.$workspace-button-background-selected};
     --red-ui-workspace-button-border-selected: #{colors.$workspace-button-border-selected};
+    --red-ui-workspace-button-border-selected-inverse: #{colors.$workspace-button-border-selected-inverse};
 
     --red-ui-workspace-button-color: #{colors.$workspace-button-color};
     --red-ui-workspace-button-color-disabled: #{colors.$workspace-button-color-disabled};


### PR DESCRIPTION
If a node is under the sidebar tab buttons, there is poor contrast between the button and the node (particularly for darker nodes).

<img width="182" height="53" alt="SCR-20260430-jlda" src="https://github.com/user-attachments/assets/d39d982f-ee9b-40b4-8f07-0890b412c3bc" />


This PR inverts the border to improve the contrast:

<img width="215" height="63" alt="image" src="https://github.com/user-attachments/assets/aa5440e0-0bc2-40b7-9af7-9dff9b4cca12" />

Dark theme doesn't use the same light/dark flip of the button background, so it keeps the existing border color.

