### PR TITLE
Do not adjust focus when navigating search results

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/search.js
@@ -498,7 +498,7 @@ RED.search = (function() {
         const n = activeResults[currentIndex];
         if (n && n.node && n.node.id) {
             RED.view.reveal(n.node.id);
-            $("#red-ui-view-searchtools-prev").trigger("focus");
+            // $("#red-ui-view-searchtools-prev").trigger("focus");
         }
         updateSearchToolbar();
     }
@@ -519,7 +519,7 @@ RED.search = (function() {
         const n = activeResults[currentIndex];
         if (n && n.node && n.node.id) {
             RED.view.reveal(n.node.id);
-            $("#red-ui-view-searchtools-next").trigger("focus");
+            // $("#red-ui-view-searchtools-next").trigger("focus");
         }
         updateSearchToolbar();
     }


### PR DESCRIPTION
With the changes made in #5744 , the search status bar is now in a popover rather than the status bar itself.

When using the keyboard shortcuts to navigate between results, focus was being set on the prev/next buttons. However, as they are now in the popover, they are not in scope of the keyboard handler of the main workspace. As such the `f` shortcut fails to trigger the next action.

The quick fix is to not change focus to the button after navigating the results. Not ideal, but don't want to make a global keyboard handler for `f` as that'll have other side-effects.