### PR TITLE
Ensure hidden tabs are restored on reload

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/tabs.js
@@ -712,18 +712,16 @@ RED.tabs = (function() {
                         }
                     }
                     li.removeClass("active");
-                    li.one("transitionend", function(evt) {
-                        li.addClass("hide");
-                        updateTabWidths();
-                        if (options.onhide) {
-                            options.onhide(tabs[id])
-                        }
-                        setTimeout(function() {
-                            updateScroll()
-                        },200)
-                    })
                     li.addClass("hide-tab");
                     li.css({width:0})
+                    li.addClass("hide");
+                    updateTabWidths();
+                    if (options.onhide) {
+                        options.onhide(tabs[id])
+                    }
+                    setTimeout(function() {
+                        updateScroll()
+                    },200)
                 }
             }
         }

--- a/packages/node_modules/@node-red/editor-client/src/sass/tabs.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tabs.scss
@@ -29,9 +29,6 @@ body .red-ui-tabs {
     height: 35px;
     box-sizing: border-box;
 
-    .hide-tab {
-        transition: width 0.1s ease-in;
-    }
     .red-ui-tabs-scroll-container {
         height: 60px;
         overflow-x: scroll;


### PR DESCRIPTION
The code to hide tabs applies a class (`hide-tab`) and sets an `transitionend` event listener to complete the hide.

In v5, the whole tab bar is hidden whilst loading flows - meaning the css transitionend event never fires and the tabs aren't hidden properly.

My first fix was to use `.is(":visible")` to skip the transition event if the tab was not visible. However, I then spotted the transition itself wasn't having any visible effect - the intent was to shrink the tab to nothing rather than just have it vanish. The move to flex layout in v5 has broken this effect. Rather than fight it, I'm going with it - so the tab just vanishes now.

We still apply the (empty) `hide-tab` class as a bunch of code still uses the presence of that class to determine the state of things.

