### PR TITLE
Fix svg tooltip text alignment

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -4456,7 +4456,7 @@ RED.view = (function() {
 
         let path;
         let lx;
-        let ly = -labelHeight + 2;;
+        let ly = -labelHeight / 2 - cornerRadius - (innerPadding / 2);
         let anchor;
 
         if (direction === "left") {
@@ -4470,7 +4470,7 @@ RED.view = (function() {
         } else if (direction === "top") {
             path = `M0 0 l ${arrowBaseLength} -${arrowBaseLength} h ${labelWidth1} q 4 0 4 -4 v -${labelHeight} q 0 -4 -4 -4 h -${labelWidth2} q -4 0 -4 4 v ${labelHeight} q 0 4 4 4 h ${labelWidth1} l ${arrowBaseLength} ${arrowBaseLength}`;
             lx = -labelWidth/2 + cornerRadius;
-            ly = -labelHeight-lineHeight + 2;
+            ly = -labelHeight - arrowBaseLength - 2 * cornerRadius - (innerPadding / 2);
             anchor = "start";
         }
         tooltip.append("path").attr("d",path);
@@ -4482,7 +4482,6 @@ RED.view = (function() {
                 .attr("text-anchor",anchor)
                 .text(l||" ")
         });
-        // setTimeout(() => { debugger;}, 2000)
         return tooltip;
     }
 


### PR DESCRIPTION
Fixes the vertical alignment of svg-generated tooltips following the changes made in #5740 