### PR TITLE
Move sidebar resize-handle down one level in z-index

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/sidebar.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/sidebar.scss
@@ -116,7 +116,7 @@
         width: 12px;
         height: calc(100% - 40px);;
         // Below the full-screen shade
-        z-index: 14;
+        z-index: 13;
     }
 }
 


### PR DESCRIPTION
Fixes #5799 

Moves the sidebar resize handle down one level in z-Index so it doesn't overlay the expanded editor.