### PR TITLE
[5683] No discernible outline on junctions and node ports in dark mode in NR5 + lighten shade color

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/dark-theme.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/dark-theme.scss
@@ -79,7 +79,7 @@ html.nr-theme-dark {
 
     // ── Shadow ──
     --red-ui-shadow:      rgba(0, 0, 0, 0.70);
-    --red-ui-shade-color: rgba(0, 0, 0, 0.80);
+    --red-ui-shade-color: rgba(0, 0, 0, 0.45);
 
     // ── Forms ──
     --red-ui-form-background:                   #1b1b23;
@@ -220,7 +220,7 @@ html.nr-theme-dark {
     --red-ui-node-border-unknown:           #ff6369;
     --red-ui-node-border-placeholder:       #aaaaaa; // dashed comment border
     --red-ui-node-background-placeholder:   #f0f0f0; // light so dark label reads
-    --red-ui-node-port-background:          #888888;
+    --red-ui-node-port-background:          #b8b8b8;
     --red-ui-node-port-background-hover:    #e84a4a;
     --red-ui-node-icon-color:               #f0f0f0;
     --red-ui-node-icon-background-color:    rgba(255, 255, 255, 0.07);


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Resolves https://github.com/node-red/node-red/issues/5683

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
