### PR TITLE
Refactor workspace grid to use single pattern definition

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1368,7 +1368,7 @@ RED.view = (function() {
     function updateGrid() {
         const size = +gridSize
         gridPattern.attr("width", size).attr("height", size)
-        gridPath.attr("d", "M 0 0 H " + size + " V " + size + " H 0 Z")
+        gridPath.attr("d", "M " + size + " 0.5 L 0.5 0.5 0.5 " + size)
     }
 
     function showDragLines(nodes) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -154,7 +154,9 @@ RED.view = (function() {
      */
     var eventLayer;
 
-    /** @type {SVGGElement} */ let gridLayer;
+    /** @type {d3.Selection<SVGGElement, any, any, any>} */ let gridLayer;
+    /** @type {d3.Selection<SVGGElement, any, any, any>} */ let gridPattern;
+    /** @type {d3.Selection<SVGGElement, any, any, any>} */ let gridPath;
     /** @type {SVGGElement} */ let linkLayer;
     /** @type {SVGGElement} */ let junctionLayer;
     /** @type {SVGGElement} */ let dragGroupLayer;
@@ -698,6 +700,16 @@ RED.view = (function() {
             .attr("height", space_height);
 
         gridLayer = eventLayer.append("g").attr("class","red-ui-workspace-chart-grid");
+        gridPattern = gridLayer.append("defs").append("pattern")
+            .attr("id","red-ui-workspace-chart-grid-pattern")
+            .attr("patternUnits","userSpaceOnUse");
+        gridPath = gridPattern.append("path")
+            .attr("class","red-ui-workspace-chart-grid-line")
+            .attr("vector-effect","non-scaling-stroke");
+        gridLayer.append("rect")
+            .attr("width", space_width)
+            .attr("height", space_height)
+            .attr("fill", "url(#red-ui-workspace-chart-grid-pattern)");
         updateGrid();
 
         groupLayer = eventLayer.append("g");
@@ -1354,32 +1366,9 @@ RED.view = (function() {
 
 
     function updateGrid() {
-        var gridTicks = [];
-        for (var i=0;i<space_width;i+=+gridSize) {
-            gridTicks.push(i);
-        }
-        gridLayer.selectAll("line.red-ui-workspace-chart-grid-h").remove();
-        gridLayer.selectAll("line.red-ui-workspace-chart-grid-h").data(gridTicks).enter()
-            .append("line")
-            .attr(
-                {
-                    "class":"red-ui-workspace-chart-grid-h",
-                    "x1" : 0,
-                    "x2" : space_width,
-                    "y1" : function(d){ return d;},
-                    "y2" : function(d){ return d;}
-                });
-        gridLayer.selectAll("line.red-ui-workspace-chart-grid-v").remove();
-        gridLayer.selectAll("line.red-ui-workspace-chart-grid-v").data(gridTicks).enter()
-            .append("line")
-            .attr(
-                {
-                    "class":"red-ui-workspace-chart-grid-v",
-                    "y1" : 0,
-                    "y2" : space_width,
-                    "x1" : function(d){ return d;},
-                    "x2" : function(d){ return d;}
-                });
+        const size = +gridSize
+        gridPattern.attr("width", size).attr("height", size)
+        gridPath.attr("d", "M 0 0 H " + size + " V " + size + " H 0 Z")
     }
 
     function showDragLines(nodes) {

--- a/packages/node_modules/@node-red/editor-client/src/sass/workspace.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/workspace.scss
@@ -73,7 +73,7 @@
 .red-ui-workspace-chart-background {
     fill: var(--red-ui-view-background);
 }
-.red-ui-workspace-chart-grid line {
+.red-ui-workspace-chart-grid-line {
     fill: none;
     shape-rendering: crispEdges;
     stroke: var(--red-ui-view-grid-color);
@@ -83,7 +83,7 @@
     .red-ui-workspace-chart-background {
         opacity: 0.7;
     }
-    .red-ui-workspace-chart-grid line {
+    .red-ui-workspace-chart-grid-line {
         opacity: 0.8;
     }
 }


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

closes #5728

## Proposed changes

Replace the individual dom line elements with a single rect that uses a pattern def

### Before and after 

#### Stats:

(index) | before | after | ratio
-- | -- | -- | --
elements (DOM nodes under gridLayer) | 800 | 4 | '200.0x'
markup size (bytes) | 70219 | 402 | '174.7x'
updateGrid avg (ms, x1000 calls) | '1.632 (rebuild)' | '0.003' | '652.8x'
  |   |   |  



#### Comparison

- Original lines on the left
- Pattern def grid on the right

https://github.com/user-attachments/assets/f654ecf1-5ec2-4a4e-81d4-614bc18f315a


#### DOM
<img width="1528" height="791" alt="image" src="https://github.com/user-attachments/assets/5f2640e5-151b-486b-ab22-7ca43cfbf379" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
