### PR TITLE
fix tests for windows env

### DIFF
--- a/test/nodes/core/function/90-exec_spec.js
+++ b/test/nodes/core/function/90-exec_spec.js
@@ -127,6 +127,7 @@ describe('exec node', function() {
         it('should exec a simple command with appended value from message', function (done) {
             var flow = [{id:"n1", type:"exec", wires:[["n2"]], command:"echo", addpay:"topic", append:"more", oldrc:"false"},
                         {id:"n2", type:"helper"}];
+            var expected = (osType === "Windows_NT") ? "bar more\r\n" : "bar more\n";
             helper.load(execNode, flow, function () {
                 var n1 = helper.getNode("n1");
                 var n2 = helper.getNode("n2");
@@ -134,7 +135,7 @@ describe('exec node', function() {
                     try {
                         msg.should.have.property("payload");
                         msg.payload.should.be.a.String();
-                        msg.payload.should.equal("bar more\n");
+                        msg.payload.should.equal(expected);
                         done();
                     } catch(err) {
                         done(err)
@@ -710,7 +711,13 @@ describe('exec node', function() {
                     try {
                         msg.should.have.property("payload");
                         msg.payload.should.have.property("code");
-                        msg.payload.code.should.be.below(0);
+                        if (osType === "Windows_NT") {
+                            // On Windows the command runs via the shell (cmd.exe), which
+                            // reports an unknown command as a positive exit code (1).
+                            msg.payload.code.should.be.above(0);
+                        } else {
+                            msg.payload.code.should.be.below(0);
+                        }
                         done();
                     }
                     catch(err) { done(err); }
@@ -933,12 +940,15 @@ describe('exec node', function() {
                 var n3 = helper.getNode("n3");
                 var n4 = helper.getNode("n4");
                 var received = 0;
+                var finished = false;
                 var messages = [null,null];
                 var completeTest = function() {
                     if (messages[0] === null || messages[1] === null) {
                         // We have not yet had responses on both ports.
                         return
                     }
+                    if (finished) { return; }
+                    finished = true;
                     try {
                         var msg = messages[0];
                         msg.should.have.property("payload");
@@ -957,6 +967,12 @@ describe('exec node', function() {
                     }
                 };
 
+                // The failing command writes its diagnostic to stderr on Linux
+                // (mkdir) but to stdout on Windows (ping), so listen on both ports.
+                n2.on("input", function(msg) {
+                    messages[0] = msg;
+                    completeTest();
+                });
                 n3.on("input", function(msg) {
                     messages[0] = msg;
                     completeTest();

--- a/test/nodes/core/storage/10-file_spec.js
+++ b/test/nodes/core/storage/10-file_spec.js
@@ -99,7 +99,8 @@ describe('file Nodes', function() {
         });
 
         it('should write to a file using JSONata', function(done) {
-            var fileToTest4jsonata = "'" + resourcesDir + "/'&(20+30)&'-file-test-file.txt'";
+            // Use forward slashes: backslashes in a Windows path would be treated as escape sequences in a JSONata string literal
+            var fileToTest4jsonata = "'" + resourcesDir.replace(/\\/g,"/") + "/'&(20+30)&'-file-test-file.txt'";
             var flow = [{id:"fileNode1", type:"file", name: "fileNode", "filename": fileToTest4jsonata, "filenameType": "jsonata", "appendNewline":false, "overwriteFile":true, wires: [["helperNode1"]]},
                         {id:"helperNode1", type:"helper"}];
             helper.load(fileNode, flow, function() {
@@ -240,7 +241,7 @@ describe('file Nodes', function() {
                                 f.should.equal("Line1\nLine2\nLine3\nLine4");
                             }
                             else {
-                                f.should.have.length(23);
+                                f.should.have.length(26);
                                 f.should.equal("Line1\r\nLine2\r\nLine3\r\nLine4");
                             }
                             done();
@@ -1285,7 +1286,8 @@ describe('file Nodes', function() {
         });
 
         it('should read in a file using JSONata and output a utf8 string', function(done) {
-            var fileToTest4jsonata = "'" + resourcesDir + "/'&(20+30)&'-file-test-file.txt'";
+            // Use forward slashes: backslashes in a Windows path would be treated as escape sequences in a JSONata string literal
+            var fileToTest4jsonata = "'" + resourcesDir.replace(/\\/g,"/") + "/'&(20+30)&'-file-test-file.txt'";
             var flow = [{id:"fileInNode1", type:"file in", name: "fileInNode", "filename":fileToTest4jsonata, "filenameType": "jsonata", "format":"utf8", wires:[["n2"]]},
                         {id:"n2", type:"helper"}];
             helper.load(fileNode, flow, function() {

--- a/test/unit/@node-red/registry/lib/installer_spec.js
+++ b/test/unit/@node-red/registry/lib/installer_spec.js
@@ -276,7 +276,7 @@ describe('nodes/registry/installer', function() {
 
             installer.installModule("foo",null,"/example path/foo-0.1.1.tgz").then(function(info) {
                 const lastCallArgs = exec.run.lastCall.args[1];
-                lastCallArgs[0].should.match(/npm\/bin\/npm-cli\.js$/)
+                lastCallArgs[0].should.match(/npm[\\/]bin[\\/]npm-cli\.js$/)
                 const remainingArgs = lastCallArgs.slice(1);
                 remainingArgs.should.eql([ 'install', '--no-audit', '--no-update-notifier', '--no-fund', '--save', '--save-prefix=~', '--omit=dev', '--engine-strict', '--', '/example path/foo-0.1.1.tgz' ]);
                 info.should.eql(nodeInfo);

--- a/test/unit/_spec.js
+++ b/test/unit/_spec.js
@@ -40,8 +40,10 @@ var walkDirectory = function(dir) {
         var promises = [];
         list.forEach(function(file) {
             var filePath = path.join(dir,file);
+            // Normalise separators so the exclusion checks below work on Windows (\) as well as POSIX (/)
+            var normalisedPath = filePath.split(path.sep).join("/");
 
-            if (!/@node-red\/(editor-client|nodes)/.test(filePath) && !/node-red\/settings\.js/.test(filePath) && !/\/docs\//.test(filePath)) {
+            if (!/@node-red\/(editor-client|nodes)/.test(normalisedPath) && !/node-red\/settings\.js/.test(normalisedPath) && !/\/docs\//.test(normalisedPath)) {
                 promises.push(fs.stat(filePath).then(function(stat){
                     if (stat.isDirectory()) {
                         return walkDirectory(filePath).then(function(results) {


### PR DESCRIPTION
closes #5865



## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

**Fix cross-platform (Windows) test failures in `npm run test`**

These are all non-cross-platform-ready test issues (plus one genuine OS
difference in exit-code convention) rather than defects in runtime behaviour.

### 1. `test/unit/_spec.js:79` — "is checking if all .js files have a corresponding _spec.js test file."
The exclusion checks (`@node-red/(editor-client|nodes)`, `node-red/settings.js`,
`/docs/`) matched forward slashes only, but on Windows `path.join` produces `\`.
None of the editor-client/nodes files were excluded → hundreds of false
"missing _spec" errors. **Fix:** normalise the path to `/` before the regex tests.

### 2. `test/unit/@node-red/registry/lib/installer_spec.js:261` — "succeeds when file path is valid node-red module"
`/npm\/bin\/npm-cli\.js$/` cannot match `...\npm\bin\npm-cli.js`.
**Fix:** separator-agnostic `/npm[\\/]bin[\\/]npm-cli\.js$/`.

### 3. `test/nodes/core/function/90-exec_spec.js:127` — "should exec a simple command with appended value from message"
Windows `echo` appends `\r\n`, not `\n`. **Fix:** branch `expected` on `osType`.

### 4. `test/nodes/core/function/90-exec_spec.js:702` — "should return an error for a bad command" *(genuine OS difference)*
The exec node runs the command via the shell on Windows, and cmd.exe reports an
unknown command as exit code **1** (positive); Linux `spawn` without a shell
yields a negative code. **Fix:** assert `code > 0` on Windows, `code < 0` otherwise.

### 5. `test/nodes/core/function/90-exec_spec.js:924` — "should preserve existing properties on msg object for a failing command"
On Windows `ping /foo/bar/doo/dah` writes its diagnostic to **stdout**, but the
test only listened on the stderr port, so it waited forever (timeout).
**Fix:** listen on both stdout (n2) and stderr (n3), guarded against double `done()`.

### 6. `test/nodes/core/storage/10-file_spec.js:101` — "should write to a file using JSONata"
The test built a JSONata **string literal** by concatenating a Windows path, so
`\n`, `\t`, `\r` in `...\node-red\test\resources` were parsed as control
characters → mangled filename, write landed in the wrong directory.
**Fix:** `resourcesDir.replace(/\\/g,"/")` (forward slashes are valid for `fs`
on Windows and are not JSONata escapes).

### 7. `test/nodes/core/storage/10-file_spec.js:220` — "should append to a file and add newline, except last line of multipart input"
`"Line1\r\nLine2\r\nLine3\r\nLine4"` is 26 chars, not 23 (the POSIX `\n` count);
the sibling `equal` assertion already proved 26. **Fix:** `length(26)` in the
Windows branch.

### 8. `test/nodes/core/storage/10-file_spec.js:1288` — "should read in a file using JSONata and output a utf8 string"
Same JSONata backslash-escape problem as `#6`; the read then timed out because the
file never existed at the mangled path. **Fix:** same forward-slash conversion.

---

**Verification:** `mocha` over the four affected spec files → **250 passing, 0 failing**.


## Checklist


- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
