### PR TITLE
[5696] `editorTheme.header.title`: long values clip without ellipsis, and misalign when `header.url` is set

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/header.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/header.scss
@@ -53,12 +53,12 @@
 
         span {
             font-size: 14px !important;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            display: inline-block;
+            min-width: 0;
             &:not(:first-child) {
                 margin-left: 8px;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                display: inline-block;
-                min-width: 0;
             }
         }
         img {

--- a/packages/node_modules/@node-red/editor-client/src/sass/header.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/header.scss
@@ -49,6 +49,7 @@
         overflow: hidden;
         display: inline-flex;
         align-items: center;
+        min-width: 0;
 
         span {
             font-size: 14px !important;
@@ -57,6 +58,7 @@
                 overflow: hidden;
                 text-overflow: ellipsis;
                 display: inline-block;
+                min-width: 0;
             }
         }
         img {
@@ -66,6 +68,9 @@
 
         a {
             color: inherit;
+            display: flex;
+            align-items: center;
+            min-width: 0;
             &:hover {
                 text-decoration: none;
             }


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Resolves https://github.com/node-red/node-red/issues/5696

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
