### PR TITLE
Do not show context menu if in the middle of another action

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -361,7 +361,9 @@ RED.view = (function() {
             if (RED.view.DEBUG) {
                 console.warn("contextmenu", { mouse_mode, event: d3.event });
             }
-            mouse_mode = RED.state.DEFAULT
+            if (mouse_mode !== RED.state.DEFAULT) {
+                return
+            }
             evt.preventDefault()
             evt.stopPropagation()
             RED.contextMenu.show({


### PR DESCRIPTION
Fixes #5761 

If we're in the middle of another mouse-based action when the user clicks the right mouse button, we shouldn't interrupt things and show the context menu.