### PR TITLE
fix(network): prevent unhandled TypeError crash on invalid TCP payload type

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
+++ b/packages/node_modules/@node-red/nodes/core/network/31-tcpin.js
@@ -668,7 +668,15 @@ module.exports = function(RED) {
                             let event;
                             while (event = dequeue(clients[connection_id].msgQueue)) {
                                 if (event.msg.payload !== undefined) {
-                                    clients[connection_id].client.write(event.msg.payload);
+                                    if (typeof event.msg.payload !== 'string' && !Buffer.isBuffer(event.msg.payload) && !(event.msg.payload instanceof Uint8Array)) {
+                                        node.error(`TCP Out Invalid payload type: ${typeof event.msg.payload}. Expected Buffer, Uint8Array, or string.`, event.msg);
+                                    } else {
+                                        try {
+                                            clients[connection_id].client.write(event.msg.payload);
+                                        } catch (err) {
+                                            node.error(err, event.msg);
+                                        }
+                                    }
                                 }
                                 event.nodeDone();
                             }
@@ -870,7 +878,15 @@ module.exports = function(RED) {
                 if (clients[connection_id] && clients[connection_id].client) {
                     let event = dequeue(clients[connection_id].msgQueue)
                     if (event.msg.payload !== undefined ) {
-                        clients[connection_id].client.write(event.msg.payload);
+                        if (typeof event.msg.payload !== 'string' && !Buffer.isBuffer(event.msg.payload) && !(event.msg.payload instanceof Uint8Array)) {
+                            node.error(`TCP Out Invalid payload type: ${typeof event.msg.payload}. Expected Buffer, Uint8Array, or string.`, event.msg);
+                        } else {
+                            try {
+                                clients[connection_id].client.write(event.msg.payload);
+                            } catch (err) {
+                                node.error(err, event.msg);
+                            }
+                        }
                     }
                     event.nodeDone();
                 }

--- a/test/nodes/core/network/31-tcprequest_spec.js
+++ b/test/nodes/core/network/31-tcprequest_spec.js
@@ -351,5 +351,34 @@ describe('TCP Request Node', function() {
                 topic: 'quux'
             }, done);
         });
+
+        it('should handle payload mutation to number during connection without crashing and log an error', function(done) {
+            var flow = [{id:"n1", type:"tcp request", server:"localhost", port:port, out:"time", splitc: "0", wires:[["n2"]] },
+                        {id:"n2", type:"helper"}];
+            helper.load(tcpinNode, flow, function() {
+                var n1 = helper.getNode("n1");
+                var msg = { payload: Buffer.from("foo") };
+                n1.receive(msg);
+                // Mutate the payload to a number synchronously after enqueue but before connection callback runs
+                msg.payload = 2;
+
+                setTimeout(function() {
+                    try {
+                        helper.log().called.should.be.true();
+                        var logEvents = helper.log().args.filter(function (evt) {
+                            return evt[0].type == "tcp request";
+                        });
+                        logEvents.should.have.length(1);
+                        var logMsg = logEvents[0][0];
+                        logMsg.should.have.property('level', helper.log().ERROR);
+                        logMsg.should.have.property('id', 'n1');
+                        logMsg.msg.should.containEql('Invalid payload type: number');
+                        done();
+                    } catch (err) {
+                        done(err);
+                    }
+                }, 100);
+            });
+        });
     });
 });


### PR DESCRIPTION
### Summary
This PR fixes a Denial of Service (DoS) crash in the TCP Request / TCP Out nodes that occurs when a message's `payload` is mutated to an unsupported type (such as a `number` or `object`) after it has been enqueued but before it is written to the socket.

Node.js's internal `socket.write()` throws a synchronous `TypeError` when it receives an invalid argument type. Because this write operation runs asynchronously inside the network connection callback or event emitter context, the exception goes uncaught, causing Node-RED to crash.

### Changes
- **Strict Validation in `31-tcpin.js`**: Added validation to verify that `event.msg.payload` is either a `string`, a `Buffer`, or a `Uint8Array` before invoking `.write()`. If invalid, `node.error()` is called to log the issue safely.
- **Robust Exception Handling**: Wrapped the `.write()` call in a `try/catch` block to protect against any unexpected socket-level write exceptions.
- **Leak Prevention**: Kept the vital `event.nodeDone()` call intact to ensure Node-RED's message tracking lifecycle completes correctly under both valid and invalid payload branches.
- **Regression Unit Test in `31-tcprequest_spec.js`**: Added a test case that replicates the asynchronous mutation of `payload` to a number, confirming that it is safely rejected and logged as a node error without crashing Node-RED.

### Verification
Verified locally by running the Mocha test suite:
`npx mocha test/nodes/core/network/31-tcprequest_spec.js`
Result: All 17 tests passed successfully.
