### PR TITLE
Standardize popover colors

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
@@ -185,6 +185,9 @@ RED.popover = (function() {
                 if (options.class) {
                     div.addClass(options.class);
                 }
+                if (options.tooltip) {
+                    div.addClass('red-ui-tooltip');
+                }
                 contentDiv = $('<div class="red-ui-popover-content">').appendTo(div);
                 if (size !== "default") {
                     div.addClass("red-ui-popover-size-"+size);

--- a/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/colors.scss
@@ -144,13 +144,15 @@ $workspace-button-color-focus-outline: $form-input-focus-color;
 
 $shade-color: rgba(0,0,0,0.35);
 
-$popover-background: #1e1e1e;
-$popover-border: $popover-background;
-$popover-color: #eee;
+$popover-background: $secondary-background;
+$popover-border: $primary-border-color;
+$popover-color: $primary-text-color;
 $popover-button-border-color: #bbb;
 $popover-button-border-color-hover: #666;
 
-
+$tooltip-background: #1e1e1e;
+$tooltip-border: $tooltip-background;
+$tooltip-color: #eee;
 
 $diff-text-header-color: $secondary-text-color;
 $diff-text-header-background: #fefbe9;

--- a/packages/node_modules/@node-red/editor-client/src/sass/dark-theme.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/dark-theme.scss
@@ -212,6 +212,10 @@ html.nr-theme-dark {
     --red-ui-popover-button-border-color:       #{dc.$popover-button-border-color};
     --red-ui-popover-button-border-color-hover: #{dc.$popover-button-border-color-hover};
 
+    --red-ui-tooltip-background: var(--red-ui-popover-background);
+    --red-ui-tooltip-border: var(--red-ui-popover-border);
+    --red-ui-tooltip-color: var(--red-ui-popover-color);
+
     // ── Canvas / workspace ──
     --red-ui-view-background:           #{dc.$view-background};
     --red-ui-view-grid-color:           #{dc.$view-grid-color};

--- a/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
@@ -292,13 +292,8 @@ svg:not(.red-ui-workspace-lasso-active) {
 }
 
 .red-ui-flow-annotation-popover {
-    // Re-point annotation popover (node badge popovers) to have theme-aware backgrounds so that
-    // rich markdown content inside (links, code blocks, tables, alerts, ...) reads correctly in
-    // both light and dark themes. Same pattern as red-ui-tourGuide-popover in tourGuide.scss.
+
     z-index: 2002; // 1 less than the tourGuide popovers
-    --red-ui-popover-background: var(--red-ui-secondary-background);
-    --red-ui-popover-border: var(--red-ui-primary-border-color);
-    --red-ui-popover-color: var(--red-ui-primary-text-color);
 
     .red-ui-popover-content {
         // Section provides the inner chrome, so drop the default popover-content padding.

--- a/packages/node_modules/@node-red/editor-client/src/sass/popover.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/popover.scss
@@ -32,6 +32,11 @@
     line-height: 1.4em;
     @include mixins.component-shadow;
     border-color: var(--red-ui-popover-border);
+    &.red-ui-tooltip {
+        --red-ui-popover-background: var(--red-ui-tooltip-background);
+        --red-ui-popover-border: var(--red-ui-tooltip-border);
+        --red-ui-popover-color: var(--red-ui-tooltip-color);
+    }
 }
 .red-ui-popover-content {
     padding: 8px;
@@ -124,6 +129,7 @@
 .red-ui-popover-size-small {
     font-size: 12px;
     line-height: 1.8em;
+    padding: 1px;
     .red-ui-popover-content {
         padding: 1px 4px;
     }

--- a/packages/node_modules/@node-red/editor-client/src/sass/variables.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/variables.scss
@@ -144,6 +144,9 @@
     --red-ui-popover-button-border-color: #{colors.$popover-button-border-color};
     --red-ui-popover-button-border-color-hover: #{colors.$popover-button-border-color-hover};
 
+    --red-ui-tooltip-background: #{colors.$tooltip-background};
+    --red-ui-tooltip-border: #{colors.$tooltip-border};
+    --red-ui-tooltip-color: #{colors.$tooltip-color};
 
 
     --red-ui-diff-text-header-color: #{colors.$diff-text-header-color};


### PR DESCRIPTION
This updates the default popover colours. For the light theme, popovers would default to a dark background. With this PR, they are now light themed.

Tooltips remain dark background.

CSS vars have been added for tooltips. 

The dark theme sets a consistent dark theme to popovers and tooltips alike.

The most obvious change is the popover shown when hovering over a palette node:

<img width="532" height="202" alt="image" src="https://github.com/user-attachments/assets/7879793a-b511-4204-a09d-06dc02588d19" />
