### PR TITLE
Shrink popover height if not sufficient vertical space

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
@@ -270,6 +270,7 @@ RED.popover = (function() {
             } else {
                 div.css("max-width", 'auto');
             }
+            contentDiv.css("max-height", 'auto')
 
             var targetPos = target[0].getBoundingClientRect();
             var targetHeight = targetPos.height;
@@ -306,17 +307,45 @@ RED.popover = (function() {
                         top -= (top+divHeight+targetHeight/2 - viewportBottom + 5)
                     }
                 } else if (top+divHeight > viewportBottom) {
-                    direction = 'top';
-                    top = targetPos.top-deltaSizes[size].y-divHeight-popupOffset;
-                    left = targetPos.left+targetWidth/2-divWidth/2;
+                    // Overlaps bottom of screen - check to see if there is room above
+                    const newTop = targetPos.top-deltaSizes[size].y-divHeight-popupOffset;
+                    const topOverlap = -newTop;
+                    const bottomOverlap = (top + divHeight) - viewportBottom;
+                    if (newTop > 0 || bottomOverlap > topOverlap) {
+                        // Flip to top if there's not space below, *or* there's more room above
+                        direction = 'top';
+                        top = newTop
+                        left = targetPos.left+targetWidth/2-divWidth/2;
+                        if (topOverlap > 0) {
+                            top += topOverlap + 10;
+                            contentDiv.css("max-height", divHeight - topOverlap - 10)
+                        }
+                    } else if (bottomOverlap > 0) {
+                        // Stay below, but reduce content height to fit
+                        contentDiv.css("max-height", divHeight - bottomOverlap - 10)
+                    }
                 }
             } else if (direction === 'top') {
                 top = targetPos.top-deltaSizes[size].y-divHeight-popupOffset;
                 left = targetPos.left+targetWidth/2-divWidth/2;
                 if (top < 0) {
-                    direction = 'bottom';
-                    top = targetPos.top+targetHeight+deltaSizes[size].y+popupOffset;
-                    left = targetPos.left+targetWidth/2-divWidth/2;
+                    // Check if flipping to bottom has vertical space
+                    const topOverlap = -top;
+                    const newTop = targetPos.top+targetHeight+deltaSizes[size].y+popupOffset;
+                    const bottomOverlap = (newTop + divHeight) - viewportBottom;
+                    if (newTop+divHeight < viewportBottom || bottomOverlap < topOverlap) {
+                        // Flip to bottom if there's not space above, *or* there's more room below
+                        direction = 'bottom';
+                        top = newTop
+                        left = targetPos.left+targetWidth/2-divWidth/2;
+                        if (bottomOverlap > 0) {
+                            contentDiv.css("max-height", divHeight - bottomOverlap - 10)
+                        }
+                    } else if (topOverlap > 0) {
+                        // Stay above, but reduce content height to fit
+                        top += topOverlap + 10;
+                        contentDiv.css("max-height", divHeight - topOverlap - 10)
+                    }
                 }
             } else if (/inset/.test(direction)) {
                 top = targetPos.top + targetHeight/2 - divHeight/2;

--- a/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/flow.scss
@@ -648,9 +648,6 @@ g.red-ui-flow-link-unknown path.red-ui-flow-link-line {
     cursor: crosshair;
     transform: scale(1);
     transition: transform 0.1s;
-    &:hover {
-
-    }
 }
 .red-ui-flow-junction-hovered {
     stroke: var(--red-ui-port-selected-color);


### PR DESCRIPTION
With the introduction of the docs annotation that opens a popover in the workspace, the popover positioning needed updating to try to ensure it doesn't overflow the screen.

As the main use case for this is the docs popover, which is top/bottom aligned, this focusses on that case. For a node on the left/right edge of the screen, the docs popover will still overflow the visible edge.