### PR TITLE
Fix subflow virtual port halo sizing

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -5312,10 +5312,10 @@ RED.view = (function() {
 
         const nodeHalo = document.createElementNS("http://www.w3.org/2000/svg","rect");
         nodeHalo.setAttribute("class", "red-ui-flow-node-highlight");
-        nodeHalo.setAttribute("rx", 5);
-        nodeHalo.setAttribute("ry", 5);
-        nodeHalo.setAttribute("x", -8)
-        nodeHalo.setAttribute("y", -5)
+        nodeHalo.setAttribute("rx", 11);
+        nodeHalo.setAttribute("ry", 11);
+        nodeHalo.setAttribute("x", -3)
+        nodeHalo.setAttribute("y", -3)
         nodeHalo.setAttribute("width", 40);
         nodeHalo.setAttribute("height", 40);
         node[0][0].__halo__ = nodeHalo;
@@ -5430,7 +5430,7 @@ RED.view = (function() {
                 this.__mainRect__.setAttribute("width", d.w)
                 this.__mainRect__.setAttribute("height", d.h)
                 this.__mainRect__.classList.toggle("red-ui-flow-node-highlighted",!!d.highlighted );
-                this.__halo__.setAttribute("width", d.w + 16);
+                this.__halo__.setAttribute("width", d.w + 6);
                 this.__halo__.setAttribute("height", d.h + 6);
 
                 if (labelParts) {
@@ -5523,8 +5523,8 @@ RED.view = (function() {
                     .on("touchend", nodeTouchEnd);
                 statusGroup.append("rect")
                     .attr("class", "red-ui-flow-node-highlight")
-                    .attr("x",-8).attr("y",-5).attr("width", 56).attr("height", 50)
-                    .attr("rx", 5).attr("ry", 5);
+                    .attr("x",-3).attr("y",-3).attr("width", 46).attr("height", 46)
+                    .attr("rx", 11).attr("ry", 11);
                 statusGroup.append("g").attr('transform','translate(-5,15)').append("rect").attr("class","red-ui-flow-port").attr("rx",3).attr("ry",3).attr("width",10).attr("height",10)
                     .on("mousedown", function(d,i){portMouseDown(d,PORT_TYPE_INPUT,0);} )
                     .on("touchstart", function(d,i){portMouseDown(d,PORT_TYPE_INPUT,0);d3.event.preventDefault();} )


### PR DESCRIPTION
Closes #5746 

When the node selection halo sizing was adjusted, the subflow virtual ports were overlooked. This PR aligns their selection appearance with that of other nodes:

<img width="626" height="229" alt="image" src="https://github.com/user-attachments/assets/bb984a5f-ed66-4c81-8dd0-c0bbc05abff3" />
