### PR TITLE
Sanitize all args passed to projects/git api

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/git/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/git/index.js
@@ -23,10 +23,149 @@ var gitCommand = "git";
 var gitVersion;
 const {log,exec} = require("@node-red/util");
 
+// ---------------------------------------------------------------------------
+// Argument-injection defenses
+//
+// `runGitCommand` ultimately calls child_process.spawn without a shell, so
+// shell metacharacters (;, |, $(), `, &&) are not interpreted. The remaining
+// threat is *argument injection*: a value that looks like an option (starts
+// with "-") being parsed by git as a flag (e.g. --upload-pack=<cmd>,
+// --output=<file>, -c <key>=<value>). The defenses below are in two layers:
+//
+//   1. Input validators used at call sites to reject obviously dangerous
+//      values early and produce a meaningful error.
+//   2. A central guard inside runGitCommand that double-checks every argv
+//      element against an allow-list of flags this module is known to use.
+//      Any "-" prefixed argument that is not on the allow-list is rejected.
+// ---------------------------------------------------------------------------
+
+// Flags this module legitimately passes to git. Used by the central guard to
+// distinguish "argv element we deliberately built" from "argv element that
+// came from untrusted input and happens to start with -".
+var ALLOWED_GIT_FLAGS = new Set([
+    "-c",
+    "-u", "-o", "-b", "-d", "-D", "-m", "-n", "-r", "-v", "-vv", "-w",
+    "--version",
+    "--global", "--cached", "--count", "--porcelain", "--no-color",
+    "--no-rebase", "--allow-unrelated-histories",
+    "--others", "--exclude-standard",
+    "--initial-branch",
+    "--set-upstream-to",
+    "--abbrev-ref", "--symbolic-full-name",
+    "--abort",
+    "--format=sha: %H%nparents: %p%nrefs: %D%nauthor: %an%ndate: %ct%nsubject: %s%n-----"
+]);
+
+function badArg(value, reason) {
+    var err = new Error("Invalid argument passed to git: " + reason);
+    err.code = "git_invalid_argument";
+    err.value = value;
+    return err;
+}
+
+// Reject values that begin with "-" (would be parsed as an option by git).
+// Use this for any user-controlled positional argument.
+function assertNotAFlag(value, label) {
+    if (typeof value !== "string") {
+        throw badArg(value, label + " must be a string");
+    }
+    if (value.length === 0) {
+        throw badArg(value, label + " must not be empty");
+    }
+    if (value[0] === "-") {
+        throw badArg(value, label + " must not start with '-'");
+    }
+}
+
+// Refnames (branches, tags, remote names) — git's own rules are in
+// git-check-ref-format(1); we use a conservative subset that's safe to pass
+// positionally and disallows the constructs that have historically been
+// abused (leading "-", "..", "@{", control chars, whitespace, ":", "?", "*",
+// "[", "\", "^", "~").
+var REFNAME_RE = /^[A-Za-z0-9_@][A-Za-z0-9_./+\-@]*$/;
+function assertValidRefname(value, label) {
+    assertNotAFlag(value, label);
+    // Allow '@' as a literal character (real-world branch names like
+    // user@host-style use it), but reject the '@{...}' sequence to prevent
+    // git's reflog/date query syntax (e.g. main@{yesterday}, @{u}) from
+    // being smuggled in through user-input refnames.
+    if (!REFNAME_RE.test(value) ||
+        value.indexOf("..") !== -1 ||
+        value.indexOf("@{") !== -1 ||
+        /\.lock$/.test(value)) {
+        throw badArg(value, label + " is not a valid git refname");
+    }
+}
+
+// Remote names — same rules as refnames, plus reject the empty/dot cases.
+function assertValidRemoteName(value, label) {
+    assertValidRefname(value, label || "remote name");
+}
+
+// Remote URLs — allow http(s), ssh, git, file, and scp-like (user@host:path) forms.
+// Reject anything starting with "-" (argv injection), and any other schemes
+var URL_SCHEME_RE = /^(file:\/\/|https?:\/\/|ssh:\/\/|git:\/\/|git\+ssh:\/\/)/i;
+var SCP_LIKE_RE = /^[A-Za-z0-9_.\-]+@[A-Za-z0-9_.\-]+:[^\s]+$/;
+function assertValidRemoteUrl(value, label) {
+    assertNotAFlag(value, label || "remote url");
+    if (!URL_SCHEME_RE.test(value) && !SCP_LIKE_RE.test(value)) {
+        throw badArg(value, (label || "remote url") + " must use file://, http(s)://, ssh://, git://, or user@host:path");
+    }
+}
+
+// Values passed as the operand of `git -c key=value`. The risk is newline-
+// or null-injection that could let an attacker smuggle a second config key
+// into the value (e.g. "x\ncore.sshCommand=evil"). git's own config parser
+// does not split -c values on newline, but defense-in-depth: reject any
+// control character.
+function assertValidGitConfigValue(value, label) {
+    if (typeof value !== "string") {
+        throw badArg(value, label + " must be a string");
+    }
+    if (/[\x00-\x1f\x7f]/.test(value)) {
+        throw badArg(value, label + " must not contain control characters");
+    }
+}
+
+// Central guard. Called by runGitCommand on every invocation. Walks the
+// fully-assembled args array and rejects anything that starts with "-" but
+// isn't on ALLOWED_GIT_FLAGS or an explicitly allowed pattern (e.g. -c's
+// "key=value" operand, which is the *next* argv element after -c).
+function guardArgs(args) {
+    for (var i = 0; i < args.length; i++) {
+        var a = args[i];
+        if (typeof a !== "string") {
+            throw badArg(a, "argv element at index " + i + " is not a string");
+        }
+        if (a.length === 0) {
+            continue;
+        }
+        if (a[0] !== "-") {
+            continue;
+        }
+        // Allow explicit known flags.
+        if (ALLOWED_GIT_FLAGS.has(a)) {
+            continue;
+        }
+        // Allow "-n N" where the join into a single argv was historic; we
+        // also allow "-nN" form. The value after the digit is parsed by git
+        // as the count.
+        if (/^-n ?\d+$/.test(a)) {
+            continue;
+        }
+        // Allow "--" as an explicit end-of-options marker.
+        if (a === "--") {
+            continue;
+        }
+        throw badArg(a, "argv element at index " + i + " looks like an option but is not on the allow-list: " + a);
+    }
+}
+
 function runGitCommand(args,cwd,env,emit) {
     log.trace(gitCommand + JSON.stringify(args));
     args.unshift("credential.helper=")
     args.unshift("-c");
+    guardArgs(args);
     return exec.run(gitCommand, args, {cwd:cwd, detached:true, env:env}, emit).then(result => {
         return result.stdout;
     }).catch(result => {
@@ -368,6 +507,7 @@ function getBranches(cwd, remote) {
     })
 }
 function getBranchStatus(cwd,remoteBranch) {
+    assertValidRefname(remoteBranch, "remote branch");
     var commands = [
         // #commits master ahead
         runGitCommand(['rev-list', 'HEAD','^'+remoteBranch, '--count'],cwd),
@@ -385,10 +525,15 @@ function getBranchStatus(cwd,remoteBranch) {
 }
 
 function addRemote(cwd,name,options) {
+    assertValidRemoteName(name, "remote name");
+    assertValidRemoteUrl(options.url, "remote url");
+    // git remote add does not honor "--" as an end-of-options marker for the
+    // <name> positional, so strict name validation above is the defense.
     var args = ["remote","add",name,options.url]
     return runGitCommand(args,cwd);
 }
 function removeRemote(cwd,name) {
+    assertValidRemoteName(name, "remote name");
     var args = ["remote","remove",name];
     return runGitCommand(args,cwd);
 }
@@ -429,23 +574,32 @@ module.exports = {
         });
     },
     setUpstream: function(cwd,remoteBranch) {
+        assertValidRefname(remoteBranch, "remote branch");
         var args = ["branch","--set-upstream-to",remoteBranch];
         return runGitCommand(args,cwd);
     },
     pull: function(cwd,remote,branch,allowUnrelatedHistories,auth,gitUser) {
         var args = ["pull", "--no-rebase"];
+        if (allowUnrelatedHistories) {
+            args.push("--allow-unrelated-histories");
+        }
         if (remote && branch) {
+            assertValidRemoteName(remote, "remote");
+            assertValidRefname(branch, "branch");
+            // -- terminates options so remote/branch can't be parsed as flags
+            args.push("--");
             args.push(remote);
             args.push(branch);
         }
         if (gitUser && gitUser['name'] && gitUser['email']) {
-            args.unshift('user.name="'+gitUser['name']+'"');
-            args.unshift('-c');
-            args.unshift('user.email="'+gitUser['email']+'"');
-            args.unshift('-c');
-        }
-        if (allowUnrelatedHistories) {
-            args.push("--allow-unrelated-histories");
+            assertValidGitConfigValue(gitUser['name'], "git user name");
+            assertValidGitConfigValue(gitUser['email'], "git user email");
+            // Pass each -c key=value as TWO argv elements. Do not wrap the
+            // value in literal double quotes — git's -c does not unquote.
+            args.unshift("user.name=" + gitUser['name']);
+            args.unshift("-c");
+            args.unshift("user.email=" + gitUser['email']);
+            args.unshift("-c");
         }
         var promise;
         if (auth) {
@@ -473,17 +627,19 @@ module.exports = {
         // });
     },
     push: function(cwd,remote,branch,setUpstream, auth) {
+        assertValidRemoteName(remote, "remote");
         var args = ["push"];
-        if (branch) {
-            if (setUpstream) {
-                args.push("-u");
-            }
-            args.push(remote);
-            args.push("HEAD:"+branch);
-        } else {
-            args.push(remote);
+        if (setUpstream && branch) {
+            args.push("-u");
         }
         args.push("--porcelain");
+        // -- terminates options so remote/refspec can't be parsed as flags
+        args.push("--");
+        args.push(remote);
+        if (branch) {
+            assertValidRefname(branch, "branch");
+            args.push("HEAD:"+branch);
+        }
         var promise;
         if (auth) {
             if ( auth.key_path ) {
@@ -507,15 +663,21 @@ module.exports = {
         });
     },
     clone: function(remote, auth, cwd) {
-        var args = ["clone",remote.url];
+        assertValidRemoteUrl(remote.url, "clone url");
+        var args = ["clone"];
         if (remote.name) {
+            assertValidRemoteName(remote.name, "remote name");
             args.push("-o");
             args.push(remote.name);
         }
         if (remote.branch) {
+            assertValidRefname(remote.branch, "branch");
             args.push("-b");
             args.push(remote.branch);
         }
+        // -- terminates options so url and target dir can't be parsed as flags
+        args.push("--");
+        args.push(remote.url);
         args.push(".");
         if (auth) {
             if ( auth.key_path ) {
@@ -530,7 +692,11 @@ module.exports = {
     },
     getStatus: getStatus,
     getFile: function(cwd, filePath, treeish) {
-        var args = ["show",treeish+":"+filePath];
+        assertValidRefname(treeish, "treeish");
+        assertNotAFlag(filePath, "file path");
+        // git show does not honor -- as end-of-options for the <rev>:<path> form;
+        // safety comes from validating treeish as a refname and filePath as not-a-flag.
+        var args = ["show", treeish+":"+filePath];
         return runGitCommand(args,cwd);
     },
     getFiles: function(cwd) {
@@ -539,14 +705,17 @@ module.exports = {
         })
     },
     revertFile: function(cwd, filePath) {
-        var args = ["checkout",filePath];
+        assertNotAFlag(filePath, "file path");
+        var args = ["checkout", "--", filePath];
         return runGitCommand(args,cwd);
     },
     stageFile: function(cwd,file) {
-        var args = ["add"];
+        var args = ["add", "--"];
         if (Array.isArray(file)) {
+            file.forEach(function(f) { assertNotAFlag(f, "file path"); });
             args = args.concat(file);
         } else {
+            assertNotAFlag(file, "file path");
             args.push(file);
         }
         return runGitCommand(args,cwd);
@@ -554,33 +723,45 @@ module.exports = {
     unstageFile: function(cwd, file) {
         var args = ["reset","--"];
         if (file) {
+            assertNotAFlag(file, "file path");
             args.push(file);
         }
         return runGitCommand(args,cwd);
     },
     commit: function(cwd, message, gitUser) {
+        // message is consumed as the operand of -m, so it cannot be parsed
+        // as a flag. We just sanity-check the type.
+        if (typeof message !== "string") {
+            throw badArg(message, "commit message must be a string");
+        }
         var args = ["commit","-m",message];
         var env;
         if (gitUser && gitUser['name'] && gitUser['email']) {
-            args.unshift('user.name="'+gitUser['name']+'"');
-            args.unshift('-c');
-            args.unshift('user.email="'+gitUser['email']+'"');
-            args.unshift('-c');
+            assertValidGitConfigValue(gitUser['name'], "git user name");
+            assertValidGitConfigValue(gitUser['email'], "git user email");
+            // Pass each -c key=value as TWO argv elements without literal quotes.
+            args.unshift("user.name=" + gitUser['name']);
+            args.unshift("-c");
+            args.unshift("user.email=" + gitUser['email']);
+            args.unshift("-c");
         }
         return runGitCommand(args,cwd,env);
     },
     getFileDiff(cwd,file,type) {
+        assertNotAFlag(file, "file path");
         var args = ["diff","-w"];
         if (type === "tree") {
             // nothing else to do
         } else if (type === "index") {
             args.push("--cached");
         }
+        args.push("--");
         args.push(file);
         return runGitCommand(args,cwd);
     },
     fetch: function(cwd,remote,auth) {
-        var args = ["fetch",remote];
+        assertValidRemoteName(remote, "remote");
+        var args = ["fetch", "--", remote];
         if (auth) {
             if ( auth.key_path ) {
                 return runGitCommandWithSSHCommand(args,cwd,auth);
@@ -595,9 +776,16 @@ module.exports = {
     getCommits: function(cwd,options) {
         var args = ["log", "--format=sha: %H%nparents: %p%nrefs: %D%nauthor: %an%ndate: %ct%nsubject: %s%n-----"];
         var limit = parseInt(options.limit) || 20;
-        args.push("-n "+limit);
+        // Push -n and its value as separate argv elements (the previous
+        // "-n "+limit form happened to work but is fragile).
+        args.push("-n");
+        args.push(String(limit));
         var before = options.before;
         if (before) {
+            // "before" is a commit sha/ref used as a pagination cursor.
+            // git log does not honor -- here (it would treat the sha as a pathspec);
+            // safety comes from validating before as a refname.
+            assertValidRefname(before, "before");
             args.push(before);
         }
         var commands = [
@@ -618,7 +806,10 @@ module.exports = {
         })
     },
     getCommit: function(cwd,sha) {
-        var args = ["show",sha];
+        assertValidRefname(sha, "sha");
+        // git show does not honor -- as end-of-options for an <object> argument;
+        // safety comes from validating sha as a refname.
+        var args = ["show", sha];
         return runGitCommand(args,cwd);
     },
     abortMerge: function(cwd) {
@@ -636,6 +827,7 @@ module.exports = {
     getBranches: getBranches,
     // getBranchInfo: getBranchInfo,
     checkoutBranch: function(cwd, branchName, isCreate) {
+        assertValidRefname(branchName, "branch");
         var args = ['checkout'];
         if (isCreate) {
             args.push('-b');
@@ -647,12 +839,14 @@ module.exports = {
         if (isRemote) {
             throw new Error("Deleting remote branches not supported");
         }
+        assertValidRefname(branchName, "branch");
         var args = ['branch'];
         if (force) {
             args.push('-D');
         } else {
             args.push('-d');
         }
+        args.push("--");
         args.push(branchName);
         return runGitCommand(args, cwd);
     },


### PR DESCRIPTION
The Projects feature makes heavy use of the git cli.

This PR adds a number of protections to validate the calls made to the git cli.