### PR TITLE
Make docs popup styling consistent with info sidebar

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info.js
@@ -150,17 +150,6 @@ RED.sidebar.info = (function() {
         RED.sidebar.show("info");
     }
 
-    // TODO: DRY - projects.js
-    function addTargetToExternalLinks(el) {
-        $(el).find("a").each(function(el) {
-            var href = $(this).attr('href');
-            if (/^https?:/.test(href)) {
-                $(this).attr('target','_blank');
-            }
-        });
-        return el;
-    }
-
     function refresh(node) {
         if (node === undefined) {
             refreshSelection();
@@ -410,7 +399,8 @@ RED.sidebar.info = (function() {
             }
             var infoSectionContainer = $("<div>").css("padding","0 6px 6px").appendTo(propertiesPanelContent)
 
-            setInfoText(infoText, infoSectionContainer);
+            RED.utils.renderInfoText(infoText, infoSectionContainer);
+            RED.editor.mermaid.render()
 
             $(".red-ui-sidebar-info-stack").scrollTop(0);
             $(".node-info-property-header").on("click", function(e) {
@@ -434,24 +424,6 @@ RED.sidebar.info = (function() {
 
 
 
-    }
-
-    function setInfoText(infoText,target) {
-        var info = addTargetToExternalLinks($('<div class="red-ui-help"><span class="red-ui-text-bidi-aware" dir=\"'+RED.text.bidi.resolveBaseTextDir(infoText)+'">'+infoText+'</span></div>')).appendTo(target);
-        info.find(".red-ui-text-bidi-aware").contents().filter(function() { return this.nodeType === 3 && this.textContent.trim() !== "" }).wrap( "<span></span>" );
-        var foldingHeader = "H3";
-        info.find(foldingHeader).wrapInner('<a class="red-ui-help-info-header expanded" href="#"></a>')
-            .find("a").prepend('<i class="fa fa-angle-right">').on("click", function(e) {
-                e.preventDefault();
-                var isExpanded = $(this).hasClass('expanded');
-                var el = $(this).parent().next();
-                while(el.length === 1 && el[0].nodeName !== foldingHeader) {
-                    el.toggle(!isExpanded);
-                    el = el.next();
-                }
-                $(this).toggleClass('expanded',!isExpanded);
-            });
-        RED.editor.mermaid.render()
     }
 
     var tips = (function() {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/utils.js
@@ -1607,6 +1607,44 @@ RED.utils = (function() {
         return r;
     }
 
+    // TODO: DRY - projects.js
+    function addTargetToExternalLinks(el) {
+        $(el).find("a").each(function(el) {
+            const href = $(this).attr('href');
+            if (/^https?:/.test(href)) {
+                $(this).attr('target','_blank');
+            }
+        });
+        return el;
+    }
+
+    // Adds `text` to `target` with the following additions:
+    // - wraps text in a div with class `red-ui-help`
+    // - wraps text in a span with class `red-ui-text-bidi-aware` and sets the `dir` attribute to the base text direction of the text
+    // - wraps any text nodes in a span
+    // - wraps any H3 elements in an anchor with class `red-ui-help-info-header` and adds a click handler to toggle the visibility of the following elements until the next H3
+    // - ensures any <a> links to external sites open in a new tab
+    function renderInfoText(text, target, options) {
+        const info = addTargetToExternalLinks($('<div class="red-ui-help"><span class="red-ui-text-bidi-aware" dir=\"'+RED.text.bidi.resolveBaseTextDir(text)+'">'+text+'</span></div>')).appendTo(target);
+        info.find(".red-ui-text-bidi-aware").contents().filter(function() { return this.nodeType === 3 && this.textContent.trim() !== "" }).wrap( "<span></span>" );
+        if (options?.collapseSections !== false ) {
+            const foldingHeader = "H3";
+            const breakHeader = ["H1","H2","H3"];
+            info.find(foldingHeader).wrapInner('<a class="red-ui-help-info-header expanded" href="#"></a>')
+                .find("a").prepend('<i class="fa fa-angle-right">').on("click", function(e) {
+                    e.preventDefault();
+                    const isExpanded = $(this).hasClass('expanded');
+                    let el = $(this).parent().next();
+                    while(el.length === 1 && breakHeader.indexOf(el[0].nodeName) === -1) {
+                        el.toggle(!isExpanded);
+                        el = el.next();
+                    }
+                    $(this).toggleClass('expanded',!isExpanded);
+                });
+        }
+    }
+
+
     return {
         createObjectElement: createObjectElement,
         getMessageProperty: getMessageProperty,
@@ -1632,6 +1670,7 @@ RED.utils = (function() {
         parseModuleList: parseModuleList,
         checkModuleAllowed: checkModuleAllowed,
         getBrowserInfo: getBrowserInfo,
-        validateTypedProperty: validateTypedProperty
+        validateTypedProperty: validateTypedProperty,
+        renderInfoText: renderInfoText
     }
 })();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1292,8 +1292,8 @@ RED.view = (function() {
                             editInfo()
                         })
                     }
-
-                    $(`<div class="red-ui-help red-ui-flow-annotation-popover-body"><span class="red-ui-text-bidi-aware">${RED.utils.renderMarkdown(n.info)}</span></div>`).appendTo(section)
+                    const body = $('<div class="red-ui-flow-annotation-popover-body"></div>').appendTo(section)
+                    RED.utils.renderInfoText(RED.utils.renderMarkdown(n.info), body, { collapseSections: false });
 
                     // Resolve data-i18n attributes on content
                     section.i18n()

--- a/packages/node_modules/@node-red/editor-client/src/sass/popover.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/popover.scss
@@ -166,12 +166,12 @@
 .red-ui-popover {
     a {
         text-decoration: none;
-        color: var(--red-ui-popover-color) !important;
+        color: var(--red-ui-popover-color);
     }
     a:hover,
     a:focus {
         text-decoration: none;
-        color: var(--red-ui-popover-color) !important;
+        color: var(--red-ui-popover-color);
     }
     a:focus {
         outline: 1px solid var(--red-ui-form-input-focus-color);

--- a/packages/node_modules/@node-red/editor-client/src/sass/tab-info.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/tab-info.scss
@@ -119,13 +119,13 @@ div.red-ui-info-table {
     line-height: 1.5em;
 
     a {
-        color: var(--red-ui-text-color-link);
+        color: var(--red-ui-text-color-link) !important; 
         text-decoration: none;
     }
 
     a:hover,
     a:focus {
-        color: var(--red-ui-text-color-link);
+        color: var(--red-ui-text-color-link) !important;
         text-decoration: underline;
     }
 
@@ -150,6 +150,12 @@ div.red-ui-info-table {
         font-size: 1.138em;
         margin: 7px auto 5px;
         line-height: 1.3em;
+        a {
+            color: var(--red-ui-primary-text-color) !important;
+            &:hover,&:focus {
+                color: var(--red-ui-primary-text-color) !important;
+            }   
+        }
     }
     h4,
     h5 {


### PR DESCRIPTION
The Info sidebar renders node info differently to the new docs popup.

Specifically:
 - info sidebar adds `_blank` to any external links
 - makes `h3` sections collapsible
 - links appear blue, not default colour.

This PR fixes *some* of that:

 - adds `RED.utils.renderInfoText` to make the code reuseable
 - makes the 'make sections collapsible' behaviour optional (see below)
 - updates CSS to ensure the `red-ui-help` styling takes priority over the `red-ui-popover` styling when it comes to `<a>` elements.

I had to disable the collapsible sections behaviour as it causes the popover to resize unexpectedly. Couldn't think of a quick fix for that, so disabled this edge case behaviour.