### PR TITLE
Fix expandOnClick behaviour of treeList

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/treeList.js
@@ -28,7 +28,6 @@
  *   - autoSelect: boolean - default true - triggers item selection when navigating
  *                           list by keyboard. If the list has checkboxed items
  *                           you probably want to set this to false
- *   - expandOnLabel: boolean - default true - items expand when their label is clicked
  *
  * methods:
  *   - data(items) - clears existing items and replaces with new data
@@ -56,6 +55,7 @@
  *                                    until it is expanded by the user.
  *         element: // custom dom element to use for the item - ignored if `label` is set
  *         collapsible: true/false, // prevent a parent item from being collapsed. default true.
+ *         expandOnClick: boolean - default true - expand when their label is clicked when not selected
  *     }
  * ]
  *
@@ -661,11 +661,11 @@
                 // $('<span class="red-ui-treeList-icon"><i class="fa fa-folder-o" /></span>').appendTo(label);
                 label.on("click.red-ui-treeList-expand", function(e) {
                     if (container.hasClass("expanded")) {
-                        if (item.expandOnLabel === true || label.hasClass("selected")) {
+                        if (item.expandOnClick !== false || label.hasClass("selected")) {
                             item.treeList.collapse();
                         }
                     } else {
-                        if (item.expandOnLabel === true || label.hasClass("selected")) {
+                        if (item.expandOnClick !== false || label.hasClass("selected")) {
                             item.treeList.expand();
                         }
                     }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info-outliner.js
@@ -19,13 +19,11 @@ RED.sidebar.info.outliner = (function() {
             {
                 label: RED._("menu.label.flows"),
                 expanded: true,
-                expandOnLabel: true,
                 children: []
             },
             {
                 id: "__subflow__",
                 label: RED._("menu.label.subflows"),
-                expandOnLabel: true,
                 children: [
                     getEmptyItem("__subflow__")
                 ]
@@ -34,7 +32,6 @@ RED.sidebar.info.outliner = (function() {
                 id: "__global__",
                 flow: "__global__",
                 label: RED._("sidebar.info.globalConfig"),
-                expandOnLabel: true,
                 types: {},
                 children: [
                     getEmptyItem("__global__")
@@ -303,8 +300,7 @@ RED.sidebar.info.outliner = (function() {
         // <div class="red-ui-info-outline-item red-ui-info-outline-item-flow" style=";"><div class="red-ui-search-result-description red-ui-info-outline-item-label">Space Monkey</div><div class="red-ui-info-outline-item-controls"><button class="red-ui-button red-ui-button-small" style="position:absolute;right:5px;"><i class="fa fa-ellipsis-h"></i></button></div></div></div>').appendTo(container)
 
         treeList = $("<div>").css({width: "100%"}).appendTo(container).treeList({
-            data:getFlowData(),
-            expandOnLabel: false
+            data:getFlowData()
         })
         treeList.on('treelistselect', function(e,item) {
             var node = RED.nodes.node(item.id) || RED.nodes.group(item.id) || RED.nodes.workspace(item.id) || RED.nodes.subflow(item.id);
@@ -383,7 +379,8 @@ RED.sidebar.info.outliner = (function() {
             children:[],
             deferBuild: true,
             icon: "red-ui-icons red-ui-icons-flow",
-            gutter: getGutter(ws)
+            gutter: getGutter(ws),
+            expandOnClick: false
         }
         if (missingParents[ws.id]) {
             objects[ws.id].children = missingParents[ws.id];
@@ -447,7 +444,8 @@ RED.sidebar.info.outliner = (function() {
             element: getNodeLabel(sf),
             children:[],
             deferBuild: true,
-            gutter: getGutter(sf)
+            gutter: getGutter(sf),
+            expandOnClick: false
         }
         if (missingParents[sf.id]) {
             objects[sf.id].children = missingParents[sf.id];
@@ -619,7 +617,6 @@ RED.sidebar.info.outliner = (function() {
                 config: true,
                 flow: parent,
                 types: {},
-                expandOnLabel: true,
                 label: RED._("menu.label.displayConfig"),
                 children: []
             }
@@ -630,7 +627,6 @@ RED.sidebar.info.outliner = (function() {
             configNodeTypes[parent].types[type] = {
                 config: true,
                 label: type,
-                expandOnLabel: true,
                 children: []
             }
             configNodeTypes[parent].treeList.addChild(configNodeTypes[parent].types[type]);
@@ -646,6 +642,7 @@ RED.sidebar.info.outliner = (function() {
         if (n.type === "group") {
             objects[n.id].children = [];
             objects[n.id].deferBuild = true;
+            objects[n.id].expandOnClick = false;
             if (missingParents[n.id]) {
                 objects[n.id].children = missingParents[n.id];
                 delete missingParents[n.id]


### PR DESCRIPTION
https://github.com/node-red/node-red/pull/5570 introduced a new behaviour of treeList badly. This PR fixes it.

By default, TreeList will expand an parent item when it is clicked. There are cases where it is desirable to only select the item on the first click, and expand on a second click. This is what the previous PR attempted to achieve, but it made that behaviour the default across the board, rather than opt-in.

This PR changes its approach and standardises it for other consumers of TreeList to take advantage.

In summary, if you do not want a parent item to expand when clicked (but not selected) then set its `expandOnClick` property to `false`.

I've updated the website docs for TreeList - https://nodered.org/docs/api/ui/treeList/#options-data