### PR TITLE
Redraw halo if node status changes

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -5215,10 +5215,13 @@ RED.view = (function() {
             // - global flag set
             // - node has no status
             // - node is disabled
+            const currentStatusHeight = d.statusHeight || 0
             if (!showStatus || !d.status || d.d === true) {
                 nodeEl.__statusGroup__.style.display = "none";
                 d.statusHeight = 0;
             } else {
+                let hasStatusIcon = false
+                let hasStatusText = false
                 nodeEl.__statusGroup__.style.display = "inline";
                 let backgroundWidth = 15
                 var fill = status_colours[d.status.fill]; // Only allow our colours for now
@@ -5233,9 +5236,11 @@ RED.view = (function() {
                     nodeEl.__statusShape__.style.display = "inline";
                     nodeEl.__statusShape__.setAttribute("class","red-ui-flow-node-status "+statusClass);
                     nodeEl.__statusBackground__.setAttribute("x", 3)
+                    hasStatusIcon = true
                 }
                 if (d.status.hasOwnProperty('text')) {
                     nodeEl.__statusLabel__.textContent = d.status.text;
+                    hasStatusText = true
                 } else {
                     nodeEl.__statusLabel__.textContent = "";
                 }
@@ -5244,10 +5249,18 @@ RED.view = (function() {
                 if (backgroundWidth > 0 && textSize.width > 0) {
                     backgroundWidth += 6
                 }
-                d.statusHeight = nodeEl.__statusGroup__.getBBox().height
+                if (hasStatusIcon || hasStatusIcon) {
+                    d.statusHeight = 14
+                } else {
+                    d.statusHeight = 0
+                }
                 nodeEl.__statusBackground__.setAttribute('width', backgroundWidth)
             }
             delete d.dirtyStatus;
+            if (currentStatusHeight !== d.statusHeight) {
+                nodeEl.__halo__.setAttribute("height", d.h + (d.statusHeight || 0) + 6)
+            }
+
         }
     }
 
@@ -5411,7 +5424,7 @@ RED.view = (function() {
                 this.__mainRect__.setAttribute("height", d.h)
                 this.__mainRect__.classList.toggle("red-ui-flow-node-highlighted",!!d.highlighted );
                 this.__halo__.setAttribute("width", d.w + 16);
-                this.__halo__.setAttribute("height", d.h + 10);
+                this.__halo__.setAttribute("height", d.h + 6);
 
                 if (labelParts) {
                     // The label has changed
@@ -6030,9 +6043,11 @@ RED.view = (function() {
                                 this.__buttonGroup__.classList.toggle("red-ui-flow-node-button-stopped", !RED.runtime.started);
                             }
 
-                            var x = d._def.align == "right"?d.w-6:-25;
+                            var x = d._def.align == "right"?d.w-6:-26;
+                            let haloWidthAdjustment = 32
                             if (d._def.button.toggle && !d[d._def.button.toggle]) {
                                 x = x - (d._def.align == "right"?8:-8);
+                                haloWidthAdjustment = haloWidthAdjustment - 8;
                             }
                             this.__buttonGroup__.setAttribute("transform", "translate("+x+",2)");
 
@@ -6050,9 +6065,9 @@ RED.view = (function() {
                                 }
                             }
                             if (buttonVisible) {
-                                this.__halo__.setAttribute("width", d.w + 31)
+                                this.__halo__.setAttribute("width", d.w + haloWidthAdjustment)
                                 if (d._def.align !== 'right') {
-                                    this.__halo__.setAttribute("x", -28)
+                                    this.__halo__.setAttribute("x", - (haloWidthAdjustment - 3))
                                 }
                             }
                         }
@@ -6075,11 +6090,7 @@ RED.view = (function() {
                     }
 
                     if (d.dirtyStatus) {
-                        const currentStatusHeight = d.statusHeight || 0
                         redrawStatus(d,this)
-                        if (currentStatusHeight !== d.statusHeight) {
-                            this.__halo__.setAttribute("height", d.h + (d.statusHeight || 0) + 10)
-                        }
                     }
 
                     d.dirty = false;


### PR DESCRIPTION
Closes #5705 
Closes #5703 

If a node status changes whilst it is selected, this will resize the selection halo automatically to match.

*However* - I have chosen *not* to modify the width of the halo for long status text - the width is determined by the node body. We can, of course, change that, but for now, it will mean it's possible for overlapping status text like this:

<img width="200" height="153" alt="image" src="https://github.com/user-attachments/assets/8b3a8f8e-3213-4c59-952c-9e72dfe1e064" />
