### PR TITLE
Fix issue with monaco after expanding and collapsing the editor

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
@@ -55,7 +55,6 @@ RED.editor.codeEditor.monaco = (function() {
     const type = "monaco";
     const monacoThemes = ["vs","vs-dark","hc-black"]; //TODO: consider setting hc-black autmatically based on acessability?
     let userSelectedTheme;
-    let tsFuncData; //used to cache the original func.d.ts data for later use when updating linkcall targets
 
     //TODO: get from externalModules.js  For now this is enough for feature parity with ACE (and then some).
     const knownModules = {
@@ -144,9 +143,6 @@ RED.editor.codeEditor.monaco = (function() {
                 var typePath = "types/" + libPath;
                 $.get(typePath)
                     .done(function(data) {
-                        if (libPath === "node-red/func.d.ts") {
-                            tsFuncData = data; //cache the original func.d.ts data for later use when updating linkcall targets
-                        }
                         modulesCache[libPath] =  data;
                         if(!preloadOnly) {
                             loadedLibs.JS[libModule] = monaco.typescript.javascriptDefaults.addExtraLib(data, "file://types/" + libPackage + "/" + libModule + "/index.d.ts");
@@ -938,63 +934,6 @@ RED.editor.codeEditor.monaco = (function() {
 
         //check if extraLibs are to be loaded (e.g. fs or os)
         refreshModuleLibs(editorOptions.extraLibs)
-
-        // update func.d.ts definitions for up-to-date link-in target names in the node.linkcall() definition
-        if (tsFuncData && options.node && options.node.type === 'function') {
-            const getUpdatedLinkcallDefs = () => {
-                const linkInNodes = RED.nodes.filterNodes({type:'link in'})
-                const viableLinkTargets = []
-                for (const target of linkInNodes) {
-                    // links on same flow/subflow as caller node are valid targets
-                    // however links inside a (different) subflow are not valid targets.
-                    if (target.z === options.node.z || !RED.nodes.subflow(target.z)) {
-                        viableLinkTargets.push(target)
-                    }
-                }
-                const targetsByName = [...new Set(viableLinkTargets.map(node => node.name || '').filter(name => name.length > 0))].map(s => JSON.stringify(s));
-                const targetsById = [...new Set(viableLinkTargets.map(node => node.id))].map(s => JSON.stringify(s));
-                const targets = [...targetsByName, ...targetsById].filter(s => s && s.length > 0).join("|") || 'string';
-                return `
-    // #region:linkcall
-    /**
-     * Utility function to call, a reusable flow defined as a subroutine (link-in ~ <nodes> ~ link-out).
-     * When the \`linkcall\` function resolves, it returns the \`msg\` object returned by the link-out
-     * (return) node of the subroutine.
-     * 
-     * @param {string} target - the name or ID of the target link-in subroutine to call
-     * @param {Object} msg - the message object to pass to the subroutine
-     * @param {Object} [options] - call options
-     * @param {number} [options.timeout=5000] - the maximum time to wait for a response (default: 5000ms)
-     * @param {boolean} [options.clone=true] - flag to indicate if the message should be cloned (default: true) 
-     * @return {Promise<Object>} - resolves with the returned message
-     * 
-     * @example Call "greeting-person" subroutine by name:
-     * \`\`\`javascript
-     * msg.payload = "Joe Bloggs";
-     * const resultMsg = await node.linkcall("greeting-person", msg, {timeout: 10000});
-     * msg.payload = resultMsg.payload; // payload = "Hello Joe Bloggs"
-     * return msg; // return updated msg
-     * \`\`\`
-     * 
-     * @example Call "greeting-person" subroutine by node id:
-     * \`\`\`javascript
-     * msg.payload = "John Doe";
-     * const result = await node.linkcall("a1b2c3d4e5f6", msg); // result.payload will be "Hello John Doe"
-     * return result; // return new result object
-     * \`\`\`
-     */
-    static linkcall(target: ${targets}, msg: object, options?: { timeout?: number; clone?: boolean; [key: string]: any }): Promise<object>;
-    // #endregion:linkcall
-`
-            }
-            const newDefs = getUpdatedLinkcallDefs();
-            data = tsFuncData.replace(/\/\/ #region:linkcall[\s\S]*?\/\/ #endregion:linkcall/g, newDefs);
-            if (loadedLibs.JS.func) {
-                loadedLibs.JS.func.dispose();
-                loadedLibs.JS.func = null;
-            }
-            loadedLibs.JS.func = monaco.languages.typescript.javascriptDefaults.addExtraLib(data, 'file://types/node-red/func/index.d.ts');
-        }
 
         function refreshModuleLibs(extraModuleLibs) {
             var defs = [];


### PR DESCRIPTION
closes #5796

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Remove the dynamic regeneration of dynamic JSDoc info for linkcall - this seems to resolve 

Ideally this temporary until the issue with regenerating type defs dynamically is resolved.
Until then, all that is lost is the suggested link names and node ids offered int he autocompletion parameter help. 

What users will get with this PR merged is a generic parameter hint (i.e. link targets will no longer be suggested dynamically) e.g:
<img width="642" height="227" alt="image" src="https://github.com/user-attachments/assets/8ae2c254-f2b9-46ed-940e-9106cac2f975" />

Built-in help & AST parameter type checking and remains in place.
<img width="948" height="290" alt="image" src="https://github.com/user-attachments/assets/2aa32891-b826-4971-9942-58bd563da116" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
