### PR TITLE
Fix error handling for `linkcall` in function node

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -186,49 +186,48 @@ module.exports = function(RED) {
         }
 
         node.linkcall = async function (target, msg, options) {
-            try {
-                if (typeof target !== "string" || target.trim() === "") {
-                    throw new Error(RED._("function.error.linkcallTargetInvalid"));
-                }
-                if (typeof msg !== "object" || msg === null) {
-                    throw new Error(RED._("function.error.linkcallMsgInvalid"));
-                }
-                options = options || {}
-                options.timeout = options.timeout || 5000 // default timeout 5s
-                options.clone = options.clone === false ? false : true // default to cloning the message for safety
-
-                const isDynamic = !RED.nodes.getNode(target) // if target is a node id, then its a static choice (not dynamic)
-                const targetNode = RED.nodes.linkcallTargets.getTargetNode(node, target, isDynamic)
-                if (!targetNode || targetNode.type !== 'link in') {
-                    // getTargetNode should have already thrown an error if the target was not found, but in case it didn't for some reason, we throw here too.
-                    throw new Error(RED._("function.error.linkcallTargetNotFound"));
-                }
-
-                const m = options.clone === false ? msg : RED.util.cloneMessage(msg)
-                m._linkSource = m._linkSource || []
-                const messageEvent = {
-                    id: crypto.randomBytes(14).toString('hex'),
-                    node: node.id,
-                }
-                messageEvents[messageEvent.id] = {
-                    msg: m,
-                    options: options,
-                    send: sandbox.__send__,
-                    done: sandbox.__done__,
-                    ts: setTimeout(function () {
-                        timeoutMessage(messageEvent.id)
-                    }, options.timeout)
-                }
-                m._linkSource.push(messageEvent)
-                targetNode.receive(m)
-                return new Promise((resolve, reject) => {
-                    messageEvents[messageEvent.id].resolve = resolve
-                    messageEvents[messageEvent.id].reject = reject
-                })
-            } catch (error) {
-                node.error(error, msg);
-                return null;
+            // Errors (invalid args, target not found, timeout, link-out reject) propagate
+            // as a rejection so user code can `try { await node.linkcall(...) } catch (e) {}`.
+            // Unhandled rejections are caught by the function-node wrapper's outer `.catch`
+            // and routed to catch-nodes / node.error, so safety is preserved.
+            if (typeof target !== "string" || target.trim() === "") {
+                throw new Error(RED._("function.error.linkcallTargetInvalid"));
             }
+            if (typeof msg !== "object" || msg === null) {
+                throw new Error(RED._("function.error.linkcallMsgInvalid"));
+            }
+            options = options || {}
+            options.timeout = options.timeout || 5000 // default timeout 5s
+            options.clone = options.clone === false ? false : true // default to cloning the message for safety
+
+            const isDynamic = !RED.nodes.getNode(target) // if target is a node id, then its a static choice (not dynamic)
+            const targetNode = RED.nodes.linkcallTargets.getTargetNode(node, target, isDynamic)
+            if (!targetNode || targetNode.type !== 'link in') {
+                // getTargetNode should have already thrown an error if the target was not found, but in case it didn't for some reason, we throw here too.
+                throw new Error(RED._("function.error.linkcallTargetNotFound"));
+            }
+
+            const m = options.clone === false ? msg : RED.util.cloneMessage(msg)
+            m._linkSource = m._linkSource || []
+            const messageEvent = {
+                id: crypto.randomBytes(14).toString('hex'),
+                node: node.id,
+            }
+            messageEvents[messageEvent.id] = {
+                msg: m,
+                options: options,
+                send: sandbox.__send__,
+                done: sandbox.__done__,
+                ts: setTimeout(function () {
+                    timeoutMessage(messageEvent.id)
+                }, options.timeout)
+            }
+            m._linkSource.push(messageEvent)
+            targetNode.receive(m)
+            return new Promise((resolve, reject) => {
+                messageEvents[messageEvent.id].resolve = resolve
+                messageEvents[messageEvent.id].reject = reject
+            })
         }
 
         var sandbox = {

--- a/test/nodes/core/function/10-function_spec.js
+++ b/test/nodes/core/function/10-function_spec.js
@@ -2241,6 +2241,45 @@ describe('function node', function() {
                 f1.receive({ payload: "original", topic: "test" })
             })
         })
+        it('should allow function code to catch linkcall errors via try/catch', async function () {
+            this.timeout(1000);
+            const flow = [
+                { id: "tab-flow-main", type: "tab", label: "Main Flow" },
+                // ↓↓ main flow — user code catches the error itself ↓↓
+                { id: "f1", type: "function", z: "tab-flow-main", wires: [["h1"]], func: `
+                    try {
+                        await node.linkcall('non-existent-subroutine', msg, { timeout: 500 });
+                        msg.caught = false;
+                    } catch (err) {
+                        msg.caught = true;
+                        msg.caughtMessage = err.message;
+                    }
+                    return msg;
+                ` },
+                { id: "c1", type: "catch", z: "tab-flow-main", scope: ["f1"], uncaught: true, wires: [["h1"]] },
+                { id: "h1", type: "helper", z: "tab-flow-main" }
+            ]
+
+            await helper.load([linkNode, functionNode], flow)
+            const f1 = helper.getNode("f1")
+            const h1 = helper.getNode("h1")
+            const c1 = helper.getNode("c1")
+            const c1SpyReceived = sinon.spy(c1, "receive")
+
+            await new Promise((resolve, reject) => {
+                h1.on("input", function (msg) {
+                    try {
+                        msg.should.have.property("caught", true)
+                        msg.should.have.property("caughtMessage").and.match(/target link-in node 'non-existent-subroutine' not found/i)
+                        c1SpyReceived.called.should.be.false() // user handled it, so catch-node should NOT fire
+                        resolve()
+                    } catch (err) {
+                        reject(err)
+                    }
+                })
+                f1.receive({ payload: "original", topic: "test" })
+            })
+        })
         it('should raise error due to multiple targets on same tab', async function () {
             const flow = [
                 // ↓↓ flow tabs ↓↓


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## TLDR

If the call to `node.linkcall()` errored / timed out, it could not be caught in the function node code & would ALWAYS perform a `node.error` even when wrapped in a try catch

## Proposed changes

Remove try/catch handling so that user-defined function code can catch errors thrown by `node.linkcall` using a try/catch block, and that such handled errors do not trigger the catch node when they are handled by user code.

**Testing enhancements:**

* Added a test to `10-function_spec.js` that ensures errors from `node.linkcall` can be caught within user function code, and confirms that the catch node is not triggered when the error is handled by the user.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
