### PR TITLE
Add a button to ignore the import of unknown types

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/nodes.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/nodes.js
@@ -2078,7 +2078,7 @@ RED.nodes = (function() {
                 notificationOptions.buttons = [
                     {
                         text: RED._("palette.editor.installAll"),
-                        class: "primary",
+                        class: "primary pull-right",
                         click: function(e) {
                             unknownNotification.close();
 
@@ -2102,7 +2102,13 @@ RED.nodes = (function() {
                                 filter: '"' + missingModules.join('", "') + '"'
                             });
                         }
-                    }
+                    },
+                    {
+                        text: RED._("deploy.confirm.button.ignore"),
+                        click: function(e) {
+                            unknownNotification.close();
+                        }
+                    },
                 ]
                 let moduleList = $("<ul>");
                 missingModules.forEach(function(t) {


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Request from: https://discourse.nodered.org/t/node-red-5-now-available/101239/64

Add a button to ignore the import of unknown types.

Allow to import a flow without having to install the missing modules.

Preview:

<img width="512" height="203" alt="Capture d’écran 2026-06-19 à 12 54 51" src="https://github.com/user-attachments/assets/190b3aa1-2836-4261-8dec-ae99375496db" />


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
