### PR TITLE
Reposition active popups in response to window resize events

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
@@ -137,7 +137,7 @@
  */
 
 RED.popover = (function() {
-    var deltaSizes = {
+    const deltaSizes = {
         "default": {
             x: 12,
             y: 12
@@ -147,6 +147,7 @@ RED.popover = (function() {
             y:8
         }
     }
+
     function createPopover(options) {
         var target = options.target;
         var direction = options.direction || "right";
@@ -169,6 +170,8 @@ RED.popover = (function() {
         var contentDiv;
         var currentStyle;
         var closeOnOutsideClickHandler;
+
+        const popoverId = RED.nodes.id();
 
         var openPopup = function(instant) {
             if (isOpen) {
@@ -255,8 +258,12 @@ RED.popover = (function() {
                     };
                     document.addEventListener('mousedown', closeOnOutsideClickHandler, true);
                 }
+                $(window).on('resize.red-ui-popover.'+popoverId, function () {
+                    movePopup({target,direction,width,maxWidth});
+                });
             }
         }
+
         var movePopup = function(options) {
             target = options.target || target;
             direction = options.direction || direction || "right";
@@ -387,6 +394,7 @@ RED.popover = (function() {
         var closePopup = function(instant) {
             isOpen = false
             $(document).off('mousedown.red-ui-popover');
+            $(window).off('resize.red-ui-popover.'+popoverId);
             if (closeOnOutsideClickHandler) {
                 document.removeEventListener('mousedown', closeOnOutsideClickHandler, true);
                 closeOnOutsideClickHandler = null;


### PR DESCRIPTION
Most popovers are transient tooltips that disappear when the mouse moves off their target. However we now have some that are more permanently show - such as the search toolbar.

This PR attaches a handler to the window resize event so the popover can be repositioned if its target element has moved.