### PR TITLE
[5702] UX: Sidebar tab buttons do not show focus indicator when clicking on them

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
@@ -246,6 +246,8 @@ RED.sidebar = (function() {
                 draggingTabButton = false
                 return
             }
+            // sortable's mousedown preventDefault suppresses focus-on-click
+            evt.currentTarget.focus()
             const targetSidebar = options.target === 'secondary' ? sidebars.secondary : sidebars.primary;
             if (targetSidebar.sections[options.targetSection].active === options.id && RED.menu.isSelected(targetSidebar.menuToggle)) {
                 if (!targetSidebar.sections[options.targetSection].hidden) {


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Resolves https://github.com/node-red/node-red/issues/5702

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
