### PR TITLE
Handle repositioning tooltip when aligned to top

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
@@ -335,7 +335,18 @@ RED.popover = (function() {
             } else if (direction === 'top') {
                 top = targetPos.top-deltaSizes[size].y-divHeight-popupOffset;
                 left = targetPos.left+targetWidth/2-divWidth/2;
-                if (top < 0) {
+                if (left < 0) {
+                    direction = "right";
+                    top = targetPos.top+targetHeight/2-divHeight/2;
+                    left = targetPos.left+targetWidth+deltaSizes[size].x+popupOffset;
+                } else if (left+divWidth+paddingRight > viewportRight) {
+                    direction = "left";
+                    top = targetPos.top+targetHeight/2-divHeight/2;
+                    left = targetPos.left-deltaSizes[size].x-divWidth-popupOffset;
+                    if (top+divHeight+targetHeight/2 + 5 > viewportBottom) {
+                        top -= (top+divHeight+targetHeight/2 - viewportBottom + 5)
+                    }
+                } else if (top < 0) {
                     // Check if flipping to bottom has vertical space
                     const topOverlap = -top;
                     const newTop = targetPos.top+targetHeight+deltaSizes[size].y+popupOffset;


### PR DESCRIPTION
Fixes #5829 

The tooltip repositioning logic didn't handle a 'top' aligned tooltip that overlapped left/right edges. It does now,