### PR TITLE
Fix module name validation for uninstall and tgz install

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/installer.js
+++ b/packages/node_modules/@node-red/registry/lib/installer.js
@@ -147,8 +147,7 @@ async function installModule(module,version,url) {
         var isExisting = false;
         if (url) {
             if (pkgurlRe.test(url) || localtgzRe.test(url)) {
-                // Git remote url or Tarball url - check the valid package url
-                installName = localtgzRe.test(url) && slashRe.test(url) ? `"${url}"` : url;
+                installName = url;
                 isRegistryPackage = false;
             } else {
                 log.warn(log._("server.install.install-failed-url",{name:module,url:url}));
@@ -504,12 +503,13 @@ async function getTarballModuleInfo(tarball) {
 
 function uninstallModule(module) {
     // This function is called when the admin api is called to remove a module.
-    // A check in node.js#removeModule verifies the module being removed is already in the registry
+    // A check in nodes.js#removeModule verifies the module being removed is already in the registry
     // as a user module. As such, we can have confidence that the `module` passed here is 
-    // a valid and recognised module name.
+    // a valid and recognised module name. But lets not rely 100% on that.
     activePromise = activePromise.then(() => {
         return new Promise((resolve,reject) => {
-            if (/[.\s;]/.test(module)) {
+            // Ensure its a valid package name and nothing has slipped through other checks
+            if (!validateNpmPackageName(module).validForOldPackages) {
                 reject(new Error(log._("server.install.invalid")));
                 return;
             }

--- a/test/unit/@node-red/registry/lib/installer_spec.js
+++ b/test/unit/@node-red/registry/lib/installer_spec.js
@@ -278,7 +278,7 @@ describe('nodes/registry/installer', function() {
                 const lastCallArgs = exec.run.lastCall.args[1];
                 lastCallArgs[0].should.match(/npm\/bin\/npm-cli\.js$/)
                 const remainingArgs = lastCallArgs.slice(1);
-                remainingArgs.should.eql([ 'install', '--no-audit', '--no-update-notifier', '--no-fund', '--save', '--save-prefix=~', '--omit=dev', '--engine-strict', '--', '"/example path/foo-0.1.1.tgz"' ]);
+                remainingArgs.should.eql([ 'install', '--no-audit', '--no-update-notifier', '--no-fund', '--save', '--save-prefix=~', '--omit=dev', '--engine-strict', '--', '/example path/foo-0.1.1.tgz' ]);
                 info.should.eql(nodeInfo);
                 done();
             }).catch(done);


### PR DESCRIPTION
Fixes #5719 
Fixes #5721 

Two regressions in 4.1.9 related to embedding npm.

1. `tgz` filenames were being quoted twice => No longer necessary to explicitly quote tgz file names as we no longer use the `shell` option.
2. Inaccurate module name validation in the uninstall path => switch to the standard library to validate the package name