### PR TITLE
Ensure png icon is centrally aligned on first layout

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -5188,7 +5188,9 @@ RED.view = (function() {
                     icon.attr("width",width);
                     icon.attr("height",height);
                     icon.attr("x",15-width/2);
-                    icon.attr("y",(30-height)/2);
+                    // Get the dimension of the icon_group to set the vertical position properly
+                    const iconGroupRect = icon_group[0][0].getBoundingClientRect();
+                    icon.attr("y",(iconGroupRect.height-height)/2);
                 }
                 icon.attr("xlink:href",iconUrl);
                 icon.style("display",null);


### PR DESCRIPTION
Reported on the forum; png icons for nodes with multiple outputs (ie, non-default height) initial display at the top of the node box. Clicking on the node forces a redraw and the icon moves to its proper position.

The issue was the initial layout code for non svg icons assumed the standard node height. This PR updates to use the actual icon_group height to calculate the required y position.