### PR TITLE
Enable badge annotations on groups

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -34,7 +34,8 @@
             "unlock": "Unlock",
             "locked": "Locked",
             "unlocked": "Unlocked",
-            "format": "Format"
+            "format": "Format",
+            "edit": "Edit"
         },
         "type": {
             "string": "string",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
@@ -168,6 +168,7 @@ RED.popover = (function() {
         var div;
         var contentDiv;
         var currentStyle;
+        var closeOnOutsideClickHandler;
 
         var openPopup = function(instant) {
             if (isOpen) {
@@ -237,6 +238,19 @@ RED.popover = (function() {
                     div.show();
                 } else {
                     div.fadeIn("fast");
+                }
+                if (options.closeOnOutsideClick) {
+                    // Close when the user clicks outside the target and the popover.
+                    // Use capture phase so handlers further down that call stopPropagation
+                    // (e.g. the popover's own click toggle, or a node's mousedown handler)
+                    // can't prevent the dismiss from firing.
+                    closeOnOutsideClickHandler = function (event) {
+                        if (target[0].contains(event.target)) { return; }
+                        if (div && div[0].contains(event.target)) { return; }
+                        active = false;
+                        closePopup();
+                    };
+                    document.addEventListener('mousedown', closeOnOutsideClickHandler, true);
                 }
             }
         }
@@ -341,6 +355,10 @@ RED.popover = (function() {
         var closePopup = function(instant) {
             isOpen = false
             $(document).off('mousedown.red-ui-popover');
+            if (closeOnOutsideClickHandler) {
+                document.removeEventListener('mousedown', closeOnOutsideClickHandler, true);
+                closeOnOutsideClickHandler = null;
+            }
             if (!active) {
                 if (div) {
                     if (instant) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-annotations.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-annotations.js
@@ -150,17 +150,26 @@ RED.view.annotations = (function() {
             const popoverInstance = RED.popover.create({
                 target: $(annotation),
                 trigger: 'click',
-                interactive: true,
+                // interactive: true,
                 closeOnOutsideClick: true,
                 autoClose: false, // keep open - user may want to scroll or copy content
                 direction,
                 delay,
                 class: 'red-ui-flow-annotation-popover',
+                width: 400,
                 maxWidth,
                 content: function() {
                     return opts.popover(node, popoverInstance)
                 }
             })
+            // Stop mousedown/mouseup at the badge so clicking it doesn't bubble to
+            // the parent node/group/canvas and trigger selection changes. The popover's
+            // own click handler (added by RED.popover.create with trigger:'click') still
+            // fires because click is a native event
+            $(annotation).on('mousedown mouseup', function(evt) {
+                evt.stopPropagation()
+            })
+
         }
         if (annotationGroup.hasChildNodes()) {
             annotationGroup.removeChild(annotationGroup.firstChild)

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-annotations.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-annotations.js
@@ -132,6 +132,25 @@ RED.view.annotations = (function() {
             annotation.addEventListener("mouseenter", getAnnotationMouseEnter(annotation, node, opts.tooltip));
             annotation.addEventListener("mouseleave", annotationMouseLeave);
         }
+        if (opts.popover) {
+            const direction = opts.popoverDirection || 'bottom'
+            const maxWidth = opts.popoverMaxWidth || 400
+            const delay = opts.popoverDelay || { show: 350, hide: 150 }
+            const popoverInstance = RED.popover.create({
+                target: $(annotation),
+                trigger: 'click',
+                interactive: true,
+                closeOnOutsideClick: true,
+                autoClose: false, // keep open - user may want to scroll or copy content
+                direction,
+                delay,
+                class: 'red-ui-flow-annotation-popover',
+                maxWidth,
+                content: function() {
+                    return opts.popover(node, popoverInstance)
+                }
+            })
+        }
         if (annotationGroup.hasChildNodes()) {
             annotationGroup.removeChild(annotationGroup.firstChild)
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-annotations.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-annotations.js
@@ -46,16 +46,27 @@ RED.view.annotations = (function() {
                                 // getBoundingClientRect is in real-world scale so needs to be adjusted according to
                                 // the current scale factor
                                 const rectWidth = annotation.element.getBoundingClientRect().width / scale;
-                                let annotationX
-                                if (!opts.align || opts.align === 'right') {
-                                    annotationX = evt.node.w - 3 - badgeRDX - rectWidth
-                                    badgeRDX += rectWidth + 4;
-
-                                } else if (opts.align === 'left') {
-                                    annotationX = 3 + badgeLDX
-                                    badgeLDX += rectWidth + 4;
+                                // Allow annotations to provide per-node custom positioning (e.g. group badges
+                                // placed inline with the group label). If the callback returns falsy, fall
+                                // through to the default top-right stacking.
+                                let customPos = null;
+                                if (typeof opts.position === 'function') {
+                                    customPos = opts.position(evt.node, rectWidth);
                                 }
-                                annotation.element.setAttribute("transform", "translate("+annotationX+", -8)");
+                                if (customPos) {
+                                    annotation.element.setAttribute("transform", "translate("+customPos.x+", "+customPos.y+")");
+                                } else {
+                                    let annotationX
+                                    if (!opts.align || opts.align === 'right') {
+                                        annotationX = evt.node.w - 3 - badgeRDX - rectWidth
+                                        badgeRDX += rectWidth + 4;
+
+                                    } else if (opts.align === 'left') {
+                                        annotationX = 3 + badgeLDX
+                                        badgeLDX += rectWidth + 4;
+                                    }
+                                    annotation.element.setAttribute("transform", "translate("+annotationX+", -8)");
+                                }
                             }
                         // } else {
                         //     if (showAnnotation) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-annotations.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-annotations.js
@@ -46,27 +46,15 @@ RED.view.annotations = (function() {
                                 // getBoundingClientRect is in real-world scale so needs to be adjusted according to
                                 // the current scale factor
                                 const rectWidth = annotation.element.getBoundingClientRect().width / scale;
-                                // Allow annotations to provide per-node custom positioning (e.g. group badges
-                                // placed inline with the group label). If the callback returns falsy, fall
-                                // through to the default top-right stacking.
-                                let customPos = null;
-                                if (typeof opts.position === 'function') {
-                                    customPos = opts.position(evt.node, rectWidth);
+                                let annotationX
+                                if (!opts.align || opts.align === 'right') {
+                                    annotationX = evt.node.w - 3 - badgeRDX - rectWidth
+                                    badgeRDX += rectWidth + 4;
+                                } else if (opts.align === 'left') {
+                                    annotationX = 3 + badgeLDX
+                                    badgeLDX += rectWidth + 4;
                                 }
-                                if (customPos) {
-                                    annotation.element.setAttribute("transform", "translate("+customPos.x+", "+customPos.y+")");
-                                } else {
-                                    let annotationX
-                                    if (!opts.align || opts.align === 'right') {
-                                        annotationX = evt.node.w - 3 - badgeRDX - rectWidth
-                                        badgeRDX += rectWidth + 4;
-
-                                    } else if (opts.align === 'left') {
-                                        annotationX = 3 + badgeLDX
-                                        badgeLDX += rectWidth + 4;
-                                    }
-                                    annotation.element.setAttribute("transform", "translate("+annotationX+", -8)");
-                                }
+                                annotation.element.setAttribute("transform", "translate("+annotationX+", -8)");
                             }
                         // } else {
                         //     if (showAnnotation) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-annotations.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-annotations.js
@@ -9,6 +9,7 @@ RED.view.annotations = (function() {
                     addAnnotation(evt.node.__pendingAnnotation__,evt);
                     delete evt.node.__pendingAnnotation__;
                 }
+                if (!evt.el || !evt.el.__annotations__) { return; }
                 let badgeRDX = 0;
                 let badgeLDX = 0;
                 const scale = RED.view.scale()
@@ -64,7 +65,7 @@ RED.view.annotations = (function() {
                         //     }
                         }
                     } else {
-                        annotation.element.parentNode.removeChild(annotation.element);
+                        $(annotation.element).remove() // use jq to clean up to ensure its event handlers are triggered
                         evt.el.__annotations__.splice(i,1);
                         i--;
                         l--;

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1304,12 +1304,15 @@ RED.view = (function() {
                 $('<div class="red-ui-sidebar-banner-icon"><i class="fa fa-info"></i></div>').appendTo(banner)
                 $('<div class="red-ui-sidebar-banner-label" data-i18n="sidebar.info.name"></div>').appendTo(banner)
                 const tools = $('<div class="red-ui-sidebar-banner-tools"></div>').appendTo(banner)
-                const editButton = $('<button type="button" data-i18n="[title]common.label.edit"><i class="fa fa-edit"></i></button>').appendTo(tools)
-                editButton.on('click', function(evt) {
-                    evt.preventDefault()
-                    evt.stopPropagation()
-                    editInfo()
-                })
+                const canEdit = RED.user.hasPermission('flows.write') && !RED.workspaces.isLocked()
+                if (canEdit) {
+                    const editButton = $('<button type="button" data-i18n="[title]common.label.edit"><i class="fa fa-edit"></i></button>').appendTo(tools)
+                    editButton.on('click', function(evt) {
+                        evt.preventDefault()
+                        evt.stopPropagation()
+                        editInfo()
+                    })
+                }
 
                 $(`<div class="red-ui-help red-ui-flow-annotation-popover-body"><span class="red-ui-text-bidi-aware">${RED.utils.renderMarkdown(n.info)}</span></div>`).appendTo(section)
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1268,19 +1268,61 @@ RED.view = (function() {
                 pageLines.setAttribute("d", "M 7 3 h -3 v -3 M 2 8 h 3 M 2 6 h 3 M 2 4 h 2")
                 docsBadge.appendChild(pageLines)
 
-                $(docsBadge).on('click', function (evt) {
-                    if (node.type === "subflow") {
-                        RED.editor.editSubflow(activeSubflow, 'editor-tab-description');
-                    } else if (node.type === "group") {
-                        RED.editor.editGroup(node, 'editor-tab-description');
-                    } else {
-                        RED.editor.edit(node, 'editor-tab-description');
-                    }
+                // Stop mousedown/mouseup at the badge so clicking it doesn't bubble to
+                // the parent node/group/canvas and trigger selection changes. The popover's
+                // own click handler (added by RED.popover.create with trigger:'click') still
+                // fires because click is a native event
+                $(docsBadge).on('mousedown mouseup', function(evt) {
+                    evt.stopPropagation()
                 })
 
                 return docsBadge;
             },
-            show: function(n) { return showNodeInfo && !!n.info }
+            show: function(n) { return showNodeInfo && !!n.info },
+            popover: function(n, popoverInstance) {
+                // This is called when popover is triggered. It should return the content for the popover when the badge is clicked.
+                // Since we are exclusively using this badge to show node info, we can be opinionated about the content we generate
+                // we know it needs to render the info as markdown (and support mermaid diagrams).
+                // The popover mimics the sidebar info panel layout: a `red-ui-sidebar-section` rounded container
+                // with a `red-ui-sidebar-banner` header containing a label and a button to open the editor's
+                // description tab.
+                if (!n.info) { return null }
+
+                const editInfo = function() {
+                    if (popoverInstance) { popoverInstance.close() }
+                    if (n.type === "subflow") {
+                        RED.editor.editSubflow(activeSubflow, 'editor-tab-description')
+                    } else if (n.type === "group") {
+                        RED.editor.editGroup(n, 'editor-tab-description')
+                    } else {
+                        RED.editor.edit(n, 'editor-tab-description')
+                    }
+                }
+
+                const section = $('<div class="red-ui-sidebar-section red-ui-flow-annotation-popover-section"></div>')
+                const banner = $('<div class="red-ui-sidebar-banner"></div>').appendTo(section)
+                $('<div class="red-ui-sidebar-banner-icon"><i class="fa fa-info"></i></div>').appendTo(banner)
+                $('<div class="red-ui-sidebar-banner-label" data-i18n="sidebar.info.name"></div>').appendTo(banner)
+                const tools = $('<div class="red-ui-sidebar-banner-tools"></div>').appendTo(banner)
+                const editButton = $('<button type="button" data-i18n="[title]common.label.edit"><i class="fa fa-edit"></i></button>').appendTo(tools)
+                editButton.on('click', function(evt) {
+                    evt.preventDefault()
+                    evt.stopPropagation()
+                    editInfo()
+                })
+
+                $(`<div class="red-ui-help red-ui-flow-annotation-popover-body"><span class="red-ui-text-bidi-aware">${RED.utils.renderMarkdown(n.info)}</span></div>`).appendTo(section)
+
+                // Resolve data-i18n attributes on content
+                section.i18n()
+
+                // On the next tick, render any unrendered mermaid diagrams
+                // (Already-rendered diagrams will be skipped via the `mermaid-processed` attribute)
+                setTimeout(function() {
+                    RED.editor.mermaid.render()
+                }, 0)
+                return section
+            }
         })
 
         RED.view.annotations.register("red-ui-flow-node-changed",{

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1292,7 +1292,37 @@ RED.view = (function() {
 
                 return docsBadge;
             },
-            show: function(n) { return showNodeInfo && !!n.info }
+            show: function(n) { return showNodeInfo && !!n.info },
+            position: function(n, rectWidth) {
+                // Default top-right placement for nodes and subflows; groups place
+                // the badge inline with the label (or top-left inside the group when
+                // the label is hidden entirely).
+                if (n.type !== "group") { return null }
+                if (!n.style || !n.style.label) {
+                    // Label hidden: park inside the top-left of the group.
+                    return { x: 5, y: 5 };
+                }
+                const labelPos = n.style["label-position"] || "nw";
+                const textWidth = n.labelTextWidth || 0;
+                // labels can be empty when the group name is blank but label:true;
+                // clamp to 1 so the y calculation still places the badge where the
+                // first line of label text would sit.
+                const lineCount = Math.max(1, (n.labels && n.labels.length) || 1);
+                let x, y;
+                if (labelPos[0] === 'n') {
+                    y = 5;
+                } else {
+                    y = n.h - 15 - (lineCount - 1) * 16;
+                }
+                if (labelPos[1] === 'w') {
+                    x = 5;
+                } else if (labelPos[1] === 'e') {
+                    x = n.w - 5 - textWidth - rectWidth - 4;
+                } else {
+                    x = (n.w - textWidth - rectWidth - 4) / 2;
+                }
+                return { x: x, y: y };
+            }
         })
 
         RED.view.annotations.register("red-ui-flow-node-changed",{
@@ -6571,12 +6601,17 @@ RED.view = (function() {
                         recalculateLabelOffsets = true;
                     }
                     if (recalculateLabelOffsets) {
+                        // Reserve space inline with the group label for the info docs badge
+                        // (icon + gap). Used both to extend minWidth and to offset labelX below.
+                        var infoBadgeReserve = (showNodeInfo && !!d.info) ? 12 : 0;
                         if (!d.minWidth) {
                             if (d.style.label && d.name) {
                                 var labelParts = getLabelParts(d.name||"","red-ui-flow-group-label");
-                                d.minWidth = labelParts.width + 8;
+                                d.labelTextWidth = labelParts.width;
+                                d.minWidth = labelParts.width + 8 + infoBadgeReserve;
                                 d.labels = labelParts.lines;
                             } else {
+                                d.labelTextWidth = 0;
                                 d.minWidth = 40;
                                 d.labels = [];
                             }
@@ -6650,19 +6685,24 @@ RED.view = (function() {
                         var labelX = 0;
                         var labelY = 0;
 
+                        // When the info docs badge is going to be rendered inline with the label,
+                        // shift the label to leave room for it on the side of the text.
+                        var hasInfoBadge = showNodeInfo && !!d.info;
+                        var infoBadgeReserve = hasInfoBadge ? 12 : 0;
+
                         if (labelPos[0] === 'n') {
                             labelY = 0+15; // Allow for font-height
                         } else {
                             labelY = d.h - 5 -(d.labels.length -1) * 16;
                         }
                         if (labelPos[1] === 'w') {
-                            labelX = 5;
+                            labelX = 5 + infoBadgeReserve;
                             labelAnchor = "start"
                         } else if (labelPos[1] === 'e') {
                             labelX = d.w-5;
                             labelAnchor = "end"
                         } else {
-                            labelX = d.w/2;
+                            labelX = d.w/2 + infoBadgeReserve/2;
                             labelAnchor = "middle"
                         }
                         if (d.style.hasOwnProperty('color')) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1328,36 +1328,6 @@ RED.view = (function() {
                     RED.editor.mermaid.render()
                 }, 0)
                 return section
-            },
-            position: function(n, rectWidth) {
-                // Default top-right placement for nodes and subflows; groups place
-                // the badge inline with the label (or top-left inside the group when
-                // the label is hidden entirely).
-                if (n.type !== "group") { return null }
-                if (!n.style || !n.style.label) {
-                    // Label hidden: park inside the top-left of the group.
-                    return { x: 5, y: 5 };
-                }
-                const labelPos = n.style["label-position"] || "nw";
-                const textWidth = n.labelTextWidth || 0;
-                // labels can be empty when the group name is blank but label:true;
-                // clamp to 1 so the y calculation still places the badge where the
-                // first line of label text would sit.
-                const lineCount = Math.max(1, (n.labels && n.labels.length) || 1);
-                let x, y;
-                if (labelPos[0] === 'n') {
-                    y = 5;
-                } else {
-                    y = n.h - 15 - (lineCount - 1) * 16;
-                }
-                if (labelPos[1] === 'w') {
-                    x = 5;
-                } else if (labelPos[1] === 'e') {
-                    x = n.w - 5 - textWidth - rectWidth - 4;
-                } else {
-                    x = (n.w - textWidth - rectWidth - 4) / 2;
-                }
-                return { x: x, y: y };
             }
         })
 
@@ -6637,17 +6607,12 @@ RED.view = (function() {
                         recalculateLabelOffsets = true;
                     }
                     if (recalculateLabelOffsets) {
-                        // Reserve space inline with the group label for the info docs badge
-                        // (icon + gap). Used both to extend minWidth and to offset labelX below.
-                        var infoBadgeReserve = (showNodeInfo && !!d.info) ? 12 : 0;
                         if (!d.minWidth) {
                             if (d.style.label && d.name) {
                                 var labelParts = getLabelParts(d.name||"","red-ui-flow-group-label");
-                                d.labelTextWidth = labelParts.width;
-                                d.minWidth = labelParts.width + 8 + infoBadgeReserve;
+                                d.minWidth = labelParts.width + 8;
                                 d.labels = labelParts.lines;
                             } else {
-                                d.labelTextWidth = 0;
                                 d.minWidth = 40;
                                 d.labels = [];
                             }
@@ -6721,24 +6686,19 @@ RED.view = (function() {
                         var labelX = 0;
                         var labelY = 0;
 
-                        // When the info docs badge is going to be rendered inline with the label,
-                        // shift the label to leave room for it on the side of the text.
-                        var hasInfoBadge = showNodeInfo && !!d.info;
-                        var infoBadgeReserve = hasInfoBadge ? 12 : 0;
-
                         if (labelPos[0] === 'n') {
                             labelY = 0+15; // Allow for font-height
                         } else {
                             labelY = d.h - 5 -(d.labels.length -1) * 16;
                         }
                         if (labelPos[1] === 'w') {
-                            labelX = 5 + infoBadgeReserve;
+                            labelX = 5;
                             labelAnchor = "start"
                         } else if (labelPos[1] === 'e') {
                             labelX = d.w-5;
                             labelAnchor = "end"
                         } else {
-                            labelX = d.w/2 + infoBadgeReserve/2;
+                            labelX = d.w/2;
                             labelAnchor = "middle"
                         }
                         if (d.style.hasOwnProperty('color')) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1279,15 +1279,6 @@ RED.view = (function() {
                 const pageLines = document.createElementNS("http://www.w3.org/2000/svg","path");
                 pageLines.setAttribute("d", "M 7 3 h -3 v -3 M 2 8 h 3 M 2 6 h 3 M 2 4 h 2")
                 docsBadge.appendChild(pageLines)
-
-                // Stop mousedown/mouseup at the badge so clicking it doesn't bubble to
-                // the parent node/group/canvas and trigger selection changes. The popover's
-                // own click handler (added by RED.popover.create with trigger:'click') still
-                // fires because click is a native event
-                $(docsBadge).on('mousedown mouseup', function(evt) {
-                    evt.stopPropagation()
-                })
-
                 return docsBadge;
             },
             show: function(n) { return showNodeInfo && !!n.info },
@@ -1318,7 +1309,7 @@ RED.view = (function() {
                 const tools = $('<div class="red-ui-sidebar-banner-tools"></div>').appendTo(banner)
                 const canEdit = RED.user.hasPermission('flows.write') && !RED.workspaces.isLocked()
                 if (canEdit) {
-                    const editButton = $('<button type="button" data-i18n="[title]common.label.edit"><i class="fa fa-edit"></i></button>').appendTo(tools)
+                    const editButton = $('<button type="button" data-i18n="[title]common.label.edit"><i class="fa fa-pencil"></i></button>').appendTo(tools)
                     editButton.on('click', function(evt) {
                         evt.preventDefault()
                         evt.stopPropagation()

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1286,6 +1286,7 @@ RED.view = (function() {
         RED.view.annotations.register("red-ui-flow-node-changed",{
             type: "badge",
             class: "red-ui-flow-node-changed",
+            filter: function(n) { return n.type !== "group" }, // dont show change badge on groups
             element: function() {
                 var changeBadge = document.createElementNS("http://www.w3.org/2000/svg","circle");
                 changeBadge.setAttribute("cx",5);
@@ -1299,6 +1300,7 @@ RED.view = (function() {
         RED.view.annotations.register("red-ui-flow-node-error",{
             type: "badge",
             class: "red-ui-flow-node-error",
+            filter: function(n) { return n.type !== "group" }, // dont show error badge on groups
             element: function(d) {
                 var errorBadge = document.createElementNS("http://www.w3.org/2000/svg","path");
                 errorBadge.setAttribute("d","M 0,9 l 10,0 -5,-8 z");
@@ -6498,6 +6500,7 @@ RED.view = (function() {
 
                 g.append('svg:text').attr("class","red-ui-flow-group-label");
                 d.dirty = true;
+                RED.hooks.trigger("viewAddNode",{node:d,el:selectGroup.node()})
             });
             if (addedGroups) {
                 group.sort(function(a,b) {
@@ -6686,6 +6689,7 @@ RED.view = (function() {
                     delete dirtyGroups[d.id];
                     delete d.dirty;
                 }
+                RED.hooks.trigger("viewRedrawNode",{node:d,el:document.getElementById("group_select_"+d.id)})
             })
         } else {
             // JOINING - unselect any selected links

--- a/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
@@ -297,7 +297,7 @@ svg:not(.red-ui-workspace-lasso-active) {
     // both light and dark themes. Same pattern as red-ui-tourGuide-popover in tourGuide.scss.
     z-index: 2002; // 1 less than the tourGuide popovers
     --red-ui-popover-background: var(--red-ui-secondary-background);
-    --red-ui-popover-border: var(--red-ui-secondary-border-color);
+    --red-ui-popover-border: var(--red-ui-primary-border-color);
     --red-ui-popover-color: var(--red-ui-primary-text-color);
 
     .red-ui-popover-content {
@@ -311,6 +311,8 @@ svg:not(.red-ui-workspace-lasso-active) {
         display: flex;
         flex-direction: column;
     }
+
+
     .red-ui-flow-annotation-popover-section {
         // Sidebar section is designed for column flow inside the sidebar; reset for the popover.
         margin: 0;
@@ -321,6 +323,12 @@ svg:not(.red-ui-workspace-lasso-active) {
         display: flex;
         flex-direction: column;
     }
+    &.red-ui-popover-bottom .red-ui-flow-annotation-popover-section {
+        flex-direction: column-reverse;
+    }
+
+
+
     .red-ui-sidebar-banner {
         // Slightly taller than the sidebar banner so the tool buttons don't crowd
         height: 22px;

--- a/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
@@ -291,6 +291,64 @@ svg:not(.red-ui-workspace-lasso-active) {
     }
 }
 
+.red-ui-flow-annotation-popover {
+    // Re-point annotation popover (node badge popovers) to have theme-aware backgrounds so that
+    // rich markdown content inside (links, code blocks, tables, alerts, ...) reads correctly in
+    // both light and dark themes. Same pattern as red-ui-tourGuide-popover in tourGuide.scss.
+    z-index: 2002; // 1 less than the tourGuide popovers
+    --red-ui-popover-background: var(--red-ui-secondary-background);
+    --red-ui-popover-border: var(--red-ui-secondary-border-color);
+    --red-ui-popover-color: var(--red-ui-primary-text-color);
+
+    .red-ui-popover-content {
+        // Section provides the inner chrome, so drop the default popover-content padding.
+        // overflow:hidden clips the popover's 2px border-color frame against the section's
+        // rounded corners so the corner triangles don't show through.
+        padding: 0;
+        max-height: 400px;
+        overflow: hidden;
+        border-radius: 4px;
+        display: flex;
+        flex-direction: column;
+    }
+    .red-ui-flow-annotation-popover-section {
+        // Sidebar section is designed for column flow inside the sidebar; reset for the popover.
+        margin: 0;
+        border: none;
+        border-radius: 0;
+        flex: 1 1 auto;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+    }
+    .red-ui-sidebar-banner {
+        // Slightly taller than the sidebar banner so the tool buttons don't crowd
+        height: 22px;
+        cursor: default;
+    }
+    .red-ui-sidebar-banner-tools button {
+        // The sidebar.scss button styles are scoped via `.red-ui-editor & button`. The popover
+        // is appended to <body> (outside .red-ui-editor), so re-declare them here.
+        width: 18px;
+        height: 18px;
+        padding: 0;
+        line-height: 18px;
+        border: none;
+        background-color: transparent;
+        color: var(--red-ui-secondary-text-color);
+        cursor: pointer;
+        &:hover {
+            color: var(--red-ui-primary-text-color);
+        }
+    }
+    .red-ui-flow-annotation-popover-body {
+        padding: 8px;
+        overflow-y: auto;
+        flex: 1 1 auto;
+        min-height: 0;
+    }
+}
+
 g.red-ui-flow-node-selected {
     .red-ui-workspace-select-mode & {
         opacity: 1;

--- a/packages/node_modules/@node-red/editor-client/src/sass/popover.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/popover.scss
@@ -188,12 +188,13 @@
         border-color: var(--red-ui-popover-button-border-color-hover);
     }
 }
-.red-ui-popover code {
-    border: none;
-    background: none;
-    color: var(--red-ui-tertiary-text-color);
-}
 
+// disabled ↓ to let the popover pick up styles from class set in the popover options or its content
+// .red-ui-popover code {
+//     border: none;
+//     background: none;
+//     color: var(--red-ui-tertiary-text-color);
+// }
 
 .red-ui-popover-panel {
     @include mixins.component-shadow;

--- a/packages/node_modules/@node-red/editor-client/src/sass/popover.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/popover.scss
@@ -49,74 +49,74 @@
 }
 .red-ui-popover.red-ui-popover-right:after, .red-ui-popover.red-ui-popover-right:before {
     top: 50%;
-    right: 100%;
+    right: calc(100% - 2px);
 }
 .red-ui-popover.red-ui-popover-left:after, .red-ui-popover.red-ui-popover-left:before {
     top: 50%;
-    left: 100%;
+    left: calc(100% - 2px);
 }
 
 .red-ui-popover.red-ui-popover-bottom:after, .red-ui-popover.red-ui-popover-bottom:before {
-    bottom: 100%;
+    bottom: calc(100% - 2px);
     left: 50%;
 }
 
 .red-ui-popover.red-ui-popover-top:after, .red-ui-popover.red-ui-popover-top:before {
-    top: 100%;
+    top: calc(100% - 2px);
     left: 50%;
 }
 
 .red-ui-popover.red-ui-popover-right:after {
     border-color: transparent;
-    border-right-color: var(--red-ui-popover-border);
+    border-right-color: var(--red-ui-popover-background);
     border-width: 10px;
     margin-top: -10px;
 }
 .red-ui-popover.red-ui-popover-right:before {
     border-color: transparent;
     border-right-color: var(--red-ui-popover-border);
-    border-width: 11px;
-    margin-top: -11px;
+    border-width: 13px;
+    margin-top: -13px;
 }
 
 .red-ui-popover.red-ui-popover-left:after {
     border-color: transparent;
-    border-left-color: var(--red-ui-popover-border);
+    border-left-color: var(--red-ui-popover-background);
     border-width: 10px;
     margin-top: -10px;
 }
 .red-ui-popover.red-ui-popover-left:before {
     border-color: transparent;
     border-left-color: var(--red-ui-popover-border);
-    border-width: 11px;
-    margin-top: -11px;
+    border-width: 13px;
+    margin-top: -13px;
 }
 
 
 .red-ui-popover.red-ui-popover-bottom:after {
     border-color: transparent;
-    border-bottom-color: var(--red-ui-popover-border);
+    border-bottom-color: var(--red-ui-popover-background);
     border-width: 10px;
     margin-left: -10px;
 }
 .red-ui-popover.red-ui-popover-bottom:before {
     border-color: transparent;
     border-bottom-color: var(--red-ui-popover-border);
-    border-width: 11px;
-    margin-left: -11px;
+    border-width: 13px;
+    margin-left: -13px;
 }
 
 .red-ui-popover.red-ui-popover-top:after {
     border-color: transparent;
-    border-top-color: var(--red-ui-popover-border);
+    border-top-color: var(--red-ui-popover-background);
     border-width: 10px;
     margin-left: -10px;
 }
 .red-ui-popover.red-ui-popover-top:before {
     border-color: transparent;
     border-top-color: var(--red-ui-popover-border);
-    border-width: 11px;
-    margin-left: -11px;
+    border-width: 13px;
+    margin-left: -13px;
 }
 
 


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

Discussed here: https://discourse.nodered.org/t/quick-contextual-access-to-info-on-my-node-group/100980

## Proposed changes

Adds the note icon to groups (same as nodes)

<img width="475" height="157" alt="image" src="https://github.com/user-attachments/assets/1a625147-d773-4773-ab51-e700958a1674" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
