### PR TITLE
Avoid initialising sidebars with tabs that do not exist yet

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
@@ -697,8 +697,18 @@ RED.sidebar = (function() {
                 ;['top','bottom'].forEach(function(position) {
                     if (lastSessionState[sidebarKey]?.[position]?.hidden !== true) {
                         let lastTabId = lastSessionState[sidebarKey]?.[position]?.active;
-                        if (lastTabId) {
+                        if (lastTabId && knownTabs[lastTabId]) {
                             showSidebar(lastTabId)
+                        } else if (!knownTabs[lastTabId]) {
+                            // lastTabId isn't currently valid. It has either been removed, or is going
+                            // to get added asynchronously. We can't restore it if it isn't present right now.
+                            // Fall back to showing the first tab in the section if there is one.
+                            if (sidebar.sections[position].tabs.length > 0) {
+                                showSidebar(sidebar.sections[position].tabs[0])
+                            } else {
+                                // We don't have a alternative sidebar to show here - hide the section
+                                sidebar.hideSection(position)
+                            }
                         }
                     }
                 })
@@ -1097,6 +1107,15 @@ RED.sidebar = (function() {
             if (otherPosition === 'bottom') {
                 sidebar.sections[otherPosition].container.css('margin-top', '')
             }
+
+            if (sidebar.sections[position].active && knownTabs[sidebar.sections[position].active]) {
+                const tabOptions = knownTabs[sidebar.sections[position].active]
+                const sidebarSectionDisplay = $(tabOptions.wrapper).css('display');
+                if (sidebarSectionDisplay === 'none') {
+                    showSidebar(sidebar.sections[position].active)
+                }
+            }
+
             resyncSidebarButtonStates()
             sidebar.resizeSidebar()
         }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/sidebar.js
@@ -717,7 +717,8 @@ RED.sidebar = (function() {
             Object.keys(sidebars).forEach(function(sidebarKey) {
                 const sidebar = sidebars[sidebarKey]
                 const hasTabs = sidebar.sections.top.tabs.length > 0 || sidebar.sections.bottom.tabs.length > 0
-                if (!hasTabs && RED.menu.isSelected(sidebar.menuToggle)) {
+                const bothSectionsHidden = sidebar.sections.top.hidden && sidebar.sections.bottom.hidden
+                if ((!hasTabs || bothSectionsHidden) && RED.menu.isSelected(sidebar.menuToggle)) {
                     RED.menu.setSelected(sidebar.menuToggle, false);
                 }
             })
@@ -1110,8 +1111,8 @@ RED.sidebar = (function() {
 
             if (sidebar.sections[position].active && knownTabs[sidebar.sections[position].active]) {
                 const tabOptions = knownTabs[sidebar.sections[position].active]
-                const sidebarSectionDisplay = $(tabOptions.wrapper).css('display');
-                if (sidebarSectionDisplay === 'none') {
+                // Check the active tab wrapper is actually visible - if not, trigger a show
+                if (!$(tabOptions.wrapper).is(':visible')) {
                     showSidebar(sidebar.sections[position].active)
                 }
             }


### PR DESCRIPTION
Fixes #5802 

If a sidebar tab is added asynchronously to plugin/node loading, then it won't exist when the editor initialises the sidebar layout.

If such a sidebar tab was selected when the editor was last open, the sidebar will try to restore it on load and fail. However, the sidebar section is opened regardless - leading to the odd scrollbar position reported in the linked issue.

This fixes the immediate issue by:
 - if the active sidebar tab is not known, we revert to the first available tab in that section. If no other tabs are in that section, hide the section.

It also fixes a latent issue around showing a section for the first time when its sidebar tab was never explicitly shown - causing a blank section to appear.