### PR TITLE
Fix CSV node to remove initial BOM char

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/parsers/70-CSV.js
+++ b/packages/node_modules/@node-red/nodes/core/parsers/70-CSV.js
@@ -520,16 +520,17 @@ module.exports = function(RED) {
 
                             // join lines, don't forget to add the last new line
                             msg.payload = stringBuilder.join(node.ret) + node.ret
-                            msg.columns = templateArrayToColumnString(template) // always strict commas + double quotes  for 
+                            msg.columns = templateArrayToColumnString(template) // always strict commas + double quotes  for
                             if (msg.payload !== '') { send(msg) }
                             done()
                         }
-                        catch (e) { 
+                        catch (e) {
                             done(e)
                         }
                     }
                     else if (typeof inputData == "string") { // convert CSV string to object
                         try {
+                            inputData = inputData.replace(/^\uFEFF/, ''); // remove any BOM character
                             let firstLine = true; // is this the first line
                             let last = false
                             let linecount = 0
@@ -669,7 +670,7 @@ module.exports = function(RED) {
                             done(e)
                         }
                     }
-                    else { 
+                    else {
                         // RFC-vs-legacy mode difference: In RFC mode, we throw catchable errors and provide a status message
                         const err = new Error(RED._("csv.errors.csv_js"))
                         node.status({ fill: "red", shape: "dot", text: err.message })


### PR DESCRIPTION
makes column parsing much cleaner if no hidden unwanted BOM char at start of file
see https://node-red.slack.com/archives/C0LBBMNRY/p1783118747637039
for discussion and reason


<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Removes an unwanted BOM char that many CSV exports (eg excel) add to the head of a CSV text file. This causes the column parser to include that char and so creates a column name with a hidden initial character. This fix removes any BOM char found at the beginning of the file.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
