### PR TITLE
Move notifications bar to below tab bar

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/notifications.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/notifications.scss
@@ -20,7 +20,7 @@
     margin-left: -250px;
     left: 50%;
     position: absolute;
-    top: 5px;
+    top: 42px;
 }
 .red-ui-notification {
     box-sizing: border-box;


### PR DESCRIPTION
Move the notification bar so notifications appear below the tab bar. This keeps the tab bar accessible.

Not sure if this is the right long-term solution, but lets see what the feedback is like.