### PR TITLE
[5810] NR5: "0 plugins" in palette manager

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -371,7 +371,9 @@ RED.palette.editor = (function() {
                         }
                     }
 
-                    setCount.push(RED._('palette.editor.pluginCount', { count: pluginCount }));
+                    if (pluginCount > 0) {
+                        setCount.push(RED._('palette.editor.pluginCount', { count: pluginCount }));
+                    }
 
                     if (!moduleInfo.nodeSet) {
                         // Module only have plugins


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Resolves https://github.com/node-red/node-red/issues/5810

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
