### PR TITLE
fix: use websocket path for proxy

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
+++ b/packages/node_modules/@node-red/nodes/core/network/22-websocket.js
@@ -69,7 +69,7 @@ module.exports = function(RED) {
 
         node.startconn = function() {    // Connect to remote endpoint
             node.tout = null;
-            const prox = getProxyForUrl(node.brokerurl, RED.settings.proxyOptions);
+            const prox = getProxyForUrl(node.path, RED.settings.proxyOptions);
             let agent = undefined;
             if (prox) {
                 agent = new HttpsProxyAgent(prox);

--- a/test/nodes/core/network/22-websocket_spec.js
+++ b/test/nodes/core/network/22-websocket_spec.js
@@ -17,7 +17,8 @@
 var ws = require("ws");
 var should = require("should");
 var helper = require("node-red-node-test-helper");
-var websocketNode = require("nr-test-utils").require("@node-red/nodes/core/network/22-websocket.js");
+var NR_TEST_UTILS = require("nr-test-utils");
+var websocketNode = NR_TEST_UTILS.require("@node-red/nodes/core/network/22-websocket.js");
 
 var sockets = [];
 
@@ -389,6 +390,38 @@ describe('websocket Node', function() {
                     done();
                 });
 
+            });
+        });
+
+        it('should use the client path when resolving a proxy', function(done) {
+            var proxyHelper = NR_TEST_UTILS.require("@node-red/nodes/core/network/lib/proxyHelper");
+            var originalGetProxyForUrl = proxyHelper.getProxyForUrl;
+            var websocketNodePath = NR_TEST_UTILS.resolve("@node-red/nodes/core/network/22-websocket.js");
+            var clientPath = getWsUrl("/ws");
+            var proxyTarget;
+
+            proxyHelper.getProxyForUrl = function(target) {
+                proxyTarget = target;
+                return "";
+            };
+            delete require.cache[websocketNodePath];
+            var websocketNodeWithProxySpy = require(websocketNodePath);
+
+            var flow = [
+                { id: "server", type: "websocket-listener", path: "/ws" },
+                { id: "client", type: "websocket-client", path: clientPath },
+                { id: "out", type: "websocket out", client: "client" }
+            ];
+            helper.load(websocketNodeWithProxySpy, flow, function() {
+                try {
+                    proxyTarget.should.equal(clientPath);
+                    done();
+                } catch(err) {
+                    done(err);
+                } finally {
+                    proxyHelper.getProxyForUrl = originalGetProxyForUrl;
+                    delete require.cache[websocketNodePath];
+                }
             });
         });
 


### PR DESCRIPTION
## Summary

- resolve WebSocket proxy settings from the configured client URL
- add a regression test that verifies the proxy resolver receives that URL

## Root cause

The WebSocket client passed `node.brokerurl` to the proxy resolver. That field is not configured for WebSocket clients, so the resolver received `undefined` and never selected `ws_proxy` or `wss_proxy` settings.

## Validation

- `npx mocha test/nodes/core/network/22-websocket_spec.js`
- `npx eslint packages/node_modules/@node-red/nodes/core/network/22-websocket.js test/nodes/core/network/22-websocket_spec.js`

Fixes #5250.
