### PR TITLE
Clip user profile image to the round button in the header

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/header.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/header.scss
@@ -96,7 +96,7 @@
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        min-width: 32px;
+        min-width: 30px;
         text-align: center;
         font-size: 16px;
         padding: 0px;
@@ -407,6 +407,7 @@ a#red-ui-header-button-user.button {
     background-color: var(--red-ui-header-background);
     border: 1px solid var(--red-ui-header-button-border);
     border-radius: 20px;
+    overflow: hidden;
 }
 
 .red-ui-user-profile {
@@ -414,7 +415,7 @@ a#red-ui-header-button-user.button {
     padding: 3px;
     background-position: center center;
     background-repeat: no-repeat;
-    background-size: contain;
+    background-size: cover;
     display: inline-flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
Fixes #5656 

This ensures any user profile image is clipped to the circular button it is shown in.