### PR TITLE
Ensure quick-add aligns nodes and junctions to the grid

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1036,9 +1036,11 @@ RED.view = (function() {
                     }
 
                     if (snapGrid) {
+                        // eventLayer.append("circle").attr("cx",nn.x).attr("cy",nn.y).attr("r","2").attr('fill','red')
                         var gridOffset = RED.view.tools.calculateGridSnapOffsets(nn);
                         nn.x -= gridOffset.x;
                         nn.y -= gridOffset.y;
+                        // eventLayer.append("circle").attr("cx",nn.x).attr("cy",nn.y).attr("r","2").attr('fill','blue')
                     }
 
                     if (linkToSplice) {
@@ -1713,8 +1715,9 @@ RED.view = (function() {
 
         if (RED.settings.get("editor").view['view-snap-grid']) {
             // eventLayer.append("circle").attr("cx",point[0]).attr("cy",point[1]).attr("r","2").attr('fill','red')
-            point[0] = Math.round(point[0] / gridSize) * gridSize;
-            point[1] = Math.round(point[1] / gridSize) * gridSize;
+            const gridOffset = RED.view.tools.calculateGridSnapOffsets({ x: point[0], y: point[1], w: node_width, h: node_height });
+            point[0] -= gridOffset.x;
+            point[1] -= gridOffset.y;
             // eventLayer.append("circle").attr("cx",point[0]).attr("cy",point[1]).attr("r","2").attr('fill','blue')
         }
 
@@ -1961,6 +1964,14 @@ RED.view = (function() {
                     nn.l = showLabel;
                 }
                 if (nn.type === 'junction') {
+                    if (RED.settings.get("editor").view['view-snap-grid']) {
+                        // Junctions have no width, so need realigning to the grid
+                        // eventLayer.append("circle").attr("cx",point[0]).attr("cy",point[1]).attr("r","2").attr('fill','red')
+                        const gridOffset = RED.view.tools.calculateGridSnapOffsets(nn);
+                        nn.x -= gridOffset.x;
+                        nn.y -= gridOffset.y;
+                        // eventLayer.append("circle").attr("cx",point[0]).attr("cy",point[1]).attr("r","2").attr('fill','blue')
+                    }
                     nn = RED.nodes.addJunction(nn);
                 } else {
                     nn = RED.nodes.add(nn, { source: 'typeSearch', splice: !!linkToSplice });


### PR DESCRIPTION
Fixes #5758 

Ensures nodes and junctions added via the quick-add dialog snap to the grid as expected.

