### PR TITLE
fix: report missing plugin files

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/loader.js
+++ b/packages/node_modules/@node-red/registry/lib/loader.js
@@ -333,6 +333,10 @@ async function loadPluginConfig(fileInfo) {
             plugin.file = jsFile;
         }
     }
+    if (!plugin.file) {
+        plugin.err = "Error: "+file+" does not exist";
+        log.warn("["+plugin.id+"] "+plugin.err);
+    }
     if (fs.existsSync(htmlFile)) {
         plugin.template = htmlFile;
     }

--- a/test/unit/@node-red/registry/lib/loader_spec.js
+++ b/test/unit/@node-red/registry/lib/loader_spec.js
@@ -22,6 +22,7 @@ var fs = require("fs-extra");
 var NR_TEST_UTILS = require("nr-test-utils");
 
 var loader = NR_TEST_UTILS.require("@node-red/registry/lib/loader");
+var runtimeUtil = NR_TEST_UTILS.require("@node-red/util");
 
 var localfilesystem = NR_TEST_UTILS.require("@node-red/registry/lib/localfilesystem");
 var registry = NR_TEST_UTILS.require("@node-red/registry/lib/registry");
@@ -408,6 +409,39 @@ describe("red/nodes/registry/loader",function() {
 
                 nodes.registerType.called.should.be.false();
 
+                done();
+            }).catch(function(err) {
+                done(err);
+            });
+        });
+
+        it("reports a plugin that declares a missing runtime file", function(done) {
+            var pluginFile = path.join(resourcesDir,"doesnotexist","missing-plugin.js");
+            stubs.push(sinon.stub(localfilesystem,"getNodeFiles").callsFake(function(){
+                return {
+                    "node-red": {
+                        name: "node-red",
+                        version: "1.2.3",
+                        nodes: {},
+                        plugins: {
+                            "MissingPlugin": {
+                                file: pluginFile,
+                                module: "node-red",
+                                name: "MissingPlugin"
+                            }
+                        }
+                    }
+                };
+            }));
+
+            stubs.push(sinon.stub(registry,"saveNodeList").callsFake(function(){ return }));
+            stubs.push(sinon.stub(registry,"addModule").callsFake(function(){ return }));
+            stubs.push(sinon.stub(runtimeUtil.log,"warn"));
+            loader.init({nodes:nodes,settings:{available:function(){return true;}}});
+            loader.load().then(function() {
+                var module = registry.addModule.lastCall.args[0];
+                module.plugins.MissingPlugin.err.should.eql("Error: "+pluginFile+" does not exist");
+                runtimeUtil.log.warn.calledWith("[node-red/MissingPlugin] Error: "+pluginFile+" does not exist").should.be.true();
                 done();
             }).catch(function(err) {
                 done(err);


### PR DESCRIPTION
## Summary

- report a warning when a plugin declares a runtime file that is not present
- retain the load error so the invalid plugin is not treated as a plugin without a runtime component
- add a regression test covering the missing-file path

## Root cause

Plugin loading only set `plugin.file` when the declared JavaScript or CommonJS file existed. When neither file was present, the plugin was treated as having no runtime component and loading returned successfully without a diagnostic.

## Validation

- `npx mocha test/unit/_spec.js test/unit/@node-red/registry/lib/loader_spec.js`
- `npx eslint packages/node_modules/@node-red/registry/lib/loader.js test/unit/@node-red/registry/lib/loader_spec.js`

Fixes #5840.
