### PR TITLE
Rework search statusBar

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/de/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/de/editor.json
@@ -152,7 +152,7 @@
         "search-flows": "Flows durchsuchen",
         "search-prev": "Vorherige",
         "search-next": "Nächste",
-        "search-counter": "\"__term__\" __result__ von __count__"
+        "search-counter": "__result__ von __count__"
     },
     "user": {
         "loggedInAs": "Angemeldet als __name__",

--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -186,7 +186,7 @@
         "search-flows": "Search flows",
         "search-prev": "Previous",
         "search-next": "Next",
-        "search-counter": "\"__term__\" __result__ of __count__"
+        "search-counter": "__result__ of __count__"
     },
     "user": {
         "loggedInAs": "Logged in as __name__",

--- a/packages/node_modules/@node-red/editor-client/locales/es-ES/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/es-ES/editor.json
@@ -172,7 +172,7 @@
         "search-flows": "Buscar flujos",
         "search-prev": "Anterior",
         "search-next": "Siguiente",
-        "search-counter": "\"__term__\" __result__ de __count__"
+        "search-counter": "__result__ de __count__"
     },
     "user": {
         "loggedInAs": "Conectado como __name__",

--- a/packages/node_modules/@node-red/editor-client/locales/fr/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/fr/editor.json
@@ -171,7 +171,7 @@
     "search-flows": "Rechercher le flux",
     "search-prev": "Précédent",
     "search-next": "Suivant",
-    "search-counter": "\"__term__\" __result__ sur __count__"
+    "search-counter": "__result__ sur __count__"
   },
   "user": {
     "loggedInAs": "Connecté en tant que __name__",

--- a/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ja/editor.json
@@ -172,7 +172,7 @@
         "search-flows": "フローを検索",
         "search-prev": "前へ",
         "search-next": "次へ",
-        "search-counter": "\"__term__\" __count__ 件中の __result__ 件目"
+        "search-counter": "__count__ 件中の __result__ 件目"
     },
     "user": {
         "loggedInAs": "__name__ としてログインしました",

--- a/packages/node_modules/@node-red/editor-client/locales/ko/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/ko/editor.json
@@ -122,7 +122,7 @@
     "search-flows": "플로우 찾기",
     "search-prev": "이전",
     "search-next": "다음",
-    "search-counter": "\"__term__\" __result__ of __count__"
+    "search-counter": "__result__ of __count__"
   },
   "user": {
     "loggedInAs": "__name__ 에 로그인됨",

--- a/packages/node_modules/@node-red/editor-client/locales/pt-BR/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/pt-BR/editor.json
@@ -152,7 +152,7 @@
         "search-flows": "Procura fluxos",
         "search-prev": "Anterior",
         "search-next": "Próximo",
-        "search-counter": "\"__term__\" __result__ of __count__"
+        "search-counter": "__result__ of __count__"
     },
     "user": {
         "loggedInAs": "Acessado como __name__",

--- a/packages/node_modules/@node-red/editor-client/locales/zh-CN/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/zh-CN/editor.json
@@ -168,7 +168,7 @@
     "search-flows": "搜索流程",
     "search-prev": "上一个",
     "search-next": "下一个",
-    "search-counter": "\"__term__\" __result__ of __count__"
+    "search-counter": "__result__ of __count__"
   },
   "user": {
     "loggedInAs": "作为 __name__ 登录",

--- a/packages/node_modules/@node-red/editor-client/locales/zh-TW/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/zh-TW/editor.json
@@ -168,7 +168,7 @@
         "search-flows": "搜索流程",
         "search-prev": "上一個",
         "search-next": "下一個",
-        "search-counter": "\"__term__\" __result__ of __count__"
+        "search-counter": "__result__ of __count__"
     },
     "user": {
         "loggedInAs": "作為 __name__ 登入",

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
@@ -29,6 +29,8 @@ RED.search = (function() {
     var currentIndex = 0;
     var previousActiveElement;
 
+    let searchToolbarPopover;
+
     function indexProperty(node,label,property) {
         if (typeof property === 'string' || typeof property === 'number') {
             property = (""+property).toLowerCase();
@@ -527,6 +529,9 @@ RED.search = (function() {
             updateSearchToolbar();
             return;
         }
+        if (searchToolbarPopover) {
+            searchToolbarPopover.close()
+        }
         if (!visible) {
             previousActiveElement = document.activeElement;
             RED.notifications.shade.show();
@@ -574,21 +579,19 @@ RED.search = (function() {
     }
     function updateSearchToolbar() {
         if (!disabled && currentIndex >= 0 && activeResults && activeResults.length) {
-            let term = $("#red-ui-view-searchtools-search").data("term") || "";
-            if (term.length > 16) {
-                term = term.substring(0, 12) + "..."
-            }
-            const i18nSearchCounterData = {
-                term: term,
-                result: (currentIndex + 1),
-                count: activeResults.length
-            }
-            $("#red-ui-view-searchtools-counter-label").text(RED._('actions.search-counter', i18nSearchCounterData));
-            $("#view-search-tools > :not(:first-child)").show(); //show other tools
+            searchToolbarPopover.open()
+            updateSearchToolbarCounts();
         } else {
             clearActiveSearch();
-            $("#view-search-tools > :not(:first-child)").hide(); //hide all but search button
+            searchToolbarPopover.close()
         }
+    }
+    function updateSearchToolbarCounts() {
+        const i18nSearchCounterData = {
+            result: (currentIndex + 1),
+            count: activeResults.length
+        }
+        $("#red-ui-view-searchtools-counter-label").text(RED._('actions.search-counter', i18nSearchCounterData));
     }
     function clearIndex() {
         index = {};
@@ -649,12 +652,6 @@ RED.search = (function() {
             updateSearchToolbar();
         });
 
-        $("#red-ui-view-searchtools-close").on("click", function close() {
-            clearActiveSearch();
-            updateSearchToolbar();
-        });
-        $("#red-ui-view-searchtools-close").trigger("click");
-
         RED.events.on("workspace:clear", clearIndex);
 
         RED.events.on("flows:add", addItemToIndex);
@@ -672,6 +669,74 @@ RED.search = (function() {
         RED.events.on("groups:add",addItemToIndex);
         RED.events.on("groups:remove",removeItemFromIndex);
         RED.events.on("groups:change",updateItemOnIndex);
+
+
+
+        const searchToolbarButton = $('<button class="red-ui-footer-button" id="red-ui-view-searchtools-search"><i class="fa fa-search"></i></button>');
+        //add search to status-toolbar
+        RED.statusBar.add({
+            id: "view-search-tools",
+            align: "left",
+            hidden: false,
+            element: searchToolbarButton
+        })
+
+        function searchFlows() { RED.actions.invoke("core:search", $(this).data("term")); }
+        function searchPrev() { RED.actions.invoke("core:search-previous"); }
+        function searchNext() { RED.actions.invoke("core:search-next"); }
+
+
+        $("#red-ui-view-searchtools-search").on("click", searchFlows);
+        RED.popover.tooltip($("#red-ui-view-searchtools-search"),RED._('actions.search-flows'),'core:search');
+
+        searchToolbarPopover = RED.popover.create({
+            target: searchToolbarButton,
+            direction: 'bottom',
+            size: 'small',
+            content: function () {
+                let term = $("#red-ui-view-searchtools-search").data("term") || "";
+                if (term.length > 16) {
+                    term = term.substring(0, 12) + "..."
+                }
+                const i18nSearchCounterData = {
+                    result: (currentIndex + 1),
+                    count: activeResults.length
+                }
+
+
+                const content = $('<div style="padding: 2px"></div>');
+
+                const labelSpan = $('<span class="button-group red-ui-view-searchtools-counter">' +
+                       '<span id="red-ui-view-searchtools-label"></span>' + 
+                       '<span id="red-ui-view-searchtools-counter-label"></span>' +
+                    '</span>').appendTo(content)
+                labelSpan.find("#red-ui-view-searchtools-label").text(`"${term}"`);
+                labelSpan.find("#red-ui-view-searchtools-counter-label").text(RED._('actions.search-counter', i18nSearchCounterData));
+                
+                const navButtons = $('<span class="button-group">' +
+                      '<button class="red-ui-footer-button" id="red-ui-view-searchtools-prev"><i class="fa fa-chevron-left"></i></button>' +
+                      '<button class="red-ui-footer-button" id="red-ui-view-searchtools-next"><i class="fa fa-chevron-right"></i></button>' +
+                    '</span>').appendTo(content);
+                const prevButton = navButtons.find("#red-ui-view-searchtools-prev");
+                const nextButton = navButtons.find("#red-ui-view-searchtools-next");
+                const closeButton = $('<button class="red-ui-footer-button" id="red-ui-view-searchtools-close"><i class="fa fa-close"></i></button>').appendTo(content);
+
+
+                prevButton.on("click", searchPrev);
+                RED.popover.tooltip(prevButton,RED._('actions.search-prev'),'core:search-previous');
+                nextButton.on("click", searchNext);
+                RED.popover.tooltip(nextButton,RED._('actions.search-next'),'core:search-next');
+                RED.popover.tooltip(closeButton,RED._('common.label.close'));
+                closeButton.on("click", function close() {
+                    clearActiveSearch();
+                    updateSearchToolbar();
+                });
+
+
+                return content
+            },
+            delay: { show: 750, hide: 250 }
+        });
 
     }
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1232,35 +1232,6 @@ RED.view = (function() {
         $("#red-ui-view-zoom-fit").on("click", zoomToFitAll);
         RED.popover.tooltip($("#red-ui-view-zoom-fit"),RED._('actions.zoom-fit'),'core:zoom-fit');
 
-        //add search to status-toolbar
-        RED.statusBar.add({
-            id: "view-search-tools",
-            align: "left",
-            hidden: false,
-            element: $('<span class="button-group">'+
-                    '<button class="red-ui-footer-button" id="red-ui-view-searchtools-search"><i class="fa fa-search"></i></button>' +
-                    '</span>' +
-                    '<span class="button-group red-ui-view-searchtools-counter">' +
-                    '<span class="red-ui-footer-button" id="red-ui-view-searchtools-counter-label">? of ?</span>' +
-                    '</span>' +
-                    '<span class="button-group">' +
-                    '<button class="red-ui-footer-button" id="red-ui-view-searchtools-prev"><i class="fa fa-chevron-left"></i></button>' +
-                    '<button class="red-ui-footer-button" id="red-ui-view-searchtools-next"><i class="fa fa-chevron-right"></i></button>' +
-                    '</span>' +
-                    '<span class="button-group">' +
-                    '<button class="red-ui-footer-button" id="red-ui-view-searchtools-close"><i class="fa fa-close"></i></button>' +
-                    '</span>')
-        })
-        $("#red-ui-view-searchtools-search").on("click", searchFlows);
-        RED.popover.tooltip($("#red-ui-view-searchtools-search"),RED._('actions.search-flows'),'core:search');
-        $("#red-ui-view-searchtools-prev").on("click", searchPrev);
-        RED.popover.tooltip($("#red-ui-view-searchtools-prev"),RED._('actions.search-prev'),'core:search-previous');
-        $("#red-ui-view-searchtools-next").on("click", searchNext);
-        RED.popover.tooltip($("#red-ui-view-searchtools-next"),RED._('actions.search-next'),'core:search-next');
-        RED.popover.tooltip($("#red-ui-view-searchtools-close"),RED._('common.label.close'));
-
-
-
         RED.view.annotations.register("red-ui-flow-node-docs",{
             type: "badge",
             class: "red-ui-flow-node-docs",
@@ -3119,9 +3090,7 @@ RED.view = (function() {
         }
     }
 
-    function searchFlows() { RED.actions.invoke("core:search", $(this).data("term")); }
-    function searchPrev() { RED.actions.invoke("core:search-previous"); }
-    function searchNext() { RED.actions.invoke("core:search-next"); }
+
 
 
     function zoomView(factor, focalPoint) {

--- a/packages/node_modules/@node-red/editor-client/src/sass/search.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/search.scss
@@ -236,9 +236,6 @@
         right: 7px;
     }
 }
-.red-ui-search-history-result {
-
-}
 
 .red-ui-search-result-action {
     color: var(--red-ui-primary-text-color);
@@ -250,3 +247,18 @@
     margin-right: 10px;
     color: var(--red-ui-tertiary-text-color);
 }
+
+
+.red-ui-popover .red-ui-view-searchtools-counter {
+    font-size: 12px;
+    white-space: nowrap;
+    span {
+        display: inline-block;
+        min-width: 55px;
+    }
+    #red-ui-view-searchtools-counter-label {
+        min-width: 55px;
+        text-align: right;
+    }
+}
+

--- a/packages/node_modules/@node-red/editor-client/src/sass/workspace.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/workspace.scss
@@ -191,14 +191,6 @@
             margin-top: -1px;
         }
     }
-
-    .red-ui-view-searchtools-counter {
-        display: inline-block;
-        font-size: smaller;
-        font-weight: 600;
-        white-space: nowrap;
-        background: var(--red-ui-view-background);
-    }
 }
 
 a.red-ui-footer-button,


### PR DESCRIPTION
Closes #5682 

Rather than expand the status bar to show search navigation, it now shows a popover:

<img width="243" height="114" alt="image" src="https://github.com/user-attachments/assets/340d5da2-cfdd-4832-b382-b81691a7b46e" />

This keeps the statusBar widget positions static and not shuffling around as the search is navigated.