### PR TITLE
Remove reveal on hover in search results and provide button

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
@@ -443,12 +443,14 @@ RED.search = (function() {
                     $('<div>',{class:"red-ui-search-result-node-label"}).text(object.label || node.id).appendTo(contentDiv);
                     $('<div>',{class:"red-ui-search-result-node-type"}).text(node.type).appendTo(contentDiv);
                     $('<div>',{class:"red-ui-search-result-node-id"}).text(node.id).appendTo(contentDiv);
-
-                    div.on("mouseover", function(evt) {
-                        if ( node.z == RED.workspaces.active() ) {
-                            RED.view.reveal(node.id)
-                        }
+                    const toolsContainer = $('<div>',{class:"red-ui-search-result-tools"}).appendTo(contentDiv);
+                    $('<button type="button" class="red-ui-button red-ui-button-small"><i class="fa fa-search"></i></button>').attr('aria-label', RED._('sidebar.info.find')).appendTo(toolsContainer).on('click', function(evt) {
+                        evt.preventDefault();
+                        evt.stopImmediatePropagation();
+                        evt.stopPropagation();
+                        reveal(node, true);
                     });
+
                     
                     div.on("click", function(evt) {
                         evt.preventDefault();
@@ -462,7 +464,7 @@ RED.search = (function() {
 
     }
 
-    function reveal(node) {
+    function reveal(node, keepSearchOpen) {
         var searchVal = searchInput.val();
         var existingIndex = searchHistory.indexOf(searchVal);
         if (existingIndex > -1) {
@@ -471,7 +473,9 @@ RED.search = (function() {
         searchHistory.unshift(searchVal);
         $("#red-ui-view-searchtools-search").data("term", searchVal);
         activeResults = Object.assign([], currentResults);
-        hide(null, activeResults.length > 0);
+        if (!keepSearchOpen) {
+            hide(null, activeResults.length > 0);
+        }
         RED.view.reveal(node.id);
     }
 

--- a/packages/node_modules/@node-red/editor-client/src/sass/search.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/search.scss
@@ -206,6 +206,9 @@
     font-size: 0.8em;
     color: var(--red-ui-tertiary-text-color);
 }
+.red-ui-search-result-tools{
+    float: right;
+}
 .red-ui-search-empty {
     padding: 10px;
     text-align: center;


### PR DESCRIPTION
Feedback on the behaviour of revealing search results when hovering over them wasn't great.

This removes that behaviour in favour of a button that can be clicked to reveal the result without closing the dialog.

<img width="522" height="364" alt="image" src="https://github.com/user-attachments/assets/5b70efde-eea2-4726-9f61-bfe28dd3d4db" />
