### PR TITLE
fix: default editor theme to auto

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/userSettings.js
@@ -189,7 +189,7 @@ RED.userSettings = (function() {
         {
             title: "menu.label.view.appearance",
             options: [
-                {setting:"view-dark-theme", local: true, label:"menu.label.view.darkThemeLabel", default: 'light', hidden: function() {
+                {setting:"view-dark-theme", local: true, label:"menu.label.view.darkThemeLabel", default: 'auto', hidden: function() {
                     return hasCustomTheme() && !customThemeOffersBothSchemes();
                 }, options: function(done) {
                     done([


### PR DESCRIPTION
## Summary

- default the editor appearance setting to `auto` instead of `light`

## Why

New installations without a stored `view-dark-theme` preference currently force the light scheme. The setting already supports `auto`, so using it as the default follows the operating system theme while preserving explicit user choices.

Closes #5854

## Validation

- executable source assertion confirms `view-dark-theme` defaults to `auto` and retains the `auto` option
- `git diff --check`

The repository's root test runner dependencies are not installed in this clean checkout, so its full suite was not run locally.