### PR TITLE
Feat: Show rendered info upon node/group note annotation badge click

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -34,7 +34,8 @@
             "unlock": "Unlock",
             "locked": "Locked",
             "unlocked": "Unlocked",
-            "format": "Format"
+            "format": "Format",
+            "edit": "Edit"
         },
         "type": {
             "string": "string",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
@@ -168,6 +168,7 @@ RED.popover = (function() {
         var div;
         var contentDiv;
         var currentStyle;
+        var closeOnOutsideClickHandler;
 
         var openPopup = function(instant) {
             if (isOpen) {
@@ -237,6 +238,19 @@ RED.popover = (function() {
                     div.show();
                 } else {
                     div.fadeIn("fast");
+                }
+                if (options.closeOnOutsideClick) {
+                    // Close when the user clicks outside the target and the popover.
+                    // Use capture phase so handlers further down that call stopPropagation
+                    // (e.g. the popover's own click toggle, or a node's mousedown handler)
+                    // can't prevent the dismiss from firing.
+                    closeOnOutsideClickHandler = function (event) {
+                        if (target[0].contains(event.target)) { return; }
+                        if (div && div[0].contains(event.target)) { return; }
+                        active = false;
+                        closePopup();
+                    };
+                    document.addEventListener('mousedown', closeOnOutsideClickHandler, true);
                 }
             }
         }
@@ -341,6 +355,10 @@ RED.popover = (function() {
         var closePopup = function(instant) {
             isOpen = false
             $(document).off('mousedown.red-ui-popover');
+            if (closeOnOutsideClickHandler) {
+                document.removeEventListener('mousedown', closeOnOutsideClickHandler, true);
+                closeOnOutsideClickHandler = null;
+            }
             if (!active) {
                 if (div) {
                     if (instant) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-annotations.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-annotations.js
@@ -150,17 +150,26 @@ RED.view.annotations = (function() {
             const popoverInstance = RED.popover.create({
                 target: $(annotation),
                 trigger: 'click',
-                interactive: true,
+                // interactive: true,
                 closeOnOutsideClick: true,
                 autoClose: false, // keep open - user may want to scroll or copy content
                 direction,
                 delay,
                 class: 'red-ui-flow-annotation-popover',
+                width: 400,
                 maxWidth,
                 content: function() {
                     return opts.popover(node, popoverInstance)
                 }
             })
+            // Stop mousedown/mouseup at the badge so clicking it doesn't bubble to
+            // the parent node/group/canvas and trigger selection changes. The popover's
+            // own click handler (added by RED.popover.create with trigger:'click') still
+            // fires because click is a native event
+            $(annotation).on('mousedown mouseup', function(evt) {
+                evt.stopPropagation()
+            })
+
         }
         if (annotationGroup.hasChildNodes()) {
             annotationGroup.removeChild(annotationGroup.firstChild)

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view-annotations.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view-annotations.js
@@ -132,6 +132,25 @@ RED.view.annotations = (function() {
             annotation.addEventListener("mouseenter", getAnnotationMouseEnter(annotation, node, opts.tooltip));
             annotation.addEventListener("mouseleave", annotationMouseLeave);
         }
+        if (opts.popover) {
+            const direction = opts.popoverDirection || 'bottom'
+            const maxWidth = opts.popoverMaxWidth || 400
+            const delay = opts.popoverDelay || { show: 350, hide: 150 }
+            const popoverInstance = RED.popover.create({
+                target: $(annotation),
+                trigger: 'click',
+                interactive: true,
+                closeOnOutsideClick: true,
+                autoClose: false, // keep open - user may want to scroll or copy content
+                direction,
+                delay,
+                class: 'red-ui-flow-annotation-popover',
+                maxWidth,
+                content: function() {
+                    return opts.popover(node, popoverInstance)
+                }
+            })
+        }
         if (annotationGroup.hasChildNodes()) {
             annotationGroup.removeChild(annotationGroup.firstChild)
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1304,12 +1304,15 @@ RED.view = (function() {
                 $('<div class="red-ui-sidebar-banner-icon"><i class="fa fa-info"></i></div>').appendTo(banner)
                 $('<div class="red-ui-sidebar-banner-label" data-i18n="sidebar.info.name"></div>').appendTo(banner)
                 const tools = $('<div class="red-ui-sidebar-banner-tools"></div>').appendTo(banner)
-                const editButton = $('<button type="button" data-i18n="[title]common.label.edit"><i class="fa fa-edit"></i></button>').appendTo(tools)
-                editButton.on('click', function(evt) {
-                    evt.preventDefault()
-                    evt.stopPropagation()
-                    editInfo()
-                })
+                const canEdit = RED.user.hasPermission('flows.write') && !RED.workspaces.isLocked()
+                if (canEdit) {
+                    const editButton = $('<button type="button" data-i18n="[title]common.label.edit"><i class="fa fa-edit"></i></button>').appendTo(tools)
+                    editButton.on('click', function(evt) {
+                        evt.preventDefault()
+                        evt.stopPropagation()
+                        editInfo()
+                    })
+                }
 
                 $(`<div class="red-ui-help red-ui-flow-annotation-popover-body"><span class="red-ui-text-bidi-aware">${RED.utils.renderMarkdown(n.info)}</span></div>`).appendTo(section)
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1268,19 +1268,61 @@ RED.view = (function() {
                 pageLines.setAttribute("d", "M 7 3 h -3 v -3 M 2 8 h 3 M 2 6 h 3 M 2 4 h 2")
                 docsBadge.appendChild(pageLines)
 
-                $(docsBadge).on('click', function (evt) {
-                    if (node.type === "subflow") {
-                        RED.editor.editSubflow(activeSubflow, 'editor-tab-description');
-                    } else if (node.type === "group") {
-                        RED.editor.editGroup(node, 'editor-tab-description');
-                    } else {
-                        RED.editor.edit(node, 'editor-tab-description');
-                    }
+                // Stop mousedown/mouseup at the badge so clicking it doesn't bubble to
+                // the parent node/group/canvas and trigger selection changes. The popover's
+                // own click handler (added by RED.popover.create with trigger:'click') still
+                // fires because click is a native event
+                $(docsBadge).on('mousedown mouseup', function(evt) {
+                    evt.stopPropagation()
                 })
 
                 return docsBadge;
             },
-            show: function(n) { return showNodeInfo && !!n.info }
+            show: function(n) { return showNodeInfo && !!n.info },
+            popover: function(n, popoverInstance) {
+                // This is called when popover is triggered. It should return the content for the popover when the badge is clicked.
+                // Since we are exclusively using this badge to show node info, we can be opinionated about the content we generate
+                // we know it needs to render the info as markdown (and support mermaid diagrams).
+                // The popover mimics the sidebar info panel layout: a `red-ui-sidebar-section` rounded container
+                // with a `red-ui-sidebar-banner` header containing a label and a button to open the editor's
+                // description tab.
+                if (!n.info) { return null }
+
+                const editInfo = function() {
+                    if (popoverInstance) { popoverInstance.close() }
+                    if (n.type === "subflow") {
+                        RED.editor.editSubflow(activeSubflow, 'editor-tab-description')
+                    } else if (n.type === "group") {
+                        RED.editor.editGroup(n, 'editor-tab-description')
+                    } else {
+                        RED.editor.edit(n, 'editor-tab-description')
+                    }
+                }
+
+                const section = $('<div class="red-ui-sidebar-section red-ui-flow-annotation-popover-section"></div>')
+                const banner = $('<div class="red-ui-sidebar-banner"></div>').appendTo(section)
+                $('<div class="red-ui-sidebar-banner-icon"><i class="fa fa-info"></i></div>').appendTo(banner)
+                $('<div class="red-ui-sidebar-banner-label" data-i18n="sidebar.info.name"></div>').appendTo(banner)
+                const tools = $('<div class="red-ui-sidebar-banner-tools"></div>').appendTo(banner)
+                const editButton = $('<button type="button" data-i18n="[title]common.label.edit"><i class="fa fa-edit"></i></button>').appendTo(tools)
+                editButton.on('click', function(evt) {
+                    evt.preventDefault()
+                    evt.stopPropagation()
+                    editInfo()
+                })
+
+                $(`<div class="red-ui-help red-ui-flow-annotation-popover-body"><span class="red-ui-text-bidi-aware">${RED.utils.renderMarkdown(n.info)}</span></div>`).appendTo(section)
+
+                // Resolve data-i18n attributes on content
+                section.i18n()
+
+                // On the next tick, render any unrendered mermaid diagrams
+                // (Already-rendered diagrams will be skipped via the `mermaid-processed` attribute)
+                setTimeout(function() {
+                    RED.editor.mermaid.render()
+                }, 0)
+                return section
+            }
         })
 
         RED.view.annotations.register("red-ui-flow-node-changed",{

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1279,15 +1279,6 @@ RED.view = (function() {
                 const pageLines = document.createElementNS("http://www.w3.org/2000/svg","path");
                 pageLines.setAttribute("d", "M 7 3 h -3 v -3 M 2 8 h 3 M 2 6 h 3 M 2 4 h 2")
                 docsBadge.appendChild(pageLines)
-
-                // Stop mousedown/mouseup at the badge so clicking it doesn't bubble to
-                // the parent node/group/canvas and trigger selection changes. The popover's
-                // own click handler (added by RED.popover.create with trigger:'click') still
-                // fires because click is a native event
-                $(docsBadge).on('mousedown mouseup', function(evt) {
-                    evt.stopPropagation()
-                })
-
                 return docsBadge;
             },
             show: function(n) { return showNodeInfo && !!n.info },
@@ -1318,7 +1309,7 @@ RED.view = (function() {
                 const tools = $('<div class="red-ui-sidebar-banner-tools"></div>').appendTo(banner)
                 const canEdit = RED.user.hasPermission('flows.write') && !RED.workspaces.isLocked()
                 if (canEdit) {
-                    const editButton = $('<button type="button" data-i18n="[title]common.label.edit"><i class="fa fa-edit"></i></button>').appendTo(tools)
+                    const editButton = $('<button type="button" data-i18n="[title]common.label.edit"><i class="fa fa-pencil"></i></button>').appendTo(tools)
                     editButton.on('click', function(evt) {
                         evt.preventDefault()
                         evt.stopPropagation()

--- a/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
@@ -297,7 +297,7 @@ svg:not(.red-ui-workspace-lasso-active) {
     // both light and dark themes. Same pattern as red-ui-tourGuide-popover in tourGuide.scss.
     z-index: 2002; // 1 less than the tourGuide popovers
     --red-ui-popover-background: var(--red-ui-secondary-background);
-    --red-ui-popover-border: var(--red-ui-secondary-border-color);
+    --red-ui-popover-border: var(--red-ui-primary-border-color);
     --red-ui-popover-color: var(--red-ui-primary-text-color);
 
     .red-ui-popover-content {
@@ -311,6 +311,8 @@ svg:not(.red-ui-workspace-lasso-active) {
         display: flex;
         flex-direction: column;
     }
+
+
     .red-ui-flow-annotation-popover-section {
         // Sidebar section is designed for column flow inside the sidebar; reset for the popover.
         margin: 0;
@@ -321,6 +323,12 @@ svg:not(.red-ui-workspace-lasso-active) {
         display: flex;
         flex-direction: column;
     }
+    &.red-ui-popover-bottom .red-ui-flow-annotation-popover-section {
+        flex-direction: column-reverse;
+    }
+
+
+
     .red-ui-sidebar-banner {
         // Slightly taller than the sidebar banner so the tool buttons don't crowd
         height: 22px;

--- a/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
@@ -291,6 +291,64 @@ svg:not(.red-ui-workspace-lasso-active) {
     }
 }
 
+.red-ui-flow-annotation-popover {
+    // Re-point annotation popover (node badge popovers) to have theme-aware backgrounds so that
+    // rich markdown content inside (links, code blocks, tables, alerts, ...) reads correctly in
+    // both light and dark themes. Same pattern as red-ui-tourGuide-popover in tourGuide.scss.
+    z-index: 2002; // 1 less than the tourGuide popovers
+    --red-ui-popover-background: var(--red-ui-secondary-background);
+    --red-ui-popover-border: var(--red-ui-secondary-border-color);
+    --red-ui-popover-color: var(--red-ui-primary-text-color);
+
+    .red-ui-popover-content {
+        // Section provides the inner chrome, so drop the default popover-content padding.
+        // overflow:hidden clips the popover's 2px border-color frame against the section's
+        // rounded corners so the corner triangles don't show through.
+        padding: 0;
+        max-height: 400px;
+        overflow: hidden;
+        border-radius: 4px;
+        display: flex;
+        flex-direction: column;
+    }
+    .red-ui-flow-annotation-popover-section {
+        // Sidebar section is designed for column flow inside the sidebar; reset for the popover.
+        margin: 0;
+        border: none;
+        border-radius: 0;
+        flex: 1 1 auto;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+    }
+    .red-ui-sidebar-banner {
+        // Slightly taller than the sidebar banner so the tool buttons don't crowd
+        height: 22px;
+        cursor: default;
+    }
+    .red-ui-sidebar-banner-tools button {
+        // The sidebar.scss button styles are scoped via `.red-ui-editor & button`. The popover
+        // is appended to <body> (outside .red-ui-editor), so re-declare them here.
+        width: 18px;
+        height: 18px;
+        padding: 0;
+        line-height: 18px;
+        border: none;
+        background-color: transparent;
+        color: var(--red-ui-secondary-text-color);
+        cursor: pointer;
+        &:hover {
+            color: var(--red-ui-primary-text-color);
+        }
+    }
+    .red-ui-flow-annotation-popover-body {
+        padding: 8px;
+        overflow-y: auto;
+        flex: 1 1 auto;
+        min-height: 0;
+    }
+}
+
 g.red-ui-flow-node-selected {
     .red-ui-workspace-select-mode & {
         opacity: 1;

--- a/packages/node_modules/@node-red/editor-client/src/sass/popover.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/popover.scss
@@ -188,12 +188,13 @@
         border-color: var(--red-ui-popover-button-border-color-hover);
     }
 }
-.red-ui-popover code {
-    border: none;
-    background: none;
-    color: var(--red-ui-tertiary-text-color);
-}
 
+// disabled ↓ to let the popover pick up styles from class set in the popover options or its content
+// .red-ui-popover code {
+//     border: none;
+//     background: none;
+//     color: var(--red-ui-tertiary-text-color);
+// }
 
 .red-ui-popover-panel {
     @include mixins.component-shadow;

--- a/packages/node_modules/@node-red/editor-client/src/sass/popover.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/popover.scss
@@ -49,74 +49,74 @@
 }
 .red-ui-popover.red-ui-popover-right:after, .red-ui-popover.red-ui-popover-right:before {
     top: 50%;
-    right: 100%;
+    right: calc(100% - 2px);
 }
 .red-ui-popover.red-ui-popover-left:after, .red-ui-popover.red-ui-popover-left:before {
     top: 50%;
-    left: 100%;
+    left: calc(100% - 2px);
 }
 
 .red-ui-popover.red-ui-popover-bottom:after, .red-ui-popover.red-ui-popover-bottom:before {
-    bottom: 100%;
+    bottom: calc(100% - 2px);
     left: 50%;
 }
 
 .red-ui-popover.red-ui-popover-top:after, .red-ui-popover.red-ui-popover-top:before {
-    top: 100%;
+    top: calc(100% - 2px);
     left: 50%;
 }
 
 .red-ui-popover.red-ui-popover-right:after {
     border-color: transparent;
-    border-right-color: var(--red-ui-popover-border);
+    border-right-color: var(--red-ui-popover-background);
     border-width: 10px;
     margin-top: -10px;
 }
 .red-ui-popover.red-ui-popover-right:before {
     border-color: transparent;
     border-right-color: var(--red-ui-popover-border);
-    border-width: 11px;
-    margin-top: -11px;
+    border-width: 13px;
+    margin-top: -13px;
 }
 
 .red-ui-popover.red-ui-popover-left:after {
     border-color: transparent;
-    border-left-color: var(--red-ui-popover-border);
+    border-left-color: var(--red-ui-popover-background);
     border-width: 10px;
     margin-top: -10px;
 }
 .red-ui-popover.red-ui-popover-left:before {
     border-color: transparent;
     border-left-color: var(--red-ui-popover-border);
-    border-width: 11px;
-    margin-top: -11px;
+    border-width: 13px;
+    margin-top: -13px;
 }
 
 
 .red-ui-popover.red-ui-popover-bottom:after {
     border-color: transparent;
-    border-bottom-color: var(--red-ui-popover-border);
+    border-bottom-color: var(--red-ui-popover-background);
     border-width: 10px;
     margin-left: -10px;
 }
 .red-ui-popover.red-ui-popover-bottom:before {
     border-color: transparent;
     border-bottom-color: var(--red-ui-popover-border);
-    border-width: 11px;
-    margin-left: -11px;
+    border-width: 13px;
+    margin-left: -13px;
 }
 
 .red-ui-popover.red-ui-popover-top:after {
     border-color: transparent;
-    border-top-color: var(--red-ui-popover-border);
+    border-top-color: var(--red-ui-popover-background);
     border-width: 10px;
     margin-left: -10px;
 }
 .red-ui-popover.red-ui-popover-top:before {
     border-color: transparent;
     border-top-color: var(--red-ui-popover-border);
-    border-width: 11px;
-    margin-left: -11px;
+    border-width: 13px;
+    margin-left: -13px;
 }
 
 


### PR DESCRIPTION
## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

Discussed here: https://discourse.nodered.org/t/quick-contextual-access-to-info-on-my-node-group/100980

## Proposed changes

**TL;DR**

Clicking the docs badge on a node, group, or subflow opens a themed popover showing the rendered description, with an edit button to jump to the editor's description tab. Dismisses on outside-click; follows the active light/dark theme.

**Detail**

- **Annotation system gains a `popover` option.** Registrations can declare `popover: function(node, popoverInstance) → DOM/jQuery element`. When set, the annotation framework wires a `RED.popover.create` to the badge — `trigger: 'click'`, `interactive`, `closeOnOutsideClick`.
- **Docs badge content mirrors the sidebar info panel.** A `red-ui-sidebar-section` wraps a `red-ui-sidebar-banner` (info icon + "Information" label + a tools area with an `fa-edit` button) and a `red-ui-help` body containing the rendered markdown. The edit button opens the editor on the description tab via `RED.editor.edit / editGroup / editSubflow` and closes the popover. `data-i18n` attributes are resolved with a `.i18n()` pass on the dynamically-built section.
- **Click on the badge no longer deselects.** Mousedown/mouseup are stopped at the badge so the click doesn't bubble to `nodeMouseDown` / `groupMouseDown` / `canvasMouseDown` and clear the selection. The popover's own click handler still fires (click is a derived event).
- **Theme-aware popover.** The annotation popover overrides `--red-ui-popover-background` / `-color` / `-border` to point at `--red-ui-secondary-background` / `--red-ui-primary-text-color` / `--red-ui-secondary-border-color` (same pattern as `tourGuide.scss`). Light theme renders a light popover with light-theme content; dark theme renders a dark popover with dark-theme content. Avoids the always-dark popover chrome clashing with light-theme content (`pre code` backgrounds, link colours, etc.).
- **Outside-click dismissal.** New `closeOnOutsideClick` option on `RED.popover.create` (opt-in, default `false`). Attaches a **capture-phase** `mousedown` listener on `document` that closes the popover unless the click is on the target or inside the popover; removed in `closePopup`. Capture phase is required because both the badge (to preserve node selection) and `popover.js`'s click-toggle call `stopPropagation`, so a bubble-phase listener wouldn't reliably fire on clicks elsewhere in the editor.

### Screenshots

#### dark
<img width="690" height="346" alt="image" src="https://github.com/user-attachments/assets/6a73805e-af6f-4551-8192-7699ed48ed35" />

#### light
<img width="690" height="346" alt="image" src="https://github.com/user-attachments/assets/1459e815-46b0-4c5a-b015-8531a4db069b" />

#### in action
<img alt="image" src="https://us1.discourse-cdn.com/flex026/uploads/nodered/original/3X/7/4/74cf062d2f7300add7e54511701a407868ccce7e.gif" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
