### PR TITLE
[5808] NR5: navigaton elements overlap workspace content at edges

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -38,6 +38,9 @@ RED.view = (function() {
         node_height = 30,
         dblClickInterval = 650;
 
+    var scrollOvershootX = 16,
+        scrollOvershootY = 50;
+
     var cancelInProgressAnimation = null; // For smooth zoom animation
 
     var touchLongPressTimeout = 1000,
@@ -349,8 +352,8 @@ RED.view = (function() {
                 position: 'absolute',
                 top: 0,
                 left: 0,
-                width: space_width + 'px',
-                height: space_height + 'px',
+                width: (space_width + scrollOvershootX) + 'px',
+                height: (space_height + scrollOvershootY) + 'px',
                 pointerEvents: 'none',
                 visibility: 'hidden'
             })
@@ -5498,8 +5501,8 @@ RED.view = (function() {
         // Browser calculates maxScroll = scrollWidth - viewport, which correctly
         // allows scrolling to see the far edges of canvas without going beyond
         $('#red-ui-workspace-scroll-spacer').css({
-            width: (space_width * scaleFactor) + 'px',
-            height: (space_height * scaleFactor) + 'px'
+            width: (space_width * scaleFactor + scrollOvershootX) + 'px',
+            height: (space_height * scaleFactor + scrollOvershootY) + 'px'
         });
 
         // Don't bother redrawing nodes if we're drawing links


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Resolves https://github.com/node-red/node-red/issues/5808

Adds overflow padding to bottom edges: 

<img width="310" height="222" alt="Screenshot 2026-06-16 at 1 14 24 PM" src="https://github.com/user-attachments/assets/5ac6e1e3-18c9-4bb3-8d13-dcdecb01afeb" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
