### PR TITLE
Ensure project files are inside project root path

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/Project.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/Project.js
@@ -60,6 +60,11 @@ function getGitUser(user) {
     return null;
 }
 
+function isPathInsideProject(projectPath, filePath) {
+    var relativePath = fspath.relative(projectPath,filePath);
+    return relativePath && !/^\.\./.test(relativePath) && !fspath.isAbsolute(relativePath);
+}
+
 function Project(path) {
     this.path = path;
     this.name = fspath.basename(path);
@@ -161,7 +166,13 @@ Project.prototype.initialise = function(user,data) {
             project.files.flow = data.files.flow;
             project.files.credentials = data.files.credentials;
             var flowFilePath = fspath.join(project.path,project.files.flow);
+            if (!isPathInsideProject(project.path, flowFilePath)) {
+                throw new Error("Flow file path is outside the project directory");
+            }
             var credsFilePath = getCredentialsFilename(flowFilePath);
+            if (!isPathInsideProject(project.path, credsFilePath)) {
+                throw new Error("Credentials file path is outside the project directory");
+            }
             promises.push(util.writeFile(flowFilePath,"[]"));
             promises.push(util.writeFile(credsFilePath,"{}"));
             files.push(project.files.flow);


### PR DESCRIPTION
When initialising a project, it was possible to specify paths outside of the project root. They would then fail to get version controlled.