### PR TITLE
[5839] NR5: info popover does not support node.info()

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1254,7 +1254,15 @@ RED.view = (function() {
                 docsBadge.appendChild(pageLines)
                 return docsBadge;
             },
-            show: function(n) { return showNodeInfo && !!n.info },
+            show: function(n) {
+                if (!showNodeInfo) { return false }
+                if (n.info) { return true }
+                if (n._def && n._def.info) {
+                    const info = n._def.info
+                    return !!(typeof info === "function" ? info.call(n) : info)
+                }
+                return false
+            },
             popover: {
                 content: function(n, popoverInstance) {
                     // This is called when popover is triggered. It should return the content for the popover when the badge is clicked.
@@ -1263,7 +1271,19 @@ RED.view = (function() {
                     // The popover mimics the sidebar info panel layout: a `red-ui-sidebar-section` rounded container
                     // with a `red-ui-sidebar-banner` header containing a label and a button to open the editor's
                     // description tab.
-                    if (!n.info) { return null }
+
+                    // Mirror the sidebar info panel: combine the node definition's `info`
+                    // (which may be a string or a function) with the user-set `info`.
+                    let infoText = ""
+                    if (n._def && n._def.info) {
+                        const info = n._def.info
+                        const textInfo = (typeof info === "function" ? info.call(n) : info)
+                        infoText += RED.utils.renderMarkdown(textInfo)
+                    }
+                    if (n.info) {
+                        infoText += RED.utils.renderMarkdown(n.info || "")
+                    }
+                    if (!infoText) { return null }
 
                     const editInfo = function() {
                         if (popoverInstance) { popoverInstance.close() }
@@ -1291,7 +1311,7 @@ RED.view = (function() {
                         })
                     }
                     const body = $('<div class="red-ui-flow-annotation-popover-body"></div>').appendTo(section)
-                    RED.utils.renderInfoText(RED.utils.renderMarkdown(n.info), body, { collapseSections: false });
+                    RED.utils.renderInfoText(infoText, body, { collapseSections: false });
 
                     // Resolve data-i18n attributes on content
                     section.i18n()


### PR DESCRIPTION


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Resolves https://github.com/node-red/node-red/issues/5839

The flow node info popover only rendered the user-set node.info, ignoring the node definition's _def.info (which may be a string or a function). So it now combines both to match the sidebar Info panel, with the docs badge appearing only when that resolved content is non-empty.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
