### PR TITLE
Add support for GH style blockquote alerts

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -108,6 +108,29 @@ RED.utils = (function() {
         }
     };
 
+    // GitHub-style alerts: a blockquote whose first line is one of
+    // `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]` or `[!CAUTION]`.
+    // Anything else falls through as a regular blockquote.
+    // Older versions of the editor simply fallback to rendering the alert MD as regular block quote.
+    const alertTagRegex = /^\s*<p>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][ \t]*(<br\s*\/?>|\n|<\/p>)/i;
+    renderer.blockquote = function (quote) {
+        const m = alertTagRegex.exec(quote)
+        if (m) {
+            const type = m[1].toLowerCase();
+            const title = type.charAt(0).toUpperCase() + type.slice(1)
+            // If the marker terminated its own paragraph, drop that paragraph
+            // entirely; otherwise keep the paragraph open with the body text.
+            const body = m[2] === '</p>'
+                ? quote.substring(m[0].length)
+                : '<p>' + quote.substring(m[0].length);
+            return `<div class="markdown-alert markdown-alert-${type}">\n` +
+                `<p class="markdown-alert-title">${title}</p>\n` +
+                body +
+                '</div>\n'
+        }
+        return `<blockquote>\n${quote}</blockquote>\n`
+    }
+
     window._marked.setOptions({
         renderer: renderer,
         gfm: true,

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -123,8 +123,8 @@ RED.utils = (function() {
             const body = m[2] === '</p>'
                 ? quote.substring(m[0].length)
                 : '<p>' + quote.substring(m[0].length);
-            return `<div class="markdown-alert markdown-alert-${type}">\n` +
-                `<p class="markdown-alert-title">${title}</p>\n` +
+            return `<div class="red-ui-markdown-alert red-ui-markdown-alert-${type}">\n` +
+                `<p class="red-ui-markdown-alert-title">${title}</p>\n` +
                 body +
                 '</div>\n'
         }

--- a/packages/node_modules/@node-red/editor-client/src/sass/base.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/base.scss
@@ -218,9 +218,10 @@ html, body {
         border: 0;
     }
 
-    blockquote {
-        padding: 0 0 0 15px;
-        margin: 0 0 20px;
+    blockquote,
+    .markdown-alert {
+        padding: 0 0 0 12px;
+        margin: 0 0 16px;
         border-left: 4px solid var(--red-ui-secondary-border-color);
         color: var(--red-ui-secondary-text-color);
 
@@ -229,6 +230,60 @@ html, body {
             font-weight: inherit;
             line-height: 1.25;
             margin-bottom: 0;
+        }
+    }
+
+    // GitHub-style markdown alerts (see RED.utils renderer.blockquote).
+    // Older editors that don't recognise the [!TYPE] marker fall back to
+    // rendering the as a regular blockquote -- same base styles above.
+    .markdown-alert {
+        > .markdown-alert-title {
+            display: flex;
+            align-items: center;
+            font-size: 14px;
+            font-weight: 500;
+            line-height: 1.25;
+            margin: 0 0 4px;
+            &::before {
+                font-family: FontAwesome;
+                font-weight: normal;
+                margin-right: 6px;
+            }
+        }
+    }
+    .markdown-alert-note {
+        border-left-color: var(--red-ui-text-color-markdown-alert-note, var(--red-ui-secondary-text-color, #4493f8));
+        > .markdown-alert-title {
+            color: var(--red-ui-text-color-markdown-alert-note, var(--red-ui-secondary-text-color, #4493f8));
+            &::before { content: "\f05a"; } // fa-info-circle
+        }
+    }
+    .markdown-alert-tip {
+        border-left-color: var(--red-ui-text-color-markdown-alert-tip, var(--red-ui-text-color-success, #3fb950));
+        > .markdown-alert-title {
+            color: var(--red-ui-text-color-markdown-alert-tip, var(--red-ui-text-color-success, #3fb950));
+            &::before { content: "\f0eb"; } // fa-lightbulb-o
+        }
+    }
+    .markdown-alert-important {
+        border-left-color: var(--red-ui-text-color-markdown-alert-important,  #ab7df8);
+        > .markdown-alert-title {
+            color: var(--red-ui-text-color-markdown-alert-important, #ab7df8);
+            &::before { content: "\f0a1"; } // fa-bullhorn
+        }
+    }
+    .markdown-alert-warning {
+        border-left-color: var(--red-ui-text-color-markdown-alert-warning, var(--red-ui-text-color-warning, #d29922));
+        > .markdown-alert-title {
+            color: var(--red-ui-text-color-markdown-alert-warning, var(--red-ui-text-color-warning, #d29922));
+            &::before { content: "\f071"; } // fa-exclamation-triangle
+        }
+    }
+    .markdown-alert-caution {
+        border-left-color: var(--red-ui-text-color-markdown-alert-caution, var(--red-ui-text-color-error, #f85149));
+        > .markdown-alert-title {
+            color: var(--red-ui-text-color-markdown-alert-caution, var(--red-ui-text-color-error, #f85149));
+            &::before { content: "\f057"; } // fa-times-circle
         }
     }
 

--- a/packages/node_modules/@node-red/editor-client/src/sass/base.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/base.scss
@@ -252,37 +252,37 @@ html, body {
         }
     }
     .markdown-alert-note {
-        border-left-color: var(--red-ui-text-color-markdown-alert-note, var(--red-ui-secondary-text-color, #4493f8));
+        border-left-color: var(--red-ui-text-color-markdown-alert-note);
         > .markdown-alert-title {
-            color: var(--red-ui-text-color-markdown-alert-note, var(--red-ui-secondary-text-color, #4493f8));
+            color: var(--red-ui-text-color-markdown-alert-note);
             &::before { content: "\f05a"; } // fa-info-circle
         }
     }
     .markdown-alert-tip {
-        border-left-color: var(--red-ui-text-color-markdown-alert-tip, var(--red-ui-text-color-success, #3fb950));
+        border-left-color: var(--red-ui-text-color-markdown-alert-tip);
         > .markdown-alert-title {
-            color: var(--red-ui-text-color-markdown-alert-tip, var(--red-ui-text-color-success, #3fb950));
+            color: var(--red-ui-text-color-markdown-alert-tip);
             &::before { content: "\f0eb"; } // fa-lightbulb-o
         }
     }
     .markdown-alert-important {
-        border-left-color: var(--red-ui-text-color-markdown-alert-important,  #ab7df8);
+        border-left-color: var(--red-ui-text-color-markdown-alert-important);
         > .markdown-alert-title {
-            color: var(--red-ui-text-color-markdown-alert-important, #ab7df8);
+            color: var(--red-ui-text-color-markdown-alert-important);
             &::before { content: "\f0a1"; } // fa-bullhorn
         }
     }
     .markdown-alert-warning {
-        border-left-color: var(--red-ui-text-color-markdown-alert-warning, var(--red-ui-text-color-warning, #d29922));
+        border-left-color: var(--red-ui-text-color-markdown-alert-warning);
         > .markdown-alert-title {
-            color: var(--red-ui-text-color-markdown-alert-warning, var(--red-ui-text-color-warning, #d29922));
+            color: var(--red-ui-text-color-markdown-alert-warning);
             &::before { content: "\f071"; } // fa-exclamation-triangle
         }
     }
     .markdown-alert-caution {
-        border-left-color: var(--red-ui-text-color-markdown-alert-caution, var(--red-ui-text-color-error, #f85149));
+        border-left-color: var(--red-ui-text-color-markdown-alert-caution);
         > .markdown-alert-title {
-            color: var(--red-ui-text-color-markdown-alert-caution, var(--red-ui-text-color-error, #f85149));
+            color: var(--red-ui-text-color-markdown-alert-caution);
             &::before { content: "\f057"; } // fa-times-circle
         }
     }

--- a/packages/node_modules/@node-red/editor-client/src/sass/base.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/base.scss
@@ -219,7 +219,7 @@ html, body {
     }
 
     blockquote,
-    .markdown-alert {
+    .red-ui-markdown-alert {
         padding: 0 0 0 12px;
         margin: 0 0 16px;
         border-left: 4px solid var(--red-ui-secondary-border-color);
@@ -236,8 +236,8 @@ html, body {
     // GitHub-style markdown alerts (see RED.utils renderer.blockquote).
     // Older editors that don't recognise the [!TYPE] marker fall back to
     // rendering the as a regular blockquote -- same base styles above.
-    .markdown-alert {
-        > .markdown-alert-title {
+    .red-ui-markdown-alert {
+        > .red-ui-markdown-alert-title {
             display: flex;
             align-items: center;
             font-size: 14px;
@@ -251,37 +251,37 @@ html, body {
             }
         }
     }
-    .markdown-alert-note {
+    .red-ui-markdown-alert-note {
         border-left-color: var(--red-ui-text-color-markdown-alert-note);
-        > .markdown-alert-title {
+        > .red-ui-markdown-alert-title {
             color: var(--red-ui-text-color-markdown-alert-note);
             &::before { content: "\f05a"; } // fa-info-circle
         }
     }
-    .markdown-alert-tip {
+    .red-ui-markdown-alert-tip {
         border-left-color: var(--red-ui-text-color-markdown-alert-tip);
-        > .markdown-alert-title {
+        > .red-ui-markdown-alert-title {
             color: var(--red-ui-text-color-markdown-alert-tip);
             &::before { content: "\f0eb"; } // fa-lightbulb-o
         }
     }
-    .markdown-alert-important {
+    .red-ui-markdown-alert-important {
         border-left-color: var(--red-ui-text-color-markdown-alert-important);
-        > .markdown-alert-title {
+        > .red-ui-markdown-alert-title {
             color: var(--red-ui-text-color-markdown-alert-important);
             &::before { content: "\f0a1"; } // fa-bullhorn
         }
     }
-    .markdown-alert-warning {
+    .red-ui-markdown-alert-warning {
         border-left-color: var(--red-ui-text-color-markdown-alert-warning);
-        > .markdown-alert-title {
+        > .red-ui-markdown-alert-title {
             color: var(--red-ui-text-color-markdown-alert-warning);
             &::before { content: "\f071"; } // fa-exclamation-triangle
         }
     }
-    .markdown-alert-caution {
+    .red-ui-markdown-alert-caution {
         border-left-color: var(--red-ui-text-color-markdown-alert-caution);
-        > .markdown-alert-title {
+        > .red-ui-markdown-alert-title {
             color: var(--red-ui-text-color-markdown-alert-caution);
             &::before { content: "\f057"; } // fa-times-circle
         }

--- a/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
@@ -54,6 +54,13 @@ $text-color-success: #218358;
 $text-color-code: #AD1625;
 $text-color-link: #0d74ce;
 
+// GitHub style markdown alert accent colours
+$text-color-markdown-alert-note: $secondary-text-color;
+$text-color-markdown-alert-tip: $text-color-success;
+$text-color-markdown-alert-important: #65A3E4;
+$text-color-markdown-alert-warning: $text-color-warning;
+$text-color-markdown-alert-caution: $text-color-error;
+
 
 $primary-border-color: #d9d9d9;//#f00;
 $secondary-border-color: #e8e8e8;//#0f0;

--- a/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
@@ -57,7 +57,7 @@ $text-color-link: #0d74ce;
 // GitHub style markdown alert accent colours
 $text-color-markdown-alert-note: $secondary-text-color;
 $text-color-markdown-alert-tip: $text-color-success;
-$text-color-markdown-alert-important: #65A3E4;
+$text-color-markdown-alert-important: #3a5bc7;
 $text-color-markdown-alert-warning: $text-color-warning;
 $text-color-markdown-alert-caution: $text-color-error;
 

--- a/packages/node_modules/@node-red/editor-client/src/sass/dark-colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/dark-colors.scss
@@ -53,6 +53,13 @@ $text-color-success: #4cc38a;
 $text-color-code:    #00d4c8;
 $text-color-link:    $accent;
 
+// GitHub-style markdown alert accent colours
+$text-color-markdown-alert-note:      $secondary-text-color;
+$text-color-markdown-alert-tip:       $text-color-success;
+$text-color-markdown-alert-important: #65A3E4;
+$text-color-markdown-alert-warning:   $text-color-warning;
+$text-color-markdown-alert-caution:   $text-color-error;
+
 // ── Borders ──
 $primary-border-color:   $border-1;
 $secondary-border-color: $border-1;

--- a/packages/node_modules/@node-red/editor-client/src/sass/dark-colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/dark-colors.scss
@@ -56,7 +56,7 @@ $text-color-link:    $accent;
 // GitHub-style markdown alert accent colours
 $text-color-markdown-alert-note:      $secondary-text-color;
 $text-color-markdown-alert-tip:       $text-color-success;
-$text-color-markdown-alert-important: #65A3E4;
+$text-color-markdown-alert-important: #3a5bc7;
 $text-color-markdown-alert-warning:   $text-color-warning;
 $text-color-markdown-alert-caution:   $text-color-error;
 

--- a/packages/node_modules/@node-red/editor-client/src/sass/dark-theme.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/dark-theme.scss
@@ -77,6 +77,12 @@ html.nr-theme-dark {
     --red-ui-text-color-code:    #{dc.$text-color-code};
     --red-ui-text-color-link:    #{dc.$text-color-link};
 
+    --red-ui-text-color-markdown-alert-note:      #{dc.$text-color-markdown-alert-note};
+    --red-ui-text-color-markdown-alert-tip:       #{dc.$text-color-markdown-alert-tip};
+    --red-ui-text-color-markdown-alert-important: #{dc.$text-color-markdown-alert-important};
+    --red-ui-text-color-markdown-alert-warning:   #{dc.$text-color-markdown-alert-warning};
+    --red-ui-text-color-markdown-alert-caution:   #{dc.$text-color-markdown-alert-caution};
+
     // ── Borders ──
     --red-ui-primary-border-color:   #{dc.$primary-border-color};
     --red-ui-secondary-border-color: #{dc.$secondary-border-color};

--- a/packages/node_modules/@node-red/editor-client/src/sass/dark-theme.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/dark-theme.scss
@@ -213,7 +213,7 @@ html.nr-theme-dark {
 
     // ── Nodes ──
     --red-ui-node-label-color:              #191919; // dark so labels read on colored node bgs
-    // Config sidebar: labels on dark bg — use bright text
+    // Config sidebar: labels on dark bg - use bright text
     .red-ui-sidebar-node-config .red-ui-palette-label { color: var(--red-ui-primary-text-color); }
     --red-ui-node-port-label-color:         #aaaaaa;
     --red-ui-node-border:                   #888888;
@@ -345,7 +345,7 @@ html.nr-theme-dark {
     // ── Ace editor ──
     // Override the light tomorrow theme token colors. The ace theme injects
     // .ace-tomorrow .ace_* with 2-class specificity; html.nr-theme-dark
-    // .ace-tomorrow .ace_* is 3-class + element — always wins.
+    // .ace-tomorrow .ace_* is 3-class + element - always wins.
     .ace-tomorrow {
         background-color: var(--red-ui-text-editor-background);
         color: var(--red-ui-text-editor-color);

--- a/packages/node_modules/@node-red/editor-client/src/sass/variables.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/variables.scss
@@ -47,6 +47,12 @@
     --red-ui-text-color-code: #{colors.$text-color-code};
     --red-ui-text-color-link: #{colors.$text-color-link};
 
+    --red-ui-text-color-markdown-alert-note: #{colors.$text-color-markdown-alert-note};
+    --red-ui-text-color-markdown-alert-tip: #{colors.$text-color-markdown-alert-tip};
+    --red-ui-text-color-markdown-alert-important: #{colors.$text-color-markdown-alert-important};
+    --red-ui-text-color-markdown-alert-warning: #{colors.$text-color-markdown-alert-warning};
+    --red-ui-text-color-markdown-alert-caution: #{colors.$text-color-markdown-alert-caution};
+
 
     --red-ui-primary-border-color: #{colors.$primary-border-color};
     --red-ui-secondary-border-color: #{colors.$secondary-border-color};

--- a/scripts/build/attach-copyright.js
+++ b/scripts/build/attach-copyright.js
@@ -22,7 +22,10 @@ async function attachToFile(file) {
     if (!fs.existsSync(file)) {
         throw new Error(`attachCopyright: file not found: ${file}`);
     }
-    const content = await fs.promises.readFile(file, "utf8");
+    let content = await fs.promises.readFile(file, "utf8");
+    if (content.charCodeAt(0) === 0xFEFF) {
+        content = content.slice(1);
+    }
     if (content.indexOf(HEADER) !== -1) {
         return false;
     }


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

closes #5727

## Proposed changes

Add Github style alert support to markdown rendering (reference: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts)



> [!IMPORTANT]
> This pull request includes a small change to the `attachToFile` function in `scripts/build/attach-copyright.js`. The update ensures that if a file starts with a UTF-8 Byte Order Mark (BOM), it is removed before further processing. 
> During development of this PR, I was seeing a BOM getting added before `:root` which prevented styles from loading in the editor
> <img width="1104" height="123" alt="image" src="https://github.com/user-attachments/assets/aacea015-ff91-49e4-b57c-03de944cb6ed" />
> This is apparently due to  when in compressed mode, node sass emits a UTF-8 BOM at the start of result.css whenever the source contains non-ASCII bytes (Sass uses BOM instead of @charset in compressed output to declare UTF-8).
> Additionally, I removed em-dash chars from `editor-client/src/sass/variables.scss`


### Screenshots

#### dark mode
<img width="894" height="723" alt="image" src="https://github.com/user-attachments/assets/a7343106-dc82-45cb-a9af-da0b971546da" />


#### light mode
<img width="885" height="728" alt="image" src="https://github.com/user-attachments/assets/24aec178-334f-48b1-abeb-645be21dc13a" />

#### editor & preview
<img width="1179" height="556" alt="image" src="https://github.com/user-attachments/assets/516e9a0e-255c-4f38-ac84-826016948c05" />



## Checklist


- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
