### PR TITLE
fix: support custom authorization tokens

### DIFF
--- a/packages/node_modules/@node-red/editor-api/lib/auth/index.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/index.js
@@ -61,7 +61,7 @@ function init(_settings,storage) {
 function needsPermission(permission) {
     return function(req,res,next) {
         if (settings && settings.adminAuth) {
-            return passport.authenticate(['bearer','tokens','anon'],{ session: false })(req,res,function() {
+            return passport.authenticate(['tokens','bearer','anon'],{ session: false })(req,res,function() {
                 if (!req.user) {
                     return next();
                 }

--- a/packages/node_modules/@node-red/editor-api/lib/auth/strategies.js
+++ b/packages/node_modules/@node-red/editor-api/lib/auth/strategies.js
@@ -138,8 +138,12 @@ function authenticateUserToken(req) {
             reject();
             return;
         } else if (Users.tokenHeader() === 'authorization') {
-            if (req.headers.authorization && req.headers.authorization.split(' ')[0] === 'Bearer') {
-                token = req.headers.authorization.split(' ')[1];
+            if (req.headers.authorization) {
+                if (req.headers.authorization.split(' ')[0] === 'Bearer') {
+                    token = req.headers.authorization.split(' ')[1];
+                } else {
+                    token = req.headers.authorization;
+                }
             }
         } else {
             token = req.headers[Users.tokenHeader()];

--- a/test/unit/@node-red/editor-api/lib/auth/index_spec.js
+++ b/test/unit/@node-red/editor-api/lib/auth/index_spec.js
@@ -168,6 +168,7 @@ describe("api/auth/index",function() {
 
         it('passes for valid user permission', function(done) {
             sinon.stub(passport,"authenticate").callsFake(function(scopes,opts) {
+                scopes.should.eql(['tokens','bearer','anon']);
                 return function(req,res,next) {
                     next();
                 }

--- a/test/unit/@node-red/editor-api/lib/auth/strategies_spec.js
+++ b/test/unit/@node-red/editor-api/lib/auth/strategies_spec.js
@@ -177,6 +177,23 @@ describe("api/auth/strategies", function() {
             };
             strategies.tokensStrategy.authenticate({headers:{"authorization":"Bearer 1234"}});
         });
+        it('Succeeds if tokens user enabled default header with a non-Bearer value',function(done) {
+            var userTokens = sinon.stub(Users,"tokens").callsFake(function(token) {
+                token.should.equal("custom-token");
+                return Promise.resolve("tokens-"+token);
+            });
+            var userTokenHeader = sinon.stub(Users,"tokenHeader").callsFake(function(token) {
+                return "authorization";
+            });
+            strategies.tokensStrategy._success = strategies.tokensStrategy.success;
+            strategies.tokensStrategy.success = function(user) {
+                user.should.equal("tokens-custom-token");
+                strategies.tokensStrategy.success = strategies.tokensStrategy._success;
+                delete strategies.tokensStrategy._success;
+                done();
+            };
+            strategies.tokensStrategy.authenticate({headers:{"authorization":"custom-token"}});
+        });
         it('Fails if tokens user not enabled',function(done) {
             var userTokens = sinon.stub(Users,"tokens").callsFake(function() {
                 return Promise.resolve(null);


### PR DESCRIPTION
## Summary

- try the configured custom token strategy before the strict Bearer parser
- pass a non-Bearer `Authorization` header through to the configured `tokens` function
- preserve the existing Bearer token extraction and fallback behavior

## Root cause

`passport-http-bearer` rejects malformed or non-Bearer authorization headers before Node-RED's custom token strategy gets a chance to inspect them. The custom strategy also only extracted values from `Authorization` when the scheme was `Bearer`.

## Validation

- `npx mocha test/unit/_spec.js test/unit/@node-red/editor-api/lib/auth/index_spec.js test/unit/@node-red/editor-api/lib/auth/strategies_spec.js`
- `npx eslint packages/node_modules/@node-red/editor-api/lib/auth/index.js packages/node_modules/@node-red/editor-api/lib/auth/strategies.js test/unit/@node-red/editor-api/lib/auth/index_spec.js test/unit/@node-red/editor-api/lib/auth/strategies_spec.js`

Fixes #5595.
