### PR TITLE
Add description tooltips to palette categories

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -207,9 +207,23 @@ async function loadThemePlugin () {
                     }
                 })
             }
-            if (Array.isArray(themePlugin.palette?.categories)) {
-                themeSettings.palette = themeSettings.palette || {};
-                themeSettings.palette.categories = themePlugin.palette.categories;
+            if (themePlugin.palette?.categories) {
+                // Prior to NR4.1.11, this could be an array of category names.
+                // Since 4.1.11, this is an object with properties 'order' and 'descriptions'.
+                // The 'order' property is an array of category names - equivalent to the previous array value of this property.
+                // The 'descriptions' property is an object mapping category names to descriptions
+                if (Array.isArray(themePlugin.palette.categories)) {
+                    themeSettings.palette = themeSettings.palette || {};
+                    themeSettings.palette.categories = {
+                        order: themePlugin.palette.categories,
+                    }
+                } else if (Array.isArray(themePlugin.palette.categories.order) || typeof themePlugin.palette.categories.descriptions === 'object') {
+                    themeSettings.palette = themeSettings.palette || {};
+                    themeSettings.palette.categories = {
+                        order: Array.isArray(themePlugin.palette.categories.order) ? themePlugin.palette.categories.order : undefined,
+                        descriptions: typeof themePlugin.palette.categories.descriptions === 'object' ? themePlugin.palette.categories.descriptions : undefined
+                    }
+                }
             }
 
             // These settings are not exposed under `editorTheme`, so we don't have a merge strategy for them
@@ -371,6 +385,11 @@ module.exports = {
 
         if (theme.hasOwnProperty("palette")) {
             themeSettings.palette = theme.palette;
+            if (themeSettings.palette.categories && Array.isArray(themeSettings.palette.categories)) {
+                themeSettings.palette.categories = {
+                    order: themeSettings.palette.categories
+                }
+            }
         }
 
         if (theme.hasOwnProperty("projects")) {

--- a/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/en-US/editor.json
@@ -589,6 +589,20 @@
             "analysis": "analysis",
             "advanced": "advanced"
         },
+        "description": {
+            "subflows": "Reusable flows that can be added to other flows as a single node.",
+            "network": "Nodes for sending and receiving messages over network protocols.",
+            "common": "General purpose nodes used for common operations.",
+            "input": "Nodes that produce messages from external sources or triggers.",
+            "output": "Nodes that send messages out to external systems or services.",
+            "function": "Nodes for processing and transforming messages as they pass through a flow.",
+            "sequence": "Nodes for working with sequences of messages, such as splitting, joining and sorting.",
+            "parser": "Nodes for converting messages between different data formats.",
+            "social": "Nodes for interacting with social media and communication platforms.",
+            "storage": "Nodes for reading from and writing to files, databases and other storage systems.",
+            "analysis": "Nodes for analysing message content.",
+            "advanced": "Less commonly used nodes for more specialised tasks."
+        },
         "actions": {
             "collapse-all": "Collapse all categories",
             "expand-all": "Expand all categories"

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -16,8 +16,8 @@
 
 RED.palette = (function() {
 
-    var exclusion = ['config','unknown','deprecated'];
-    var coreCategories = [
+    const exclusion = ['config','unknown','deprecated'];
+    const coreCategories = [
         'subflows',
         'common',
         'function',
@@ -32,8 +32,10 @@ RED.palette = (function() {
         'advanced'
     ];
 
-    var categoryContainers = {};
-    var sidebarControls;
+    const CATEGORIES = {}
+
+    const categoryContainers = {};
+    let sidebarControls;
 
     let paletteState = { filter: "", collapsed: [] };
 
@@ -49,7 +51,7 @@ RED.palette = (function() {
         }
     }
     function createCategoryContainer(originalCategory,category, labelId) {
-        var label = RED._(labelId, {defaultValue:category});
+        let label = RED._(labelId, {defaultValue:category});
         label = (label || category).replace(/_/g, " ");
         var catDiv = $('<div id="red-ui-palette-container-'+category+'" class="red-ui-palette-category hide">'+
             '<div id="red-ui-palette-header-'+category+'" class="red-ui-palette-header"><i class="expanded fa fa-angle-down"></i><span>'+label+'</span></div>'+
@@ -122,8 +124,26 @@ RED.palette = (function() {
             }
         };
 
-        $("#red-ui-palette-header-"+category).on('click', function(e) {
+        const header = $("#red-ui-palette-header-"+category);
+
+        header.on('click', function(e) {
             categoryContainers[category].toggle();
+        });
+        RED.popover.create({
+            target:header,
+            trigger: "hover",
+            interactive: true,
+            width: "300px",
+            content: () => {
+                // If no category description is found, return null to prevent the popover from being shown at all
+                if (!CATEGORIES[originalCategory]) {
+                    return null
+                }
+                // Lookup on demand as plugin message catalogues will not have
+                // been loaded yet.
+                return RED._(CATEGORIES[originalCategory])
+            },
+            delay: { show: 750, hide: 50 }
         });
     }
 
@@ -264,6 +284,11 @@ RED.palette = (function() {
             var originalCategory = nodeCategory;
             var category = escapeCategory(nodeCategory);
             var rootCategory = category.split("-")[0];
+
+            if (def.categoryDescription) {
+                // Do this first so that a description is known for the category when the popover is created in createCategoryContainer
+                registerCategory(def.category, def.categoryDescription);
+            }
 
             var d = $('<div>',{class:"red-ui-palette-node"}).attr("data-palette-type",nt).data('category',rootCategory);
 
@@ -462,6 +487,7 @@ RED.palette = (function() {
                     categoryContainers[rootCategory].close(true);
                 }
             }
+
             clearTimeout(filterRefreshTimeout)
             filterRefreshTimeout = setTimeout(() => {
                 refreshFilter()
@@ -607,6 +633,11 @@ RED.palette = (function() {
 
     function init() {
 
+
+        coreCategories.forEach(function(category) {
+            registerCategory(category, "palette.description."+category);
+        })
+
         $('<img src="red/images/spin.svg" class="red-ui-palette-spinner hide"/>').appendTo("#red-ui-palette");
         $('<div id="red-ui-palette-search" class="red-ui-palette-search hide"><input type="text" data-i18n="[placeholder]palette.filter"></input></div>').appendTo("#red-ui-palette");
         $('<div id="red-ui-palette-container" class="red-ui-palette-scroll hide"></div>').appendTo("#red-ui-palette");
@@ -687,7 +718,17 @@ RED.palette = (function() {
         if (RED.settings.paletteCategories) {
             userCategories = RED.settings.paletteCategories;
         } else if (RED.settings.theme('palette.categories')) {
-            userCategories = RED.settings.theme('palette.categories');
+            const themeCategories = RED.settings.theme('palette.categories');
+            if (Array.isArray(themeCategories.order)) {
+                userCategories = themeCategories.order;
+            }
+            if (themeCategories.descriptions) {
+                for (const category in themeCategories.descriptions) {
+                    if (themeCategories.descriptions.hasOwnProperty(category)) {
+                        registerCategory(category, themeCategories.descriptions[category]);
+                    }
+                }
+            }
         }
         if (!Array.isArray(userCategories)) {
             userCategories = [];
@@ -779,6 +820,12 @@ RED.palette = (function() {
         }
     }
 
+    function registerCategory(category, description) {
+        if (!CATEGORIES[category]) {
+            CATEGORIES[category] = description
+        }
+    }
+
     return {
         init: init,
         add:addNodeType,
@@ -786,6 +833,7 @@ RED.palette = (function() {
         hide:hideNodeType,
         show:showNodeType,
         refresh:refreshNodeTypes,
-        getCategories: getCategories
+        getCategories: getCategories,
+        registerCategory: registerCategory
     };
 })();

--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -432,7 +432,9 @@ module.exports = {
              * added to the end of the palette.
              * If not set, the following default order is used:
              */
-            //categories: ['subflows', 'common', 'function', 'network', 'sequence', 'parser', 'storage'],
+            //categories: {
+            //     order: ['subflows', 'common', 'function', 'network', 'sequence', 'parser', 'storage'],
+            // },
         },
 
         projects: {


### PR DESCRIPTION
Closes #5765 

This adds description tooltips to the default palette categories:

<img width="1021" height="326" alt="image" src="https://github.com/user-attachments/assets/fcaea477-416a-4691-8627-256b8806204e" />


Furthermore, custom categories can have a description set by either a theme plugin, or individual nodes (on a first-registered basis - with theme plugin taking priority)

It updates the format of the existing `palette.categories` setting so that it can specify both the custom order of categories as well as the descriptions of custom categoies. See #5765 for specific details.

