### PR TITLE
fix: palette tooltip descriptions not loading when using deferred scripts

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -77,24 +77,12 @@ var RED = (function() {
             var nodeConfigEls = $("<div>"+config+"</div>");
             var scripts = nodeConfigEls.find("script");
             var scriptCount = scripts.length;
+            var deferredScripts = [];
             scripts.each(function(i,el) {
                 var srcUrl = $(el).attr('src');
                 if (srcUrl && !/^\s*(https?:|\/|\.)/.test(srcUrl)) {
                     $(el).remove();
-                    var newScript = document.createElement("script");
-                    newScript.onload = function() {
-                        scriptCount--;
-                        if (scriptCount === 0) {
-                            $(targetContainer).append(nodeConfigEls);
-                            delete RED._loadingModule;
-                            done()
-                        }
-                    }
-                    if ($(el).attr('type') === "module") {
-                        newScript.type = "module";
-                    }
-                    $(targetContainer).append(newScript);
-                    newScript.src = RED.settings.apiRootUrl+srcUrl;
+                    deferredScripts.push({srcUrl: srcUrl, type: $(el).attr('type')});
                     hasDeferred = true;
                 } else {
                     if (/\/ace.js$/.test(srcUrl) || /\/ext-language_tools.js$/.test(srcUrl)) {
@@ -108,10 +96,31 @@ var RED = (function() {
                     scriptCount--;
                 }
             })
+            // Append templates, help scripts, and other non-deferred content
+            // to the DOM before loading external scripts. This ensures that
+            // data-help-name scripts are available when the external script
+            // calls RED.nodes.registerType, which triggers palette tooltip
+            // generation via getNodeHelp().
+            $(targetContainer).append(nodeConfigEls);
             if (!hasDeferred) {
-                $(targetContainer).append(nodeConfigEls);
                 delete RED._loadingModule;
                 done();
+            } else {
+                deferredScripts.forEach(function(ds) {
+                    var newScript = document.createElement("script");
+                    newScript.onload = function() {
+                        scriptCount--;
+                        if (scriptCount === 0) {
+                            delete RED._loadingModule;
+                            done()
+                        }
+                    }
+                    if (ds.type === "module") {
+                        newScript.type = "module";
+                    }
+                    $(targetContainer).append(newScript);
+                    newScript.src = RED.settings.apiRootUrl+ds.srcUrl;
+                });
             }
         } catch(err) {
             RED.notify(RED._("notification.errors.failedToAppendNode",{module:moduleId, error:err.toString()}),{


### PR DESCRIPTION

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
When a node's HTML includes an external <script src="...">, the help <script data-help-name> tags were not appended to the DOM until the external script finished loading. But during loading, the script calls registerType() which triggers the palette tooltip to read help content via getNodeHelp(). Since the help tags weren't in the DOM yet, the tooltip showed "no information available".

Fixed by appending templates and help scripts to the DOM before loading external scripts, so help content is available when registerType runs.

### Before
<img width="469" height="295" alt="image" src="https://github.com/user-attachments/assets/7db70705-247e-465b-b15f-8b036c92659f" />


### After
<img width="465" height="301" alt="image" src="https://github.com/user-attachments/assets/1ffdd21d-1247-4dd8-9a28-203a1fa2785b" />

Tested in Node-RED v4.1.8

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
