### PR TITLE
Add alert types toolbar functionality to markdown editor

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -1088,6 +1088,14 @@
         "link": "Link",
         "horizontal-rule": "Horizontal rule",
         "toggle-preview": "Toggle preview",
+        "alert-tooltip": "Alert",
+        "alert": {
+            "note": "Note",
+            "tip": "Tip",
+            "important": "Important",
+            "warning": "Warning",
+            "caution": "Caution"
+        },
         "mermaid": {
             "summary": "Mermaid Diagram"
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/markdown.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/markdown.js
@@ -119,11 +119,56 @@
         '<span class="button-group">'+
             '<button type="button" class="red-ui-button" data-style="ol"><i class="fa fa-list-ol"></i></button>'+
             '<button type="button" class="red-ui-button" data-style="ul"><i class="fa fa-list-ul"></i></button>'+
-            '<button type="button" class="red-ui-button" data-style="bq"><i class="fa fa-quote-left"></i></button>'+
+            '<button type="button" class="red-ui-button" data-style="bq" style="border-right: 0px;padding-left: 6px;padding-right: 6px;"><i class="fa fa-quote-left"></i></button>'+
+            '<button type="button" class="red-ui-button" data-action="alert-menu" style="border-left: 0px; padding-left: 6px; padding-right: 6px;"><i class="fa fa-caret-down"></i></button>'+
             '<button type="button" class="red-ui-button" data-style="hr"><i class="fa fa-minus"></i></button>'+
             '<button type="button" class="red-ui-button" data-style="link"><i class="fa fa-link"></i></button>'+
         '</span>'+
     '</div>';
+
+    const alertTypes = [
+        { id: 'note', tag: '[!NOTE]', icon: 'fa-info-circle' },
+        { id: 'tip', tag: '[!TIP]', icon: 'fa-lightbulb-o' },
+        { id: 'important', tag: '[!IMPORTANT]', icon: 'fa-bullhorn' },
+        { id: 'warning', tag: '[!WARNING]', icon: 'fa-exclamation-triangle' },
+        { id: 'caution', tag: '[!CAUTION]', icon: 'fa-exclamation-circle' }
+    ];
+
+    function insertAlert(editor, tag) {
+        const range = editor.selection.getRange();
+        const hasSelection = editor.getSelectedText() !== "";
+        const session = editor.session;
+
+        if (!hasSelection) {
+            // Insert the alert tag line and a newline plus another quote to push the cursor onto the next line ready to type the alert content
+            session.insert({row: range.start.row, column: 0}, "> " + tag + "\n> ");
+        } else {
+            // Normalise the range bounds. On the Monaco shim, range.start uses the
+            // selection anchor, so a reverse selection (dragged bottom-to-top)
+            // collapses start.row and end.row to the same line. Prefer the
+            // underlying Range's normalised start/end fields when present.
+            const startRow = (typeof range.startLineNumber === 'number')
+                ? range.startLineNumber - 1
+                : Math.min(range.start.row, range.end.row);
+            let endRow = (typeof range.endLineNumber === 'number')
+                ? range.endLineNumber - 1
+                : Math.max(range.start.row, range.end.row);
+            const endCol = (typeof range.endColumn === 'number')
+                ? range.endColumn - 1
+                : (range.end.row >= range.start.row ? range.end.column : range.start.column);
+            // A selection ending at column 0 of a row doesn't really include that row
+            if (endCol === 0 && endRow > startRow) {
+                endRow--;
+            }
+            // Prefix each selected line with "> " (bottom-up to keep row indices stable)
+            for (let i = endRow; i >= startRow; i--) {
+                session.insert({row: i, column: 0}, "> ");
+            }
+            // Prepend the alert tag line above the selection
+            session.insert({row: startRow, column: 0}, "> " + tag + "\n");
+        }
+        editor.focus();
+    }
 
     var template = '<script type="text/x-red" data-template-name="_markdown">'+
         '<div id="red-ui-editor-type-markdown-panels">'+
@@ -310,6 +355,34 @@
                     RED.popover.tooltip($(this),style.tooltip);
                 }
             })
+
+            const alertBtn = toolbar.find('button[data-action="alert-menu"]');
+            if (alertBtn.length) {
+                let alertMenuShown = false;
+                const alertMenu = RED.popover.menu({
+                    options: alertTypes.map(function(a) {
+                        const label = $('<span>')
+                            .append($('<i>').addClass('fa').addClass(a.icon).css({width: '1.1em', marginRight: '6px'}))
+                            .append($('<span>').text(RED._('markdownEditor.alert.' + a.id)));
+                        return {
+                            label: label,
+                            onselect: function() { insertAlert(editor, a.tag); }
+                        };
+                    }),
+                    onclose: function() { alertMenuShown = false; },
+                    disposeOnClose: false
+                });
+                alertBtn.on("click", function(e) {
+                    e.preventDefault();
+                    if (!alertMenuShown) {
+                        alertMenuShown = true;
+                        alertMenu.show({ target: alertBtn, align: "right", offset: [0, 0], dispose: false });
+                    } else {
+                        alertMenu.hide(true);
+                    }
+                });
+                RED.popover.tooltip(alertBtn, RED._("markdownEditor.alert-tooltip"));
+            }
             return toolbar;
         },
         postInit: function (editor, options) {


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Allow user to discover GH style alerts via MD toolbar
<img width="472" height="281" alt="image" src="https://github.com/user-attachments/assets/9ce383e6-a066-4a8c-bbb4-c271afdc9c26" />


## Demo

<img width="1137" height="676" alt="chrome_sCWPxMrqQh" src="https://github.com/user-attachments/assets/d784f280-ed1c-4c49-ab2e-ba4c013a6207" />



## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
