### PR TITLE
Tidy up import error popover

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/clipboard.js
@@ -384,6 +384,8 @@ RED.clipboard = (function() {
                             //   which is the least useful, but most consistent message
                             // - use a custom/library parser that gives consistent messages
                             //   which can be translated.
+                            errString = errString.replace(/^[a-z]*Error: /i, "").replace(/^JSON.parse: /,'');
+                            errString = errString.charAt(0).toUpperCase() + errString.slice(1);
                             var message = $('<div class="red-ui-clipboard-import-error"></div>').text(errString);
                             var errorPos;
                             // Chrome error messages
@@ -566,6 +568,7 @@ RED.clipboard = (function() {
             target: $("#red-ui-clipboard-dialog-import-text"),
             trigger: "manual",
             direction: "bottom",
+            size: 'small',
             content: ""
         });
     }

--- a/packages/node_modules/@node-red/editor-client/src/sass/library.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/library.scss
@@ -18,16 +18,19 @@
 
 .red-ui-clipboard-import-error {
     pre {
-        margin: 10px 0;
-        border: none;
+        margin: 6px 0;
+        font-size: 10px;
+        border: 1px solid var(--red-ui-form-input-border-color);
+        border-radius: 4px;
         color: var(--red-ui-primary-text-color);
+        padding: 4px;
         span {
-            padding: 5px 0;
+            padding: 3px 0;
         }
         span.error {
-            padding: 5px;
+            padding: 3px;
             border: 1px solid var(--red-ui-form-input-border-error-color);
-            margin: 0 1px;
+            margin: 0 2px;
         }
     }
 }


### PR DESCRIPTION
Closes #5720 

Tidy up the visual appearance of import error messages.

1. More compact
2. Strips `SyntaxError:`/`Error:`/`JSON.parse` from browser-generated errors.
3. Better styling of the error position

<img width="470" height="124" alt="image" src="https://github.com/user-attachments/assets/1fe9f4b5-5afa-41a7-8db3-ec07cb90d275" />
