### PR TITLE
Ensure subsequent calls to the node editor can open

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1018,8 +1018,8 @@ RED.editor = (function() {
     function showEditDialog(node, defaultTab) {
         if (buildingEditDialog) { return }
         if (editStack.includes(node)) { return }
-        buildingEditDialog = true;
         if (node.z && RED.workspaces.isLocked(node.z)) { return }
+        buildingEditDialog = true;
         var editing_node = node;
         var removeInfoEditorOnClose = false;
         var skipInfoRefreshOnClose = false;
@@ -1329,14 +1329,14 @@ RED.editor = (function() {
      */
     function showEditConfigNodeDialog(name,type,id,prefix,editContext) {
         if (buildingEditDialog) { return }
+        var editing_config_node = RED.nodes.node(id);
+        if (editStack.includes(editing_config_node)) { return }
+        if (editing_config_node && editing_config_node.z && RED.workspaces.isLocked(editing_config_node.z)) { return }
         buildingEditDialog = true;
         var adding = (id == "_ADD_");
         var node_def = RED.nodes.getType(type);
-        var editing_config_node = RED.nodes.node(id);
         var activeEditPanes = [];
 
-        if (editStack.includes(editing_config_node)) { return }
-        if (editing_config_node && editing_config_node.z && RED.workspaces.isLocked(editing_config_node.z)) { return }
 
         var configNodeScope = ""; // default to global
         var activeSubflow = RED.nodes.subflow(RED.workspaces.active());
@@ -1997,8 +1997,8 @@ RED.editor = (function() {
     function showEditGroupDialog(group, defaultTab) {
         if (buildingEditDialog) { return }
         if (editStack.includes(group)) { return }
-        buildingEditDialog = true;
         if (group.z && RED.workspaces.isLocked(group.z)) { return }
+        buildingEditDialog = true;
         var editing_node = group;
         editStack.push(group);
         RED.view.state(RED.state.EDITING);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1016,309 +1016,314 @@ RED.editor = (function() {
     }
 
     function showEditDialog(node, defaultTab) {
-        if (buildingEditDialog) { return }
-        if (editStack.includes(node)) { return }
-        if (node.z && RED.workspaces.isLocked(node.z)) { return }
-        buildingEditDialog = true;
-        var editing_node = node;
-        var removeInfoEditorOnClose = false;
-        var skipInfoRefreshOnClose = false;
-        var activeEditPanes = [];
+        try {
+            if (buildingEditDialog) { return }
+            if (editStack.includes(node)) { return }
+            if (node.z && RED.workspaces.isLocked(node.z)) { return }
+            buildingEditDialog = true;
+            var editing_node = node;
+            var removeInfoEditorOnClose = false;
+            var skipInfoRefreshOnClose = false;
+            var activeEditPanes = [];
 
-        editStack.push(node);
-        RED.view.state(RED.state.EDITING);
-        var type = node.type;
-        if (node.type.substring(0,8) == "subflow:") {
-            type = "subflow";
-        }
+            editStack.push(node);
+            RED.view.state(RED.state.EDITING);
+            var type = node.type;
+            if (node.type.substring(0,8) == "subflow:") {
+                type = "subflow";
+            }
 
-        var trayOptions = {
-            title: getEditStackTitle(),
-            buttons: [
-                {
-                    id: "node-dialog-delete",
-                    class: 'leftButton',
-                    text: RED._("common.label.delete"),
-                    click: function() {
-                        var startDirty = RED.nodes.dirty();
-                        var removedNodes = [];
-                        var removedLinks = [];
-                        var removedEntities = RED.nodes.remove(editing_node.id);
-                        removedNodes.push(editing_node);
-                        removedNodes = removedNodes.concat(removedEntities.nodes);
-                        removedLinks = removedLinks.concat(removedEntities.links);
+            var trayOptions = {
+                title: getEditStackTitle(),
+                buttons: [
+                    {
+                        id: "node-dialog-delete",
+                        class: 'leftButton',
+                        text: RED._("common.label.delete"),
+                        click: function() {
+                            var startDirty = RED.nodes.dirty();
+                            var removedNodes = [];
+                            var removedLinks = [];
+                            var removedEntities = RED.nodes.remove(editing_node.id);
+                            removedNodes.push(editing_node);
+                            removedNodes = removedNodes.concat(removedEntities.nodes);
+                            removedLinks = removedLinks.concat(removedEntities.links);
 
-                        var historyEvent = {
-                            t:'delete',
-                            nodes:removedNodes,
-                            links:removedLinks,
-                            changes: {},
-                            dirty: startDirty
-                        }
-
-                        if (editing_node.g) {
-                            const group = RED.nodes.group(editing_node.g);
-                            // Don't use RED.group.removeFromGroup as that emits
-                            // a change event on the node - but we're deleting it
-                            const index = group?.nodes.indexOf(editing_node) ?? -1;
-                            if (index > -1) {
-                                group.nodes.splice(index, 1);
-                                RED.group.markDirty(group);
+                            var historyEvent = {
+                                t:'delete',
+                                nodes:removedNodes,
+                                links:removedLinks,
+                                changes: {},
+                                dirty: startDirty
                             }
-                        }
 
-                        RED.nodes.dirty(true);
-                        RED.view.redraw(true);
-                        RED.history.push(historyEvent);
-                        RED.tray.close();
-                    }
-                },
-                {
-                    id: "node-dialog-cancel",
-                    text: RED._("common.label.cancel"),
-                    click: function() {
-                        if (editing_node._def) {
-                            if (editing_node._def.oneditcancel) {
-                                try {
-                                    editing_node._def.oneditcancel.call(editing_node);
-                                } catch(err) {
-                                    console.log("oneditcancel",editing_node.id,editing_node.type,err.toString());
+                            if (editing_node.g) {
+                                const group = RED.nodes.group(editing_node.g);
+                                // Don't use RED.group.removeFromGroup as that emits
+                                // a change event on the node - but we're deleting it
+                                const index = group?.nodes.indexOf(editing_node) ?? -1;
+                                if (index > -1) {
+                                    group.nodes.splice(index, 1);
+                                    RED.group.markDirty(group);
                                 }
                             }
 
-                            for (var d in editing_node._def.defaults) {
-                                if (editing_node._def.defaults.hasOwnProperty(d)) {
-                                    var def = editing_node._def.defaults[d];
-                                    if (def.type) {
-                                        var configTypeDef = RED.nodes.getType(def.type);
-                                        if (configTypeDef && configTypeDef.exclusive) {
-                                            var input = $("#node-input-"+d).val()||"";
-                                            if (input !== "" && !editing_node[d]) {
-                                                // This node has an exclusive config node that
-                                                // has just been added. As the user is cancelling
-                                                // the edit, need to delete the just-added config
-                                                // node so that it doesn't get orphaned.
-                                                RED.nodes.remove(input);
+                            RED.nodes.dirty(true);
+                            RED.view.redraw(true);
+                            RED.history.push(historyEvent);
+                            RED.tray.close();
+                        }
+                    },
+                    {
+                        id: "node-dialog-cancel",
+                        text: RED._("common.label.cancel"),
+                        click: function() {
+                            if (editing_node._def) {
+                                if (editing_node._def.oneditcancel) {
+                                    try {
+                                        editing_node._def.oneditcancel.call(editing_node);
+                                    } catch(err) {
+                                        console.log("oneditcancel",editing_node.id,editing_node.type,err.toString());
+                                    }
+                                }
+
+                                for (var d in editing_node._def.defaults) {
+                                    if (editing_node._def.defaults.hasOwnProperty(d)) {
+                                        var def = editing_node._def.defaults[d];
+                                        if (def.type) {
+                                            var configTypeDef = RED.nodes.getType(def.type);
+                                            if (configTypeDef && configTypeDef.exclusive) {
+                                                var input = $("#node-input-"+d).val()||"";
+                                                if (input !== "" && !editing_node[d]) {
+                                                    // This node has an exclusive config node that
+                                                    // has just been added. As the user is cancelling
+                                                    // the edit, need to delete the just-added config
+                                                    // node so that it doesn't get orphaned.
+                                                    RED.nodes.remove(input);
+                                                }
                                             }
                                         }
                                     }
+
                                 }
-
                             }
+                            RED.tray.close();
                         }
-                        RED.tray.close();
-                    }
-                },
-                {
-                    id: "node-dialog-ok",
-                    text: RED._("common.label.done"),
-                    class: "primary",
-                    click: function() {
-                        var editState = {
-                            changes: {},
-                            changed: false,
-                            outputMap: null
-                        }
-                        var wasDirty = RED.nodes.dirty();
-
-                        handleEditSave(editing_node,editState)
-
-                        activeEditPanes.forEach(function(pane) {
-                            if (pane.apply) {
-                                pane.apply.call(pane, editState);
+                    },
+                    {
+                        id: "node-dialog-ok",
+                        text: RED._("common.label.done"),
+                        class: "primary",
+                        click: function() {
+                            var editState = {
+                                changes: {},
+                                changed: false,
+                                outputMap: null
                             }
-                        })
+                            var wasDirty = RED.nodes.dirty();
 
-                        var removedLinks = updateNodeProperties(editing_node, editState.outputMap);
+                            handleEditSave(editing_node,editState)
 
-                        if ($("#node-input-node-disabled").prop('checked')) {
-                            if (node.d !== true) {
-                                editState.changes.d = node.d;
-                                editState.changed = true;
-                                node.d = true;
+                            activeEditPanes.forEach(function(pane) {
+                                if (pane.apply) {
+                                    pane.apply.call(pane, editState);
+                                }
+                            })
+
+                            var removedLinks = updateNodeProperties(editing_node, editState.outputMap);
+
+                            if ($("#node-input-node-disabled").prop('checked')) {
+                                if (node.d !== true) {
+                                    editState.changes.d = node.d;
+                                    editState.changed = true;
+                                    node.d = true;
+                                }
+                            } else {
+                                if (node.d === true) {
+                                    editState.changes.d = node.d;
+                                    editState.changed = true;
+                                    delete node.d;
+                                }
                             }
-                        } else {
-                            if (node.d === true) {
-                                editState.changes.d = node.d;
-                                editState.changed = true;
-                                delete node.d;
-                            }
-                        }
 
-                        node.resize = true;
+                            node.resize = true;
 
-                        if (editState.changed) {
-                            var wasChanged = editing_node.changed;
-                            editing_node.changed = true;
-                            RED.nodes.dirty(true);
+                            if (editState.changed) {
+                                var wasChanged = editing_node.changed;
+                                editing_node.changed = true;
+                                RED.nodes.dirty(true);
 
-                            var activeSubflow = RED.nodes.subflow(RED.workspaces.active());
-                            var subflowInstances = null;
-                            if (activeSubflow) {
-                                subflowInstances = [];
-                                RED.nodes.eachNode(function(n) {
-                                    if (n.type == "subflow:"+RED.workspaces.active()) {
-                                        subflowInstances.push({
-                                            id:n.id,
-                                            changed:n.changed
-                                        });
-                                        n.changed = true;
-                                        n.dirty = true;
-                                        updateNodeProperties(n);
+                                var activeSubflow = RED.nodes.subflow(RED.workspaces.active());
+                                var subflowInstances = null;
+                                if (activeSubflow) {
+                                    subflowInstances = [];
+                                    RED.nodes.eachNode(function(n) {
+                                        if (n.type == "subflow:"+RED.workspaces.active()) {
+                                            subflowInstances.push({
+                                                id:n.id,
+                                                changed:n.changed
+                                            });
+                                            n.changed = true;
+                                            n.dirty = true;
+                                            updateNodeProperties(n);
+                                        }
+                                    });
+                                }
+                                let historyEvent = {
+                                    t:'edit',
+                                    node:editing_node,
+                                    changes:editState.changes,
+                                    links:removedLinks,
+                                    dirty:wasDirty,
+                                    changed:wasChanged
+                                };
+                                if (editState.outputMap) {
+                                    historyEvent.outputMap = editState.outputMap;
+                                }
+                                if (subflowInstances && subflowInstances.length) {
+                                    historyEvent.subflow = {
+                                        instances:subflowInstances
                                     }
-                                });
-                            }
-                            let historyEvent = {
-                                t:'edit',
-                                node:editing_node,
-                                changes:editState.changes,
-                                links:removedLinks,
-                                dirty:wasDirty,
-                                changed:wasChanged
-                            };
-                            if (editState.outputMap) {
-                                historyEvent.outputMap = editState.outputMap;
-                            }
-                            if (subflowInstances && subflowInstances.length) {
-                                historyEvent.subflow = {
-                                    instances:subflowInstances
                                 }
-                            }
 
-                            if (editState.history) {
-                                historyEvent = {
-                                    t: 'multi',
-                                    events: [ historyEvent, ...editState.history ],
-                                    dirty: wasDirty
+                                if (editState.history) {
+                                    historyEvent = {
+                                        t: 'multi',
+                                        events: [ historyEvent, ...editState.history ],
+                                        dirty: wasDirty
+                                    }
                                 }
-                            }
 
-                            RED.history.push(historyEvent);
+                                RED.history.push(historyEvent);
+                            }
+                            editing_node.dirty = true;
+                            validateNode(editing_node);
+                            RED.events.emit("editor:save",editing_node);
+                            RED.events.emit("nodes:change",editing_node);
+                            RED.tray.close();
                         }
-                        editing_node.dirty = true;
-                        validateNode(editing_node);
-                        RED.events.emit("editor:save",editing_node);
-                        RED.events.emit("nodes:change",editing_node);
-                        RED.tray.close();
                     }
-                }
-            ],
-            resize: function(dimensions) {
-                editTrayWidthCache[type] = dimensions.width;
-                $(".red-ui-tray-content").height(dimensions.height - 50);
-                var form = $(".red-ui-tray-content form").height(dimensions.height - 50 - 40);
-                var size = {width:form.width(),height:form.height()};
-                activeEditPanes.forEach(function(pane) {
-                    if (pane.resize) {
-                        pane.resize.call(pane, size);
+                ],
+                resize: function(dimensions) {
+                    editTrayWidthCache[type] = dimensions.width;
+                    $(".red-ui-tray-content").height(dimensions.height - 50);
+                    var form = $(".red-ui-tray-content form").height(dimensions.height - 50 - 40);
+                    var size = {width:form.width(),height:form.height()};
+                    activeEditPanes.forEach(function(pane) {
+                        if (pane.resize) {
+                            pane.resize.call(pane, size);
+                        }
+                    })
+                },
+                open: function(tray, done) {
+                    if (editing_node.hasOwnProperty('outputs')) {
+                        editing_node.__outputs = editing_node.outputs;
                     }
-                })
-            },
-            open: function(tray, done) {
-                if (editing_node.hasOwnProperty('outputs')) {
-                    editing_node.__outputs = editing_node.outputs;
-                }
 
-                var trayFooter = tray.find(".red-ui-tray-footer");
-                var trayBody = tray.find('.red-ui-tray-body');
-                trayBody.parent().css('overflow','hidden');
+                    var trayFooter = tray.find(".red-ui-tray-footer");
+                    var trayBody = tray.find('.red-ui-tray-body');
+                    trayBody.parent().css('overflow','hidden');
 
-                var trayFooterLeft = $('<div class="red-ui-tray-footer-left"></div>').appendTo(trayFooter)
+                    var trayFooterLeft = $('<div class="red-ui-tray-footer-left"></div>').appendTo(trayFooter)
 
-                var helpButton = $('<button type="button" class="red-ui-button"><i class="fa fa-book"></button>').on("click", function(evt) {
-                    evt.preventDefault();
-                    evt.stopPropagation();
-                    RED.sidebar.help.show(editing_node.type);
-                }).appendTo(trayFooterLeft);
-                RED.popover.tooltip(helpButton, RED._("sidebar.help.showHelp"));
+                    var helpButton = $('<button type="button" class="red-ui-button"><i class="fa fa-book"></button>').on("click", function(evt) {
+                        evt.preventDefault();
+                        evt.stopPropagation();
+                        RED.sidebar.help.show(editing_node.type);
+                    }).appendTo(trayFooterLeft);
+                    RED.popover.tooltip(helpButton, RED._("sidebar.help.showHelp"));
 
-                $('<input id="node-input-node-disabled" type="checkbox">').prop("checked",!!node.d).appendTo(trayFooterLeft).toggleButton({
-                    enabledIcon: "fa-circle-thin",
-                    disabledIcon: "fa-ban",
-                    invertState: true
-                })
+                    $('<input id="node-input-node-disabled" type="checkbox">').prop("checked",!!node.d).appendTo(trayFooterLeft).toggleButton({
+                        enabledIcon: "fa-circle-thin",
+                        disabledIcon: "fa-ban",
+                        invertState: true
+                    })
 
-                var nodeEditPanes = ['editor-tab-properties'];
-                if (/^subflow:/.test(node.type)) {
-                    nodeEditPanes.push("editor-tab-envProperties");
-                }
-                if (!node._def.defaults || !node._def.defaults.hasOwnProperty('info'))  {
-                    nodeEditPanes.push('editor-tab-description');
-                    removeInfoEditorOnClose = true;
-                    if(node.infoEditor) {
-                        //As 'editor-tab-description' adds `node.infoEditor` store original & set a
-                        //flag to NOT remove this property
-                        node.infoEditor__orig = node.infoEditor;
-                        delete node.infoEditor;
-                        removeInfoEditorOnClose = false;
+                    var nodeEditPanes = ['editor-tab-properties'];
+                    if (/^subflow:/.test(node.type)) {
+                        nodeEditPanes.push("editor-tab-envProperties");
                     }
-                }
-                nodeEditPanes.push("editor-tab-appearance");
+                    if (!node._def.defaults || !node._def.defaults.hasOwnProperty('info'))  {
+                        nodeEditPanes.push('editor-tab-description');
+                        removeInfoEditorOnClose = true;
+                        if(node.infoEditor) {
+                            //As 'editor-tab-description' adds `node.infoEditor` store original & set a
+                            //flag to NOT remove this property
+                            node.infoEditor__orig = node.infoEditor;
+                            delete node.infoEditor;
+                            removeInfoEditorOnClose = false;
+                        }
+                    }
+                    nodeEditPanes.push("editor-tab-appearance");
 
-                prepareEditDialog(trayBody, nodeEditPanes,node,node._def,"node-input", defaultTab, function(_activeEditPanes) {
-                    activeEditPanes = _activeEditPanes;
-                    trayBody.i18n();
-                    trayFooter.i18n();
-                    buildingEditDialog = false;
-                    done();
-                });
-            },
-            close: function() {
-                if (RED.view.state() != RED.state.IMPORT_DRAGGING) {
-                    RED.view.state(RED.state.DEFAULT);
-                }
-                if (editing_node) {
-                    if (editing_node.infoEditor__orig) {
-                        editing_node.infoEditor = editing_node.infoEditor__orig;
-                        delete editing_node.infoEditor__orig;
+                    prepareEditDialog(trayBody, nodeEditPanes,node,node._def,"node-input", defaultTab, function(_activeEditPanes) {
+                        activeEditPanes = _activeEditPanes;
+                        trayBody.i18n();
+                        trayFooter.i18n();
+                        buildingEditDialog = false;
+                        done();
+                    });
+                },
+                close: function() {
+                    if (RED.view.state() != RED.state.IMPORT_DRAGGING) {
+                        RED.view.state(RED.state.DEFAULT);
                     }
-                    if (removeInfoEditorOnClose) {
-                        delete editing_node.infoEditor;
+                    if (editing_node) {
+                        if (editing_node.infoEditor__orig) {
+                            editing_node.infoEditor = editing_node.infoEditor__orig;
+                            delete editing_node.infoEditor__orig;
+                        }
+                        if (removeInfoEditorOnClose) {
+                            delete editing_node.infoEditor;
+                        }
+                        if (!skipInfoRefreshOnClose) {
+                            RED.sidebar.info.refresh(editing_node);
+                        }
                     }
-                    if (!skipInfoRefreshOnClose) {
+                    RED.workspaces.refresh();
+
+                    activeEditPanes.forEach(function(pane) {
+                        if (pane.close) {
+                            pane.close.call(pane);
+                        }
+                    })
+
+                    RED.view.redraw(true);
+                    editStack.pop();
+                },
+                show: function() {
+                    if (editing_node) {
                         RED.sidebar.info.refresh(editing_node);
-                    }
-                }
-                RED.workspaces.refresh();
-
-                activeEditPanes.forEach(function(pane) {
-                    if (pane.close) {
-                        pane.close.call(pane);
-                    }
-                })
-
-                RED.view.redraw(true);
-                editStack.pop();
-            },
-            show: function() {
-                if (editing_node) {
-                    RED.sidebar.info.refresh(editing_node);
-                    RED.sidebar.help.show(editing_node.type, false);
-                    //ensure focused element is NOT body (for keyboard scope to operate correctly)
-                    if (document.activeElement.tagName === 'BODY') {
-                        $('#red-ui-editor-stack').trigger('focus')
+                        RED.sidebar.help.show(editing_node.type, false);
+                        //ensure focused element is NOT body (for keyboard scope to operate correctly)
+                        if (document.activeElement.tagName === 'BODY') {
+                            $('#red-ui-editor-stack').trigger('focus')
+                        }
                     }
                 }
             }
-        }
-        if (editTrayWidthCache.hasOwnProperty(type)) {
-            trayOptions.width = editTrayWidthCache[type];
-        }
+            if (editTrayWidthCache.hasOwnProperty(type)) {
+                trayOptions.width = editTrayWidthCache[type];
+            }
 
-        if (type === 'subflow') {
-            var id = editing_node.type.substring(8);
-            trayOptions.buttons.unshift({
-                class: 'leftButton',
-                text: RED._("subflow.edit"),
-                click: function() {
-                    RED.workspaces.show(id);
-                    skipInfoRefreshOnClose = true;
-                    $("#node-dialog-ok").trigger("click");
-                }
-            });
-        }
+            if (type === 'subflow') {
+                var id = editing_node.type.substring(8);
+                trayOptions.buttons.unshift({
+                    class: 'leftButton',
+                    text: RED._("subflow.edit"),
+                    click: function() {
+                        RED.workspaces.show(id);
+                        skipInfoRefreshOnClose = true;
+                        $("#node-dialog-ok").trigger("click");
+                    }
+                });
+            }
 
-        RED.tray.show(trayOptions);
+            RED.tray.show(trayOptions);
+        } catch (error) {
+            console.warn('An error occured in showEditDialog', error)
+            buildingEditDialog = false;
+        }
     }
     /**
      * name - name of the property that holds this config node
@@ -1328,937 +1333,957 @@ RED.editor = (function() {
      * editContext - the node that was being edited that triggered editing this node
      */
     function showEditConfigNodeDialog(name,type,id,prefix,editContext) {
-        if (buildingEditDialog) { return }
-        var editing_config_node = RED.nodes.node(id);
-        if (editStack.includes(editing_config_node)) { return }
-        if (editing_config_node && editing_config_node.z && RED.workspaces.isLocked(editing_config_node.z)) { return }
-        buildingEditDialog = true;
-        var adding = (id == "_ADD_");
-        var node_def = RED.nodes.getType(type);
-        var activeEditPanes = [];
+        try {
+            if (buildingEditDialog) { return }
+            var editing_config_node = RED.nodes.node(id);
+            if (editStack.includes(editing_config_node)) { return }
+            if (editing_config_node && editing_config_node.z && RED.workspaces.isLocked(editing_config_node.z)) { return }
+            buildingEditDialog = true;
+            var adding = (id == "_ADD_");
+            var node_def = RED.nodes.getType(type);
+            var activeEditPanes = [];
 
 
-        var configNodeScope = ""; // default to global
-        var activeSubflow = RED.nodes.subflow(RED.workspaces.active());
-        if (activeSubflow) {
-            configNodeScope = activeSubflow.id;
-        }
-        if (editing_config_node == null) {
-            editing_config_node = {
-                id: RED.nodes.id(),
-                _def: node_def,
-                type: type,
-                z: configNodeScope,
-                users: []
+            var configNodeScope = ""; // default to global
+            var activeSubflow = RED.nodes.subflow(RED.workspaces.active());
+            if (activeSubflow) {
+                configNodeScope = activeSubflow.id;
             }
-            for (var d in node_def.defaults) {
-                if (node_def.defaults[d].value) {
-                    editing_config_node[d] = JSON.parse(JSON.stringify(node_def.defaults[d].value));
+            if (editing_config_node == null) {
+                editing_config_node = {
+                    id: RED.nodes.id(),
+                    _def: node_def,
+                    type: type,
+                    z: configNodeScope,
+                    users: []
                 }
-            }
-            editing_config_node["_"] = node_def._;
-        }
-        editStack.push(editing_config_node);
-
-        RED.view.state(RED.state.EDITING);
-        var trayOptions = {
-            title: getEditStackTitle(), //(adding?RED._("editor.addNewConfig", {type:type}):RED._("editor.editConfig", {type:type})),
-            resize: function(dimensions) {
-                $(".red-ui-tray-content").height(dimensions.height - 50);
-                var form = $("#node-config-dialog-edit-form");
-                var size = {width:form.width(),height:form.height()};
-                activeEditPanes.forEach(function(pane) {
-                    if (pane.resize) {
-                        pane.resize.call(pane, size);
+                for (var d in node_def.defaults) {
+                    if (node_def.defaults[d].value) {
+                        editing_config_node[d] = JSON.parse(JSON.stringify(node_def.defaults[d].value));
                     }
-                })
-            },
-            open: function(tray, done) {
-                var trayHeader = tray.find(".red-ui-tray-header");
-                var trayBody = tray.find('.red-ui-tray-body');
-                var trayFooter = tray.find(".red-ui-tray-footer");
+                }
+                editing_config_node["_"] = node_def._;
+            }
+            editStack.push(editing_config_node);
 
-                var trayFooterLeft = $('<div class="red-ui-tray-footer-left"></div>').appendTo(trayFooter)
+            RED.view.state(RED.state.EDITING);
+            var trayOptions = {
+                title: getEditStackTitle(), //(adding?RED._("editor.addNewConfig", {type:type}):RED._("editor.editConfig", {type:type})),
+                resize: function(dimensions) {
+                    $(".red-ui-tray-content").height(dimensions.height - 50);
+                    var form = $("#node-config-dialog-edit-form");
+                    var size = {width:form.width(),height:form.height()};
+                    activeEditPanes.forEach(function(pane) {
+                        if (pane.resize) {
+                            pane.resize.call(pane, size);
+                        }
+                    })
+                },
+                open: function(tray, done) {
+                    var trayHeader = tray.find(".red-ui-tray-header");
+                    var trayBody = tray.find('.red-ui-tray-body');
+                    var trayFooter = tray.find(".red-ui-tray-footer");
 
-                var helpButton = $('<button type="button" class="red-ui-button"><i class="fa fa-book"></button>').on("click", function(evt) {
-                    evt.preventDefault();
-                    evt.stopPropagation();
-                    RED.sidebar.help.show(editing_config_node.type);
-                }).appendTo(trayFooterLeft);
-                RED.popover.tooltip(helpButton, RED._("sidebar.help.showHelp"));
+                    var trayFooterLeft = $('<div class="red-ui-tray-footer-left"></div>').appendTo(trayFooter)
 
-                $('<input id="node-config-input-node-disabled" type="checkbox">').prop("checked",!!editing_config_node.d).appendTo(trayFooterLeft).toggleButton({
-                    enabledIcon: "fa-circle-thin",
-                    disabledIcon: "fa-ban",
-                    invertState: true
-                })
-
-                if (node_def.hasUsers !== false) {
-                    // $('<span><i class="fa fa-info-circle"></i> <span id="red-ui-editor-config-user-count"></span></span>').css("margin-left", "10px").appendTo(trayFooterLeft);
-                    $('<button type="button" class="red-ui-button"><i class="fa fa-user"></i><span id="red-ui-editor-config-user-count"></span></button>').on('click', function() {
-                        RED.sidebar.info.outliner.search('uses:'+editing_config_node.id)
-                        RED.sidebar.info.show()
+                    var helpButton = $('<button type="button" class="red-ui-button"><i class="fa fa-book"></button>').on("click", function(evt) {
+                        evt.preventDefault();
+                        evt.stopPropagation();
+                        RED.sidebar.help.show(editing_config_node.type);
                     }).appendTo(trayFooterLeft);
-                }
-                trayFooter.append('<span class="red-ui-tray-footer-right"><span id="red-ui-editor-config-scope-warning" data-i18n="[title]editor.errors.scopeChange"><i class="fa fa-warning"></i></span><select id="red-ui-editor-config-scope"></select></span>');
+                    RED.popover.tooltip(helpButton, RED._("sidebar.help.showHelp"));
 
+                    $('<input id="node-config-input-node-disabled" type="checkbox">').prop("checked",!!editing_config_node.d).appendTo(trayFooterLeft).toggleButton({
+                        enabledIcon: "fa-circle-thin",
+                        disabledIcon: "fa-ban",
+                        invertState: true
+                    })
 
-                var nodeEditPanes = [ 'editor-tab-properties' ];
-                if (!editing_config_node._def.defaults || !editing_config_node._def.defaults.hasOwnProperty('info'))  {
-                    nodeEditPanes.push('editor-tab-description');
-                }
-
-                prepareEditDialog(trayBody, nodeEditPanes, editing_config_node, node_def, "node-config-input", null, function(_activeEditPanes) {
-                    activeEditPanes = _activeEditPanes;
-                    if (editing_config_node._def.exclusive) {
-                        $("#red-ui-editor-config-scope").hide();
-                    } else {
-                        $("#red-ui-editor-config-scope").show();
-                    }
-                    $("#red-ui-editor-config-scope-warning").hide();
-
-                    var nodeUserFlows = {};
-                    editing_config_node.users.forEach(function(n) {
-                        nodeUserFlows[n.z] = true;
-                    });
-                    var flowCount = Object.keys(nodeUserFlows).length;
-                    var tabSelect = $("#red-ui-editor-config-scope").empty();
-                    tabSelect.off("change");
-                    tabSelect.append('<option value=""'+(!editing_config_node.z?" selected":"")+' data-i18n="sidebar.config.global"></option>');
-                    tabSelect.append('<option disabled data-i18n="sidebar.config.flows"></option>');
-                    RED.nodes.eachWorkspace(function(ws) {
-                        var workspaceLabel = ws.label;
-                        if (nodeUserFlows[ws.id]) {
-                            workspaceLabel = "* "+workspaceLabel;
-                        }
-                        $('<option value="'+ws.id+'"'+(ws.id==editing_config_node.z?" selected":"")+'></option>').text(workspaceLabel).appendTo(tabSelect);
-                    });
-                    tabSelect.append('<option disabled data-i18n="sidebar.config.subflows"></option>');
-                    RED.nodes.eachSubflow(function(ws) {
-                        var workspaceLabel = ws.name;
-                        if (nodeUserFlows[ws.id]) {
-                            workspaceLabel = "* "+workspaceLabel;
-                        }
-                        $('<option value="'+ws.id+'"'+(ws.id==editing_config_node.z?" selected":"")+'></option>').text(workspaceLabel).appendTo(tabSelect);
-                    });
-                    if (flowCount > 0) {
-                        tabSelect.on('change',function() {
-                            var newScope = $(this).val();
-                            if (newScope === '') {
-                                // global scope - everyone can use it
-                                $("#red-ui-editor-config-scope-warning").hide();
-                            } else if (!nodeUserFlows[newScope] || flowCount > 1) {
-                                // a user will loose access to it
-                                $("#red-ui-editor-config-scope-warning").show();
-                            } else {
-                                $("#red-ui-editor-config-scope-warning").hide();
-                            }
-                        });
-                    }
                     if (node_def.hasUsers !== false) {
-                        $("#red-ui-editor-config-user-count").text(editing_config_node.users.length).parent().show();
-                        RED.popover.tooltip($("#red-ui-editor-config-user-count").parent(), function() { return RED._('editor.nodesUse',{count:editing_config_node.users.length})});
+                        // $('<span><i class="fa fa-info-circle"></i> <span id="red-ui-editor-config-user-count"></span></span>').css("margin-left", "10px").appendTo(trayFooterLeft);
+                        $('<button type="button" class="red-ui-button"><i class="fa fa-user"></i><span id="red-ui-editor-config-user-count"></span></button>').on('click', function() {
+                            RED.sidebar.info.outliner.search('uses:'+editing_config_node.id)
+                            RED.sidebar.info.show()
+                        }).appendTo(trayFooterLeft);
                     }
-                    trayBody.i18n();
-                    trayFooter.i18n();
-                    buildingEditDialog = false;
-                    done();
-                });
-            },
-            close: function() {
-                RED.workspaces.refresh();
+                    trayFooter.append('<span class="red-ui-tray-footer-right"><span id="red-ui-editor-config-scope-warning" data-i18n="[title]editor.errors.scopeChange"><i class="fa fa-warning"></i></span><select id="red-ui-editor-config-scope"></select></span>');
 
-                activeEditPanes.forEach(function(pane) {
-                    if (pane.close) {
-                        pane.close.call(pane);
+
+                    var nodeEditPanes = [ 'editor-tab-properties' ];
+                    if (!editing_config_node._def.defaults || !editing_config_node._def.defaults.hasOwnProperty('info'))  {
+                        nodeEditPanes.push('editor-tab-description');
                     }
-                })
 
-                editStack.pop();
-            },
-            show: function() {
-                if (editing_config_node) {
-                    RED.sidebar.info.refresh(editing_config_node);
-                    RED.sidebar.help.show(type, false);
+                    prepareEditDialog(trayBody, nodeEditPanes, editing_config_node, node_def, "node-config-input", null, function(_activeEditPanes) {
+                        activeEditPanes = _activeEditPanes;
+                        if (editing_config_node._def.exclusive) {
+                            $("#red-ui-editor-config-scope").hide();
+                        } else {
+                            $("#red-ui-editor-config-scope").show();
+                        }
+                        $("#red-ui-editor-config-scope-warning").hide();
+
+                        var nodeUserFlows = {};
+                        editing_config_node.users.forEach(function(n) {
+                            nodeUserFlows[n.z] = true;
+                        });
+                        var flowCount = Object.keys(nodeUserFlows).length;
+                        var tabSelect = $("#red-ui-editor-config-scope").empty();
+                        tabSelect.off("change");
+                        tabSelect.append('<option value=""'+(!editing_config_node.z?" selected":"")+' data-i18n="sidebar.config.global"></option>');
+                        tabSelect.append('<option disabled data-i18n="sidebar.config.flows"></option>');
+                        RED.nodes.eachWorkspace(function(ws) {
+                            var workspaceLabel = ws.label;
+                            if (nodeUserFlows[ws.id]) {
+                                workspaceLabel = "* "+workspaceLabel;
+                            }
+                            $('<option value="'+ws.id+'"'+(ws.id==editing_config_node.z?" selected":"")+'></option>').text(workspaceLabel).appendTo(tabSelect);
+                        });
+                        tabSelect.append('<option disabled data-i18n="sidebar.config.subflows"></option>');
+                        RED.nodes.eachSubflow(function(ws) {
+                            var workspaceLabel = ws.name;
+                            if (nodeUserFlows[ws.id]) {
+                                workspaceLabel = "* "+workspaceLabel;
+                            }
+                            $('<option value="'+ws.id+'"'+(ws.id==editing_config_node.z?" selected":"")+'></option>').text(workspaceLabel).appendTo(tabSelect);
+                        });
+                        if (flowCount > 0) {
+                            tabSelect.on('change',function() {
+                                var newScope = $(this).val();
+                                if (newScope === '') {
+                                    // global scope - everyone can use it
+                                    $("#red-ui-editor-config-scope-warning").hide();
+                                } else if (!nodeUserFlows[newScope] || flowCount > 1) {
+                                    // a user will loose access to it
+                                    $("#red-ui-editor-config-scope-warning").show();
+                                } else {
+                                    $("#red-ui-editor-config-scope-warning").hide();
+                                }
+                            });
+                        }
+                        if (node_def.hasUsers !== false) {
+                            $("#red-ui-editor-config-user-count").text(editing_config_node.users.length).parent().show();
+                            RED.popover.tooltip($("#red-ui-editor-config-user-count").parent(), function() { return RED._('editor.nodesUse',{count:editing_config_node.users.length})});
+                        }
+                        trayBody.i18n();
+                        trayFooter.i18n();
+                        buildingEditDialog = false;
+                        done();
+                    });
+                },
+                close: function() {
+                    RED.workspaces.refresh();
+
+                    activeEditPanes.forEach(function(pane) {
+                        if (pane.close) {
+                            pane.close.call(pane);
+                        }
+                    })
+
+                    editStack.pop();
+                },
+                show: function() {
+                    if (editing_config_node) {
+                        RED.sidebar.info.refresh(editing_config_node);
+                        RED.sidebar.help.show(type, false);
+                    }
                 }
             }
-        }
-        trayOptions.buttons = [
-            {
-                id: "node-config-dialog-cancel",
-                text: RED._("common.label.cancel"),
-                click: function() {
-                    var configType = type;
-                    var configId = editing_config_node.id;
-                    var configAdding = adding;
-                    var configTypeDef = RED.nodes.getType(configType);
-                    if (configTypeDef.oneditcancel) {
-                        // TODO: what to pass as this to call
+            trayOptions.buttons = [
+                {
+                    id: "node-config-dialog-cancel",
+                    text: RED._("common.label.cancel"),
+                    click: function() {
+                        var configType = type;
+                        var configId = editing_config_node.id;
+                        var configAdding = adding;
+                        var configTypeDef = RED.nodes.getType(configType);
                         if (configTypeDef.oneditcancel) {
-                            var cn = RED.nodes.node(configId);
-                            if (cn) {
-                                try {
-                                    configTypeDef.oneditcancel.call(cn,false);
-                                } catch(err) {
-                                    console.log("oneditcancel",cn.id,cn.type,err.toString());
-                                }
-                            } else {
-                                try {
-                                    configTypeDef.oneditcancel.call({id:configId},true);
-                                } catch(err) {
-                                    console.log("oneditcancel",configId,configType,err.toString());
-                                }
-                            }
-                        }
-                    }
-                    RED.tray.close();
-                }
-            },
-            {
-                id: "node-config-dialog-ok",
-                text: adding ? RED._("editor.configAdd") : RED._("editor.configUpdate"),
-                class: "primary",
-                click: function() {
-                    // TODO: Already defined
-                    const configProperty = name;
-                    const configType = type;
-                    const configTypeDef = RED.nodes.getType(configType);
-
-                    const wasChanged = editing_config_node.changed;
-                    const editState = {
-                        changes: {},
-                        changed: false,
-                        outputMap: null
-                    };
-                    
-                    // Call `oneditsave` and search for changes
-                    handleEditSave(editing_config_node, editState);
-
-                    // Search for changes in the edit box (panes)
-                    activeEditPanes.forEach(function (pane) {
-                        if (pane.apply) {
-                            pane.apply.call(pane, editState);
-                        }
-                    });
-
-                    // TODO: Why?
-                    editing_config_node.label = configTypeDef.label
-
-                    // Check if disabled has changed
-                    if ($("#node-config-input-node-disabled").prop('checked')) {
-                        if (editing_config_node.d !== true) {
-                            editState.changes.d = editing_config_node.d;
-                            editState.changed = true;
-                            editing_config_node.d = true;
-                        }
-                    } else {
-                        if (editing_config_node.d === true) {
-                            editState.changes.d = editing_config_node.d;
-                            editState.changed = true;
-                            delete editing_config_node.d;
-                        }
-                    }
-
-                    // NOTE: must be undefined if no scope used
-                    const scope = $("#red-ui-editor-config-scope").val() || undefined;
-
-                    // Check if the scope has changed
-                    if (editing_config_node.z !== scope) {
-                        editState.changes.z = editing_config_node.z;
-                        editState.changed = true;
-                        editing_config_node.z = scope;
-                    }
-
-                    // Search for nodes that use this config node that are no longer
-                    // in scope, so must be removed
-                    const historyEvents = [];
-                    if (scope) {
-                        const newUsers = editing_config_node.users.filter(function (node) {
-                            let keepNode = false;
-                            let nodeModified = null;
-
-                            for (const d in node._def.defaults) {
-                                if (node._def.defaults.hasOwnProperty(d)) {
-                                    if (node._def.defaults[d].type === editing_config_node.type) {
-                                        if (node[d] === editing_config_node.id) {
-                                            if (node.z === editing_config_node.z) {
-                                                // The node is kept only if at least one property uses
-                                                // this config node in the correct scope.
-                                                keepNode = true;
-                                            } else {
-                                                if (!nodeModified) {
-                                                    nodeModified = {
-                                                        t: "edit",
-                                                        node: node,
-                                                        changes: { [d]: node[d] },
-                                                        changed: node.changed,
-                                                        dirty: node.dirty
-                                                    };
-                                                } else {
-                                                    nodeModified.changes[d] = node[d];
-                                                }
-
-                                                // Remove the reference to the config node
-                                                node[d] = "";
-                                            }
-                                        }
+                            // TODO: what to pass as this to call
+                            if (configTypeDef.oneditcancel) {
+                                var cn = RED.nodes.node(configId);
+                                if (cn) {
+                                    try {
+                                        configTypeDef.oneditcancel.call(cn,false);
+                                    } catch(err) {
+                                        console.log("oneditcancel",cn.id,cn.type,err.toString());
+                                    }
+                                } else {
+                                    try {
+                                        configTypeDef.oneditcancel.call({id:configId},true);
+                                    } catch(err) {
+                                        console.log("oneditcancel",configId,configType,err.toString());
                                     }
                                 }
                             }
-
-                            // Add the node modified to the history
-                            if (nodeModified) {
-                                historyEvents.push(nodeModified);
-                            }
-
-                            // Mark as changed and revalidate this node
-                            if (!keepNode) {
-                                node.changed = true;
-                                node.dirty = true;
-                                validateNode(node);
-                                RED.events.emit("nodes:change", node);
-                            }
-
-                            return keepNode;
-                        });
-
-                        // Check if users are changed
-                        if (editing_config_node.users.length !== newUsers.length) {
-                            editState.changes.users = editing_config_node.users;
-                            editState.changed = true;
-                            editing_config_node.users = newUsers;
                         }
-                    }
-
-                    if (editState.changed) {
-                        // Set the congig node as changed
-                        editing_config_node.changed = true;
-                    }
-
-                    // Now, validate the config node
-                    validateNode(editing_config_node);
-
-                    // And validate nodes using this config node too
-                    const validatedNodes = new Set();
-                    const userStack = editing_config_node.users.slice();
-
-                    validatedNodes.add(editing_config_node.id);
-                    while (userStack.length) {
-                        const node = userStack.pop();
-                        if (!validatedNodes.has(node.id)) {
-                            validatedNodes.add(node.id);
-                            if (node.users) {
-                                userStack.push(...node.users);
-                            }
-                            validateNode(node);
-                        }
-                    }
-
-                    let historyEvent = {
-                        t: "edit",
-                        node: editing_config_node,
-                        changes: editState.changes,
-                        changed: wasChanged,
-                        dirty: RED.nodes.dirty()
-                    };
-
-                    if (historyEvents.length) {
-                        // Need a multi events
-                        historyEvent = {
-                            t: "multi",
-                            events: [historyEvent].concat(historyEvents),
-                            dirty: historyEvent.dirty
-                        };
-                    }
-
-                    if (!adding) {
-                        // This event is triggered when the edit box is saved,
-                        // regardless of whether there are any modifications.
-                        RED.events.emit("editor:save", editing_config_node);
-                    }
-
-                    if (editState.changed) {
-                        if (adding) {
-                            RED.history.push({ t: "add", nodes: [editing_config_node.id], dirty: RED.nodes.dirty() });
-                            // Add the new config node and trigger the `nodes:add` event
-                            RED.nodes.add(editing_config_node);
-                        } else {
-                            RED.history.push(historyEvent);
-                            RED.events.emit("nodes:change", editing_config_node);
-                        }
-
-                        RED.nodes.dirty(true);
-                        RED.view.redraw(true);
-                    }
-
-                    RED.tray.close(function() {
-                        var filter = null;
-                        // when editing a config via subflow edit panel, the `configProperty` will not
-                        // necessarily be a property of the editContext._def.defaults object
-                        // Also, when editing via dashboard sidebar, editContext can be null
-                        // so we need to guard both scenarios
-                        if (editContext?._def) {
-                            const isSubflow = (editContext._def.type === 'subflow' || /subflow:.*/.test(editContext._def.type))
-                            if (editContext && !isSubflow && typeof editContext._def.defaults?.[configProperty]?.filter === 'function') {
-                                filter = function(n) {
-                                    return editContext._def.defaults[configProperty].filter.call(editContext,n);
-                                }
-                            }
-                        }
-                        updateConfigNodeSelect(configProperty,configType,editing_config_node.id,prefix,filter);
-                    });
-                }
-            }
-        ];
-
-        if (!adding) {
-            trayOptions.buttons.unshift({
-                class: 'leftButton',
-                text: RED._("editor.configDelete"), //'<i class="fa fa-trash"></i>',
-                click: function() {
-                    var configProperty = name;
-                    var configId = editing_config_node.id;
-                    var configType = type;
-                    var configTypeDef = RED.nodes.getType(configType);
-
-                    try {
-
-                        if (configTypeDef.ondelete) {
-                            // Deprecated: never documented but used by some early nodes
-                            console.log("Deprecated API warning: config node type ",configType," has an ondelete function - should be oneditdelete");
-                            configTypeDef.ondelete.call(editing_config_node);
-                        }
-                        if (configTypeDef.oneditdelete) {
-                            configTypeDef.oneditdelete.call(editing_config_node);
-                        }
-                    } catch(err) {
-                        console.log("oneditdelete",editing_config_node.id,editing_config_node.type,err.toString());
-                    }
-
-                    var historyEvent = {
-                        t:'delete',
-                        nodes:[editing_config_node],
-                        changes: {},
-                        dirty: RED.nodes.dirty()
-                    }
-                    for (var i=0;i<editing_config_node.users.length;i++) {
-                        var user = editing_config_node.users[i];
-                        historyEvent.changes[user.id] = {
-                            changed: user.changed,
-                            valid: user.valid
-                        };
-                        for (var d in user._def.defaults) {
-                            if (user._def.defaults.hasOwnProperty(d) && user[d] == configId) {
-                                historyEvent.changes[user.id][d] = configId
-                                user[d] = "";
-                                user.changed = true;
-                                user.dirty = true;
-                            }
-                        }
-                        validateNode(user);
-                    }
-                    RED.nodes.remove(configId);
-                    RED.nodes.dirty(true);
-                    RED.view.redraw(true);
-                    RED.history.push(historyEvent);
-                    RED.tray.close(function() {
-                        var filter = null;
-                        if (editContext && typeof editContext._def.defaults[configProperty]?.filter === 'function') {
-                            filter = function(n) {
-                                return editContext._def.defaults[configProperty].filter.call(editContext,n);
-                            }
-                        }
-                        updateConfigNodeSelect(configProperty,configType,"",prefix,filter);
-                    });
-                }
-            });
-        }
-
-        RED.tray.show(trayOptions);
-    }
-
-    function showEditSubflowDialog(subflow, defaultTab) {
-        if (buildingEditDialog) { return }
-        if (editStack.includes(subflow)) { return }
-        buildingEditDialog = true;
-
-        editStack.push(subflow);
-        RED.view.state(RED.state.EDITING);
-
-        let editingNode = subflow;
-        let activeEditPanes = [];
-        const trayOptions = {
-            title: getEditStackTitle(),
-            buttons: [
-                {
-                    id: "node-dialog-cancel",
-                    text: RED._("common.label.cancel"),
-                    click: function () {
                         RED.tray.close();
                     }
                 },
                 {
-                    id: "node-dialog-ok",
+                    id: "node-config-dialog-ok",
+                    text: adding ? RED._("editor.configAdd") : RED._("editor.configUpdate"),
                     class: "primary",
-                    text: RED._("common.label.done"),
-                    click: function () {
-                        const wasDirty = RED.nodes.dirty();
+                    click: function() {
+                        // TODO: Already defined
+                        const configProperty = name;
+                        const configType = type;
+                        const configTypeDef = RED.nodes.getType(configType);
+
+                        const wasChanged = editing_config_node.changed;
                         const editState = {
                             changes: {},
                             changed: false,
                             outputMap: null
                         };
+                        
+                        // Call `oneditsave` and search for changes
+                        handleEditSave(editing_config_node, editState);
 
-                        // Search for changes in edit boxes (panes)
-                        // NOTE: no `oneditsave` for Subflow def
+                        // Search for changes in the edit box (panes)
                         activeEditPanes.forEach(function (pane) {
                             if (pane.apply) {
                                 pane.apply.call(pane, editState);
                             }
                         });
 
-                        // Search for env changes (not handled in properties pane)
-                        const oldEnv = editingNode.env;
-                        const newEnv = RED.subflow.exportSubflowTemplateEnv($("#node-input-env-container").editableList("items"));
+                        // TODO: Why?
+                        editing_config_node.label = configTypeDef.label
 
-                        if (newEnv && newEnv.length > 0) {
-                            newEnv.forEach(function (prop) {
-                                if (prop.type === "cred") {
-                                    editingNode.credentials = editingNode.credentials || { _: {} };
-                                    editingNode.credentials[prop.name] = prop.value;
-                                    editingNode.credentials['has_' + prop.name] = (prop.value !== "");
-                                    if (prop.value !== '__PWRD__') {
-                                        editState.changed = true;
-                                    }
-                                    delete prop.value;
-                                }
-                            });
+                        // Check if disabled has changed
+                        if ($("#node-config-input-node-disabled").prop('checked')) {
+                            if (editing_config_node.d !== true) {
+                                editState.changes.d = editing_config_node.d;
+                                editState.changed = true;
+                                editing_config_node.d = true;
+                            }
+                        } else {
+                            if (editing_config_node.d === true) {
+                                editState.changes.d = editing_config_node.d;
+                                editState.changed = true;
+                                delete editing_config_node.d;
+                            }
                         }
 
-                        const envToRemove = new Set();
-                        if (!isSameObj(oldEnv, newEnv)) {
-                            // Get a list of env properties that have been removed
-                            // by comparing oldEnv and newEnv
-                            if (oldEnv) {
-                                oldEnv.forEach((env) => { envToRemove.add(env.name) });
-                            }
-                            if (newEnv) {
-                                newEnv.forEach((env) => {
-                                    envToRemove.delete(env.name)
-                                });
-                            }
-                            editState.changes.env = oldEnv;
-                            editingNode.env = newEnv;
+                        // NOTE: must be undefined if no scope used
+                        const scope = $("#red-ui-editor-config-scope").val() || undefined;
+
+                        // Check if the scope has changed
+                        if (editing_config_node.z !== scope) {
+                            editState.changes.z = editing_config_node.z;
                             editState.changed = true;
+                            editing_config_node.z = scope;
+                        }
+
+                        // Search for nodes that use this config node that are no longer
+                        // in scope, so must be removed
+                        const historyEvents = [];
+                        if (scope) {
+                            const newUsers = editing_config_node.users.filter(function (node) {
+                                let keepNode = false;
+                                let nodeModified = null;
+
+                                for (const d in node._def.defaults) {
+                                    if (node._def.defaults.hasOwnProperty(d)) {
+                                        if (node._def.defaults[d].type === editing_config_node.type) {
+                                            if (node[d] === editing_config_node.id) {
+                                                if (node.z === editing_config_node.z) {
+                                                    // The node is kept only if at least one property uses
+                                                    // this config node in the correct scope.
+                                                    keepNode = true;
+                                                } else {
+                                                    if (!nodeModified) {
+                                                        nodeModified = {
+                                                            t: "edit",
+                                                            node: node,
+                                                            changes: { [d]: node[d] },
+                                                            changed: node.changed,
+                                                            dirty: node.dirty
+                                                        };
+                                                    } else {
+                                                        nodeModified.changes[d] = node[d];
+                                                    }
+
+                                                    // Remove the reference to the config node
+                                                    node[d] = "";
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                // Add the node modified to the history
+                                if (nodeModified) {
+                                    historyEvents.push(nodeModified);
+                                }
+
+                                // Mark as changed and revalidate this node
+                                if (!keepNode) {
+                                    node.changed = true;
+                                    node.dirty = true;
+                                    validateNode(node);
+                                    RED.events.emit("nodes:change", node);
+                                }
+
+                                return keepNode;
+                            });
+
+                            // Check if users are changed
+                            if (editing_config_node.users.length !== newUsers.length) {
+                                editState.changes.users = editing_config_node.users;
+                                editState.changed = true;
+                                editing_config_node.users = newUsers;
+                            }
                         }
 
                         if (editState.changed) {
-                            const wasChanged = editingNode.changed;
-                            const subflowInstances = [];
-                            const instanceHistoryEvents = [];
+                            // Set the congig node as changed
+                            editing_config_node.changed = true;
+                        }
 
-                            // Marks the Subflow has changed and validate it
-                            editingNode.changed = true;
-                            validateNode(editingNode);
+                        // Now, validate the config node
+                        validateNode(editing_config_node);
 
-                            // Update each Subflow instances
-                            RED.nodes.eachNode(function (n) {
-                                if (n.type == "subflow:" + editingNode.id) {
-                                    subflowInstances.push({
-                                        id: n.id,
-                                        changed: n.changed
-                                    });
+                        // And validate nodes using this config node too
+                        const validatedNodes = new Set();
+                        const userStack = editing_config_node.users.slice();
 
-                                    n.changed = true;
-                                    n.dirty = true;
-                                    if (editState.changes.hasOwnProperty("color")) {
-                                        // Redraw the node color
-                                        n._colorChanged = true;
+                        validatedNodes.add(editing_config_node.id);
+                        while (userStack.length) {
+                            const node = userStack.pop();
+                            if (!validatedNodes.has(node.id)) {
+                                validatedNodes.add(node.id);
+                                if (node.users) {
+                                    userStack.push(...node.users);
+                                }
+                                validateNode(node);
+                            }
+                        }
+
+                        let historyEvent = {
+                            t: "edit",
+                            node: editing_config_node,
+                            changes: editState.changes,
+                            changed: wasChanged,
+                            dirty: RED.nodes.dirty()
+                        };
+
+                        if (historyEvents.length) {
+                            // Need a multi events
+                            historyEvent = {
+                                t: "multi",
+                                events: [historyEvent].concat(historyEvents),
+                                dirty: historyEvent.dirty
+                            };
+                        }
+
+                        if (!adding) {
+                            // This event is triggered when the edit box is saved,
+                            // regardless of whether there are any modifications.
+                            RED.events.emit("editor:save", editing_config_node);
+                        }
+
+                        if (editState.changed) {
+                            if (adding) {
+                                RED.history.push({ t: "add", nodes: [editing_config_node.id], dirty: RED.nodes.dirty() });
+                                // Add the new config node and trigger the `nodes:add` event
+                                RED.nodes.add(editing_config_node);
+                            } else {
+                                RED.history.push(historyEvent);
+                                RED.events.emit("nodes:change", editing_config_node);
+                            }
+
+                            RED.nodes.dirty(true);
+                            RED.view.redraw(true);
+                        }
+
+                        RED.tray.close(function() {
+                            var filter = null;
+                            // when editing a config via subflow edit panel, the `configProperty` will not
+                            // necessarily be a property of the editContext._def.defaults object
+                            // Also, when editing via dashboard sidebar, editContext can be null
+                            // so we need to guard both scenarios
+                            if (editContext?._def) {
+                                const isSubflow = (editContext._def.type === 'subflow' || /subflow:.*/.test(editContext._def.type))
+                                if (editContext && !isSubflow && typeof editContext._def.defaults?.[configProperty]?.filter === 'function') {
+                                    filter = function(n) {
+                                        return editContext._def.defaults[configProperty].filter.call(editContext,n);
                                     }
+                                }
+                            }
+                            updateConfigNodeSelect(configProperty,configType,editing_config_node.id,prefix,filter);
+                        });
+                    }
+                }
+            ];
 
-                                    if (n.env) {
-                                        const oldEnv = n.env;
-                                        const newEnv = [];
-                                        let envChanged = false;
-                                        n.env.forEach((env, index) => {
-                                            if (envToRemove.has(env.name)) {
-                                                envChanged = true;
-                                            } else {
-                                                newEnv.push(env);
-                                            }
-                                        });
-                                        if (envChanged) {
-                                            instanceHistoryEvents.push({
-                                                t: 'edit',
-                                                node: n,
-                                                changes: { env: oldEnv },
-                                                dirty: n.dirty,
-                                                changed: n.changed
-                                            });
-                                            n.env = newEnv;
-                                        }
-                                    }
+            if (!adding) {
+                trayOptions.buttons.unshift({
+                    class: 'leftButton',
+                    text: RED._("editor.configDelete"), //'<i class="fa fa-trash"></i>',
+                    click: function() {
+                        var configProperty = name;
+                        var configId = editing_config_node.id;
+                        var configType = type;
+                        var configTypeDef = RED.nodes.getType(configType);
 
-                                    updateNodeProperties(n);
-                                    validateNode(n);
+                        try {
+
+                            if (configTypeDef.ondelete) {
+                                // Deprecated: never documented but used by some early nodes
+                                console.log("Deprecated API warning: config node type ",configType," has an ondelete function - should be oneditdelete");
+                                configTypeDef.ondelete.call(editing_config_node);
+                            }
+                            if (configTypeDef.oneditdelete) {
+                                configTypeDef.oneditdelete.call(editing_config_node);
+                            }
+                        } catch(err) {
+                            console.log("oneditdelete",editing_config_node.id,editing_config_node.type,err.toString());
+                        }
+
+                        var historyEvent = {
+                            t:'delete',
+                            nodes:[editing_config_node],
+                            changes: {},
+                            dirty: RED.nodes.dirty()
+                        }
+                        for (var i=0;i<editing_config_node.users.length;i++) {
+                            var user = editing_config_node.users[i];
+                            historyEvent.changes[user.id] = {
+                                changed: user.changed,
+                                valid: user.valid
+                            };
+                            for (var d in user._def.defaults) {
+                                if (user._def.defaults.hasOwnProperty(d) && user[d] == configId) {
+                                    historyEvent.changes[user.id][d] = configId
+                                    user[d] = "";
+                                    user.changed = true;
+                                    user.dirty = true;
+                                }
+                            }
+                            validateNode(user);
+                        }
+                        RED.nodes.remove(configId);
+                        RED.nodes.dirty(true);
+                        RED.view.redraw(true);
+                        RED.history.push(historyEvent);
+                        RED.tray.close(function() {
+                            var filter = null;
+                            if (editContext && typeof editContext._def.defaults[configProperty]?.filter === 'function') {
+                                filter = function(n) {
+                                    return editContext._def.defaults[configProperty].filter.call(editContext,n);
+                                }
+                            }
+                            updateConfigNodeSelect(configProperty,configType,"",prefix,filter);
+                        });
+                    }
+                });
+            }
+
+            RED.tray.show(trayOptions);
+        } catch (error) {
+            console.warn('An error occured in showEditConfigNodeDialog', error)
+            buildingEditDialog = false;
+        }
+    }
+
+    function showEditSubflowDialog(subflow, defaultTab) {
+        try {
+            if (buildingEditDialog) { return }
+            if (editStack.includes(subflow)) { return }
+            buildingEditDialog = true;
+
+            editStack.push(subflow);
+            RED.view.state(RED.state.EDITING);
+
+            let editingNode = subflow;
+            let activeEditPanes = [];
+            const trayOptions = {
+                title: getEditStackTitle(),
+                buttons: [
+                    {
+                        id: "node-dialog-cancel",
+                        text: RED._("common.label.cancel"),
+                        click: function () {
+                            RED.tray.close();
+                        }
+                    },
+                    {
+                        id: "node-dialog-ok",
+                        class: "primary",
+                        text: RED._("common.label.done"),
+                        click: function () {
+                            const wasDirty = RED.nodes.dirty();
+                            const editState = {
+                                changes: {},
+                                changed: false,
+                                outputMap: null
+                            };
+
+                            // Search for changes in edit boxes (panes)
+                            // NOTE: no `oneditsave` for Subflow def
+                            activeEditPanes.forEach(function (pane) {
+                                if (pane.apply) {
+                                    pane.apply.call(pane, editState);
                                 }
                             });
 
-                            let historyEvent = {
-                                t: 'edit',
-                                node: editingNode,
-                                changes: editState.changes,
-                                dirty: wasDirty,
-                                changed: wasChanged,
-                                subflow: {
-                                    instances: subflowInstances
-                                }
-                            };
+                            // Search for env changes (not handled in properties pane)
+                            const oldEnv = editingNode.env;
+                            const newEnv = RED.subflow.exportSubflowTemplateEnv($("#node-input-env-container").editableList("items"));
 
-                            if (instanceHistoryEvents.length > 0) {
-                                historyEvent = {
-                                    t: 'multi',
-                                    events: [ historyEvent, ...instanceHistoryEvents ],
-                                    dirty: wasDirty
-                                };
+                            if (newEnv && newEnv.length > 0) {
+                                newEnv.forEach(function (prop) {
+                                    if (prop.type === "cred") {
+                                        editingNode.credentials = editingNode.credentials || { _: {} };
+                                        editingNode.credentials[prop.name] = prop.value;
+                                        editingNode.credentials['has_' + prop.name] = (prop.value !== "");
+                                        if (prop.value !== '__PWRD__') {
+                                            editState.changed = true;
+                                        }
+                                        delete prop.value;
+                                    }
+                                });
                             }
 
-                            RED.events.emit("subflows:change", editingNode);
-                            RED.history.push(historyEvent);
-                            RED.nodes.dirty(true);
+                            const envToRemove = new Set();
+                            if (!isSameObj(oldEnv, newEnv)) {
+                                // Get a list of env properties that have been removed
+                                // by comparing oldEnv and newEnv
+                                if (oldEnv) {
+                                    oldEnv.forEach((env) => { envToRemove.add(env.name) });
+                                }
+                                if (newEnv) {
+                                    newEnv.forEach((env) => {
+                                        envToRemove.delete(env.name)
+                                    });
+                                }
+                                editState.changes.env = oldEnv;
+                                editingNode.env = newEnv;
+                                editState.changed = true;
+                            }
+
+                            if (editState.changed) {
+                                const wasChanged = editingNode.changed;
+                                const subflowInstances = [];
+                                const instanceHistoryEvents = [];
+
+                                // Marks the Subflow has changed and validate it
+                                editingNode.changed = true;
+                                validateNode(editingNode);
+
+                                // Update each Subflow instances
+                                RED.nodes.eachNode(function (n) {
+                                    if (n.type == "subflow:" + editingNode.id) {
+                                        subflowInstances.push({
+                                            id: n.id,
+                                            changed: n.changed
+                                        });
+
+                                        n.changed = true;
+                                        n.dirty = true;
+                                        if (editState.changes.hasOwnProperty("color")) {
+                                            // Redraw the node color
+                                            n._colorChanged = true;
+                                        }
+
+                                        if (n.env) {
+                                            const oldEnv = n.env;
+                                            const newEnv = [];
+                                            let envChanged = false;
+                                            n.env.forEach((env, index) => {
+                                                if (envToRemove.has(env.name)) {
+                                                    envChanged = true;
+                                                } else {
+                                                    newEnv.push(env);
+                                                }
+                                            });
+                                            if (envChanged) {
+                                                instanceHistoryEvents.push({
+                                                    t: 'edit',
+                                                    node: n,
+                                                    changes: { env: oldEnv },
+                                                    dirty: n.dirty,
+                                                    changed: n.changed
+                                                });
+                                                n.env = newEnv;
+                                            }
+                                        }
+
+                                        updateNodeProperties(n);
+                                        validateNode(n);
+                                    }
+                                });
+
+                                let historyEvent = {
+                                    t: 'edit',
+                                    node: editingNode,
+                                    changes: editState.changes,
+                                    dirty: wasDirty,
+                                    changed: wasChanged,
+                                    subflow: {
+                                        instances: subflowInstances
+                                    }
+                                };
+
+                                if (instanceHistoryEvents.length > 0) {
+                                    historyEvent = {
+                                        t: 'multi',
+                                        events: [ historyEvent, ...instanceHistoryEvents ],
+                                        dirty: wasDirty
+                                    };
+                                }
+
+                                RED.events.emit("subflows:change", editingNode);
+                                RED.history.push(historyEvent);
+                                RED.nodes.dirty(true);
+                            }
+
+                            editingNode.dirty = true;
+                            RED.tray.close();
                         }
-
-                        editingNode.dirty = true;
-                        RED.tray.close();
                     }
-                }
-            ],
-            resize: function (dimensions) {
-                $(".red-ui-tray-content").height(dimensions.height - 50);
+                ],
+                resize: function (dimensions) {
+                    $(".red-ui-tray-content").height(dimensions.height - 50);
 
-                const form = $(".red-ui-tray-content form").height(dimensions.height - 50 - 40);
-                const size = { width: form.width(), height: form.height() };
-                activeEditPanes.forEach(function (pane) {
-                    if (pane.resize) {
-                        pane.resize.call(pane, size);
+                    const form = $(".red-ui-tray-content form").height(dimensions.height - 50 - 40);
+                    const size = { width: form.width(), height: form.height() };
+                    activeEditPanes.forEach(function (pane) {
+                        if (pane.resize) {
+                            pane.resize.call(pane, size);
+                        }
+                    });
+                },
+                open: function (tray, done) {
+                    const trayBody = tray.find('.red-ui-tray-body');
+                    const trayFooter = tray.find(".red-ui-tray-footer");
+
+                    trayBody.parent().css('overflow', 'hidden');
+
+                    const trayFooterLeft = $("<div/>", { class: "red-ui-tray-footer-left" }).appendTo(trayFooter);
+                    $('<span style="margin-left: 10px"><i class="fa fa-info-circle"></i> <i id="red-ui-editor-subflow-user-count"></i></span>').appendTo(trayFooterLeft);
+
+                    if (editingNode) {
+                        RED.sidebar.info.refresh(editingNode);
                     }
-                });
-            },
-            open: function (tray, done) {
-                const trayBody = tray.find('.red-ui-tray-body');
-                const trayFooter = tray.find(".red-ui-tray-footer");
 
-                trayBody.parent().css('overflow', 'hidden');
+                    const nodeEditPanes = [
+                        'editor-tab-properties',
+                        'editor-tab-subflow-module',
+                        'editor-tab-description',
+                        'editor-tab-appearance'
+                    ];
+                    prepareEditDialog(trayBody, nodeEditPanes, subflow, subflow._def, "subflow-input", defaultTab, function (_activeEditPanes) {
+                        activeEditPanes = _activeEditPanes;
+                        trayBody.i18n();
+                        trayFooter.i18n();
+                        buildingEditDialog = false;
+                        done();
+                    });
+                },
+                close: function () {
+                    if (RED.view.state() != RED.state.IMPORT_DRAGGING) {
+                        RED.view.state(RED.state.DEFAULT);
+                    }
 
-                const trayFooterLeft = $("<div/>", { class: "red-ui-tray-footer-left" }).appendTo(trayFooter);
-                $('<span style="margin-left: 10px"><i class="fa fa-info-circle"></i> <i id="red-ui-editor-subflow-user-count"></i></span>').appendTo(trayFooterLeft);
-
-                if (editingNode) {
                     RED.sidebar.info.refresh(editingNode);
-                }
+                    RED.workspaces.refresh();
+                    activeEditPanes.forEach(function (pane) {
+                        if (pane.close) {
+                            pane.close.call(pane);
+                        }
+                    });
 
-                const nodeEditPanes = [
-                    'editor-tab-properties',
-                    'editor-tab-subflow-module',
-                    'editor-tab-description',
-                    'editor-tab-appearance'
-                ];
-                prepareEditDialog(trayBody, nodeEditPanes, subflow, subflow._def, "subflow-input", defaultTab, function (_activeEditPanes) {
-                    activeEditPanes = _activeEditPanes;
-                    trayBody.i18n();
-                    trayFooter.i18n();
-                    buildingEditDialog = false;
-                    done();
-                });
-            },
-            close: function () {
-                if (RED.view.state() != RED.state.IMPORT_DRAGGING) {
-                    RED.view.state(RED.state.DEFAULT);
-                }
+                    editStack.pop();
+                    // TODO: useless?
+                    editingNode = null;
+                },
+                show: function () {}
+            }
 
-                RED.sidebar.info.refresh(editingNode);
-                RED.workspaces.refresh();
-                activeEditPanes.forEach(function (pane) {
-                    if (pane.close) {
-                        pane.close.call(pane);
-                    }
-                });
-
-                editStack.pop();
-                // TODO: useless?
-                editingNode = null;
-            },
-            show: function () {}
+            RED.tray.show(trayOptions);
+        } catch (error) {
+            console.warn('An error occured in showEditSubflowDialog', error)
+            buildingEditDialog = false;
         }
-
-        RED.tray.show(trayOptions);
     }
 
     function showEditGroupDialog(group, defaultTab) {
-        if (buildingEditDialog) { return }
-        if (editStack.includes(group)) { return }
-        if (group.z && RED.workspaces.isLocked(group.z)) { return }
-        buildingEditDialog = true;
-        var editing_node = group;
-        editStack.push(group);
-        RED.view.state(RED.state.EDITING);
-        var activeEditPanes = [];
+        try {
+            if (buildingEditDialog) { return }
+            if (editStack.includes(group)) { return }
+            if (group.z && RED.workspaces.isLocked(group.z)) { return }
+            buildingEditDialog = true;
+            var editing_node = group;
+            editStack.push(group);
+            RED.view.state(RED.state.EDITING);
+            var activeEditPanes = [];
 
-        var trayOptions = {
-            title: getEditStackTitle(),
-            buttons: [
-                {
-                    id: "node-dialog-cancel",
-                    text: RED._("common.label.cancel"),
-                    click: function() {
-                        RED.tray.close();
-                    }
-                },
-                {
-                    id: "node-dialog-ok",
-                    class: "primary",
-                    text: RED._("common.label.done"),
-                    click: function() {
-                        var editState = {
-                            changes: {},
-                            changed: false,
-                            outputMap: null
+            var trayOptions = {
+                title: getEditStackTitle(),
+                buttons: [
+                    {
+                        id: "node-dialog-cancel",
+                        text: RED._("common.label.cancel"),
+                        click: function() {
+                            RED.tray.close();
                         }
-                        var wasDirty = RED.nodes.dirty();
-
-                        handleEditSave(editing_node,editState);
-
-                        activeEditPanes.forEach(function(pane) {
-                            if (pane.apply) {
-                                pane.apply.call(pane, editState);
+                    },
+                    {
+                        id: "node-dialog-ok",
+                        class: "primary",
+                        text: RED._("common.label.done"),
+                        click: function() {
+                            var editState = {
+                                changes: {},
+                                changed: false,
+                                outputMap: null
                             }
-                        })
+                            var wasDirty = RED.nodes.dirty();
 
-                        if (editState.changed) {
-                            var wasChanged = editing_node.changed;
-                            editing_node.changed = true;
-                            RED.nodes.dirty(true);
-                            var historyEvent = {
-                                t:'edit',
-                                node:editing_node,
-                                changes:editState.changes,
-                                dirty:wasDirty,
-                                changed:wasChanged
-                            };
-                            RED.history.push(historyEvent);
-                            RED.events.emit("groups:change",editing_node);
+                            handleEditSave(editing_node,editState);
+
+                            activeEditPanes.forEach(function(pane) {
+                                if (pane.apply) {
+                                    pane.apply.call(pane, editState);
+                                }
+                            })
+
+                            if (editState.changed) {
+                                var wasChanged = editing_node.changed;
+                                editing_node.changed = true;
+                                RED.nodes.dirty(true);
+                                var historyEvent = {
+                                    t:'edit',
+                                    node:editing_node,
+                                    changes:editState.changes,
+                                    dirty:wasDirty,
+                                    changed:wasChanged
+                                };
+                                RED.history.push(historyEvent);
+                                RED.events.emit("groups:change",editing_node);
+                            }
+                            editing_node.dirty = true;
+                            RED.tray.close();
+                            RED.view.redraw(true);
                         }
-                        editing_node.dirty = true;
-                        RED.tray.close();
-                        RED.view.redraw(true);
                     }
-                }
-            ],
-            resize: function(dimensions) {
-                editTrayWidthCache['group'] = dimensions.width;
-                $(".red-ui-tray-content").height(dimensions.height - 50);
-                var form = $(".red-ui-tray-content form").height(dimensions.height - 50 - 40);
-                var size = {width:form.width(),height:form.height()};
-                activeEditPanes.forEach(function(pane) {
-                    if (pane.resize) {
-                        pane.resize.call(pane, size);
-                    }
-                })
-            },
-            open: function(tray, done) {
-                var trayFooter = tray.find(".red-ui-tray-footer");
-                var trayFooterLeft = $("<div/>", {
-                    class: "red-ui-tray-footer-left"
-                }).appendTo(trayFooter)
-                var trayBody = tray.find('.red-ui-tray-body');
-                trayBody.parent().css('overflow','hidden');
+                ],
+                resize: function(dimensions) {
+                    editTrayWidthCache['group'] = dimensions.width;
+                    $(".red-ui-tray-content").height(dimensions.height - 50);
+                    var form = $(".red-ui-tray-content form").height(dimensions.height - 50 - 40);
+                    var size = {width:form.width(),height:form.height()};
+                    activeEditPanes.forEach(function(pane) {
+                        if (pane.resize) {
+                            pane.resize.call(pane, size);
+                        }
+                    })
+                },
+                open: function(tray, done) {
+                    var trayFooter = tray.find(".red-ui-tray-footer");
+                    var trayFooterLeft = $("<div/>", {
+                        class: "red-ui-tray-footer-left"
+                    }).appendTo(trayFooter)
+                    var trayBody = tray.find('.red-ui-tray-body');
+                    trayBody.parent().css('overflow','hidden');
 
-                var nodeEditPanes = [
-                    'editor-tab-properties',
-                    'editor-tab-envProperties',
-                    'editor-tab-description'
-                ];
-                prepareEditDialog(trayBody, nodeEditPanes, group,group._def,"node-input", defaultTab, function(_activeEditPanes) {
-                    activeEditPanes = _activeEditPanes;
-                    trayBody.i18n();
-                    buildingEditDialog = false;
-                    done();
-                });
+                    var nodeEditPanes = [
+                        'editor-tab-properties',
+                        'editor-tab-envProperties',
+                        'editor-tab-description'
+                    ];
+                    prepareEditDialog(trayBody, nodeEditPanes, group,group._def,"node-input", defaultTab, function(_activeEditPanes) {
+                        activeEditPanes = _activeEditPanes;
+                        trayBody.i18n();
+                        buildingEditDialog = false;
+                        done();
+                    });
 
-            },
-            close: function() {
-                if (RED.view.state() != RED.state.IMPORT_DRAGGING) {
-                    RED.view.state(RED.state.DEFAULT);
-                }
-                RED.sidebar.info.refresh(editing_node);
-                activeEditPanes.forEach(function(pane) {
-                    if (pane.close) {
-                        pane.close.call(pane);
+                },
+                close: function() {
+                    if (RED.view.state() != RED.state.IMPORT_DRAGGING) {
+                        RED.view.state(RED.state.DEFAULT);
                     }
-                })
-                editStack.pop();
-                editing_node = null;
-            },
-            show: function() {
+                    RED.sidebar.info.refresh(editing_node);
+                    activeEditPanes.forEach(function(pane) {
+                        if (pane.close) {
+                            pane.close.call(pane);
+                        }
+                    })
+                    editStack.pop();
+                    editing_node = null;
+                },
+                show: function() {
+                }
             }
-        }
 
-        if (editTrayWidthCache.hasOwnProperty('group')) {
-            trayOptions.width = editTrayWidthCache['group'];
+            if (editTrayWidthCache.hasOwnProperty('group')) {
+                trayOptions.width = editTrayWidthCache['group'];
+            }
+            RED.tray.show(trayOptions);
+        } catch (error) {
+            console.warn('An error occured in showEditGroupDialog', error)
+            buildingEditDialog = false;
         }
-        RED.tray.show(trayOptions);
     }
 
     function showEditFlowDialog(workspace, defaultTab) {
-        if (buildingEditDialog) { return }
-        if (editStack.includes(workspace)) { return }
-        buildingEditDialog = true;
-        var activeEditPanes = [];
-        RED.view.state(RED.state.EDITING);
-        var trayOptions = {
-            title: RED._("workspace.editFlow",{name:RED.utils.sanitize(workspace.label)}),
-            buttons: [
-                {
-                    id: "node-dialog-delete",
-                    class: 'leftButton'+((RED.workspaces.count() === 1)?" disabled":""),
-                    text: RED._("common.label.delete"), //'<i class="fa fa-trash"></i>',
-                    click: function() {
-                        RED.workspaces.delete(workspace);
-                        RED.tray.close();
+        try {
+            if (buildingEditDialog) { return }
+            if (editStack.includes(workspace)) { return }
+            buildingEditDialog = true;
+            var activeEditPanes = [];
+            RED.view.state(RED.state.EDITING);
+            var trayOptions = {
+                title: RED._("workspace.editFlow",{name:RED.utils.sanitize(workspace.label)}),
+                buttons: [
+                    {
+                        id: "node-dialog-delete",
+                        class: 'leftButton'+((RED.workspaces.count() === 1)?" disabled":""),
+                        text: RED._("common.label.delete"), //'<i class="fa fa-trash"></i>',
+                        click: function() {
+                            RED.workspaces.delete(workspace);
+                            RED.tray.close();
+                        }
+                    },
+                    {
+                        id: "node-dialog-cancel",
+                        text: RED._("common.label.cancel"),
+                        click: function() {
+                            RED.tray.close();
+                        }
+                    },
+                    {
+                        id: "node-dialog-ok",
+                        class: "primary",
+                        text: RED._("common.label.done"),
+                        click: function() {
+                            var editState = {
+                                changes: {},
+                                changed: false,
+                                outputMap: null
+                            }
+                            var wasDirty = RED.nodes.dirty();
+
+                            activeEditPanes.forEach(function(pane) {
+                                if (pane.apply) {
+                                    pane.apply.call(pane, editState);
+                                }
+                            })
+
+                            var disabled = $("#node-input-disabled").prop("checked");
+                            if (workspace.disabled !== disabled) {
+                                editState.changes.disabled = workspace.disabled;
+                                editState.changed = true;
+                                workspace.disabled = disabled;
+
+                                $("#red-ui-tab-"+(workspace.id.replace(".","-"))).toggleClass('red-ui-workspace-disabled',!!workspace.disabled);
+                            }
+
+                            var locked = $("#node-input-locked").prop("checked");
+                            if (workspace.locked !== locked) {
+                                editState.changes.locked = workspace.locked;
+                                editState.changed = true;
+                                workspace.locked = locked;
+                                $("#red-ui-tab-"+(workspace.id.replace(".","-"))).toggleClass('red-ui-workspace-locked',!!workspace.locked);
+                            }
+                            if (editState.changed) {
+                                var historyEvent = {
+                                    t: "edit",
+                                    changes: editState.changes,
+                                    node: workspace,
+                                    dirty: wasDirty
+                                }
+                                workspace.changed = true;
+                                RED.history.push(historyEvent);
+                                RED.nodes.dirty(true);
+                                if (editState.changes.hasOwnProperty('disabled')) {
+                                    RED.nodes.eachNode(function(n) {
+                                        if (n.z === workspace.id) {
+                                            n.dirty = true;
+                                        }
+                                    });
+                                    RED.view.redraw();
+                                }
+                                RED.workspaces.refresh();
+                                RED.events.emit("flows:change",workspace);
+                            }
+                            RED.tray.close();
+                        }
                     }
+                ],
+                resize: function(dimensions) {
+                    $(".red-ui-tray-content").height(dimensions.height - 50);
+                    var form = $(".red-ui-tray-content form").height(dimensions.height - 50 - 40);
+                    var size = {width:form.width(),height:form.height()};
+                    activeEditPanes.forEach(function(pane) {
+                        if (pane.resize) {
+                            pane.resize.call(pane, size);
+                        }
+                    })
                 },
-                {
-                    id: "node-dialog-cancel",
-                    text: RED._("common.label.cancel"),
-                    click: function() {
-                        RED.tray.close();
+                open: function(tray, done) {
+                    var trayFooter = tray.find(".red-ui-tray-footer");
+                    var trayBody = tray.find('.red-ui-tray-body');
+                    trayBody.parent().css('overflow','hidden');
+                    var trayFooterLeft = $('<div class="red-ui-tray-footer-left"></div>').appendTo(trayFooter)
+                    var trayFooterRight = $('<div class="red-ui-tray-footer-right"></div>').appendTo(trayFooter)
+
+                    var nodeEditPanes = [
+                        'editor-tab-flow-properties',
+                        'editor-tab-envProperties'
+                    ];
+
+                    if (!workspace.hasOwnProperty("disabled")) {
+                        workspace.disabled = false;
                     }
+                    $('<input id="node-input-disabled" type="checkbox">').prop("checked",workspace.disabled).appendTo(trayFooterLeft).toggleButton({
+                        enabledIcon: "fa-circle-thin",
+                        disabledIcon: "fa-ban",
+                        invertState: true
+                    })
+
+                    if (!workspace.hasOwnProperty("locked")) {
+                        workspace.locked = false;
+                    }
+                    $('<input id="node-input-locked" type="checkbox">').prop("checked",workspace.locked).appendTo(trayFooterRight).toggleButton({
+                        enabledLabel: RED._("common.label.unlocked"),
+                        enabledIcon: "fa-unlock-alt",
+                        disabledLabel: RED._("common.label.locked"),
+                        disabledIcon: "fa-lock",
+                        invertState: true
+                    })
+
+                    prepareEditDialog(trayBody, nodeEditPanes, workspace, {}, "node-input", defaultTab, function(_activeEditPanes) {
+                        activeEditPanes = _activeEditPanes;
+                        trayBody.i18n();
+                        trayFooter.i18n();
+                        buildingEditDialog = false;
+                        done();
+                    });
                 },
-                {
-                    id: "node-dialog-ok",
-                    class: "primary",
-                    text: RED._("common.label.done"),
-                    click: function() {
-                        var editState = {
-                            changes: {},
-                            changed: false,
-                            outputMap: null
-                        }
-                        var wasDirty = RED.nodes.dirty();
-
-                        activeEditPanes.forEach(function(pane) {
-                            if (pane.apply) {
-                                pane.apply.call(pane, editState);
-                            }
-                        })
-
-                        var disabled = $("#node-input-disabled").prop("checked");
-                        if (workspace.disabled !== disabled) {
-                            editState.changes.disabled = workspace.disabled;
-                            editState.changed = true;
-                            workspace.disabled = disabled;
-
-                            $("#red-ui-tab-"+(workspace.id.replace(".","-"))).toggleClass('red-ui-workspace-disabled',!!workspace.disabled);
-                        }
-
-                        var locked = $("#node-input-locked").prop("checked");
-                        if (workspace.locked !== locked) {
-                            editState.changes.locked = workspace.locked;
-                            editState.changed = true;
-                            workspace.locked = locked;
-                            $("#red-ui-tab-"+(workspace.id.replace(".","-"))).toggleClass('red-ui-workspace-locked',!!workspace.locked);
-                        }
-                        if (editState.changed) {
-                            var historyEvent = {
-                                t: "edit",
-                                changes: editState.changes,
-                                node: workspace,
-                                dirty: wasDirty
-                            }
-                            workspace.changed = true;
-                            RED.history.push(historyEvent);
-                            RED.nodes.dirty(true);
-                            if (editState.changes.hasOwnProperty('disabled')) {
-                                RED.nodes.eachNode(function(n) {
-                                    if (n.z === workspace.id) {
-                                        n.dirty = true;
-                                    }
-                                });
-                                RED.view.redraw();
-                            }
-                            RED.workspaces.refresh();
-                            RED.events.emit("flows:change",workspace);
-                        }
-                        RED.tray.close();
+                close: function() {
+                    if (RED.view.state() != RED.state.IMPORT_DRAGGING) {
+                        RED.view.state(RED.state.DEFAULT);
                     }
-                }
-            ],
-            resize: function(dimensions) {
-                $(".red-ui-tray-content").height(dimensions.height - 50);
-                var form = $(".red-ui-tray-content form").height(dimensions.height - 50 - 40);
-                var size = {width:form.width(),height:form.height()};
-                activeEditPanes.forEach(function(pane) {
-                    if (pane.resize) {
-                        pane.resize.call(pane, size);
+                    activeEditPanes.forEach(function(pane) {
+                        if (pane.close) {
+                            pane.close.call(pane);
+                        }
+                    })
+                    var selection = RED.view.selection();
+                    if (!selection.nodes && !selection.links && workspace.id === RED.workspaces.active()) {
+                        RED.sidebar.info.refresh(workspace);
                     }
-                })
-            },
-            open: function(tray, done) {
-                var trayFooter = tray.find(".red-ui-tray-footer");
-                var trayBody = tray.find('.red-ui-tray-body');
-                trayBody.parent().css('overflow','hidden');
-                var trayFooterLeft = $('<div class="red-ui-tray-footer-left"></div>').appendTo(trayFooter)
-                var trayFooterRight = $('<div class="red-ui-tray-footer-right"></div>').appendTo(trayFooter)
-
-                var nodeEditPanes = [
-                    'editor-tab-flow-properties',
-                    'editor-tab-envProperties'
-                ];
-
-                if (!workspace.hasOwnProperty("disabled")) {
-                    workspace.disabled = false;
-                }
-                $('<input id="node-input-disabled" type="checkbox">').prop("checked",workspace.disabled).appendTo(trayFooterLeft).toggleButton({
-                    enabledIcon: "fa-circle-thin",
-                    disabledIcon: "fa-ban",
-                    invertState: true
-                })
-
-                if (!workspace.hasOwnProperty("locked")) {
-                    workspace.locked = false;
-                }
-                $('<input id="node-input-locked" type="checkbox">').prop("checked",workspace.locked).appendTo(trayFooterRight).toggleButton({
-                    enabledLabel: RED._("common.label.unlocked"),
-                    enabledIcon: "fa-unlock-alt",
-                    disabledLabel: RED._("common.label.locked"),
-                    disabledIcon: "fa-lock",
-                    invertState: true
-                })
-
-                prepareEditDialog(trayBody, nodeEditPanes, workspace, {}, "node-input", defaultTab, function(_activeEditPanes) {
-                    activeEditPanes = _activeEditPanes;
-                    trayBody.i18n();
-                    trayFooter.i18n();
-                    buildingEditDialog = false;
-                    done();
-                });
-            },
-            close: function() {
-                if (RED.view.state() != RED.state.IMPORT_DRAGGING) {
-                    RED.view.state(RED.state.DEFAULT);
-                }
-                activeEditPanes.forEach(function(pane) {
-                    if (pane.close) {
-                        pane.close.call(pane);
-                    }
-                })
-                var selection = RED.view.selection();
-                if (!selection.nodes && !selection.links && workspace.id === RED.workspaces.active()) {
-                    RED.sidebar.info.refresh(workspace);
                 }
             }
+            RED.tray.show(trayOptions);
+        } catch (error) {
+            console.warn('An error occured in showEditFlowDialog', error)
+            buildingEditDialog = false;
         }
-        RED.tray.show(trayOptions);
     }
 
     function showTypeEditor(type, options) {


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

closes #5731

## Proposed changes

Move  `buildingEditDialog = true` down BELOW all guard `return` statements (like `isLocked`).

This ensures subsequent calls to open the editor can be made.

NOTE: I was tempted to wrap these function blocks in `try..finally` as I have previously seen errors in contrib nodes prevent the edit dialog opening - and I suspect it is a very similar problem - where `buildingEditDialog` is being left set (probably due to a throw in their oneditshow routine).

I can update this PR to do that or we can follow it up later if required?

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
