### PR TITLE
Allow theme plugin to override node categories

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
+++ b/packages/node_modules/@node-red/editor-api/lib/editor/theme.js
@@ -209,19 +209,21 @@ async function loadThemePlugin () {
             }
             if (themePlugin.palette?.categories) {
                 // Prior to NR4.1.11, this could be an array of category names.
-                // Since 4.1.11, this is an object with properties 'order' and 'descriptions'.
+                // Since 4.1.11, this is an object with properties 'order', 'descriptions', and 'nodeOverrides'.
                 // The 'order' property is an array of category names - equivalent to the previous array value of this property.
                 // The 'descriptions' property is an object mapping category names to descriptions
+                // The 'nodeOverrides' property is an object mapping node types to category names, allowing a theme to specify that certain nodes should be in a different category when the palette is rendered.
                 if (Array.isArray(themePlugin.palette.categories)) {
                     themeSettings.palette = themeSettings.palette || {};
                     themeSettings.palette.categories = {
                         order: themePlugin.palette.categories,
                     }
-                } else if (Array.isArray(themePlugin.palette.categories.order) || typeof themePlugin.palette.categories.descriptions === 'object') {
+                } else {
                     themeSettings.palette = themeSettings.palette || {};
                     themeSettings.palette.categories = {
                         order: Array.isArray(themePlugin.palette.categories.order) ? themePlugin.palette.categories.order : undefined,
-                        descriptions: typeof themePlugin.palette.categories.descriptions === 'object' ? themePlugin.palette.categories.descriptions : undefined
+                        descriptions: typeof themePlugin.palette.categories.descriptions === 'object' ? themePlugin.palette.categories.descriptions : undefined,
+                        nodeOverrides: typeof themePlugin.palette.categories.nodeOverrides === 'object' ? themePlugin.palette.categories.nodeOverrides : undefined
                     }
                 }
             }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette.js
@@ -34,6 +34,8 @@ RED.palette = (function() {
 
     const CATEGORIES = {}
 
+    const categoryOverrides = {};
+
     const categoryContainers = {};
     let sidebarControls;
 
@@ -277,7 +279,13 @@ RED.palette = (function() {
         if (getPaletteNode(nt).length) {
             return;
         }
-        var nodeCategory = def.category;
+
+        if (categoryOverrides[nt]) {
+            console.log(`Applying node category override for ${nt}: ${def.category} -> ${categoryOverrides[nt]}`);
+            def.category = categoryOverrides[nt];
+        }
+
+        let nodeCategory = def.category;
 
         if (exclusion.indexOf(nodeCategory)===-1) {
 
@@ -726,6 +734,13 @@ RED.palette = (function() {
                 for (const category in themeCategories.descriptions) {
                     if (themeCategories.descriptions.hasOwnProperty(category)) {
                         registerCategory(category, themeCategories.descriptions[category]);
+                    }
+                }
+            }
+            if (themeCategories.nodeOverrides) {
+                for (const nodeType in themeCategories.nodeOverrides) {
+                    if (themeCategories.nodeOverrides.hasOwnProperty(nodeType)) {
+                        categoryOverrides[nodeType] = themeCategories.nodeOverrides[nodeType];
                     }
                 }
             }


### PR DESCRIPTION
Closes #5766 

This allows a theme plugin to override the categories of nodes.

This is done via the `palette.categories.nodeOverrides` property:

```
palette: {
   categories: {
      order: ["common", "my custom thing",...],
      descriptions: {
         "my custom thing": "this is a custom category description"
      },
      nodeOverrides: {
         inject: "my custom thing"
      }
   }
}
```