### PR TITLE
Sort node lists alphabetically

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/24-complete.html
+++ b/packages/node_modules/@node-red/nodes/core/common/24-complete.html
@@ -120,6 +120,11 @@
                 };
                 items.push(nodeItemMap[n.id]);
             });
+            items.sort((A, B) => {
+                const labelA = A.label;
+                const labelB = B.label;
+                return labelA.localeCompare(labelB);
+            })
             dirList.treeList('data',items);
 
             $("#node-input-complete-target-select").on("click", function(e) {

--- a/packages/node_modules/@node-red/nodes/core/common/25-catch.html
+++ b/packages/node_modules/@node-red/nodes/core/common/25-catch.html
@@ -128,6 +128,12 @@
                 };
                 items.push(nodeItemMap[n.id]);
             });
+            items.sort((A, B) => {
+                const labelA = A.label;
+                const labelB = B.label;
+                return labelA.localeCompare(labelB);
+            })
+
             dirList.treeList('data',items);
 
             $("#node-input-catch-target-select").on("click", function(e) {

--- a/packages/node_modules/@node-red/nodes/core/common/25-status.html
+++ b/packages/node_modules/@node-red/nodes/core/common/25-status.html
@@ -123,6 +123,11 @@
                 };
                 items.push(nodeItemMap[n.id]);
             });
+            items.sort((A, B) => {
+                const labelA = A.label;
+                const labelB = B.label;
+                return labelA.localeCompare(labelB);
+            })
             dirList.treeList('data',items);
 
             $("#node-input-status-target-select").on("click", function(e) {

--- a/packages/node_modules/@node-red/nodes/core/common/60-link.html
+++ b/packages/node_modules/@node-red/nodes/core/common/60-link.html
@@ -123,6 +123,11 @@
             })
         }
 
+        candidateNodes.sort((A, B) => {
+            const labelA = A.name || A.id;
+            const labelB = B.name || B.id;
+            return labelA.localeCompare(labelB);
+        })
         candidateNodes.forEach(function (n) {
             if (flowMap[n.z]) {
                 if (targetType === "link out" && n.mode === 'return') {


### PR DESCRIPTION
For the `link (in|ou|call)`, `complete`, `catch` and `status` nodes, the edit dialog presents a list of nodes to select from.

This list was shown in the natural node order - ie the order they had been added to the workspace.

This PR changes that to sort them alphabetically based on their label.

This has been requested a few times, including just now - https://discourse.nodered.org/t/sort-list-of-link-in-link-out-nodes-in-sidebar/100990

