### PR TITLE
Handle unknown node type properties in info properties table

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/tab-info.js
@@ -330,8 +330,8 @@ RED.sidebar.info = (function() {
                     if (defaults) {
                         for (var n in defaults) {
                             if (n != "name" && n != "info" && defaults.hasOwnProperty(n)) {
-                                var val = node[n];
-                                var type = typeof val;
+                                const val = node.type !== 'unknown' ? node[n] : node._orig[n];
+                                const type = typeof val;
                                 count++;
                                 propRow = $('<tr class="red-ui-help-info-property-row'+(expandedSections.property?"":" hide")+'"><td></td><td></td></tr>').appendTo(tableBody);
                                 $(propRow.children()[0]).text(n);


### PR DESCRIPTION
Fixes #5838 

Handles unknown node types when listing their properties.