### PR TITLE
Improve view navigator interaction

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-navigator.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-navigator.js
@@ -16,9 +16,9 @@
 
 
 RED.view.navigator = (function() {
-    var nav_scale = 80;
-    var nav_width = 8000/nav_scale;
-    var nav_height = 8000/nav_scale;
+    var nav_scale = 60;
+    var nav_width = 8000/nav_scale + 6;
+    var nav_height = 8000/nav_scale + 6;
     var navContainer;
     var navBox;
     var navBorder;
@@ -43,8 +43,8 @@ RED.view.navigator = (function() {
             .attr('class','red-ui-navigator-node')
             .attr("pointer-events", "none");
         navNode.each(function(d) {
-            d3.select(this).attr("x",function(d) { return (d.x-d.w/2)/nav_scale })
-                .attr("y",function(d) { return (d.y-d.h/2)/nav_scale })
+            d3.select(this).attr("x",function(d) { return 3 + ((d.x-d.w/2)/nav_scale) })
+                .attr("y",function(d) { return 3 + ((d.y-d.h/2)/nav_scale) })
                 .attr("width",function(d) { return Math.max(4,d.w/nav_scale) })
                 .attr("height",function(d) { return Math.max(2,d.h/nav_scale) })
                 .attr("fill",function(d) { return RED.utils.getNodeColor(d.type,d._def);})
@@ -63,8 +63,8 @@ RED.view.navigator = (function() {
             // Convert scroll position (in scaled pixels) to workspace coordinates, then to minimap coordinates
             // scrollPos is in scaled canvas pixels, divide by scaleFactor to get workspace coords
             if (chartSize[0] > 0 && chartSize[1] > 0) { 
-                navBorder.attr('x',scrollPos[0]/scaleFactor/nav_scale)
-                    .attr('y',scrollPos[1]/scaleFactor/nav_scale)
+                navBorder.attr('x',3 + scrollPos[0]/scaleFactor/nav_scale)
+                    .attr('y',3 + scrollPos[1]/scaleFactor/nav_scale)
                     .attr('width',chartSize[0]/nav_scale/scaleFactor)
                     .attr('height',chartSize[1]/nav_scale/scaleFactor)
             }
@@ -149,7 +149,7 @@ RED.view.navigator = (function() {
                 .attr("pointer-events", "all")
                 .attr("id","red-ui-navigator-canvas")
             navVis = navBox.append("svg:g")
-
+            let dragOrigin = { x: 0, y: 0 };
             navBox.append("rect").attr("x",0).attr("y",0).attr("width",nav_width).attr("height",nav_height).style({
                 fill:"none",
                 stroke:"none",
@@ -159,33 +159,41 @@ RED.view.navigator = (function() {
                 scaleFactor = RED.view.scale();
                 chartSize = [ $("#red-ui-workspace-chart").width(), $("#red-ui-workspace-chart").height()];
                 dimensions = [chartSize[0]/nav_scale/scaleFactor, chartSize[1]/nav_scale/scaleFactor];
-                var newX = Math.max(0,Math.min(d3.event.offsetX+dimensions[0]/2,nav_width)-dimensions[0]);
-                var newY = Math.max(0,Math.min(d3.event.offsetY+dimensions[1]/2,nav_height)-dimensions[1]);
+                var newX = Math.max(3,Math.min(d3.event.offsetX+dimensions[0]/2,nav_width - 3)-dimensions[0]);
+                var newY = Math.max(3,Math.min(d3.event.offsetY+dimensions[1]/2,nav_height - 3)-dimensions[1]);
                 navBorder.attr('x',newX).attr('y',newY);
                 isDragging = true;
-                $("#red-ui-workspace-chart").scrollLeft(newX*nav_scale*scaleFactor);
-                $("#red-ui-workspace-chart").scrollTop(newY*nav_scale*scaleFactor);
-            }).on("mousemove", function() {
-                if (!isDragging) { return }
-                if (d3.event.buttons === 0) {
+                $("#red-ui-workspace-chart").scrollLeft((newX-3)*nav_scale*scaleFactor);
+                $("#red-ui-workspace-chart").scrollTop((newY-3)*nav_scale*scaleFactor);
+                dragOrigin = navBox.node().getBoundingClientRect();
+                $(document).on("mouseup.red-ui-navigator", function() {
                     isDragging = false;
-                    return;
-                }
-                var newX = Math.max(0,Math.min(d3.event.offsetX+dimensions[0]/2,nav_width)-dimensions[0]);
-                var newY = Math.max(0,Math.min(d3.event.offsetY+dimensions[1]/2,nav_height)-dimensions[1]);
-                navBorder.attr('x',newX).attr('y',newY);
-                $("#red-ui-workspace-chart").scrollLeft(newX*nav_scale*scaleFactor);
-                $("#red-ui-workspace-chart").scrollTop(newY*nav_scale*scaleFactor);
-                RED.events.emit("view:navigate");
-            }).on("mouseup", function() {
-                isDragging = false;
+                    $(document).off("mouseup.red-ui-navigator");
+                    $(document).off("mousemove.red-ui-navigator");
+                })
+                $(document).on('mousemove.red-ui-navigator', function(event) {
+                    if (!isDragging) { return }
+                    if (event.buttons === 0) {
+                        isDragging = false;
+                        return;
+                    }
+                    const deltaX = event.clientX - dragOrigin.x;
+                    const deltaY = event.clientY - dragOrigin.y;
+                    var newX = Math.max(3,Math.min(deltaX+dimensions[0]/2,nav_width - 3)-dimensions[0]);
+                    var newY = Math.max(3,Math.min(deltaY+dimensions[1]/2,nav_height - 3)-dimensions[1]);
+                    navBorder.attr('x',newX).attr('y',newY);
+                    $("#red-ui-workspace-chart").scrollLeft((newX-3)*nav_scale*scaleFactor);
+                    $("#red-ui-workspace-chart").scrollTop((newY-3)*nav_scale*scaleFactor);
+                    RED.events.emit("view:navigate");
+
+                })
             }).on("mouseenter", function () {
                 if (isTemporaryShow) {
                     // If user hovers over the minimap while it's temporarily shown, keep it shown
                     clearTimeout(autoHideTimeout);
                 }
             }).on("mouseleave", function () {
-                if (isTemporaryShow) {
+                if (isTemporaryShow && !isDragging) {
                     // Restart the auto-hide timer after mouse leaves the minimap
                     setupAutoHide()
                 }

--- a/packages/node_modules/@node-red/editor-client/src/sass/workspace.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/workspace.scss
@@ -143,6 +143,7 @@
     background: var(--red-ui-view-navigator-background);
     box-shadow: -1px 0 3px var(--red-ui-shadow);
     border-radius: 4px;
+    cursor: grab;
 }
 
 #view-zoom-controls .button-group button.red-ui-footer-button:not(:last-child) {
@@ -165,7 +166,7 @@
     fill: none;
 }
 .red-ui-navigator-node {
-    opacity: 0.6;
+    opacity: 0.8;
 }
 #red-ui-workspace-footer {
     display: flex;


### PR DESCRIPTION
Closes #5707 

This makes three changes to the view navigator to improve its UX.

1. The navigator is slightly larger; the scale was too small.
1. There is now small margin inside the navigator. This ensures nodes at the very edge of the workspace aren't shown hard against the navigator border. At the scale things are shown, this was making it hard to see nodes in those positions.
2. The drag handling is much more forgiving; previously you had to keep the mouse inside the navigator whilst dragging - it now tracks the drag across the whole window.


Before this PR:

<img width="174" height="163" alt="image" src="https://github.com/user-attachments/assets/ca84b446-86fe-416e-95f7-f45ef9e591fa" />


With this PR. Note the larger canvas and the slight margin between the dashed border and the edge of the navigator.

<img width="167" height="168" alt="image" src="https://github.com/user-attachments/assets/f1f7701c-6a25-4110-b786-2badda50bef2" />
