### PR TITLE
Fix the hidden in-use module button on the palette

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/palette-editor.js
@@ -453,6 +453,7 @@ RED.palette.editor = (function() {
                     if (nodeEntries[module].totalUseCount > 0) {
                         nodeEntry.enableButton.text(RED._('palette.editor.inuse'));
                         nodeEntry.enableButton.addClass('disabled');
+                        nodeEntry.enableButton.show();
                         nodeEntry.removeButton.hide();
                     } else {
                         nodeEntry.enableButton.removeClass('disabled');


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes https://discourse.nodered.org/t/issue-with-the-palette-manager/101436.

The button is hidden (L380) when the module is added via the plugin handler (L870). It is not displayed again when the module is updated via the node handler (L821).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
