### PR TITLE
Fix RED.sidebar.containsTab api

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
@@ -774,7 +774,7 @@ RED.sidebar = (function() {
     }
 
     function containsTab(id) {
-        return sidebars.primary.tabs.contains(id);
+        return !!knownTabs[id];
     }
 
     // function showSectionMenu(sidebar, section, button) {


### PR DESCRIPTION
Closes #5804 

This function isn't used internally by the editor so was overlooked whilst working on the new sidebar code.