### PR TITLE
[BUGFIX] Fix git ref parsing resulting in broken merge conflicts and commit diffs

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/git/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/git/index.js
@@ -83,6 +83,8 @@ function assertNotAFlag(value, label) {
 // abused (leading "-", "..", "@{", control chars, whitespace, ":", "?", "*",
 // "[", "\", "^", "~").
 var REFNAME_RE = /^[A-Za-z0-9_@][A-Za-z0-9_./+\-@]*$/;
+var STAGE_TREEISH_RE = /^:[0-3]$/;
+var REVSPEC_RE = /^(?:@|[A-Za-z0-9_@][A-Za-z0-9_./+\-@]*)(?:[~^][0-9]*)*$/;
 function assertValidRefname(value, label) {
     assertNotAFlag(value, label);
     // Allow '@' as a literal character (real-world branch names like
@@ -94,6 +96,27 @@ function assertValidRefname(value, label) {
         value.indexOf("@{") !== -1 ||
         /\.lock$/.test(value)) {
         throw badArg(value, label + " is not a valid git refname");
+    }
+}
+
+function assertValidTreeish(value, label) {
+    if (typeof value !== "string") {
+        throw badArg(value, label + " must be a string");
+    }
+    // `git show :1:path` / `:2:path` / `:3:path` read files from the index
+    // stages during merges. These are not refnames, but they are a valid and
+    // required treeish form for the editor's conflict-resolution flow.
+    if (STAGE_TREEISH_RE.test(value)) {
+        return;
+    }
+    // The editor also uses revision expressions such as `sha~1` when showing
+    // commit diffs and paginating history. Allow that limited revspec form
+    // while still rejecting git's more dangerous ref/query syntax.
+    if (!REVSPEC_RE.test(value) ||
+        value.indexOf("..") !== -1 ||
+        value.indexOf("@{") !== -1 ||
+        /\.lock$/.test(value)) {
+        throw badArg(value, label + " is not a valid git revision");
     }
 }
 
@@ -692,7 +715,7 @@ module.exports = {
     },
     getStatus: getStatus,
     getFile: function(cwd, filePath, treeish) {
-        assertValidRefname(treeish, "treeish");
+        assertValidTreeish(treeish, "treeish");
         assertNotAFlag(filePath, "file path");
         // git show does not honor -- as end-of-options for the <rev>:<path> form;
         // safety comes from validating treeish as a refname and filePath as not-a-flag.
@@ -784,8 +807,8 @@ module.exports = {
         if (before) {
             // "before" is a commit sha/ref used as a pagination cursor.
             // git log does not honor -- here (it would treat the sha as a pathspec);
-            // safety comes from validating before as a refname.
-            assertValidRefname(before, "before");
+            // safety comes from validating before as a limited revision spec.
+            assertValidTreeish(before, "before");
             args.push(before);
         }
         var commands = [

--- a/test/unit/@node-red/runtime/lib/storage/localfilesystem/projects/index_spec.js
+++ b/test/unit/@node-red/runtime/lib/storage/localfilesystem/projects/index_spec.js
@@ -14,8 +14,55 @@
  * limitations under the License.
  **/
 
-var NR_TEST_UTILS = require("nr-test-utils");
+var should = require("should");
+var sinon = require("sinon");
 
-describe("storage/localfilesystem/projects/index", function() {
-    it.skip("NEEDS TESTS WRITING",function() {});
-})
+var NR_TEST_UTILS = require("nr-test-utils");
+var gitTools = NR_TEST_UTILS.require("@node-red/runtime/lib/storage/localfilesystem/projects/git");
+var util = NR_TEST_UTILS.require("@node-red/util");
+
+describe("storage/localfilesystem/projects/git/index", function() {
+    afterEach(function() {
+        sinon.restore();
+    });
+
+    it("allows git index stage selectors when reading conflicted files", async function() {
+        var runStub = sinon.stub(util.exec, "run").resolves({ stdout: "content" });
+
+        var content = await gitTools.getFile("/tmp/project", "flows.json", ":1");
+
+        content.should.equal("content");
+        runStub.calledOnce.should.be.true();
+        runStub.firstCall.args[0].should.equal("git");
+        runStub.firstCall.args[1].should.containEql("show");
+        runStub.firstCall.args[1].should.containEql(":1:flows.json");
+    });
+
+    it("continues to reject invalid treeish values when reading files", async function() {
+        (function() {
+            gitTools.getFile("/tmp/project", "flows.json", "--upload-pack=evil");
+        }).should.throw(/treeish is not a valid git revision/);
+    });
+
+    it("allows limited revision expressions when reading files", async function() {
+        var runStub = sinon.stub(util.exec, "run").resolves({ stdout: "content" });
+
+        var content = await gitTools.getFile("/tmp/project", "flows.json", "abc123~1");
+
+        content.should.equal("content");
+        runStub.calledOnce.should.be.true();
+        runStub.firstCall.args[1].should.containEql("show");
+        runStub.firstCall.args[1].should.containEql("abc123~1:flows.json");
+    });
+
+    it("allows limited revision expressions for commit history pagination", async function() {
+        var runStub = sinon.stub(util.exec, "run");
+        runStub.onFirstCall().resolves({ stdout: "10" });
+        runStub.onSecondCall().resolves({ stdout: "" });
+
+        var result = await gitTools.getCommits("/tmp/project", { before: "abc123~1", limit: 20 });
+
+        result.should.have.property("before", "abc123~1");
+        runStub.secondCall.args[1].should.containEql("abc123~1");
+    });
+});


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

This fixes a regression in the projects git helper introduced by the argument-sanitising change in `8011f1a12` (`Sanitize all args passed to projects/git api`).

That change updated `getFile()` to validate `treeish` as a plain git refname. However, the existing editor flows use a small set of git revision expressions that are not plain refnames:

- merge conflict resolution reads conflicted files via index stages `:1`, `:2`, `:3`
- commit diff views fetch the previous version of a flow file via `sha~1`
- commit history pagination uses `lastSha~1` as the cursor

Because those values were rejected by the new validation, the editor would silently fail to load the expected file revision and fall back to empty flow content. That showed up as bugs such as:

- merge conflict flow diffs showing empty flow and no unresolved conflicts
- saving a resolved flow conflict would delete the flow
- move-only commits showing the whole flow as `flow added` in the commit diff

This PR keeps the argument hardening in place, but narrows the fix to allow the limited git revision forms the editor already depends on:

- stage selectors `:0`..`:3`
- simple ancestry expressions such as `sha~1` / `sha^`

It also updates commit-history pagination to use the same limited revision validation.

Tests have been added to cover:

- reading conflicted files with stage selectors
- rejecting invalid revision input
- reading files with `sha~1`
- commit pagination with `before=sha~1`

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [x] I have run `npm run test` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
