### PR TITLE
Fix group default fill and fill opacity values

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/dark-colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/dark-colors.scss
@@ -289,8 +289,8 @@ $diff-merge-header-background:          #0c1428;
 $diff-merge-header-border-color:        $border-1;
 
 // ── Node groups ──
-$group-default-fill:           rgba(255, 255, 255, 0.03);
-$group-default-fill-opacity:   1;
+$group-default-fill:           #ffffff;
+$group-default-fill-opacity:   0.03;
 $group-default-stroke:         #555555;
 $group-default-stroke-opacity: 1;
 $group-default-label-color:    $text-primary;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Fix the values for `$group-default-fill` and `$group-default-fill-opacity`.

Having a color with opacity in `$group-default-fill` or `$group-default-stroke` causes weird behavior in the color picker. Even though a `rgba` color is displayed correctly in the workspace, the color picker sometimes shows `none` as the color value.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
