### PR TITLE
Add styles to prevent controls wrapping in find bar

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/editor.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/editor.scss
@@ -1167,3 +1167,8 @@ span.red-ui-editor-subflow-env-lang-icon {
     //     }
     // }
 }
+
+// Prevent controls wrapping in monaco find bar
+.monaco-editor .controls {
+    margin-left: revert !important;
+}


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Proposed changes

Revert padding-left css on the monaco find bar controls

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
