### PR TITLE
Close notification using the `escape` key

### DIFF
--- a/packages/node_modules/@node-red/editor-client/locales/fr/editor.json
+++ b/packages/node_modules/@node-red/editor-client/locales/fr/editor.json
@@ -1503,6 +1503,8 @@
     "unlock-flow": "Déverrouiller le flux",
     "show-node-help": "Afficher l'aide du noeud",
     "trigger-selected-nodes-action": "Déclencher l'action des noeuds sélectionnés",
-    "show-explorer-tab": "Afficher l'onglet explorateur"
+    "show-explorer-tab": "Afficher l'onglet explorateur",
+    "close-first-notification": "Fermer la première notification",
+    "close-all-notifications": "Fermer toutes les notifications"
   }
 }

--- a/packages/node_modules/@node-red/editor-client/src/js/keymap.json
+++ b/packages/node_modules/@node-red/editor-client/src/js/keymap.json
@@ -1,6 +1,6 @@
 {
     "*": {
-        "alt-shift-p":"core:manage-palette",
+        "alt-shift-p": "core:manage-palette",
         "ctrl-f": "core:search",
         "ctrl-shift-f": "core:list-flows",
         "ctrl-d": "core:deploy-flows",
@@ -22,7 +22,7 @@
         "ctrl-alt-n": "core:new-project",
         "ctrl-alt-o": "core:open-project",
         "ctrl-shift-l": "core:show-event-log",
-        "ctrl-shift-p":"core:show-action-list"
+        "ctrl-shift-p": "core:show-action-list"
     },
     "red-ui-sidebar-node-config": {
         "backspace": "core:delete-config-selection",
@@ -95,9 +95,13 @@
         "ctrl--": "core:zoom-out",
         "ctrl-0": "core:zoom-reset",
         "ctrl-1": "core:zoom-fit"
-     },
-     "red-ui-editor-stack": {
+    },
+    "red-ui-editor-stack": {
         "ctrl-enter": "core:confirm-edit-tray",
         "ctrl-escape": "core:cancel-edit-tray"
-     }
+    },
+    "red-ui-notifications": {
+        "escape": "core:close-first-notification",
+        "ctrl-escape": "core:close-all-notifications"
+    }
 }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/notifications.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/notifications.js
@@ -143,6 +143,7 @@ RED.notifications = (function() {
         }
         // Move focus to the notification when it has actions or is modal —
         // transient toasts must not steal focus.
+        $(n).attr("tabindex", "-1").trigger('focus');
         if (options.modal || options.buttons) {
             setTimeout(function() {
                 var firstButton = $(n).find('button:visible:first');
@@ -334,6 +335,20 @@ RED.notifications = (function() {
                 .on("click", function() {
                     showPersistent();
                 })
+
+            RED.actions.add("core:close-first-notification", function () {
+                const firstNotification = currentNotifications[0]
+                if (firstNotification) {
+                    firstNotification.close()
+                }
+            })
+            RED.actions.add("core:close-all-notifications", function () {
+                for (const notification of currentNotifications.slice()) {
+                    if (notification) {
+                        notification.close()
+                    }
+                }
+            })
         },
         notify: notify,
         shade: shade


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Request from: https://discourse.nodered.org/t/escape-key-closes-notification/101315

- Close the first notification using the `escape` key.
- Close all notifications using the `ctrl-escape` key.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality