### PR TITLE
Fix images in welcome tour for 4.1

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/tours/4.1/welcome.js
+++ b/packages/node_modules/@node-red/editor-client/src/tours/4.1/welcome.js
@@ -20,7 +20,7 @@ export default {
                 "ja": "更新の通知",
                 "fr": "Notifications de mise à jour"
             },
-            image: 'images/update-notification.png',
+            image: '4.1/images/update-notification.png',
             description: {
                 "en-US": `<p>Stay up to date with notifications when there is a new Node-RED version available, or updates to the nodes you have installed</p>`,
                 "ja": `<p>新バージョンのNode-REDの提供や、インストールしたノードの更新があった時に、通知を受け取ることができます。</p>`,
@@ -33,7 +33,7 @@ export default {
                 "ja": "フローのドキュメント",
                 "fr": "Documentation des flux"
             },
-            image: 'images/node-docs.png',
+            image: '4.1/images/node-docs.png',
             description: {
                 "en-US": `<p>Quickly see which nodes have additional documentation with the new documentation icon.</p>
                 <p>Clicking on the icon opens up the Description tab of the node edit dialog.</p>`,
@@ -76,7 +76,7 @@ export default {
                 "ja": "不足モジュールのインストール",
                 "fr": "Installation des modules manquants"
             },
-            image: 'images/missing-modules.png',
+            image: '4.1/images/missing-modules.png',
             description: {
                 "en-US": `<p>Flows exported from Node-RED 4.1 now include information on what additional modules need to be installed.</p>
                 <p>When importing a flow with this information, the editor will let you know what is missing and help to get them installed.</p>


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
In v5.0.0, the images in the welcome tour for v4.1 are not visible. Therefore, I fixed the image file path.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
