### PR TITLE
fix: release stale join callbacks

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
+++ b/packages/node_modules/@node-red/nodes/core/sequence/17-split.js
@@ -713,7 +713,8 @@ module.exports = function(RED) {
                             type:"object",
                             msg:RED.util.cloneMessage(msg),
                             send: send,
-                            dones: []
+                            dones: [],
+                            doneByKey: new Map()
                         };
                     }
                     else {
@@ -743,9 +744,17 @@ module.exports = function(RED) {
                     if (node.mode === "auto") { inflight[partId].prop = msg.parts.property; }
                     else { inflight[partId].prop = node.property; }
                 }
-                inflight[partId].dones.push(done);
-
                 var group = inflight[partId];
+                if (payloadType === 'object' && node.accumulate !== true) {
+                    var previousDone = group.doneByKey.get(propertyKey);
+                    if (previousDone) {
+                        group.dones.splice(group.dones.indexOf(previousDone), 1);
+                        previousDone();
+                    }
+                    group.doneByKey.set(propertyKey, done);
+                }
+                group.dones.push(done);
+
                 if (payloadType === 'buffer') {
                     if (property !== undefined) {
                         if (Buffer.isBuffer(property) || (typeof property === "string") || Array.isArray(property)) {

--- a/test/nodes/core/sequence/17-split_spec.js
+++ b/test/nodes/core/sequence/17-split_spec.js
@@ -684,6 +684,44 @@ describe('JOIN node', function() {
         });
     });
 
+    it('should release overwritten object message callbacks', function(done) {
+        var completeNode = require("nr-test-utils").require("@node-red/nodes/core/common/24-complete.js");
+        var flow = [{id:"n1", type:"join", wires:[["n2"]], count:2, build:"object", mode:"custom"},
+                    {id:"n2", type:"helper"},
+                    {id:"n3", type:"complete", scope:["n1"], uncaught:false, wires:[["n4"]]},
+                    {id:"n4", type:"helper"}];
+        helper.load([joinNode, completeNode], flow, function() {
+            var n1 = helper.getNode("n1");
+            var n2 = helper.getNode("n2");
+            var n4 = helper.getNode("n4");
+            var completedPayloads = [];
+            n4.on("input", function(msg) {
+                completedPayloads.push(msg.payload);
+                if (completedPayloads.length === 1) {
+                    completedPayloads.should.deepEqual([1]);
+                    setImmediate(function() {
+                        n1.receive({payload:3, topic:"rare"});
+                    });
+                }
+            });
+            n2.on("input", function(msg) {
+                try {
+                    msg.payload.should.deepEqual({frequent:2, rare:3});
+                }
+                catch(e) { done(e); }
+                setImmediate(function() {
+                    try {
+                        completedPayloads.should.deepEqual([1, 2, 3]);
+                        done();
+                    }
+                    catch(e) { done(e); }
+                });
+            });
+            n1.receive({payload:1, topic:"frequent"});
+            n1.receive({payload:2, topic:"frequent"});
+        });
+    });
+
     it('should merge objects', function(done) {
         var flow = [{id:"n1", type:"join", wires:[["n2"]], count:5, build:"merged", mode:"custom"},
                     {id:"n2", type:"helper"}];


### PR DESCRIPTION
Fixes #5101.

When a Join node is building an object, a later message for an existing key replaces the earlier value. The earlier message's completion callback was still retained until the whole object completed, which can grow without bound when one key is updated much more often than the others.

This releases the superseded callback immediately and keeps the callback for the current value. The callback lifecycle for other Join modes and accumulating object joins is unchanged.

Tests:

- `npx mocha test/nodes/core/sequence/17-split_spec.js`
- `npx eslint packages/node_modules/@node-red/nodes/core/sequence/17-split.js test/nodes/core/sequence/17-split_spec.js`