### PR TITLE
Load images in info popup before positioning

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/popover.js
@@ -173,7 +173,7 @@ RED.popover = (function() {
 
         const popoverId = RED.nodes.id();
 
-        var openPopup = function(instant) {
+        var openPopup = async function(instant) {
             if (isOpen) {
                 return
             }
@@ -196,7 +196,7 @@ RED.popover = (function() {
                     div.addClass("red-ui-popover-size-"+size);
                 }
                 if (typeof content === 'function') {
-                    var result = content.call(res);
+                    var result = await content.call(res);
                     if (result === null) {
                         return;
                     }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/mermaid.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/mermaid.js
@@ -4,10 +4,14 @@ RED.editor.mermaid = (function () {
     let pendingEvals = []
     let diagramIds = 0
 
-    function render(selector = '.mermaid') {
+    function render(selector = '.mermaid', root = document) {
+        if (selector instanceof HTMLElement) {
+            root = selector
+            selector = '.mermaid'
+        }
         // $(selector).hide()
         if (!loaded) {
-            pendingEvals.push(selector)
+            pendingEvals.push({selector, root})
             
             if (!initializing) {
                 initializing = true
@@ -35,13 +39,13 @@ RED.editor.mermaid = (function () {
                         loaded = true
                         while(pendingEvals.length > 0) {
                             const pending = pendingEvals.shift()
-                            render(pending)
+                            render(pending.selector, pending.root)
                         }
                     }
                 });
             }
         } else {
-            const nodes = document.querySelectorAll(selector)
+            const nodes = root.querySelectorAll(selector)
 
             nodes.forEach(async node => {
                 if (!node.getAttribute('mermaid-processed')) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/mermaid.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/mermaid.js
@@ -4,11 +4,12 @@ RED.editor.mermaid = (function () {
     let pendingEvals = []
     let diagramIds = 0
 
-    function render(selector = '.mermaid', root = document) {
-        if (selector instanceof HTMLElement) {
+    async function render(selector = '.mermaid', root = $(document)) {
+        if (selector instanceof jQuery) {
             root = selector
             selector = '.mermaid'
         }
+        const pendingRenders = []
         // $(selector).hide()
         if (!loaded) {
             pendingEvals.push({selector, root})
@@ -39,32 +40,36 @@ RED.editor.mermaid = (function () {
                         loaded = true
                         while(pendingEvals.length > 0) {
                             const pending = pendingEvals.shift()
-                            render(pending.selector, pending.root)
+                            pendingRenders.push(render(pending.selector, pending.root))
                         }
                     }
                 });
             }
         } else {
-            const nodes = root.querySelectorAll(selector)
+            const nodes = root[0].querySelectorAll(selector)
 
-            nodes.forEach(async node => {
-                if (!node.getAttribute('mermaid-processed')) {
-                    const mermaidContent = atob($(node).data('c64'))
-                    node.setAttribute('mermaid-processed', true)
-                    try {
-                        const { svg } = await mermaid.render('mermaid-render-'+Date.now()+'-'+(diagramIds++), mermaidContent);
-                        node.innerHTML = svg
-                    } catch (err) {
-                        $('<div>').css({
-                            fontSize: '0.8em',
-                            border: '1px solid var(--red-ui-border-color-error)',
-                            padding: '5px',
-                            marginBottom: '10px',
-                        }).text(err.toString()).prependTo(node)
+            nodes.forEach(node => {
+                const doRender = async () => {
+                    if (!node.getAttribute('mermaid-processed')) {
+                        const mermaidContent = atob($(node).data('c64'))
+                        node.setAttribute('mermaid-processed', true)
+                        try {
+                            const { svg } = await mermaid.render('mermaid-render-'+Date.now()+'-'+(diagramIds++), mermaidContent);
+                            node.innerHTML = svg
+                        } catch (err) {
+                            $('<div>').css({
+                                fontSize: '0.8em',
+                                border: '1px solid var(--red-ui-border-color-error)',
+                                padding: '5px',
+                                marginBottom: '10px',
+                            }).text(err.toString()).prependTo(node)
+                        }
                     }
                 }
+                pendingRenders.push(doRender())
             })
         }
+        return Promise.all(pendingRenders)
     }  
     function setTheme(isDark) {
         if (!loaded) { return; }

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1316,11 +1316,28 @@ RED.view = (function() {
                     // Resolve data-i18n attributes on content
                     section.i18n()
 
-                    // On the next tick, render any unrendered mermaid diagrams
-                    // (Already-rendered diagrams will be skipped via the `mermaid-processed` attribute)
-                    setTimeout(function() {
-                        RED.editor.mermaid.render()
-                    }, 0)
+                    RED.editor.mermaid.render(section[0])
+
+                    // Check for images - we need them to load so their size is known before the popover is positioned
+                    const imgs = section.find("img")
+                    if (imgs.length) {
+                        const imgPromises = []
+                        imgs.each(function() {
+                            const img = $(this)
+                            const imgPromise = new Promise((resolve, reject) => {
+                                img.on("load", function() {
+                                    resolve()
+                                })
+                                img.on("error", function() {
+                                    resolve()
+                                })
+                            })
+                            imgPromises.push(imgPromise)
+                        })
+                        return Promise.all(imgPromises).then(() => {
+                            return section
+                        })
+                    }
                     return section
                 },
                 width: 400

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -1316,12 +1316,11 @@ RED.view = (function() {
                     // Resolve data-i18n attributes on content
                     section.i18n()
 
-                    RED.editor.mermaid.render(section[0])
+                    const imgPromises = [RED.editor.mermaid.render(section)]
 
                     // Check for images - we need them to load so their size is known before the popover is positioned
                     const imgs = section.find("img")
                     if (imgs.length) {
-                        const imgPromises = []
                         imgs.each(function() {
                             const img = $(this)
                             const imgPromise = new Promise((resolve, reject) => {
@@ -1334,11 +1333,8 @@ RED.view = (function() {
                             })
                             imgPromises.push(imgPromise)
                         })
-                        return Promise.all(imgPromises).then(() => {
-                            return section
-                        })
                     }
-                    return section
+                    return Promise.all(imgPromises).then(() => section)
                 },
                 width: 400
             }


### PR DESCRIPTION
If a node's info contains an image (inc mermaid), we need it to be loaded before the popover calculates position.

This PR makes it so.

 - The `content` option for `popover` can now be an async function
 - The `mermaid.render()` api lets you points at a jQuery object rather than require it to be attached to the document
 - `mermaid.render()` is now async function that resolves when all renders have completed
 - The content code for the docs info popover checks for `<img>` and attaches load listeners to them all.
