### PR TITLE
Group sidebar tab buttons

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
@@ -86,10 +86,10 @@ RED.sidebar = (function() {
                 }
             }
         }
-        globalTabBar.container.children('button:not(.red-ui-sidebar-tab-bar-overflow-button)').each(function() {
-            const tabId = $(this).attr('data-tab-id');
-            state.tabs.push(tabId)
-        })
+        // globalTabBar.container.find('button:not(.red-ui-sidebar-tab-bar-overflow-button)').each(function() {
+        //     const tabId = $(this).attr('data-tab-id');
+        //     state.tabs.push(tabId)
+        // })
 
         if (!sidebars.primary.sections.top.hidden && !sidebars.primary.sections.bottom.hidden) {
             // Both sections are visible - store the height of the top section so it can be restored later
@@ -210,27 +210,30 @@ RED.sidebar = (function() {
         knownTabs[options.id] = options;
         options.tabButton = $('<button></button>')
         options.tabButton.data('initial-tab-index', targetTabButtonIndex)
+
+        options.tabButton.appendTo(globalTabBar.containers[options.target][targetSection]);
+
         // Insert the tab button at the correct index
-        const existingButtons = globalTabBar.container.children('button:not(.red-ui-sidebar-tab-bar-overflow-button)')
-        if (existingButtons.length === 0 || targetTabButtonIndex === -1) {
-            // Append to end
-            options.tabButton.insertBefore(globalTabBar.tools);
-        } else {
-            // Find the right place to insert the button given not all buttons will have been added yet so
-            // cannot simply insert into a particular position based on index
-            let inserted = false
-            globalTabBar.container.children('button:not(.red-ui-sidebar-tab-bar-overflow-button)').each(function() {
-                const currentIndex = $(this).data('initial-tab-index')
-                if (currentIndex > targetTabButtonIndex) {
-                    options.tabButton.insertBefore($(this));
-                    inserted = true
-                    return false;
-                }
-            })
-            if (!inserted) {
-                options.tabButton.insertBefore(globalTabBar.tools);
-            }
-        }   
+        // const existingButtons = globalTabBar.container.find('button:not(.red-ui-sidebar-tab-bar-overflow-button)')
+        // if (existingButtons.length === 0 || targetTabButtonIndex === -1) {
+        //     // Append to end
+        //     options.tabButton.insertBefore(globalTabBar.tools);
+        // } else {
+        //     // Find the right place to insert the button given not all buttons will have been added yet so
+        //     // cannot simply insert into a particular position based on index
+        //     let inserted = false
+        //     globalTabBar.container.find('button:not(.red-ui-sidebar-tab-bar-overflow-button)').each(function() {
+        //         const currentIndex = $(this).data('initial-tab-index')
+        //         if (currentIndex > targetTabButtonIndex) {
+        //             options.tabButton.insertBefore($(this));
+        //             inserted = true
+        //             return false;
+        //         }
+        //     })
+        //     if (!inserted) {
+        //         options.tabButton.insertBefore(globalTabBar.tools);
+        //     }
+        // }   
 
         targetSidebar.sections[targetSection].tabs.push(options.id)
         options.tabButton.attr('data-tab-id', options.id)
@@ -322,10 +325,14 @@ RED.sidebar = (function() {
         const currentIndex = srcSidebar.sections[srcPosition].tabs.indexOf(options.id)
         srcSidebar.sections[srcPosition].tabs.splice(currentIndex, 1);
 
+        const tabButton = globalTabBar.container.find('button[data-tab-id="'+id+'"]')
+        
         options.target = targetSidebar.id;
         options.targetSection = targetPosition;
 
         targetSidebar.sections[targetPosition].tabs.push(options.id);
+
+        globalTabBar.containers[targetSidebar.id][targetPosition].append(tabButton)
 
         $(options.wrapper).appendTo(targetSidebar.sections[targetPosition].content);
         if (options.toolbar) {
@@ -386,30 +393,42 @@ RED.sidebar = (function() {
         const tabBar = $('<div class="red-ui-sidebar-tab-bar"></div>').addClass('red-ui-sidebar-right');
         globalTabBar.container = tabBar
 
-        globalTabBar.container.sortable({
-            axis: 'x',
-            distance: 10,
-            cancel: false,
-            items: "button:not(.red-ui-sidebar-tab-bar-overflow-button):not(.red-ui-sidebar-toggle-button)",
-            start: function(event, ui) {
-                const tabId = ui.item.attr('data-tab-id');
-                const options = knownTabs[tabId];
-                options.tabButtonTooltip.delete()
-                draggingTabButton = true
+        globalTabBar.containers = {
+            secondary: {
+                top: $('<span class="button-group"></span>').appendTo(tabBar),
+                bottom: $('<span class="button-group"></span>').appendTo(tabBar)
             },
-            stop: function(event, ui) {
-                // Restore the tooltip
-                const tabId = ui.item.attr('data-tab-id');
-                const options = knownTabs[tabId];
-                options.tabButtonTooltip.delete()
-                options.tabButtonTooltip = RED.popover.tooltip(options.tabButton, options.name, options.action);
-                // Save the sidebar state
-                exportSidebarState()
-                draggingTabButton = false
+            primary: {
+                top: $('<span class="button-group"></span>').appendTo(tabBar),
+                bottom: $('<span class="button-group"></span>').appendTo(tabBar)
             }
-        })
+        }
 
-        const tabBarTools = $('<span class="button-group"></span>').appendTo(tabBar);
+        // TODO: re-enable drag to reorder the tabs within a section (and possibly move section)
+        // globalTabBar.container.sortable({
+        //     axis: 'x',
+        //     distance: 10,
+        //     cancel: false,
+        //     items: "button:not(.red-ui-sidebar-tab-bar-overflow-button):not(.red-ui-sidebar-toggle-button)",
+        //     start: function(event, ui) {
+        //         const tabId = ui.item.attr('data-tab-id');
+        //         const options = knownTabs[tabId];
+        //         options.tabButtonTooltip.delete()
+        //         draggingTabButton = true
+        //     },
+        //     stop: function(event, ui) {
+        //         // Restore the tooltip
+        //         const tabId = ui.item.attr('data-tab-id');
+        //         const options = knownTabs[tabId];
+        //         options.tabButtonTooltip.delete()
+        //         options.tabButtonTooltip = RED.popover.tooltip(options.tabButton, options.name, options.action);
+        //         // Save the sidebar state
+        //         exportSidebarState()
+        //         draggingTabButton = false
+        //     }
+        // })
+
+        const tabBarTools = $('<span class="button-group red-ui-sidebar-tab-bar-tools"></span>').appendTo(tabBar);
 
         globalTabBar.tools = tabBarTools
         globalTabBar.overflowButton = $('<button class="red-ui-sidebar-tab-bar-overflow-button" aria-haspopup="menu" aria-expanded="false"><i class="fa fa-ellipsis-v"></i></button>').attr('aria-label', RED._('sidebar.moreTabs')).appendTo(tabBarTools);
@@ -421,10 +440,14 @@ RED.sidebar = (function() {
             }
             try {
                 const menuOptions = []
-                globalTabBar.container.children('button:not(.red-ui-sidebar-tab-bar-overflow-button):not(.red-ui-sidebar-toggle-button)').each(function() {
+                let lastParent = null
+                globalTabBar.container.find('button:not(.red-ui-sidebar-tab-bar-overflow-button):not(.red-ui-sidebar-toggle-button)').each(function() {
                     const tabId = $(this).attr('data-tab-id');
                     const tabOptions = knownTabs[tabId];
                     let initialStateSet = false
+                    if (lastParent !== null && $(this).parent()[0] !== lastParent) {
+                        menuOptions.push(null) // separator
+                    }
                     menuOptions.push({
                         label: tabOptions.name,
                         selected: $(this).hasClass('selected'),
@@ -440,6 +463,7 @@ RED.sidebar = (function() {
                             globalTabBar.container.find('button[data-tab-id="'+tabId+'"]').trigger('click')
                         }
                     })
+                    lastParent = $(this).parent()[0]
                 })
                 const menu = RED.menu.init({ options: menuOptions });
                 menu.attr("id","red-ui-sidebar-tab-bar-menu");
@@ -447,7 +471,7 @@ RED.sidebar = (function() {
                     position: "absolute"
                 })
                 menu.appendTo("body");
-                var elementPos = globalTabBar.overflowButton.offset();
+                const elementPos = globalTabBar.overflowButton.offset();
                 menu.css({
                     top: (elementPos.top+globalTabBar.overflowButton.height()- menu.height() - 10)+"px",
                     left: ((elementPos.left - menu.width() - 3)+"px")
@@ -503,14 +527,14 @@ RED.sidebar = (function() {
         const globalTabBarWidth = globalTabBar.container.outerWidth();
         if (!globalTabBar.overflowShown) {
             if (windowWidth + 5 < globalTabBarWidth + globalTabBar.container.offset().left) {
-                globalTabBar.container.children('button:not(.red-ui-sidebar-tab-bar-overflow-button):not(.red-ui-sidebar-toggle-button)').hide()
+                globalTabBar.container.find('button:not(.red-ui-sidebar-tab-bar-overflow-button):not(.red-ui-sidebar-toggle-button)').hide()
                 globalTabBar.tools.addClass('overflow')
                 globalTabBar.overflowShown = true
                 globalTabBar.tabBarWidth = globalTabBarWidth
             }
         } else if (globalTabBar.overflowShown) {
             if (globalTabBarWidth > globalTabBar.tabBarWidth + 5) {
-                globalTabBar.container.children('button:not(.red-ui-sidebar-tab-bar-overflow-button):not(.red-ui-sidebar-toggle-button)').show()
+                globalTabBar.container.find('button:not(.red-ui-sidebar-tab-bar-overflow-button):not(.red-ui-sidebar-toggle-button)').show()
                 globalTabBar.tools.removeClass('overflow')
                 globalTabBar.overflowShown = false
             }
@@ -1106,6 +1130,7 @@ RED.sidebar = (function() {
 
         // Load any saved sidebar state
         lastSessionState = RED.settings.get('editor.sidebar.state', defaultSidebarConfiguration)
+
         if (typeof lastSessionState.primary[0] === 'string' || typeof lastSessionState.secondary[0] === 'string' || lastSessionState.v === undefined || lastSessionState.v !== sidebarLayoutVersion) {
             lastSessionState = defaultSidebarConfiguration
             // To migrate state format, we have to delete the old entry rather than try to merge settings

--- a/packages/node_modules/@node-red/editor-client/src/sass/sidebar.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/sidebar.scss
@@ -178,37 +178,57 @@
                 opacity: 0.7;
             }
         }
-        &.selected:not(.disabled):not(:disabled) {
-            border-color: var(--red-ui-workspace-button-border-selected-inverse);
-        }
     }
     .button-group {
         display: flex;
-        &.overflow {
-            button:not(:first-child) {
+        &:not(.red-ui-sidebar-tab-bar-tools) {
+            button:last-child:not(:first-child) {
                 border-left: none;
                 border-top-left-radius: 0;
                 border-bottom-left-radius: 0;
             }
-            button:not(:last-child) {
+            button:first-child:not(:last-child) {
                 border-right: none;
                 border-top-right-radius: 0;
                 border-bottom-right-radius: 0;
-            }
-        }
-        &:not(.overflow) {
-            button:last-child {
-                border-left: none;
-                border-top-left-radius: 0;
-                border-bottom-left-radius: 0;
             }
             button:not(:first-child):not(:last-child) {
+                border-radius: 0;
+                border-left: none;
                 border-right: none;
-                border-top-right-radius: 0;
-                border-bottom-right-radius: 0;
             }
-            .red-ui-sidebar-tab-bar-overflow-button {
+            &:not(:has(:first-child)) {
+                // Hide empty groups
                 display: none;
+            }
+        }
+        &.red-ui-sidebar-tab-bar-tools {
+            &.overflow {
+                button:not(:first-child) {
+                    border-left: none;
+                    border-top-left-radius: 0;
+                    border-bottom-left-radius: 0;
+                }
+                button:not(:last-child) {
+                    border-right: none;
+                    border-top-right-radius: 0;
+                    border-bottom-right-radius: 0;
+                }
+            }
+            &:not(.overflow) {
+                button:last-child {
+                    border-left: none;
+                    border-top-left-radius: 0;
+                    border-bottom-left-radius: 0;
+                }
+                button:not(:first-child):not(:last-child) {
+                    border-right: none;
+                    border-top-right-radius: 0;
+                    border-bottom-right-radius: 0;
+                }
+                .red-ui-sidebar-tab-bar-overflow-button {
+                    display: none;
+                }
             }
         }
 


### PR DESCRIPTION
Having tried to just have a plain row of tab buttons, this PR groups the buttons by section. This, IMHO, makes it easier to locate and maintain a mental model of where the sections are located.

<img width="493" height="188" alt="image" src="https://github.com/user-attachments/assets/e50c712b-6e86-4650-ac70-fd7e411ab3cd" />