### PR TITLE
Align unknown node style

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/98-unknown.html
+++ b/packages/node_modules/@node-red/nodes/core/common/98-unknown.html
@@ -13,7 +13,7 @@
 <script type="text/javascript">
     RED.nodes.registerType('unknown', {
         category: 'unknown',
-        color:"#fff000",
+        color:"#fee",
         defaults: {
             name: {value:""},
             modules: { value: [] }


### PR DESCRIPTION
When importing an unknown node, it has a bright yellow body. After deploying and reloading, it gets the expected appearance.

<img width="243" height="111" alt="image" src="https://github.com/user-attachments/assets/7bf1d312-69c0-4ac3-8aec-37de588cbbd4" />

<img width="243" height="111" alt="image" src="https://github.com/user-attachments/assets/7d5b75fd-5179-4daf-9ce5-88fbdbbe08ac" />


This PR ensures it doesn't get a bright yellow body and has a consistent appearance.