### PR TITLE
Overlay status above selection halo

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -5692,6 +5692,15 @@ RED.view = (function() {
                 nodeContents.appendChild(text);
                 node[0][0].__textGroup__ = text;
 
+                const nodeHalo = document.createElementNS("http://www.w3.org/2000/svg","rect");
+                nodeHalo.setAttribute("class", "red-ui-flow-node-highlight");
+                nodeHalo.setAttribute("rx", 8);
+                nodeHalo.setAttribute("ry", 8);
+                nodeHalo.setAttribute("x", -3)
+                nodeHalo.setAttribute("y", -3)
+                node[0][0].__halo__ = nodeHalo;
+                nodeContents.appendChild(nodeHalo);
+
                 var statusEl = document.createElementNS("http://www.w3.org/2000/svg","g");
                 // statusEl.__data__ = d;
                 statusEl.setAttribute("class","red-ui-flow-node-status-group");
@@ -5732,14 +5741,7 @@ RED.view = (function() {
 
                 nodeContents.appendChild(statusEl);
 
-                const nodeHalo = document.createElementNS("http://www.w3.org/2000/svg","rect");
-                nodeHalo.setAttribute("class", "red-ui-flow-node-highlight");
-                nodeHalo.setAttribute("rx", 8);
-                nodeHalo.setAttribute("ry", 8);
-                nodeHalo.setAttribute("x", -3)
-                nodeHalo.setAttribute("y", -3)
-                node[0][0].__halo__ = nodeHalo;
-                nodeContents.appendChild(nodeHalo);
+
 
                 node[0][0].appendChild(nodeContents);
 


### PR DESCRIPTION
With the new selection halo, whilst the height adjusts for any status text, the width doesn't. This was an intentional choice, but could lead to status text being obscured:


<img width="302" height="106" alt="SCR-20260511-nzxa" src="https://github.com/user-attachments/assets/8fddd8ea-07d9-4603-83e8-236517408745" />

With this PR, the selection halo is now layered beneath the status text. I *think* this is a better arrangement.

<img width="302" height="106" alt="SCR-20260511-oaij" src="https://github.com/user-attachments/assets/20ade7af-2ed8-445b-b000-e727479a240a" />

