### PR TITLE
Do not show section title if all options are hidden

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
@@ -259,11 +259,14 @@ RED.userSettings = (function() {
         currentEditorSettings.view = currentEditorSettings.view || {};
 
         viewSettings.forEach(function(section) {
+            const activeOptions = section.options.filter(opt => !(opt.hidden && opt.hidden()));
+            if (activeOptions.length === 0) {
+                return;
+            }
             if (section.title) {
                 $('<h3></h3>').text(RED._(section.title)).appendTo(pane);
             }
-            section.options.forEach(function(opt) {
-                if (opt.hidden && opt.hidden()) { return; }
+            activeOptions.forEach(function(opt) {
                 var initialState;
                 if (opt.local) {
                     var rawLocal = localStorage.getItem(opt.setting);


### PR DESCRIPTION
Fixes #5676 

If all settings in a particular section are hidden, we should not show the section title. This PR does that.