### PR TITLE
feat: Formalise reusable functions with autocompletion, parameter hints, and click-through navigation

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/code-editors/monaco.js
@@ -57,6 +57,115 @@ RED.editor.codeEditor.monaco = (function() {
     let userSelectedTheme;
     let tsFuncData; //used to cache the original func.d.ts data for later use when updating linkcall targets
 
+    // Dynamic, per-context regions spliced into func.d.ts (eg `node.linkcall`'s viable
+    // targets, `node.import`'s per-library overloads). Each Function-node editor pushes
+    // itself as the current context while open; the innermost (topmost open) dialog's
+    // context wins, and popping on close restores whichever dialog is now topmost -
+    // this is what lets two Function-node dialogs be stacked (eg via ctrl+click
+    // navigation) without the inner one's dispose() deleting the outer's typings.
+    const typeDefRegions = {}; // name -> function(contextNode) -> region string (including its own #region/#endregion markers)
+    const funcTypeDefStack = []; // [{key, node}], innermost (topmost open dialog) last
+    let funcTypeDefsLib = null;
+
+    function registerTypeDefRegion(name, fn) {
+        typeDefRegions[name] = fn;
+        refreshFuncTypeDefs();
+    }
+    function buildFuncTypeDefs(contextNode) {
+        let data = tsFuncData;
+        for (const name in typeDefRegions) {
+            if (!typeDefRegions.hasOwnProperty(name)) { continue; }
+            const re = new RegExp("// #region:" + name + "[\\s\\S]*?// #endregion:" + name, "g");
+            let body;
+            try {
+                body = typeDefRegions[name](contextNode);
+            } catch (error) {
+                continue; //leave that region's existing markers/content untouched on error
+            }
+            if (typeof body === "string") {
+                data = data.replace(re, body);
+            }
+        }
+        return data;
+    }
+    function refreshFuncTypeDefs() {
+        if (!tsFuncData) { return; } //func.d.ts not fetched yet - nothing to splice into
+        const ctx = funcTypeDefStack.length ? funcTypeDefStack[funcTypeDefStack.length - 1].node : null;
+        if (funcTypeDefsLib) {
+            funcTypeDefsLib.dispose();
+            funcTypeDefsLib = null;
+        }
+        if (!ctx) { return; } //no Function-node editor currently open
+        const data = buildFuncTypeDefs(ctx);
+        funcTypeDefsLib = monaco.languages.typescript.javascriptDefaults.addExtraLib(data, 'file://types/node-red/func/index.d.ts');
+    }
+    function pushFuncTypeDefContext(key, node) {
+        funcTypeDefStack.push({ key: key, node: node });
+        refreshFuncTypeDefs();
+    }
+    function popFuncTypeDefContext(key) {
+        const index = funcTypeDefStack.findIndex(function (entry) { return entry.key === key; });
+        if (index > -1) { funcTypeDefStack.splice(index, 1); }
+        refreshFuncTypeDefs();
+    }
+    function buildLinkcallRegion(contextNode) {
+        const linkInNodes = RED.nodes.filterNodes({type:'link in'})
+        const viableLinkTargets = []
+        for (const target of linkInNodes) {
+            // links on same flow/subflow as caller node are valid targets
+            // however links inside a (different) subflow are not valid targets.
+            if (!contextNode || target.z === contextNode.z || !RED.nodes.subflow(target.z)) {
+                viableLinkTargets.push(target)
+            }
+        }
+        const targetsByName = [...new Set(viableLinkTargets.map(node => node.name || '').filter(name => name.length > 0))].map(s => JSON.stringify(s));
+        const targetsById = [...new Set(viableLinkTargets.map(node => node.id))].map(s => JSON.stringify(s));
+        const targets = [...targetsByName, ...targetsById].filter(s => s && s.length > 0).join("|") || 'string';
+        return `
+    // #region:linkcall
+    /**
+     * Utility function to call, a reusable flow defined as a subroutine (link-in ~ <nodes> ~ link-out).
+     * When the \`linkcall\` function resolves, it returns the \`msg\` object returned by the link-out
+     * (return) node of the subroutine.
+     *
+     * @param target - the name or ID of the target link-in subroutine to call
+     * @param {Object} msg - the message object to pass to the subroutine
+     * @param {Object} [options] - call options
+     * @param {number} [options.timeout=5000] - the maximum time to wait for a response (default: 5000ms)
+     * @param {boolean} [options.clone=true] - flag to indicate if the message should be cloned (default: true)
+     * @return {Promise<Object>} - resolves with the returned message
+     *
+     * @example Call "greeting-person" subroutine by name:
+     * \`\`\`javascript
+     * msg.payload = "Joe Bloggs";
+     * const resultMsg = await node.linkcall("greeting-person", msg, {timeout: 10000});
+     * msg.payload = resultMsg.payload; // payload = "Hello Joe Bloggs"
+     * return msg; // return updated msg
+     * \`\`\`
+     *
+     * @example Call "greeting-person" subroutine by node id:
+     * \`\`\`javascript
+     * msg.payload = "John Doe";
+     * const result = await node.linkcall("a1b2c3d4e5f6", msg); // result.payload will be "Hello John Doe"
+     * return result; // return new result object
+     * \`\`\`
+     */
+    static linkcall(target: ${targets}, msg: object, options?: { timeout?: number; clone?: boolean; [key: string]: any }): Promise<object>;
+    // #endregion:linkcall
+`
+    }
+    registerTypeDefRegion("linkcall", buildLinkcallRegion);
+
+    // Retained-model opt-out: models registered here survive the `editor:close`
+    // cleanup sweep below, which otherwise disposes every remaining Monaco model
+    // on the page whenever the tray stack empties. Used for long-lived virtual
+    // models (eg Function-node "library mode" source, used for node.import() typing)
+    // that must persist across dialog opens/closes, not just for the lifetime of
+    // one editor instance.
+    const retainedModelUris = new Set();
+    function retainModel(uri) { retainedModelUris.add(uri.toString()); }
+    function releaseModel(uri) { retainedModelUris.delete(uri.toString()); }
+
     //TODO: get from externalModules.js  For now this is enough for feature parity with ACE (and then some).
     const knownModules = {
         "assert": {package: "node", module: "assert", path: "node/assert.d.ts" },
@@ -146,6 +255,7 @@ RED.editor.codeEditor.monaco = (function() {
                     .done(function(data) {
                         if (libPath === "node-red/func.d.ts") {
                             tsFuncData = data; //cache the original func.d.ts data for later use when updating linkcall targets
+                            refreshFuncTypeDefs(); //self-heal: a Function-node dialog may already be open and have pushed a context before this fetch resolved
                         }
                         modulesCache[libPath] =  data;
                         if(!preloadOnly) {
@@ -163,6 +273,56 @@ RED.editor.codeEditor.monaco = (function() {
         }
     }
 
+    /**
+     * Ensure the `.d.ts` for each named module in `libs` ([{var, module}]) is loaded
+     * (fetched + cached/addExtraLib'd, shared globally like any other known module -
+     * see _loadModuleDTS), then build the `declare global { var <name>: typeof
+     * <name>_import; }` text mapping each configured variable name to its module's
+     * inferred shape. Calls `cb(declText)` once every named module is ready (or
+     * immediately with an empty string if `libs` is empty). This is the reusable
+     * core of the per-editor `refreshModuleLibs` below, factored out so it can also
+     * be used for contexts with no single "current editor" (eg Function-node
+     * "library mode" virtual models, which persist independently of any open dialog).
+     * @param {Array<{var:string, module:string}>} libs
+     * @param {object} loadedLibsTracker - a {JS:{},TS:{}} bookkeeping object, as used by _loadModuleDTS
+     * @param {function} cb
+     */
+    function buildModuleLibsDecl(libs, loadedLibsTracker, cb) {
+        if (!libs || libs.length === 0) { cb(""); return; }
+        var defs = [];
+        var imports = [];
+        var loadList = [];
+        Array.prototype.push.apply(loadList, libs); //avoid spread operator to prevent IE syntax error
+        var loadModules = {};
+        for (let index = 0; index < libs.length; index++) {
+            const lib = libs[index];
+            const varName = lib.var;
+            const moduleName = lib.module;
+            if (varName && moduleName) {
+                imports.push("import " + varName + "_import = require('" + moduleName + "');\n");
+                defs.push("var " + varName + ": typeof " + varName + "_import;\n");
+            }
+            var km = knownModules[moduleName];
+            loadModules[moduleName] = km || { package: "other", module: moduleName, path: "other/" + moduleName + ".d.ts" };
+        }
+        Object.values(loadModules).forEach(function(m) {
+            _loadModuleDTS(m, false, loadedLibsTracker, function(err, extraLib) {
+                loadList = loadList.filter(function(e) { return e.module !== extraLib.module; });
+                if (loadList.length === 0) {
+                    var _imports = imports.join("");
+                    var _defs = "\ndeclare global {\n" + defs.join("") + "\n}";
+                    cb(_imports + _defs);
+                }
+            });
+        });
+    }
+    // never disposed - a permanent (page-lifetime) cache of external-module type
+    // libs used by Function-node "library mode" nodes, mirroring how the built-in
+    // defaultServerSideTypes are preloaded once and never torn down
+    const libraryModuleLibsTracker = { JS: {}, TS: {} };
+    function getModuleLibsDecl(libs, cb) {
+        buildModuleLibsDecl(libs, libraryModuleLibsTracker, cb);
+    }
 
     function init(options) {
         //Handles orphaned models
@@ -175,6 +335,10 @@ RED.editor.codeEditor.monaco = (function() {
                 editor.dispose();
             });
             let models = monaco.editor.getModels()
+            // exclude models explicitly retained (eg long-lived virtual models used
+            // for Function-node "library mode" type inference) - these are expected
+            // to outlive any single editor/dialog and are cleaned up by their own owner
+            models = models.filter(model => !retainedModelUris.has(model.uri.toString()))
             if(models && models.length) {
                 console.warn("Cleaning up monaco models left behind. Any node that calls createEditor() should call .destroy().")
                 for (let index = 0; index < models.length; index++) {
@@ -927,7 +1091,16 @@ RED.editor.codeEditor.monaco = (function() {
         var compilerOptions = monaco.typescript.javascriptDefaults.getCompilerOptions();
         if (serverSideSuggestions) {
             compilerOptions.lib = ["esnext"]; //dont include DOM
+            // func.d.ts for Function-node editors is dynamically managed (see
+            // pushFuncTypeDefContext/refreshFuncTypeDefs, module-scope, further
+            // down) - registering it again here, tracked per-editor-instance in
+            // `loadedLibs`, would race/conflict with that: whichever registration
+            // ran most recently wins the shared extraLib slot, and this editor's
+            // own destroy() would dispose it out from under any other currently
+            // open Function-node dialog relying on it.
+            const isFunctionNodeEditor = options.node && options.node.type === 'function';
             defaultServerSideTypes.forEach(function(m) {
+                if (isFunctionNodeEditor && m === knownModules["node-red-func"]) { return; }
                 _loadModuleDTS(m, false, loadedLibs); //load common node+node-red types
             })
         } else {
@@ -939,103 +1112,40 @@ RED.editor.codeEditor.monaco = (function() {
         //check if extraLibs are to be loaded (e.g. fs or os)
         refreshModuleLibs(editorOptions.extraLibs)
 
-        // update func.d.ts definitions for up-to-date link-in target names in the node.linkcall() definition
-        if (tsFuncData && options.node && options.node.type === 'function') {
-            const getUpdatedLinkcallDefs = () => {
-                const linkInNodes = RED.nodes.filterNodes({type:'link in'})
-                const viableLinkTargets = []
-                for (const target of linkInNodes) {
-                    // links on same flow/subflow as caller node are valid targets
-                    // however links inside a (different) subflow are not valid targets.
-                    if (target.z === options.node.z || !RED.nodes.subflow(target.z)) {
-                        viableLinkTargets.push(target)
-                    }
-                }
-                const targetsByName = [...new Set(viableLinkTargets.map(node => node.name || '').filter(name => name.length > 0))].map(s => JSON.stringify(s));
-                const targetsById = [...new Set(viableLinkTargets.map(node => node.id))].map(s => JSON.stringify(s));
-                const targets = [...targetsByName, ...targetsById].filter(s => s && s.length > 0).join("|") || 'string';
-                return `
-    // #region:linkcall
-    /**
-     * Utility function to call, a reusable flow defined as a subroutine (link-in ~ <nodes> ~ link-out).
-     * When the \`linkcall\` function resolves, it returns the \`msg\` object returned by the link-out
-     * (return) node of the subroutine.
-     * 
-     * @param {string} target - the name or ID of the target link-in subroutine to call
-     * @param {Object} msg - the message object to pass to the subroutine
-     * @param {Object} [options] - call options
-     * @param {number} [options.timeout=5000] - the maximum time to wait for a response (default: 5000ms)
-     * @param {boolean} [options.clone=true] - flag to indicate if the message should be cloned (default: true) 
-     * @return {Promise<Object>} - resolves with the returned message
-     * 
-     * @example Call "greeting-person" subroutine by name:
-     * \`\`\`javascript
-     * msg.payload = "Joe Bloggs";
-     * const resultMsg = await node.linkcall("greeting-person", msg, {timeout: 10000});
-     * msg.payload = resultMsg.payload; // payload = "Hello Joe Bloggs"
-     * return msg; // return updated msg
-     * \`\`\`
-     * 
-     * @example Call "greeting-person" subroutine by node id:
-     * \`\`\`javascript
-     * msg.payload = "John Doe";
-     * const result = await node.linkcall("a1b2c3d4e5f6", msg); // result.payload will be "Hello John Doe"
-     * return result; // return new result object
-     * \`\`\`
-     */
-    static linkcall(target: ${targets}, msg: object, options?: { timeout?: number; clone?: boolean; [key: string]: any }): Promise<object>;
-    // #endregion:linkcall
-`
+        // Push this editor as the current context for the dynamic func.d.ts regions
+        // (eg node.linkcall's viable targets, node.import's per-library overloads).
+        // The extraLib itself is owned at module scope (see pushFuncTypeDefContext/
+        // popFuncTypeDefContext above), not per-editor - with Function-node dialogs
+        // now able to stack (eg via ctrl+click navigation), disposing it in this
+        // editor's own destroy() would break a still-open dialog underneath it.
+        if (options.node && options.node.type === 'function') {
+            if (tsFuncData) {
+                pushFuncTypeDefContext(options.stateId, options.node);
+            } else {
+                // func.d.ts may not have been fetched yet (eg this is the very
+                // first Function-node editor created on the page) - ensure a fetch
+                // is in flight (or reuse the cached result/failure) rather than
+                // assuming some other, earlier code path already triggered one;
+                // preloadOnly=true since we only need tsFuncData populated, not a
+                // (now-unused, for Function editors) static addExtraLib registration
+                _loadModuleDTS(knownModules["node-red-func"], true, loadedLibs, function() {
+                    pushFuncTypeDefContext(options.stateId, options.node);
+                });
             }
-            const newDefs = getUpdatedLinkcallDefs();
-            data = tsFuncData.replace(/\/\/ #region:linkcall[\s\S]*?\/\/ #endregion:linkcall/g, newDefs);
-            if (loadedLibs.JS.func) {
-                loadedLibs.JS.func.dispose();
-                loadedLibs.JS.func = null;
-            }
-            loadedLibs.JS.func = monaco.languages.typescript.javascriptDefaults.addExtraLib(data, 'file://types/node-red/func/index.d.ts');
         }
 
         function refreshModuleLibs(extraModuleLibs) {
-            var defs = [];
-            var imports = [];
             const id = "extraModuleLibs/index.d.ts";
             const file = 'file://types/extraModuleLibs/index.d.ts';
             if(!extraModuleLibs || extraModuleLibs.length == 0) {
                 loadedLibs.JS[id] = monaco.typescript.javascriptDefaults.addExtraLib(" ", file);
-            } else {
-                var loadList = [];
-                Array.prototype.push.apply(loadList, extraModuleLibs);//Use this instead of spread operator to prevent IE syntax error
-                var loadExtraModules = {};
-                for (let index = 0; index < extraModuleLibs.length; index++) {
-                    const lib = extraModuleLibs[index];
-                    const varName = lib.var;
-                    const moduleName = lib.module;
-                    if(varName && moduleName) {
-                        imports.push("import " + varName + "_import = require('" + moduleName + "');\n");
-                        defs.push("var " + varName + ": typeof " + varName + "_import;\n");
-                    }
-                    var km = knownModules[moduleName];
-                    if(km) {
-                        loadExtraModules[moduleName] = km;
-                    } else {
-                        loadExtraModules[moduleName] = {package: "other", module: moduleName, path: "other/" +  moduleName + ".d.ts" };
-                    }
-                }
-                Object.values(loadExtraModules).forEach(function(m) {
-                    _loadModuleDTS(m, false, loadedLibs, function(err, extraLib) {
-                        loadList = loadList.filter(function(e) {return e.module != extraLib.module} );
-                        if(loadList.length == 0) {
-                            var _imports = imports.join("");
-                            var _defs  = "\ndeclare global {\n" + defs.join("") + "\n}";
-                            var libSource = _imports + _defs;
-                            setTimeout(function() {
-                                loadedLibs.JS[id] = monaco.typescript.javascriptDefaults.addExtraLib(libSource, file);
-                            }, 500);
-                        }
-                    });
-                });
+                return;
             }
+            buildModuleLibsDecl(extraModuleLibs, loadedLibs, function(libSource) {
+                setTimeout(function() {
+                    loadedLibs.JS[id] = monaco.typescript.javascriptDefaults.addExtraLib(libSource, file);
+                }, 500);
+            });
         }
 
         //#endregion
@@ -1165,6 +1275,9 @@ RED.editor.codeEditor.monaco = (function() {
 
         ed.destroy = function destroy() {
             if(watchTimer) { clearInterval(watchTimer); }
+            if (options.node && options.node.type === 'function') {
+                popFuncTypeDefContext(options.stateId);
+            }
             try {
                 //dispose serverside addExtraLib disposible we added - this is the only way (https://github.com/microsoft/monaco-editor/issues/1002#issuecomment-564123586)
                 if(Object.keys(loadedLibs.JS).length) {
@@ -1548,6 +1661,51 @@ RED.editor.codeEditor.monaco = (function() {
          * @param {object} options - the editor options
          * @memberof RED.editor.codeEditor.monaco
          */
-        create: create
+        create: create,
+        /**
+         * Register a named, dynamically-rebuilt region to splice into func.d.ts
+         * (replacing the matching `// #region:name ... // #endregion:name` markers)
+         * whenever a Function-node editor is open. `fn` is called with the current
+         * topmost open Function node and must return the full replacement region
+         * text, including its own region markers.
+         * @param {string} name - region name (matches the marker comments in func.d.ts)
+         * @param {function} fn - function(contextNode) -> string
+         * @memberof RED.editor.codeEditor.monaco
+         */
+        registerTypeDefRegion: registerTypeDefRegion,
+        /**
+         * Force an immediate rebuild of the dynamic func.d.ts regions for whichever
+         * Function node is currently topmost. Registered regions are otherwise only
+         * rebuilt when a region is (re)registered or a Function-node editor context
+         * is pushed/popped - call this after something a region depends on changes
+         * (eg the set of known "library mode" Function nodes).
+         * @memberof RED.editor.codeEditor.monaco
+         */
+        refreshFuncTypeDefs: refreshFuncTypeDefs,
+        /**
+         * Mark a Monaco model as retained, exempting it from the `editor:close`
+         * cleanup sweep that otherwise disposes every orphaned model on the page.
+         * For long-lived virtual models that must outlive any single editor/dialog.
+         * @param {monaco.Uri} uri
+         * @memberof RED.editor.codeEditor.monaco
+         */
+        retainModel: retainModel,
+        /**
+         * Undo `retainModel` - the model will be disposed by the next `editor:close`
+         * cleanup sweep if not disposed explicitly first.
+         * @param {monaco.Uri} uri
+         * @memberof RED.editor.codeEditor.monaco
+         */
+        releaseModel: releaseModel,
+        /**
+         * Ensure the `.d.ts` for each named module in `libs` ([{var, module}]) is
+         * loaded (shared/cached globally, permanently for the page's lifetime), then
+         * build the `declare global {...}` text mapping each configured variable
+         * name to its module's inferred shape. Calls `cb(declText)` once ready.
+         * @param {Array<{var:string, module:string}>} libs
+         * @param {function} cb
+         * @memberof RED.editor.codeEditor.monaco
+         */
+        getModuleLibsDecl: getModuleLibsDecl
     }
 })();

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editors/js.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editors/js.js
@@ -69,6 +69,7 @@
                         id: 'node-input-js',
                         mode: options.mode || 'ace/mode/javascript',
                         stateId: options.stateId,
+                        node: options.node,
                         focus: true,
                         value: value,
                         globals: {

--- a/packages/node_modules/@node-red/editor-client/src/types/node-red/func.d.ts
+++ b/packages/node_modules/@node-red/editor-client/src/types/node-red/func.d.ts
@@ -109,7 +109,7 @@ declare class node {
      * return msg;
      * ```
      */
-    static import(target: string): any;
+    static readonly import: (target: string) => any;
     // #endregion:import
     // #region:onclose
     /**
@@ -139,7 +139,7 @@ declare class node {
      * });
      * ```
      */
-    static onClose(fn: (() => void) | ((done: () => void) => void) | ((removed: boolean, done: () => void) => void)): void;
+    static readonly onClose: (fn: (() => void) | ((done: () => void) => void) | ((removed: boolean, done: () => void) => void)) => void;
     // #endregion:onclose
     /** the id of this node */
     public static readonly id:string;

--- a/packages/node_modules/@node-red/editor-client/src/types/node-red/func.d.ts
+++ b/packages/node_modules/@node-red/editor-client/src/types/node-red/func.d.ts
@@ -87,6 +87,30 @@ declare class node {
      */
     static linkcall(target: string, msg: object, options?: { timeout?: number; clone?: boolean; [key: string]: any }): Promise<object>;
     // #endregion:linkcall
+    // #region:import
+    /**
+     * Import the exports of another Function node running in "module" mode.
+     *
+     * @param target - the name or ID of the target module Function node
+     * @return the target node's `module.exports` object - a live reference, resolved
+     * fresh on every call (do not cache the result across a redeploy of the target)
+     *
+     * @example Import a module by name and call one of its exported functions:
+     * ```javascript
+     * const mathlib = node.import("mathlib");
+     * msg.payload = mathlib.add(1, 2);
+     * return msg;
+     * ```
+     *
+     * @example Import a module by node id:
+     * ```javascript
+     * const mathlib = node.import("a1b2c3d4e5f6");
+     * msg.payload = mathlib.add(1, 2);
+     * return msg;
+     * ```
+     */
+    static import(target: string): any;
+    // #endregion:import
     /** the id of this node */
     public static readonly id:string;
     /** the name of this node */

--- a/packages/node_modules/@node-red/editor-client/src/types/node-red/func.d.ts
+++ b/packages/node_modules/@node-red/editor-client/src/types/node-red/func.d.ts
@@ -111,6 +111,36 @@ declare class node {
      */
     static import(target: string): any;
     // #endregion:import
+    // #region:onclose
+    /**
+     * Module mode only. Register a function to run when this node is stopped,
+     * deleted, or re-deployed - the Module-mode equivalent of the "On Stop" tab.
+     *
+     * `fn` may be declared with 0, 1 or 2 parameters, matching Node-RED's standard
+     * node `close` event: `fn()` runs synchronously; `fn(done)` or
+     * `fn(removed, done)` may run asynchronously - the node is not considered
+     * fully closed until `done()` is called. `removed` is `true` if the node has
+     * been deleted, or `false` if it is just being restarted/re-deployed.
+     *
+     * Can be called more than once to register multiple independent cleanup
+     * functions.
+     *
+     * @example Synchronous cleanup:
+     * ```javascript
+     * node.onClose(function () {
+     *     clearInterval(pollHandle);
+     * });
+     * ```
+     *
+     * @example Asynchronous cleanup:
+     * ```javascript
+     * node.onClose(function (removed, done) {
+     *     connection.close().then(done).catch(done);
+     * });
+     * ```
+     */
+    static onClose(fn: (() => void) | ((done: () => void) => void) | ((removed: boolean, done: () => void) => void)): void;
+    // #endregion:onclose
     /** the id of this node */
     public static readonly id:string;
     /** the name of this node */

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.html
@@ -71,20 +71,20 @@
         <div style="display: inline-block; width: calc(100% - 105px)"><input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name"></div>
     </div>
 
-    <div class="form-row" id="func-mode-row">
-        <label for="node-input-mode"><i class="fa fa-cogs"></i> <span data-i18n="function.label.mode"></span></label>
-        <select id="node-input-mode" style="width: 250px">
-            <option value="default" data-i18n="function.mode.default"></option>
-            <option value="library" data-i18n="function.mode.library"></option>
-        </select>
-    </div>
-
     <div class="form-row func-tabs-row">
         <ul style="min-width: 600px; margin-bottom: 20px;" id="func-tabs"></ul>
     </div>
     <div id="func-tabs-content" style="min-height: calc(100% - 95px);">
 
         <div id="func-tab-config" style="display:none">
+            <div class="form-row" id="func-mode-row">
+                <label for="node-input-mode"><i class="fa fa-cogs"></i> <span data-i18n="function.label.mode"></span></label>
+                <select id="node-input-mode" style="width: 250px">
+                    <option value="default" data-i18n="function.mode.default"></option>
+                    <option value="library" data-i18n="function.mode.library"></option>
+                </select>
+            </div>
+
             <div id="func-message-options">
                 <div class="form-row" style="display: inline-block; margin-right: 50px;">
                     <label for="node-input-outputs"><i class="fa fa-random"></i> <span data-i18n="function.label.outputs"></span></label>
@@ -155,13 +155,476 @@
     RED.events.on("nodes:add", function(n) {
         if (n.type === "function") {
             knownFunctionNodes[n.id] = n;
+            scheduleLibraryModelSync();
         }
     })
     RED.events.on("nodes:remove", function(n) {
         if (n.type === "function") {
             delete knownFunctionNodes[n.id];
+            scheduleLibraryModelSync();
         }
     })
+    RED.events.on("nodes:change", function(n) {
+        // covers a library node's source being edited, its name changing, or its
+        // mode being toggled between default/library - oneditsave already emits
+        // this right after committing the node's new properties
+        if (n && n.type === "function") {
+            scheduleLibraryModelSync();
+        }
+    })
+    RED.events.on("flows:loaded", function() {
+        scheduleLibraryModelSync();
+    })
+    RED.events.on("workspace:clear", function() {
+        disposeAllLibraryModels();
+    })
+
+    // #region Function-node "library mode" editor tooling
+    //
+    // For every currently-known Function node in "library" mode, maintains a real
+    // (but never user-visible) Monaco model containing its Module/Setup source, so
+    // that:
+    //   - node.import()'s return type can be inferred by TypeScript's own CommonJS
+    //     module-shape inference (real inference, JSDoc included - not a hand-rolled
+    //     type scrape), and
+    //   - ctrl+click / alt+F12 on `node.import('name')` can navigate to (or preview)
+    //     the actual library node, via Monaco's sanctioned extension points
+    //     (registerDefinitionProvider + registerEditorOpener), redirecting "open this
+    //     resource" to RED.editor.edit(...) instead of Monaco's normal same-page
+    //     navigation.
+    //
+    // Entirely client-side/editor-only - no runtime involvement.
+
+    // "function" is this node's own type - factored out so the URI shape
+    // (file:///node/<type>/<id>.js) is already right if other node types ever
+    // want the same "virtual model of my real content" treatment.
+    var NR_NODE_TYPE = "function";
+    var LIBRARY_DIR = "file:///node/" + NR_NODE_TYPE + "/";
+    var libraryModels = {};       // nodeId -> { sid, uri, model, source }
+    var libraryUriToNodeId = {};  // uri.toString() -> nodeId
+    var libraryAliasLib = null;   // addExtraLib disposable for the type-alias file
+    var librarySyncTimer = null;
+    var libraryToolingReady = false;
+    var libraryModelSidsUsed = {}; // sid -> nodeId, for collision detection
+
+    // model URI -> owning node id, populated by buildEditor() for each of a Function
+    // node's 3 editors while its dialog is open (used to scope resolution to the
+    // caller's own flow/tab)
+    var libraryEditorNodeIds = {};
+
+    function monacoReady() {
+        var editor = RED.editor.codeEditor && RED.editor.codeEditor.editor;
+        return !!(window.monaco && editor && editor.type === "monaco" && editor.registerTypeDefRegion);
+    }
+    function isLibraryNode(n) {
+        return !!(n && n.type === "function" && n.mode === "library");
+    }
+    function librarySourceOf(n) {
+        var src = (n && n.initialize) || "";
+        // only nodes that actually assign module exports produce a usable module
+        // shape - and treating a script with no exports as a "module" would let its
+        // top-level const/let leak into the shared global scope of the one TS
+        // program every JS model on the page shares
+        return /(^|[^\w.$])(module\s*\.\s*exports|exports\s*\.)/.test(src) ? src : null;
+    }
+    // Two ways to mark a JSDoc block as documenting the module (library) as a
+    // whole, checked in priority order:
+    //  1. a comment containing an explicit `@module` tag, anywhere in the file -
+    //     lets the author place it wherever they like (eg at the top of the file)
+    //  2. failing that, a comment sitting directly (only whitespace between)
+    //     before `module.exports =` - the conventional/positional fallback
+    // In both regexes, `(?:(?!\*\/)[\s\S])*` (rather than a plain `[\s\S]*?`) stops
+    // the capture at the comment's OWN closing `*/`, so an unrelated earlier
+    // comment elsewhere in the file can never be mistaken for this one.
+    var MODULE_TAG_RE = /\/\*\*((?:(?!\*\/)[\s\S])*?@module\b(?:(?!\*\/)[\s\S])*)\*\//;
+    var MODULE_DOC_RE = /\/\*\*((?:(?!\*\/)[\s\S])*)\*\/\s*module\s*\.\s*exports\s*=/;
+    function extractModuleDoc(source) {
+        source = source || "";
+        var tagged = MODULE_TAG_RE.exec(source);
+        if (tagged) { return "/**" + tagged[1] + "*/"; }
+        var beforeExports = MODULE_DOC_RE.exec(source);
+        return beforeExports ? ("/**" + beforeExports[1] + "*/") : null;
+    }
+    function sanitiseId(id) {
+        var base = String(id).replace(/[^A-Za-z0-9_$]/g, "_");
+        var sid = base;
+        var n = 2;
+        while (libraryModelSidsUsed.hasOwnProperty(sid) && libraryModelSidsUsed[sid] !== id) {
+            sid = base + "_" + n;
+            n++;
+        }
+        libraryModelSidsUsed[sid] = id;
+        return sid;
+    }
+
+    function disposeLibraryModel(nodeId) {
+        var entry = libraryModels[nodeId];
+        if (!entry) { return; }
+        delete libraryModels[nodeId];
+        delete libraryUriToNodeId[entry.uri.toString()];
+        delete libraryModelSidsUsed[entry.sid];
+        RED.editor.codeEditor.editor.releaseModel(entry.uri);
+        if (!entry.model.isDisposed()) { entry.model.dispose(); }
+    }
+    function disposeAllLibraryModels() {
+        for (var id in libraryModels) {
+            if (libraryModels.hasOwnProperty(id)) { disposeLibraryModel(id); }
+        }
+        if (libraryAliasLib) { libraryAliasLib.dispose(); libraryAliasLib = null; }
+        if (libraryModuleDeclLib) { libraryModuleDeclLib.dispose(); libraryModuleDeclLib = null; }
+    }
+
+    function syncLibraryModels() {
+        librarySyncTimer = null;
+        if (!monacoReady()) { return; }
+        var changed = false;
+        var desiredIds = {};
+        for (var id in knownFunctionNodes) {
+            if (!knownFunctionNodes.hasOwnProperty(id)) { continue; }
+            var n = knownFunctionNodes[id];
+            if (!isLibraryNode(n)) { continue; }
+            var src = librarySourceOf(n);
+            if (src === null) { continue; }
+            desiredIds[id] = src;
+        }
+        // dispose models no longer wanted (node removed, mode flipped away, exports removed)
+        for (var existingId in libraryModels) {
+            if (libraryModels.hasOwnProperty(existingId) && !desiredIds.hasOwnProperty(existingId)) {
+                disposeLibraryModel(existingId);
+                changed = true;
+            }
+        }
+        // create/update models for desired entries
+        for (var wantedId in desiredIds) {
+            if (!desiredIds.hasOwnProperty(wantedId)) { continue; }
+            var source = desiredIds[wantedId];
+            var entry = libraryModels[wantedId];
+            if (!entry) {
+                // raw node id in the path (URI paths tolerate dots/hyphens fine);
+                // sanitised only where a valid TS identifier is actually required
+                var sid = sanitiseId(wantedId);
+                var uri = monaco.Uri.parse(LIBRARY_DIR + wantedId + ".js");
+                var model = monaco.editor.getModel(uri) || monaco.editor.createModel(source, "javascript", uri);
+                if (model.getValue() !== source) { model.setValue(source); }
+                RED.editor.codeEditor.editor.retainModel(uri);
+                entry = { sid: sid, uri: uri, model: model, source: source };
+                libraryModels[wantedId] = entry;
+                libraryUriToNodeId[uri.toString()] = wantedId;
+                changed = true;
+            } else if (entry.source !== source) {
+                entry.model.setValue(source);
+                entry.source = source;
+                changed = true;
+            }
+        }
+        if (changed) { refreshLibraryAliasLib(); }
+        // always refresh: names/flow-membership can change (affecting which literal
+        // strings are reachable) without any model's *source* changing
+        RED.editor.codeEditor.editor.refreshFuncTypeDefs();
+    }
+    function scheduleLibraryModelSync() {
+        registerLibraryTooling();
+        if (!monacoReady() || librarySyncTimer) { return; }
+        librarySyncTimer = setTimeout(syncLibraryModels, 50);
+    }
+
+    /**
+     * Mirrors the runtime's `functionLibrary.resolve()` ordering (id first, then
+     * name scoped to the caller's own flow, then flow-wide if unique) for
+     * navigation/type-completion purposes. Does not attempt the runtime's
+     * subflow-design-time-id step - a click inside a subflow instance simply
+     * degrades to "notfound", same as other client-side-only limitations already
+     * accepted in this feature.
+     * @param {string} target - a node id or name
+     * @param {string} [srcNodeId] - the calling node's id, for flow-scoping
+     * @returns {{status:"ok"|"ambiguous"|"notfound", nodeId?:string, candidates:string[]}}
+     */
+    function resolveLibraryTarget(target, srcNodeId) {
+        if (typeof target !== "string" || target.trim() === "") {
+            return { status: "notfound", candidates: [] };
+        }
+        target = target.trim();
+
+        if (isLibraryNode(knownFunctionNodes[target])) {
+            return { status: "ok", nodeId: target, candidates: [target] };
+        }
+
+        var srcNode = srcNodeId && RED.nodes.node(srcNodeId);
+        var srcZ = srcNode && srcNode.z;
+
+        var byName = [];
+        for (var id in knownFunctionNodes) {
+            if (!knownFunctionNodes.hasOwnProperty(id)) { continue; }
+            var n = knownFunctionNodes[id];
+            if (isLibraryNode(n) && (n.name || "").trim() === target) {
+                byName.push(n);
+            }
+        }
+        // viable: on the caller's own flow, or not inside any subflow at all
+        // (mirrors the same rule already applied to link-in targets)
+        var viable = byName.filter(function(n) {
+            return n.z === srcZ || !RED.nodes.subflow(n.z);
+        });
+        var sameFlow = viable.filter(function(n) { return n.z === srcZ; });
+        var candidates = sameFlow.length ? sameFlow : viable;
+
+        if (candidates.length === 1) {
+            return { status: "ok", nodeId: candidates[0].id, candidates: [candidates[0].id] };
+        }
+        if (candidates.length > 1) {
+            return { status: "ambiguous", candidates: candidates.map(function(n) { return n.id; }) };
+        }
+        return { status: "notfound", candidates: [] };
+    }
+
+    var libraryAliasLibGeneration = 0;
+    var libraryModuleDeclLib = null; // addExtraLib disposable for the external-module decl file (kept separate from the alias file below - see note)
+    function refreshLibraryAliasLib() {
+        // NOTE: kept as a pure global script (no import/export statements) so that
+        // `declare type __nrLib_<sid>` stays visible everywhere, including from
+        // func.d.ts's dynamically-spliced node.import overloads. The external-module
+        // declarations below (eg for a library's own `easyCrc` Setup-tab import) use
+        // `import X = require(...)`, which would turn THIS file into a module and
+        // make the __nrLib_* aliases module-scoped instead of global - so they go
+        // into their own separate file instead.
+        var lines = [
+            "// Generated by the Function node editor - do not edit.",
+            "// Virtual module shapes for Function nodes running in 'module' mode."
+        ];
+        for (var id in libraryModels) {
+            if (!libraryModels.hasOwnProperty(id)) { continue; }
+            var entry = libraryModels[id];
+            var sid = entry.sid;
+            // typeof import(...) doesn't carry the source module's own JSDoc (it's a
+            // pure type query - doc comments live on symbols, not types), so
+            // per-function JSDoc (add/subtract) flows through fine but nothing
+            // module-level does. Attach it directly to our OWN generated alias
+            // instead - a type alias's doc comment DOES show on hover of any value
+            // typed as that alias, sidestepping the limitation entirely.
+            var moduleDoc = extractModuleDoc(entry.source);
+            if (moduleDoc) { lines.push(moduleDoc); }
+            // alias NAME uses the sanitised id (must be a valid TS identifier); the
+            // import PATH uses the raw node id, matching the model's actual URI
+            lines.push('declare type __nrLib_' + sid + ' = typeof import("./' + id + '.js");');
+        }
+        if (libraryAliasLib) { libraryAliasLib.dispose(); libraryAliasLib = null; }
+        libraryAliasLib = monaco.languages.typescript.javascriptDefaults.addExtraLib(
+            lines.join("\n") + "\n", LIBRARY_DIR + "index.d.ts");
+
+        // aggregate every library node's own external-module imports (Setup tab),
+        // so eg `const { crc8 } = easyCrc` inside a library's source type-checks
+        // cleanly (eg in a Peek preview) even when no editor for that node is open
+        var allLibs = [];
+        var seenVars = {};
+        for (var libId in libraryModels) {
+            if (!libraryModels.hasOwnProperty(libId)) { continue; }
+            var n = knownFunctionNodes[libId];
+            var nodeLibs = (n && n.libs) || [];
+            nodeLibs.forEach(function(lib) {
+                if (lib && lib.var && lib.module && !seenVars[lib.var]) {
+                    seenVars[lib.var] = true;
+                    allLibs.push(lib);
+                }
+            });
+        }
+
+        var generation = ++libraryAliasLibGeneration;
+        RED.editor.codeEditor.editor.getModuleLibsDecl(allLibs, function(declText) {
+            if (generation !== libraryAliasLibGeneration) { return; } // superseded by a later refresh
+            if (libraryModuleDeclLib) { libraryModuleDeclLib.dispose(); libraryModuleDeclLib = null; }
+            if (declText) {
+                libraryModuleDeclLib = monaco.languages.typescript.javascriptDefaults.addExtraLib(
+                    declText, LIBRARY_DIR + "modules.d.ts");
+            }
+        });
+    }
+
+    function buildImportRegion(contextNode) {
+        var overloads = [];
+        var contextId = contextNode && contextNode.id;
+        for (var id in libraryModels) {
+            if (!libraryModels.hasOwnProperty(id)) { continue; }
+            var n = knownFunctionNodes[id];
+            if (!n) { continue; }
+            var viable = (n.z === (contextNode && contextNode.z)) || !RED.nodes.subflow(n.z);
+            if (!viable) { continue; }
+            var literals = [JSON.stringify(id)];
+            var name = (n.name || "").trim();
+            if (name) {
+                var res = resolveLibraryTarget(name, contextId);
+                if (res.status === "ok" && res.nodeId === id) {
+                    literals.push(JSON.stringify(name));
+                }
+            }
+            // per-library doc: hovering the node.import(...) CALL shows the doc
+            // attached to whichever overload TS resolved to (proven to work), so
+            // each library's own module-level doc goes directly on ITS overload -
+            // a shared/generic doc above all overloads would never be library-specific
+            var doc = extractModuleDoc(libraryModels[id].source);
+            if (doc) { overloads.push("    " + doc.split("\n").join("\n    ")); }
+            overloads.push('    static import(target: ' + literals.join("|") + '): __nrLib_' + libraryModels[id].sid + ';');
+        }
+        overloads.push(
+            "    /**\n" +
+            "     * Import the exports of another Function node running in \"module\" mode.\n" +
+            "     */\n" +
+            '    static import(target: string): any;'
+        );
+        return "\n    // #region:import\n" +
+            overloads.join("\n") + "\n" +
+            "    // #endregion:import\n";
+    }
+
+    // matches `node.import('literal')` / `node.import("literal")` - single-line only
+    var IMPORT_CALL_RE = /node\s*\.\s*import\s*\(\s*(?:'((?:[^'\\]|\\.)*)'|"((?:[^"\\]|\\.)*)")/g;
+
+    /**
+     * Find a `node.import('literal')` call whose string-literal argument's column
+     * range contains `position`, if any.
+     * @returns {{target:string,startColumn:number,endColumn:number}|null}
+     */
+    function findImportCallAt(model, position) {
+        var line = model.getLineContent(position.lineNumber);
+        var commentAt = line.indexOf("//");
+        IMPORT_CALL_RE.lastIndex = 0;
+        var m;
+        while ((m = IMPORT_CALL_RE.exec(line)) !== null) {
+            if (commentAt !== -1 && m.index > commentAt) { break; }
+            var prev = m.index > 0 ? line.charAt(m.index - 1) : "";
+            if (/[A-Za-z0-9_$.]/.test(prev)) { continue; } // reject foo.node.import / xnode.import
+            var raw = m[1] !== undefined ? m[1] : m[2];
+            var quoteStart = m.index + m[0].length - raw.length - 1; // 0-based index of the opening quote
+            var startColumn = quoteStart + 1; // monaco columns are 1-based
+            var endColumn = startColumn + raw.length + 2; // past the closing quote
+            if (position.column >= startColumn && position.column <= endColumn) {
+                return { target: raw.replace(/\\(.)/g, "$1"), startColumn: startColumn, endColumn: endColumn };
+            }
+        }
+        return null;
+    }
+
+    function nodeIdForModel(model) {
+        return model ? libraryEditorNodeIds[model.uri.toString()] : undefined;
+    }
+
+    /**
+     * Best-effort: scroll/position a just-opened library node's Module editor to
+     * match a location resolved against its virtual model (eg where Monaco's own
+     * definition provider resolved a click on an imported member, such as
+     * `mathlib.add`, to the real `add` declaration inside the library's source -
+     * the virtual model's line numbers match the real source verbatim, so the
+     * position transfers directly). The target node's editor may not exist yet
+     * (the tray/dialog opens asynchronously), so this retries briefly.
+     * @param {object} node - the library node whose dialog was just opened
+     * @param {object} position - a monaco IPosition or IRange
+     * @param {number} [attemptsLeft]
+     */
+    function revealLibraryNodePosition(node, position, attemptsLeft) {
+        attemptsLeft = attemptsLeft === undefined ? 40 : attemptsLeft; // ~2s at 50ms
+        var ed = node && node.initEditor;
+        if (ed && ed.getModel && ed.getModel()) {
+            var lineNumber = position.lineNumber || position.startLineNumber || 1;
+            var column = position.column || position.startColumn || 1;
+            try {
+                ed.revealLineInCenter(lineNumber);
+                ed.setPosition({ lineNumber: lineNumber, column: column });
+                ed.focus();
+            } catch (e) { /* best effort only */ }
+            return;
+        }
+        if (attemptsLeft > 0) {
+            setTimeout(function() { revealLibraryNodePosition(node, position, attemptsLeft - 1); }, 50);
+        }
+    }
+    function clearLibraryEditorNodeIds(node) {
+        [node.initEditor, node.editor, node.finalizeEditor].forEach(function(ed) {
+            var m = ed && ed.getModel && ed.getModel();
+            if (m) { delete libraryEditorNodeIds[m.uri.toString()]; }
+        });
+    }
+
+    function registerLibraryTooling() {
+        if (libraryToolingReady || !monacoReady()) { return; }
+        libraryToolingReady = true;
+
+        RED.editor.codeEditor.editor.registerTypeDefRegion("import", buildImportRegion);
+
+        monaco.languages.registerDefinitionProvider("javascript", {
+            provideDefinition: function(model, position) {
+                var hit = findImportCallAt(model, position);
+                if (!hit) { return null; }
+                var res = resolveLibraryTarget(hit.target, nodeIdForModel(model));
+                var targetId = res.nodeId || res.candidates[0];
+                var entry = targetId && libraryModels[targetId];
+                if (!entry) { return null; }
+                return [{
+                    uri: entry.uri,
+                    range: new monaco.Range(1, 1, 1, 1),
+                    originSelectionRange: new monaco.Range(
+                        position.lineNumber, hit.startColumn, position.lineNumber, hit.endColumn)
+                }];
+            }
+        });
+
+        monaco.editor.registerEditorOpener({
+            openCodeEditor: function(source, resource, selectionOrPosition) {
+                var uriStr = resource && resource.toString();
+                if (!uriStr || uriStr.indexOf(LIBRARY_DIR) !== 0) { return false; } // not ours: let monaco handle it
+                var sourceModel = source && source.getModel && source.getModel();
+                var sourcePos = source && source.getPosition && source.getPosition();
+                var hit = sourceModel && sourcePos ? findImportCallAt(sourceModel, sourcePos) : null;
+                var res = hit
+                    ? resolveLibraryTarget(hit.target, nodeIdForModel(sourceModel))
+                    : { status: "ok", nodeId: libraryUriToNodeId[uriStr], candidates: [] };
+                if (res.status === "ambiguous") {
+                    RED.notify(RED._("node-red:function.error.importAmbiguous", {
+                        name: hit ? hit.target : "", count: res.candidates.length
+                    }), "warning");
+                    return true;
+                }
+                var targetNode = res.nodeId && RED.nodes.node(res.nodeId);
+                if (!targetNode) {
+                    RED.notify(RED._("node-red:function.error.importNotFound", {
+                        name: hit ? hit.target : ""
+                    }), "warning");
+                    return true;
+                }
+                if (targetNode.z && RED.workspaces.isLocked(targetNode.z)) {
+                    RED.notify(RED._("node-red:function.error.importLocked", {
+                        name: targetNode.name || targetNode.id
+                    }), "warning");
+                    return true;
+                }
+                if (selectionOrPosition) {
+                    // a ctrl+click/goto-definition is an explicit request to jump to
+                    // this location - clear any remembered scroll/cursor position for
+                    // this node's Module editor first, so it can't win a race against
+                    // the position we're about to set (Monaco restores remembered
+                    // view state asynchronously, on the editor becoming visible)
+                    if (window._editorStateMonaco) {
+                        delete window._editorStateMonaco[targetNode.id + "/node-input-init-editor"];
+                    }
+                }
+                setTimeout(function() {
+                    RED.editor.edit(targetNode);
+                    if (selectionOrPosition) { revealLibraryNodePosition(targetNode, selectionOrPosition); }
+                }, 0);
+                return true;
+            }
+        });
+
+        // Run the first sync immediately, not via the debounced scheduler: this is
+        // called synchronously as the very first line of oneditprepare, and if we
+        // only *scheduled* a sync here, the rest of oneditprepare (building this
+        // same dialog's editors, which immediately push a func.d.ts type-def
+        // context) would run first - meaning node.import()'s overloads would miss
+        // every currently-known library node on this dialog's very first paint,
+        // only self-correcting a moment later (or never visibly, if nothing forces
+        // a re-check). Calling it directly here guarantees libraryModels is fully
+        // populated before this dialog's editors and context are built.
+        syncLibraryModels();
+    }
+    // #endregion Function-node "library mode" editor tooling
 
     var missingModules = [];
     var missingModuleReasons = {};
@@ -459,6 +922,8 @@
         oneditprepare: function() {
             var that = this;
 
+            registerLibraryTooling();
+
             // normalise the select for legacy nodes with no `mode` property
             $("#node-input-mode").val(this.mode === "library" ? "library" : "default");
 
@@ -609,6 +1074,15 @@
             this.editor = buildEditor('node-input-func-editor', this, true, $("#node-input-func").val(), undefined, that.libs || [], undefined, -1);
             this.finalizeEditor = buildEditor('node-input-finalize-editor', this, false, $("#node-input-finalize").val(), RED._("node-red:function.text.finalize"), that.libs || [], 0);
 
+            // map each editor's model back to this node's id, so node.import()
+            // ctrl+click/navigation can be scoped to the calling node's own flow/tab
+            if (monacoReady()) {
+                [this.initEditor, this.editor, this.finalizeEditor].forEach(function(ed) {
+                    var m = ed.getModel && ed.getModel();
+                    if (m) { libraryEditorNodeIds[m.uri.toString()] = that.id; }
+                });
+            }
+
             RED.library.create({
                 url:"functions", // where to get the data from
                 type:"function", // the type of object the library is for
@@ -658,6 +1132,7 @@
                         width: "Infinity",
                         stateId: editor.__stateId,
                         mode: "ace/mode/nrjavascript",
+                        node: { id: that.id, type: that.type, z: that.z },
                         focus: true,
                         cancel: function () {
                             setTimeout(function () {
@@ -756,6 +1231,8 @@
             const library = ($("#node-input-mode").val() || "default") === "library";
             const initDefault = node.initEditor.__defaultValue || RED._("node-red:function.text.initialize");
 
+            clearLibraryEditorNodeIds(node);
+
             const disposeEditor = function(editorName,targetName,defaultValue) {
                 const editor = node[editorName];
                 noerr += getEditorErrorCount(editor)
@@ -782,6 +1259,8 @@
         oneditcancel: function() {
             var node = this;
 
+            clearLibraryEditorNodeIds(node);
+
             node.editor.destroy();
             delete node.editor;
 
@@ -801,7 +1280,7 @@
             height -= (parseInt(editorRow.css("marginTop"))+parseInt(editorRow.css("marginBottom")));
             $("#dialog-form .node-text-editor").css("height",height+"px");
 
-            var height = size.height - ($("#func-mode-row").outerHeight(true) || 0);
+            var height = size.height;
             $("#node-input-init-editor").css("height", (height - 83)+"px");
             $("#node-input-func-editor").css("height", (height - 83)+"px");
             $("#node-input-finalize-editor").css("height", (height - 83)+"px");

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.html
@@ -64,12 +64,20 @@
     <input type="hidden" id="node-input-noerr">
     <input type="hidden" id="node-input-finalize">
     <input type="hidden" id="node-input-initialize">
+    <input type="hidden" id="node-input-inputs">
 
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
         <div style="display: inline-block; width: calc(100% - 105px)"><input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name"></div>
     </div>
 
+    <div class="form-row" id="func-mode-row">
+        <label for="node-input-mode"><i class="fa fa-cogs"></i> <span data-i18n="function.label.mode"></span></label>
+        <select id="node-input-mode" style="width: 250px">
+            <option value="default" data-i18n="function.mode.default"></option>
+            <option value="library" data-i18n="function.mode.library"></option>
+        </select>
+    </div>
 
     <div class="form-row func-tabs-row">
         <ul style="min-width: 600px; margin-bottom: 20px;" id="func-tabs"></ul>
@@ -77,7 +85,7 @@
     <div id="func-tabs-content" style="min-height: calc(100% - 95px);">
 
         <div id="func-tab-config" style="display:none">
-            <div>
+            <div id="func-message-options">
                 <div class="form-row" style="display: inline-block; margin-right: 50px;">
                     <label for="node-input-outputs"><i class="fa fa-random"></i> <span data-i18n="function.label.outputs"></span></label>
                     <input id="node-input-outputs" style="width: 60px;" value="1">
@@ -376,7 +384,27 @@
         color:"#fdd0a2",
         category: 'function',
         defaults: {
-            name: {value:"_DEFAULT_"},
+            name: {value:"_DEFAULT_",
+                    validate: function(v, opt) {
+                        var modeSelect = $("#node-input-mode");
+                        var mode = modeSelect.length ? modeSelect.val() : this.mode;
+                        if (mode !== "library") {
+                            return true;
+                        }
+                        if (!v || !v.trim()) {
+                            return RED._("node-red:function.error.libraryNameRequired");
+                        }
+                        for (var id in knownFunctionNodes) {
+                            if (knownFunctionNodes.hasOwnProperty(id) && id !== this.id &&
+                                knownFunctionNodes[id].mode === "library" &&
+                                (knownFunctionNodes[id].name || "").trim() === v.trim()) {
+                                return RED._("node-red:function.error.libraryNameDuplicate", {name: v});
+                            }
+                        }
+                        return true;
+                    }},
+            mode: {value:"default"},
+            inputs: {value:1},
             func: {value:"\nreturn msg;"},
             outputs: {value:1},
             timeout:{value:RED.settings.functionTimeout || 0},
@@ -419,15 +447,20 @@
         },
         inputs:1,
         outputs:1,
-        icon: "function.svg",
+        icon: function() {
+            return this.mode === "library" ? "font-awesome/fa-book" : "function.svg";
+        },
         label: function() {
-            return this.name||this._("function.function");
+            return this.name || this._(this.mode === "library" ? "function.label.libraryModule" : "function.function");
         },
         labelStyle: function() {
             return this.name?"node_label_italic":"";
         },
         oneditprepare: function() {
             var that = this;
+
+            // normalise the select for legacy nodes with no `mode` property
+            $("#node-input-mode").val(this.mode === "library" ? "library" : "default");
 
             var tabs = RED.tabs.create({
                 id: "func-tabs",
@@ -491,7 +524,7 @@
             
             const updateTabBadges = function () {
                 updateTabBadge("func-tab-body", "editor", "")
-                updateTabBadge("func-tab-init", "initEditor", RED._("node-red:function.text.initialize"))
+                updateTabBadge("func-tab-init", "initEditor", that.initEditor.__defaultValue || RED._("node-red:function.text.initialize"))
                 updateTabBadge("func-tab-finalize", "finalizeEditor", RED._("node-red:function.text.finalize"))
             }
             
@@ -527,6 +560,12 @@
                 }
             });
 
+            const initDefaultFor = function (mode) {
+                return mode === "library"
+                    ? RED._("node-red:function.text.library")
+                    : RED._("node-red:function.text.initialize");
+            };
+
             const buildEditor = function(id, node, focus, value, defaultValue, extraLibs, offset) {
                 const stateId = `${node.id}/${id}`;
                 const editor = RED.editor.createEditor({
@@ -552,7 +591,9 @@
                         setTimeout: true,
                         clearTimeout: true,
                         setInterval: true,
-                        clearInterval: true
+                        clearInterval: true,
+                        module: true,
+                        exports: true
                     },
                     extraLibs: extraLibs
                 });
@@ -562,9 +603,11 @@
                 editor.__stateId = stateId;
                 return editor;
             }
-            this.initEditor = buildEditor('node-input-init-editor', this, false, $("#node-input-initialize").val(), RED._("node-red:function.text.initialize"), undefined, 0);
+            const initDefaultValue = initDefaultFor($("#node-input-mode").val());
+            this.initEditor = buildEditor('node-input-init-editor', this, false, $("#node-input-initialize").val(), initDefaultValue, that.libs || [], 0);
+            this.initEditor.__defaultValue = initDefaultValue;
             this.editor = buildEditor('node-input-func-editor', this, true, $("#node-input-func").val(), undefined, that.libs || [], undefined, -1);
-            this.finalizeEditor = buildEditor('node-input-finalize-editor', this, false, $("#node-input-finalize").val(), RED._("node-red:function.text.finalize"), undefined, 0);
+            this.finalizeEditor = buildEditor('node-input-finalize-editor', this, false, $("#node-input-finalize").val(), RED._("node-red:function.text.finalize"), that.libs || [], 0);
 
             RED.library.create({
                 url:"functions", // where to get the data from
@@ -644,12 +687,74 @@
                 prepareLibraryConfig(that);
             }
 
+            // remembers the user's output count across a round-trip through library mode
+            var lastDefaultOutputs = parseInt($("#node-input-outputs").val()) || 1;
+
+            const applyMode = function (mode, isInitial) {
+                const library = (mode === "library");
+
+                tabs.renameTab("func-tab-init", that._(library
+                    ? "function.label.libraryCode"
+                    : "function.label.initialize"));
+                if (library) {
+                    tabs.hideTab("func-tab-body");
+                    tabs.hideTab("func-tab-finalize");
+                    // the Setup tab would otherwise be empty in library mode
+                    if (RED.settings.functionExternalModules === false) {
+                        tabs.hideTab("func-tab-config");
+                    }
+                } else {
+                    tabs.showTab("func-tab-body");
+                    tabs.showTab("func-tab-finalize");
+                    if (RED.settings.functionExternalModules === false) {
+                        tabs.showTab("func-tab-config");
+                    }
+                }
+
+                $("#func-message-options").toggle(!library);
+                $("#node-input-function-lookup").parent().toggle(!library);
+
+                if (library) {
+                    var cur = parseInt($("#node-input-outputs").val());
+                    if (!isNaN(cur) && cur > 0) {
+                        lastDefaultOutputs = cur;
+                    }
+                    $("#node-input-outputs").spinner("value", 0);
+                    $("#node-input-inputs").val(0);
+                } else {
+                    if (parseInt($("#node-input-outputs").val()) === 0 && !isInitial) {
+                        $("#node-input-outputs").spinner("value", lastDefaultOutputs);
+                    }
+                    $("#node-input-inputs").val(1);
+                }
+
+                const newDefault = initDefaultFor(mode);
+                if (that.initEditor.getValue().trim() === (that.initEditor.__defaultValue || "").trim()) {
+                    that.initEditor.setValue(newDefault, -1);
+                }
+                that.initEditor.__defaultValue = newDefault;
+
+                if (library) {
+                    tabs.activateTab("func-tab-init");
+                }
+            };
+
+            $("#node-input-mode").on("change", function () {
+                applyMode($(this).val(), false);
+                RED.tray.resize();
+            });
+
+            applyMode($("#node-input-mode").val(), true);
+
             updateTabBadges();
         },
         oneditsave: function() {
             const node = this;
             let noerr = 0;
             $("#node-input-noerr").val(0);
+
+            const library = ($("#node-input-mode").val() || "default") === "library";
+            const initDefault = node.initEditor.__defaultValue || RED._("node-red:function.text.initialize");
 
             const disposeEditor = function(editorName,targetName,defaultValue) {
                 const editor = node[editorName];
@@ -660,8 +765,15 @@
                 $("#"+targetName).val(val);
             }
             disposeEditor("editor","node-input-func");
-            disposeEditor("initEditor","node-input-initialize", RED._("node-red:function.text.initialize"));
+            disposeEditor("initEditor","node-input-initialize", initDefault);
             disposeEditor("finalizeEditor","node-input-finalize", RED._("node-red:function.text.finalize"));
+
+            // defensive: keep the port fields consistent with mode even if the
+            // mode `change` handler never fired (eg a programmatic edit)
+            $("#node-input-inputs").val(library ? 0 : 1);
+            if (library) {
+                $("#node-input-outputs").val(0);
+            }
 
             $("#node-input-noerr").val(noerr);
             this.noerr = noerr;
@@ -689,7 +801,7 @@
             height -= (parseInt(editorRow.css("marginTop"))+parseInt(editorRow.css("marginBottom")));
             $("#dialog-form .node-text-editor").css("height",height+"px");
 
-            var height = size.height;
+            var height = size.height - ($("#func-mode-row").outerHeight(true) || 0);
             $("#node-input-init-editor").css("height", (height - 83)+"px");
             $("#node-input-func-editor").css("height", (height - 83)+"px");
             $("#node-input-finalize-editor").css("height", (height - 83)+"px");

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -96,8 +96,10 @@ module.exports = function(RED) {
         /** @type {vm.Script} */
         node.script = null;
         node.name = n.name;
-        node.func = n.func;
-        node.outputs = n.outputs;
+        node.mode = n.mode || "default";
+        var isLibraryMode = node.mode === "library";
+        node.func = isLibraryMode ? "" : n.func;
+        node.outputs = isLibraryMode ? 0 : n.outputs;
         node.timeout = n.timeout*1000;
         if(node.timeout>0){
             node.timeoutOptions = {
@@ -106,52 +108,56 @@ module.exports = function(RED) {
             }
         }
         node.ini = n.initialize ? n.initialize.trim() : "";
-        node.fin = n.finalize ? n.finalize.trim() : "";
+        node.fin = isLibraryMode ? "" : (n.finalize ? n.finalize.trim() : "");
         node.libs = n.libs || [];
 
         if (RED.settings.functionExternalModules === false && node.libs.length > 0) {
             throw new Error(RED._("function.error.externalModuleNotAllowed"));
         }
 
-        var functionText = "var results = null;"+
-            "results = (async function(msg,__send__,__done__){ "+
-                "var __msgid__ = msg._msgid;"+
-                "var node = {"+
-                    "id:__node__.id,"+
-                    "name:__node__.name,"+
-                    "path:__node__.path,"+
-                    "outputCount:__node__.outputCount,"+
-                    "log:__node__.log,"+
-                    "error:__node__.error,"+
-                    "warn:__node__.warn,"+
-                    "debug:__node__.debug,"+
-                    "trace:__node__.trace,"+
-                    "on:__node__.on,"+
-                    "status:__node__.status,"+
-                    "send:function(msgs,cloneMsg){ __node__.send(__send__,__msgid__,msgs,cloneMsg);},"+
-                    "done:__done__,"+
-                    "linkcall: __node__.linkcall"+
-                "};\n"+
-                node.func+"\n"+
-            "})(msg,__send__,__done__);";
-
+        var functionText = null;
         var handleNodeDoneCall = true;
 
-        // Check to see if the Function appears to call `node.done()`. If so,
-        // we will assume it is well written and does actually call node.done().
-        // Otherwise, we will call node.done() after the function returns regardless.
-        if (/node\.done\s*\(\s*\)/.test(functionText)) {
-            // We have spotted the code contains `node.done`. It could be in a comment
-            // so need to do the extra work to parse the AST and examine it properly.
-            acornWalk.simple(acorn.parse(functionText,{ecmaVersion: "latest"} ), {
-                CallExpression(astNode) {
-                    if (astNode.callee && astNode.callee.object) {
-                        if (astNode.callee.object.name === "node" && astNode.callee.property.name === "done") {
-                            handleNodeDoneCall = false;
+        if (!isLibraryMode) {
+            functionText = "var results = null;"+
+                "results = (async function(msg,__send__,__done__){ "+
+                    "var __msgid__ = msg._msgid;"+
+                    "var node = {"+
+                        "id:__node__.id,"+
+                        "name:__node__.name,"+
+                        "path:__node__.path,"+
+                        "outputCount:__node__.outputCount,"+
+                        "log:__node__.log,"+
+                        "error:__node__.error,"+
+                        "warn:__node__.warn,"+
+                        "debug:__node__.debug,"+
+                        "trace:__node__.trace,"+
+                        "on:__node__.on,"+
+                        "status:__node__.status,"+
+                        "send:function(msgs,cloneMsg){ __node__.send(__send__,__msgid__,msgs,cloneMsg);},"+
+                        "done:__done__,"+
+                        "linkcall: __node__.linkcall,"+
+                        "import: __node__.import"+
+                    "};\n"+
+                    node.func+"\n"+
+                "})(msg,__send__,__done__);";
+
+            // Check to see if the Function appears to call `node.done()`. If so,
+            // we will assume it is well written and does actually call node.done().
+            // Otherwise, we will call node.done() after the function returns regardless.
+            if (/node\.done\s*\(\s*\)/.test(functionText)) {
+                // We have spotted the code contains `node.done`. It could be in a comment
+                // so need to do the extra work to parse the AST and examine it properly.
+                acornWalk.simple(acorn.parse(functionText,{ecmaVersion: "latest"} ), {
+                    CallExpression(astNode) {
+                        if (astNode.callee && astNode.callee.object) {
+                            if (astNode.callee.object.name === "node" && astNode.callee.property.name === "done") {
+                                handleNodeDoneCall = false;
+                            }
                         }
                     }
-                }
-            })
+                })
+            }
         }
 
         var finScript = null;
@@ -230,6 +236,24 @@ module.exports = function(RED) {
             })
         }
 
+        // `node.import` gives a Function node access to the live `module.exports`
+        // of a "library mode" Function node, resolved by id or name. Unlike
+        // `linkcall`, this is a direct synchronous function reference - no message
+        // cloning, no flow hop.
+        node.import = function (target, options) {
+            if (typeof target !== "string" || target.trim() === "") {
+                throw new Error(RED._("function.error.importTargetInvalid"));
+            }
+            try {
+                return RED.nodes.functionLibrary.resolve(node, target.trim());
+            } catch (err) {
+                if (options && options.optional === true) {
+                    return undefined;
+                }
+                throw err;
+            }
+        };
+
         var sandbox = {
             console:console,
             util:util,
@@ -280,6 +304,9 @@ module.exports = function(RED) {
                 },
                 linkcall: async function (msg, target, options) {
                     return node.linkcall.apply(node, arguments)
+                },
+                import: function (target, options) {
+                    return node.import(target, options);
                 }
             },
             context: {
@@ -370,6 +397,14 @@ module.exports = function(RED) {
                 }
             }
         };
+        if (isLibraryMode) {
+            // CommonJS-style exports object. Persists for the node's whole
+            // lifetime since `sandbox` is contextified in place by
+            // `vm.createContext` below - a redeploy simply constructs a fresh
+            // node (and therefore a fresh sandbox/exports object).
+            sandbox.module = { exports: {} };
+            sandbox.exports = sandbox.module.exports;
+        }
         if (util.hasOwnProperty('promisify')) {
             sandbox.setTimeout[util.promisify.custom] = function(after, value) {
                 return new Promise(function(resolve, reject) {
@@ -414,14 +449,28 @@ module.exports = function(RED) {
         var messages = [];
         var processMessage = (() => {});
 
-        node.on("input", function(msg,send,done) {
-            if(state === RESOLVING) {
-                messages.push({msg:msg, send:send, done:done});
-            }
-            else if(state === RESOLVED) {
-                processMessage(msg, send, done);
-            }
-        });
+        if (!isLibraryMode) {
+            node.on("input", function(msg,send,done) {
+                if(state === RESOLVING) {
+                    messages.push({msg:msg, send:send, done:done});
+                }
+                else if(state === RESOLVED) {
+                    processMessage(msg, send, done);
+                }
+            });
+        } else {
+            // Library mode nodes have no wired inputs in the editor; this only
+            // fires via an unusual programmatic `node.receive()` call.
+            node.on("input", function(msg,send,done) {
+                node.warn(RED._("function.error.libraryModeInput"));
+                done();
+            });
+
+            RED.nodes.functionLibrary.register(node);
+            node.on("close", function () {
+                RED.nodes.functionLibrary.remove(node);
+            });
+        }
         Promise.all(moduleLoadPromises).then(() => {
             var context = vm.createContext(sandbox);
             try {
@@ -441,6 +490,7 @@ module.exports = function(RED) {
                             debug:__node__.debug,
                             trace:__node__.trace,
                             status:__node__.status,
+                            import: __node__.import,
                             send: function(msgs, cloneMsg) {
                                 __node__.send(__send__, RED.util.generateId(), msgs, cloneMsg);
                             }
@@ -454,33 +504,35 @@ module.exports = function(RED) {
                         iniOpt.breakOnSigint = true;
                     }
                 }
-                node.script = new vm.Script(functionText, createVMOpt(node, ""));
-                if (node.fin && (node.fin !== "")) {
-                    var finText = `(function () {
-                        var node = {
-                            id:__node__.id,
-                            name:__node__.name,
-                            path:__node__.path,
-                            outputCount:__node__.outputCount,
-                            log:__node__.log,
-                            error:__node__.error,
-                            warn:__node__.warn,
-                            debug:__node__.debug,
-                            trace:__node__.trace,
-                            status:__node__.status,
-                            send: function(msgs, cloneMsg) {
-                                __node__.error("Cannot send from close function");
-                            }
-                        };
-                        `+node.fin +`
-                    })();`;
-                    finOpt = createVMOpt(node, " cleanup");
-                    finScript = new vm.Script(finText, finOpt);
-                    if(node.timeout>0){
-                        finOpt.timeout = node.timeout;
-                        finOpt.breakOnSigint = true;
-                    } else if (RED.settings.globalFunctionTimeout > 0){
-                        finOpt.timeout = RED.settings.globalFunctionTimeout * 1000
+                if (!isLibraryMode) {
+                    node.script = new vm.Script(functionText, createVMOpt(node, ""));
+                    if (node.fin && (node.fin !== "")) {
+                        var finText = `(function () {
+                            var node = {
+                                id:__node__.id,
+                                name:__node__.name,
+                                path:__node__.path,
+                                outputCount:__node__.outputCount,
+                                log:__node__.log,
+                                error:__node__.error,
+                                warn:__node__.warn,
+                                debug:__node__.debug,
+                                trace:__node__.trace,
+                                status:__node__.status,
+                                send: function(msgs, cloneMsg) {
+                                    __node__.error("Cannot send from close function");
+                                }
+                            };
+                            `+node.fin +`
+                        })();`;
+                        finOpt = createVMOpt(node, " cleanup");
+                        finScript = new vm.Script(finText, finOpt);
+                        if(node.timeout>0){
+                            finOpt.timeout = node.timeout;
+                            finOpt.breakOnSigint = true;
+                        } else if (RED.settings.globalFunctionTimeout > 0){
+                            finOpt.timeout = RED.settings.globalFunctionTimeout * 1000
+                        }
                     }
                 }
                 var promise = Promise.resolve();
@@ -580,6 +632,18 @@ module.exports = function(RED) {
                 });
 
                 promise.then(function (v) {
+                    if (isLibraryMode) {
+                        var exportsObject = context.module ? context.module.exports : undefined;
+                        var exportCount = RED.nodes.functionLibrary.setExports(node, exportsObject);
+                        if (!exportCount) {
+                            node.warn(RED._("function.error.libraryNoExports"));
+                            node.status({fill:"yellow",shape:"ring",text:"no exports"});
+                        } else {
+                            node.status({fill:"green",shape:"dot",text:RED._("function.status.exports",{count:exportCount})});
+                        }
+                        state = RESOLVED;
+                        return;
+                    }
                     var msgs = messages;
                     messages = [];
                     while (msgs.length > 0) {
@@ -593,6 +657,10 @@ module.exports = function(RED) {
                 }).catch((error) => {
                     messages = [];
                     state = ERROR;
+                    if (isLibraryMode) {
+                        RED.nodes.functionLibrary.setError(node, error);
+                        node.status({fill:"red",shape:"ring",text:"error"});
+                    }
                     node.error(error);
                 });
 

--- a/packages/node_modules/@node-red/nodes/core/function/10-function.js
+++ b/packages/node_modules/@node-red/nodes/core/function/10-function.js
@@ -167,6 +167,19 @@ module.exports = function(RED) {
         node.outstandingIntervals = [];
         node.clearStatus = false;
 
+        // Registered early (before any user code runs) so it always fires before a
+        // user-registered node.onClose() callback - otherwise a close callback that
+        // itself schedules a setTimeout (eg to defer calling its `done()`) would have
+        // that timer immediately cancelled by this same-tick sweep.
+        node.on("close", function() {
+            while (node.outstandingTimers.length > 0) {
+                clearTimeout(node.outstandingTimers.pop());
+            }
+            while (node.outstandingIntervals.length > 0) {
+                clearInterval(node.outstandingIntervals.pop());
+            }
+        });
+
         const crypto = require("crypto");
         const messageEvents = {};
         const timeoutMessage = (eventId) => {
@@ -491,6 +504,7 @@ module.exports = function(RED) {
                             trace:__node__.trace,
                             status:__node__.status,
                             import: __node__.import,
+                            `+ (isLibraryMode ? 'onClose: function (fn) { __node__.on("close", fn); },' : '') + `
                             send: function(msgs, cloneMsg) {
                                 __node__.send(__send__, RED.util.generateId(), msgs, cloneMsg);
                             }
@@ -619,12 +633,6 @@ module.exports = function(RED) {
                         catch (err) {
                             node.error(err);
                         }
-                    }
-                    while (node.outstandingTimers.length > 0) {
-                        clearTimeout(node.outstandingTimers.pop());
-                    }
-                    while (node.outstandingIntervals.length > 0) {
-                        clearInterval(node.outstandingIntervals.pop());
                     }
                     if (node.clearStatus) {
                         node.status({});

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/10-function.html
@@ -36,7 +36,23 @@
             nodes load it with <code>node.import("&lt;name&gt;")</code>, where
             <code>&lt;name&gt;</code> is this node's <b>Name</b>, which must be set and
             unique among Module nodes. The rest of the <b>Setup</b> tab is available in
-            both modes for declaring external module imports.</li>
+            both modes for declaring external module imports. A Module node has no
+            <b>On Stop</b> tab - use <code>node.onClose(fn)</code> to register cleanup
+            for anything the module's code creates (eg connections, timers, watchers).</li>
+    </ul>
+    <p>Notes on <code>node.onClose()</code> (Module mode only):</p>
+    <ul>
+        <li>Call it from the <b>Module</b> tab's top-level code to register a function
+            to run when the node is stopped, deleted, or re-deployed - it is the
+            Module-mode equivalent of the <b>On Stop</b> tab.</li>
+        <li><code>fn</code> can be declared with 0, 1 or 2 parameters, matching Node-RED's
+            standard node <code>close</code> event: <code>fn()</code> runs synchronously;
+            <code>fn(done)</code> or <code>fn(removed, done)</code> may run asynchronously -
+            the node is not considered fully closed until <code>done()</code> is called.
+            <code>removed</code> is <code>true</code> if the node has been deleted, or
+            <code>false</code> if it is just being restarted/re-deployed.</li>
+        <li>It can be called more than once to register multiple independent cleanup
+            functions.</li>
     </ul>
     <p>Notes on <code>node.import()</code>:</p>
     <ul>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/10-function.html
@@ -25,6 +25,33 @@
         The <b>On Stop</b> tab contains code that will be run when the node is stopped.</p>
     <p>If the On Start code returns a Promise object, the node will not start handling messages
         until the promise is resolved.</p>
+    <h3>Modes</h3>
+    <p>The <b>Mode</b> setting selects how the node behaves:</p>
+    <ul>
+        <li><b>Default</b> - the node processes messages using the <b>On Start</b>,
+            <b>On Message</b> and <b>On Stop</b> tabs.</li>
+        <li><b>Library</b> - the node defines reusable functions instead of processing
+            messages. It has no inputs or outputs. Write the code in the <b>Module</b>
+            tab and export it with <code>module.exports = { ... }</code>. Other Function
+            nodes load it with <code>node.import("&lt;name&gt;")</code>, where
+            <code>&lt;name&gt;</code> is this node's <b>Name</b>, which must be set and
+            unique among Library nodes. The <b>Setup</b> tab is available in both modes
+            for declaring external module imports.</li>
+    </ul>
+    <p>Notes on <code>node.import()</code>:</p>
+    <ul>
+        <li>It returns a live reference to the target's exports, resolved at the moment
+            it is called - call it inside <b>On Message</b> (or re-call it) rather than
+            caching the result at <b>On Start</b>, so a later redeploy of the library
+            node is always picked up.</li>
+        <li>Calling it from another node's <b>On Start</b> before the target library node
+            has finished starting will throw an error - prefer calling it when handling
+            a message.</li>
+        <li>Each Function node runs its own JavaScript sandbox, so values such as arrays
+            or objects returned from an imported function belong to a different realm.
+            Use <code>Array.isArray()</code>/<code>typeof</code> rather than
+            <code>instanceof</code> when working with them.</li>
+    </ul>
     <h3>Details</h3>
     <p>See the <a target="_blank" href="https://nodered.org/docs/writing-functions.html">online documentation</a>
     for more information on writing functions.</p>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/function/10-function.html
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/function/10-function.html
@@ -26,31 +26,45 @@
     <p>If the On Start code returns a Promise object, the node will not start handling messages
         until the promise is resolved.</p>
     <h3>Modes</h3>
-    <p>The <b>Mode</b> setting selects how the node behaves:</p>
+    <p>The <b>Mode</b> setting, in the <b>Setup</b> tab, selects how the node behaves:</p>
     <ul>
-        <li><b>Default</b> - the node processes messages using the <b>On Start</b>,
+        <li><b>Function</b> - the node processes messages using the <b>On Start</b>,
             <b>On Message</b> and <b>On Stop</b> tabs.</li>
-        <li><b>Library</b> - the node defines reusable functions instead of processing
+        <li><b>Module</b> - the node defines reusable functions instead of processing
             messages. It has no inputs or outputs. Write the code in the <b>Module</b>
             tab and export it with <code>module.exports = { ... }</code>. Other Function
             nodes load it with <code>node.import("&lt;name&gt;")</code>, where
             <code>&lt;name&gt;</code> is this node's <b>Name</b>, which must be set and
-            unique among Library nodes. The <b>Setup</b> tab is available in both modes
-            for declaring external module imports.</li>
+            unique among Module nodes. The rest of the <b>Setup</b> tab is available in
+            both modes for declaring external module imports.</li>
     </ul>
     <p>Notes on <code>node.import()</code>:</p>
     <ul>
         <li>It returns a live reference to the target's exports, resolved at the moment
             it is called - call it inside <b>On Message</b> (or re-call it) rather than
-            caching the result at <b>On Start</b>, so a later redeploy of the library
+            caching the result at <b>On Start</b>, so a later redeploy of the target
             node is always picked up.</li>
-        <li>Calling it from another node's <b>On Start</b> before the target library node
+        <li>Calling it from another node's <b>On Start</b> before the target module node
             has finished starting will throw an error - prefer calling it when handling
             a message.</li>
         <li>Each Function node runs its own JavaScript sandbox, so values such as arrays
             or objects returned from an imported function belong to a different realm.
             Use <code>Array.isArray()</code>/<code>typeof</code> rather than
             <code>instanceof</code> when working with them.</li>
+    </ul>
+    <p>The editor also supports code-aware autocomplete and navigation for
+        <code>node.import()</code>:</p>
+    <ul>
+        <li>Autocomplete and hover documentation for whatever the target module node
+            actually exports - typing <code>node.import("mathlib").</code> suggests its
+            exported functions, based on the module node's current code.</li>
+        <li>Ctrl (or Cmd on macOS) + click on the quoted name or id in a
+            <code>node.import(...)</code> call opens that module node's own editor.
+            If the name matches more than one module node, a notice is shown instead
+            of guessing which one to open - use the node id, or a unique name, to
+            disambiguate.</li>
+        <li>Right-click &gt; Peek Definition (or Alt+F12) shows a read-only preview of
+            the module node's source without leaving the current editor.</li>
     </ul>
     <h3>Details</h3>
     <p>See the <a target="_blank" href="https://nodered.org/docs/writing-functions.html">online documentation</a>

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -267,15 +267,15 @@
             "initialize": "On Start",
             "finalize": "On Stop",
             "libraryCode": "Module",
-            "libraryModule": "library module",
+            "libraryModule": "module",
             "mode": "Mode",
             "outputs": "Outputs",
             "modules": "Modules",
             "timeout": "Timeout"
         },
         "mode": {
-            "default": "Default",
-            "library": "Library"
+            "default": "Function",
+            "library": "Module"
         },
         "text": {
             "initialize": "// Code added here will be run once\n// whenever the node is started.\n",
@@ -306,10 +306,13 @@
             "linkcallMsgInvalid" : "Error link call msg parameter is not valid, expected an object",
             "linkcallTargetNotFound": "Error target 'link in' node not found",
             "importTargetInvalid": "Error import target parameter is not valid, expected a string",
-            "libraryModeInput": "Library mode Function node received a message. Library nodes do not process messages.",
-            "libraryNoExports": "Library function node does not export anything. Add 'module.exports = { ... }'",
-            "libraryNameRequired": "A Library function node must have a name - it is used as the import key",
-            "libraryNameDuplicate": "Another Library function node is already named '__name__'"
+            "libraryModeInput": "Module mode Function node received a message. Module nodes do not process messages.",
+            "libraryNoExports": "Module function node does not export anything. Add 'module.exports = { ... }'",
+            "libraryNameRequired": "A Module function node must have a name - it is used as the import key",
+            "libraryNameDuplicate": "Another Module function node is already named '__name__'",
+            "importAmbiguous": "__count__ Function module nodes are named '__name__' - open the one you want directly",
+            "importNotFound": "No Function module node named '__name__' could be found",
+            "importLocked": "The flow containing '__name__' is locked"
         }
     },
     "template": {

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -280,7 +280,7 @@
         "text": {
             "initialize": "// Code added here will be run once\n// whenever the node is started.\n",
             "finalize": "// Code added here will be run when the\n// node is being stopped or re-deployed.\n",
-            "library": "// Define reusable functions here and export them.\n// Other Function nodes can call them via node.import().\n\nmodule.exports = {\n\n}\n"
+            "library": "// Define reusable functions here and export them.\n// Other Function nodes can call them via node.import().\n// node.onClose(fn) can be used to register cleanup logic.\n// See built-in help for further details.\n\nmodule.exports = {\n\n}\n"
         },
         "status": {
             "exports": "__count__ exports"

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -266,13 +266,24 @@
             "function": "On Message",
             "initialize": "On Start",
             "finalize": "On Stop",
+            "libraryCode": "Module",
+            "libraryModule": "library module",
+            "mode": "Mode",
             "outputs": "Outputs",
             "modules": "Modules",
             "timeout": "Timeout"
         },
+        "mode": {
+            "default": "Default",
+            "library": "Library"
+        },
         "text": {
             "initialize": "// Code added here will be run once\n// whenever the node is started.\n",
-            "finalize": "// Code added here will be run when the\n// node is being stopped or re-deployed.\n"
+            "finalize": "// Code added here will be run when the\n// node is being stopped or re-deployed.\n",
+            "library": "// Define reusable functions here and export them.\n// Other Function nodes can call them via node.import().\n\nmodule.exports = {\n\n}\n"
+        },
+        "status": {
+            "exports": "__count__ exports"
         },
         "require": {
             "var": "variable",
@@ -293,7 +304,12 @@
             "missing-module": "Module __module__ missing",
             "linkcallTargetInvalid" : "Error link call target parameter is not valid, expected a string",
             "linkcallMsgInvalid" : "Error link call msg parameter is not valid, expected an object",
-            "linkcallTargetNotFound": "Error target 'link in' node not found"
+            "linkcallTargetNotFound": "Error target 'link in' node not found",
+            "importTargetInvalid": "Error import target parameter is not valid, expected a string",
+            "libraryModeInput": "Library mode Function node received a message. Library nodes do not process messages.",
+            "libraryNoExports": "Library function node does not export anything. Add 'module.exports = { ... }'",
+            "libraryNameRequired": "A Library function node must have a name - it is used as the import key",
+            "libraryNameDuplicate": "Another Library function node is already named '__name__'"
         }
     },
     "template": {

--- a/packages/node_modules/@node-red/registry/lib/util.js
+++ b/packages/node_modules/@node-red/registry/lib/util.js
@@ -129,6 +129,7 @@ function createNodeApi(node) {
         return i18n._.apply(null,args);
     }
     red.nodes.linkcallTargets = runtime.nodes.linkcallTargets;
+    red.nodes.functionLibrary = runtime.nodes.functionLibrary;
     return red;
 }
 

--- a/packages/node_modules/@node-red/runtime/lib/nodes/functionLibrary.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/functionLibrary.js
@@ -1,0 +1,284 @@
+/**
+ * Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+// Registry of Function nodes running in "library" mode. A library-mode node
+// registers itself here once, at construction, and other Function nodes resolve
+// against it (by id or by name) via `node.import()`. Modelled on the sibling
+// `linkcallTargets` registry in ./index.js, but entries carry a lifecycle state
+// (an "On Start" script runs asynchronously before exports are known) and the
+// resolved value is a live `module.exports` object reference rather than a
+// message-passing target.
+
+const log = require("@node-red/util").log;
+const flows = require("../flows");
+
+const STATE_INITIALISING = "initialising";
+const STATE_READY = "ready";
+const STATE_ERROR = "error";
+
+let registry = { id: {}, name: {} };
+
+function getIndex(entries, id) {
+    for (let index = 0; index < (entries || []).length; index++) {
+        if (entries[index].id === id) {
+            return index;
+        }
+    }
+    return -1;
+}
+
+/**
+ * Build a registry entry from a library-mode Function node
+ * @param {Object} node
+ * @returns {Object} entry
+ */
+function generateEntry(node) {
+    const isSubFlow = node._flow.TYPE === 'subflow';
+    return {
+        id: node.id,
+        alias: node._alias || null,
+        name: node.name || node.id,
+        flowId: node._flow.flow.id,
+        flowName: isSubFlow ? node._flow.subflowDef.name : node._flow.flow.label,
+        isSubFlow: isSubFlow,
+        node: node,
+        state: STATE_INITIALISING,
+        exports: undefined,
+        exportNames: [],
+        error: undefined
+    };
+}
+
+const functionLibrary = {
+    /**
+     * Register a library-mode Function node. Must be called synchronously from
+     * the node's constructor, before its "On Start" script has resolved - the
+     * entry starts in the "initialising" state until `setExports`/`setError` is
+     * called.
+     * @param {Object} node a Function node with `mode === 'library'`
+     */
+    register(node) {
+        if (!node || node.type !== "function" || node.mode !== "library") {
+            throw new Error("functionLibrary: node must be a Function node in library mode");
+        }
+        const entry = generateEntry(node);
+        const existingByName = this.getEntry(entry.name, entry.flowId);
+        if (!existingByName || existingByName.id !== entry.id) {
+            registry.name[entry.name] = registry.name[entry.name] || [];
+            registry.name[entry.name].push(entry);
+        }
+        registry.id[entry.id] = entry;
+        if (!node.name) {
+            log.warn(`Function node '${node.id}' is in library mode but has no name - it can only be imported by id`);
+        }
+        return entry;
+    },
+
+    /**
+     * Record the exports captured after the node's "On Start" script resolves.
+     * A no-op if the node has since been removed from the registry (eg it was
+     * closed while its own initialisation was still in flight).
+     * @param {Object} node
+     * @param {Object} exportsObject the live `module.exports` object
+     * @returns {number} the number of exported keys
+     */
+    setExports(node, exportsObject) {
+        const entry = registry.id[node.id];
+        if (!entry) {
+            return 0;
+        }
+        entry.exports = exportsObject;
+        entry.exportNames = exportsObject ? Object.keys(exportsObject) : [];
+        entry.state = STATE_READY;
+        entry.error = undefined;
+        return entry.exportNames.length;
+    },
+
+    /**
+     * Record that the node's "On Start" script failed. A no-op if the node has
+     * since been removed from the registry.
+     * @param {Object} node
+     * @param {Error} err
+     */
+    setError(node, err) {
+        const entry = registry.id[node.id];
+        if (!entry) {
+            return;
+        }
+        entry.state = STATE_ERROR;
+        entry.error = err;
+        entry.exports = undefined;
+        entry.exportNames = [];
+    },
+
+    /**
+     * Remove a library-mode Function node from the registry. Call from the
+     * node's `close` handler.
+     * @param {Object} node
+     */
+    remove(node) {
+        if (!node) {
+            return;
+        }
+        const entry = registry.id[node.id];
+        if (!entry) {
+            return;
+        }
+        const entries = registry.name[entry.name];
+        if (entries) {
+            const idx = getIndex(entries, entry.id);
+            if (idx > -1) {
+                entries.splice(idx, 1);
+            }
+            if (entries.length === 0) {
+                delete registry.name[entry.name];
+            }
+        }
+        delete registry.id[entry.id];
+    },
+
+    /**
+     * Get an entry by its registered node id
+     * @param {string} id
+     * @returns {Object}
+     */
+    getEntryById(id) {
+        return registry.id[id];
+    },
+
+    /**
+     * Get all entries registered to a given name
+     * @param {string} name
+     * @param {boolean} [excludeSubflows]
+     * @returns {Array}
+     */
+    getEntries(name, excludeSubflows) {
+        const entries = registry.name[name] || [];
+        if (excludeSubflows) {
+            return entries.filter(e => e.isSubFlow !== true);
+        }
+        return entries;
+    },
+
+    /**
+     * Get a single entry by registered name, optionally scoped to a flow. If
+     * there are zero or more than one match, returns undefined.
+     * @param {string} name
+     * @param {string} [flowId]
+     * @returns {Object}
+     */
+    getEntry(name, flowId) {
+        let candidates = this.getEntries(name);
+        if (candidates.length && flowId) {
+            candidates = candidates.filter(e => e.flowId === flowId);
+        }
+        if (candidates.length === 1) {
+            return candidates[0];
+        }
+        return undefined;
+    },
+
+    /**
+     * Resolve a `node.import()` target to its live `module.exports` object.
+     * Resolution order: subflow-local design-time id, then raw node id, then
+     * name (scoped to the caller's flow, then flow-wide if unique).
+     * @param {Object} srcNode the calling Function node
+     * @param {string} target a node id or name
+     * @returns {Object} the target's live `module.exports` object
+     */
+    resolve(srcNode, target) {
+        if (typeof target !== "string" || target.trim() === "") {
+            throw new Error("node.import() target must be a non-empty string");
+        }
+
+        let entry;
+
+        // A node inside a subflow instance may reference a sibling by its
+        // design-time id; recover the runtime instance id for it first.
+        if (srcNode._flow && srcNode._flow.TYPE === 'subflow' && srcNode.z) {
+            entry = registry.id[srcNode.z + "-" + target];
+        }
+
+        // Direct runtime node id
+        if (!entry) {
+            entry = registry.id[target];
+        }
+
+        // Name lookup: caller's flow first, then flow-wide if unique
+        if (!entry) {
+            const flowId = srcNode._flow && srcNode._flow.flow ? srcNode._flow.flow.id : undefined;
+            entry = this.getEntry(target, flowId);
+            if (!entry) {
+                const candidates = this.getEntries(target, true);
+                if (candidates.length === 1) {
+                    entry = candidates[0];
+                } else if (candidates.length > 1) {
+                    throw new Error(`Multiple function library nodes named '${target}' found`);
+                }
+            }
+        }
+
+        if (!entry) {
+            throw new Error(`Function library '${target}' not found. Check the node exists, is enabled, and is set to library mode.`);
+        }
+
+        // Self-heal a stale entry left behind by a missed `close`
+        const liveNode = flows.get(entry.id);
+        if (!liveNode || liveNode !== entry.node) {
+            this.remove(entry.node);
+            throw new Error(`Function library '${target}' is no longer available`);
+        }
+
+        if (entry.state === STATE_INITIALISING) {
+            throw new Error(`Function library '${target}' has not finished initialising. Call node.import() when handling a message rather than in On Start.`);
+        }
+        if (entry.state === STATE_ERROR) {
+            throw new Error(`Function library '${target}' failed to initialise: ${entry.error && entry.error.message}`);
+        }
+        if (!entry.exports || entry.exportNames.length === 0) {
+            throw new Error(`Function library '${target}' does not export anything. Add 'module.exports = { ... }' to the library node.`);
+        }
+
+        return entry.exports;
+    },
+
+    /**
+     * List all registered entries (for introspection/tooling; not used by
+     * `resolve`).
+     * @returns {Array}
+     */
+    list() {
+        return Object.keys(registry.id).map(id => {
+            const entry = registry.id[id];
+            return {
+                id: entry.id,
+                alias: entry.alias,
+                name: entry.name,
+                flowId: entry.flowId,
+                flowName: entry.flowName,
+                isSubFlow: entry.isSubFlow,
+                state: entry.state,
+                exportNames: entry.exportNames
+            };
+        });
+    },
+
+    clear() {
+        registry = { id: {}, name: {} };
+    }
+};
+
+module.exports = functionLibrary;

--- a/packages/node_modules/@node-red/runtime/lib/nodes/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/index.js
@@ -25,6 +25,7 @@ var flows = require("../flows");
 var flowUtil = require("../flows/util")
 var context = require("./context");
 var Node = require("./Node");
+var functionLibrary = require("./functionLibrary");
 var log;
 
 const events = require("@node-red/util").events;
@@ -356,6 +357,7 @@ module.exports = {
     disableNode: disableNode,
 
     linkcallTargets: linkcallTargets,
+    functionLibrary: functionLibrary,
 
     // Node type registry
     registerType: registerType,

--- a/test/nodes/core/function/10-function_spec.js
+++ b/test/nodes/core/function/10-function_spec.js
@@ -2561,5 +2561,56 @@ describe('function node', function() {
             await helper.unload()
             should.not.exist(functionLibrary.getEntryById("lib1"))
         })
+
+        it('should run a synchronous node.onClose() callback when a library node is unloaded', async function () {
+            const flow = [
+                { id: "lib1", type: "function", mode: "library", name: "mathlib",
+                    initialize: "module.exports = { add: function(a,b) { return a+b; } };" +
+                        "global.set('closed', false);" +
+                        "node.onClose(function () { global.set('closed', true); });" }
+            ]
+            await helper.load(functionNode, flow)
+            const lib1 = helper.getNode("lib1")
+            lib1.context().global.get('closed').should.equal(false)
+            await helper.unload()
+            lib1.context().global.get('closed').should.equal(true)
+        })
+
+        it('should await an asynchronous node.onClose(done) callback before the node is fully closed', async function () {
+            const flow = [
+                { id: "lib1", type: "function", mode: "library", name: "mathlib",
+                    initialize: "module.exports = { add: function(a,b) { return a+b; } };" +
+                        "global.set('closed', false);" +
+                        "node.onClose(function (done) { setTimeout(function () { global.set('closed', true); done(); }, 30); });" }
+            ]
+            await helper.load(functionNode, flow)
+            const lib1 = helper.getNode("lib1")
+            lib1.context().global.get('closed').should.equal(false)
+            await helper.unload()
+            // by the time unload() resolves, the async onClose's done() must already
+            // have been called - proving the runtime waited for it
+            lib1.context().global.get('closed').should.equal(true)
+        })
+
+        it('should not expose node.onClose in a default-mode node\'s Setup (On Start) code', async function () {
+            const flow = [
+                { id: "f1", type: "function", wires: [["h1"]],
+                    initialize: "global.set('onCloseType', typeof node.onClose);",
+                    func: "msg.payload = global.get('onCloseType'); return msg;" },
+                { id: "h1", type: "helper" }
+            ]
+            await helper.load(functionNode, flow)
+            const f1 = helper.getNode("f1")
+            const h1 = helper.getNode("h1")
+            await new Promise((resolve, reject) => {
+                h1.on("input", function (msg) {
+                    try {
+                        msg.should.have.property("payload", "undefined")
+                        resolve()
+                    } catch (err) { reject(err) }
+                })
+                f1.receive({ payload: "go" })
+            })
+        })
     })
 });

--- a/test/nodes/core/function/10-function_spec.js
+++ b/test/nodes/core/function/10-function_spec.js
@@ -19,6 +19,7 @@ const sinon = require("sinon");
 const functionNode = require("nr-test-utils").require("@node-red/nodes/core/function/10-function.js");
 const linkNode = require("nr-test-utils").require("@node-red/nodes/core/common/60-link.js");
 const Context = require("nr-test-utils").require("@node-red/runtime/lib/nodes/context");
+const functionLibrary = require("nr-test-utils").require("@node-red/runtime/lib/nodes/functionLibrary");
 const helper = require("node-red-node-test-helper");
 const RED = require("nr-test-utils").require("node-red/lib/red");
 describe('function node', function() {
@@ -2362,6 +2363,203 @@ describe('function node', function() {
                 })
                 f1.receive({ payload: "original", topic: "test" })
             })
+        })
+    })
+
+    describe('library mode function node', function () {
+        it('should not expose module/exports globals in default mode', async function () {
+            const flow = [
+                { id: "f1", type: "function", wires: [["h1"]], func: "msg.hasModule = (typeof module !== 'undefined'); return msg;" },
+                { id: "h1", type: "helper" }
+            ]
+            await helper.load(functionNode, flow)
+            const f1 = helper.getNode("f1")
+            const h1 = helper.getNode("h1")
+            await new Promise((resolve, reject) => {
+                h1.on("input", function (msg) {
+                    try {
+                        msg.should.have.property("hasModule", false)
+                        should.not.exist(functionLibrary.getEntryById("f1"))
+                        resolve()
+                    } catch (err) { reject(err) }
+                })
+                f1.receive({ payload: "hello" })
+            })
+        })
+
+        it('should export functions and let another function node import them by name', async function () {
+            const flow = [
+                { id: "lib1", type: "function", mode: "library", name: "mathlib",
+                    initialize: "module.exports = { add: function(a,b) { return a+b; } };" },
+                { id: "f1", type: "function", wires: [["h1"]],
+                    func: "msg.payload = node.import('mathlib').add(1,2); return msg;" },
+                { id: "h1", type: "helper" }
+            ]
+            await helper.load(functionNode, flow)
+            const f1 = helper.getNode("f1")
+            const h1 = helper.getNode("h1")
+            functionLibrary.getEntryById("lib1").should.have.property("state", "ready")
+            await new Promise((resolve, reject) => {
+                h1.on("input", function (msg) {
+                    try {
+                        msg.should.have.property("payload", 3)
+                        resolve()
+                    } catch (err) { reject(err) }
+                })
+                f1.receive({ payload: "go" })
+            })
+        })
+
+        it('should let another function node import a library node by id', async function () {
+            const flow = [
+                { id: "lib1", type: "function", mode: "library",
+                    initialize: "module.exports = { greet: function() { return 'hi'; } };" },
+                { id: "f1", type: "function", wires: [["h1"]],
+                    func: "msg.payload = node.import('lib1').greet(); return msg;" },
+                { id: "h1", type: "helper" }
+            ]
+            await helper.load(functionNode, flow)
+            const f1 = helper.getNode("f1")
+            const h1 = helper.getNode("h1")
+            await new Promise((resolve, reject) => {
+                h1.on("input", function (msg) {
+                    try {
+                        msg.should.have.property("payload", "hi")
+                        resolve()
+                    } catch (err) { reject(err) }
+                })
+                f1.receive({ payload: "go" })
+            })
+        })
+
+        it('should throw a caught error when the target is not found', async function () {
+            const flow = [
+                { id: "f1", type: "function", wires: [["h1"]],
+                    func: "msg.payload = node.import('nope').whatever(); return msg;" },
+                { id: "c1", type: "catch", scope: ["f1"], uncaught: true, wires: [["h1"]] },
+                { id: "h1", type: "helper" }
+            ]
+            await helper.load(functionNode, flow)
+            const f1 = helper.getNode("f1")
+            const h1 = helper.getNode("h1")
+            await new Promise((resolve, reject) => {
+                h1.on("input", function (msg) {
+                    try {
+                        msg.should.have.property("error")
+                        msg.error.should.have.property("message").and.match(/not found/i)
+                        resolve()
+                    } catch (err) { reject(err) }
+                })
+                f1.receive({ payload: "go" })
+            })
+        })
+
+        it('should throw a caught error when the name is ambiguous across flows', async function () {
+            // neither library node lives on the caller's own flow, so the
+            // flow-scoped lookup misses and the flow-wide fallback finds 2
+            const flow = [
+                { id: "tab-flow-main", type: "tab", label: "Main Flow" },
+                { id: "tab-flow-2", type: "tab", label: "Flow 2" },
+                { id: "tab-flow-3", type: "tab", label: "Flow 3" },
+                { id: "lib1", type: "function", z: "tab-flow-2", mode: "library", name: "mathlib",
+                    initialize: "module.exports = { add: function(a,b) { return a+b; } };" },
+                { id: "lib2", type: "function", z: "tab-flow-3", mode: "library", name: "mathlib",
+                    initialize: "module.exports = { add: function(a,b) { return a+b; } };" },
+                { id: "f1", type: "function", z: "tab-flow-main", wires: [["h1"]],
+                    func: "msg.payload = node.import('mathlib').add(1,2); return msg;" },
+                { id: "c1", type: "catch", z: "tab-flow-main", scope: ["f1"], uncaught: true, wires: [["h1"]] },
+                { id: "h1", type: "helper", z: "tab-flow-main" }
+            ]
+            await helper.load(functionNode, flow)
+            const f1 = helper.getNode("f1")
+            const h1 = helper.getNode("h1")
+            await new Promise((resolve, reject) => {
+                h1.on("input", function (msg) {
+                    try {
+                        msg.should.have.property("error")
+                        msg.error.should.have.property("message").and.match(/multiple function library nodes named/i)
+                        resolve()
+                    } catch (err) { reject(err) }
+                })
+                f1.receive({ payload: "go" })
+            })
+        })
+
+        it('should still resolve to the flow-local library node even when a same-named one exists elsewhere', async function () {
+            const flow = [
+                { id: "tab-flow-main", type: "tab", label: "Main Flow" },
+                { id: "tab-flow-2", type: "tab", label: "Flow 2" },
+                { id: "lib1", type: "function", z: "tab-flow-main", mode: "library", name: "mathlib",
+                    initialize: "module.exports = { add: function(a,b) { return a+b+100; } };" },
+                { id: "lib2", type: "function", z: "tab-flow-2", mode: "library", name: "mathlib",
+                    initialize: "module.exports = { add: function(a,b) { return a+b; } };" },
+                { id: "f1", type: "function", z: "tab-flow-main", wires: [["h1"]],
+                    func: "msg.payload = node.import('mathlib').add(1,2); return msg;" },
+                { id: "h1", type: "helper", z: "tab-flow-main" }
+            ]
+            await helper.load(functionNode, flow)
+            const f1 = helper.getNode("f1")
+            const h1 = helper.getNode("h1")
+            await new Promise((resolve, reject) => {
+                h1.on("input", function (msg) {
+                    try {
+                        msg.should.have.property("payload", 103) // resolved to lib1, not lib2
+                        resolve()
+                    } catch (err) { reject(err) }
+                })
+                f1.receive({ payload: "go" })
+            })
+        })
+
+        it('should warn without processing when a library node receives a message directly', async function () {
+            const flow = [
+                { id: "lib1", type: "function", mode: "library", name: "mathlib",
+                    initialize: "module.exports = { add: function(a,b) { return a+b; } };" }
+            ]
+            await helper.load(functionNode, flow)
+            const lib1 = helper.getNode("lib1")
+            await new Promise((resolve, reject) => {
+                lib1.once("call:warn", function () { resolve(); })
+                lib1.receive({ payload: "go" })
+                setTimeout(() => reject(new Error("node.warn was not called")), 500)
+            })
+        })
+
+        it('should warn locally and throw "no exports" for callers when a library node exports nothing', async function () {
+            const flow = [
+                { id: "lib1", type: "function", mode: "library", name: "empty",
+                    initialize: "// nothing exported" },
+                { id: "f1", type: "function", wires: [["h1"]],
+                    func: "msg.payload = node.import('empty'); return msg;" },
+                { id: "c1", type: "catch", scope: ["f1"], uncaught: true, wires: [["h1"]] },
+                { id: "h1", type: "helper" }
+            ]
+            await helper.load(functionNode, flow)
+            const f1 = helper.getNode("f1")
+            const h1 = helper.getNode("h1")
+            functionLibrary.getEntryById("lib1").should.have.property("state", "ready")
+            functionLibrary.getEntryById("lib1").exportNames.should.have.length(0)
+            await new Promise((resolve, reject) => {
+                h1.on("input", function (msg) {
+                    try {
+                        msg.should.have.property("error")
+                        msg.error.should.have.property("message").and.match(/does not export anything/i)
+                        resolve()
+                    } catch (err) { reject(err) }
+                })
+                f1.receive({ payload: "go" })
+            })
+        })
+
+        it('should deregister a library node from the registry on unload', async function () {
+            const flow = [
+                { id: "lib1", type: "function", mode: "library", name: "mathlib",
+                    initialize: "module.exports = { add: function(a,b) { return a+b; } };" }
+            ]
+            await helper.load(functionNode, flow)
+            functionLibrary.getEntryById("lib1").should.have.property("state", "ready")
+            await helper.unload()
+            should.not.exist(functionLibrary.getEntryById("lib1"))
         })
     })
 });

--- a/test/unit/@node-red/runtime/lib/nodes/functionLibrary_spec.js
+++ b/test/unit/@node-red/runtime/lib/nodes/functionLibrary_spec.js
@@ -1,0 +1,203 @@
+var should = require("should");
+var sinon = require('sinon');
+
+var NR_TEST_UTILS = require("nr-test-utils");
+var functionLibrary = NR_TEST_UTILS.require("@node-red/runtime/lib/nodes/functionLibrary");
+var flows = NR_TEST_UTILS.require("@node-red/runtime/lib/flows");
+
+describe("runtime/nodes/functionLibrary", function() {
+
+    function makeNode(overrides) {
+        var node = Object.assign({
+            id: "node1",
+            type: "function",
+            mode: "library",
+            name: "",
+            z: "flow1",
+            _flow: {
+                TYPE: "flow",
+                flow: { id: "flow1", label: "Flow 1" }
+            }
+        }, overrides || {});
+        return node;
+    }
+
+    var flowsGetStub;
+    beforeEach(function() {
+        // by default, treat every registered node as still "live"
+        flowsGetStub = sinon.stub(flows, "get").callsFake(function(id) {
+            return functionLibrary.getEntryById(id) && functionLibrary.getEntryById(id).node;
+        });
+    });
+    afterEach(function() {
+        flowsGetStub.restore();
+        functionLibrary.clear();
+    });
+
+    describe("#register", function() {
+        it("throws if the node is not a Function node in library mode", function() {
+            (function() { functionLibrary.register(null); }).should.throw();
+            (function() { functionLibrary.register(makeNode({type:"function", mode:"default"})); }).should.throw();
+            (function() { functionLibrary.register(makeNode({type:"change", mode:"library"})); }).should.throw();
+        });
+        it("indexes the node by id and by name", function() {
+            var node = makeNode({id:"n1", name:"mathlib"});
+            functionLibrary.register(node);
+            functionLibrary.getEntryById("n1").should.have.property("id","n1");
+            functionLibrary.getEntry("mathlib").should.have.property("id","n1");
+        });
+        it("does not throw when the node has no name", function() {
+            var node = makeNode({id:"n1", name:""});
+            should(function() { functionLibrary.register(node); }).not.throw();
+            should.not.exist(functionLibrary.getEntry(""));
+        });
+    });
+
+    describe("#setExports / #setError", function() {
+        it("records exports and flips state to ready", function() {
+            var node = makeNode({id:"n1", name:"mathlib"});
+            functionLibrary.register(node);
+            var count = functionLibrary.setExports(node, {add: function(){}});
+            count.should.equal(1);
+            functionLibrary.getEntryById("n1").state.should.equal("ready");
+        });
+        it("is a no-op if the node has since been removed", function() {
+            var node = makeNode({id:"n1", name:"mathlib"});
+            functionLibrary.register(node);
+            functionLibrary.remove(node);
+            should(function() { functionLibrary.setExports(node, {add:function(){}}); }).not.throw();
+            should.not.exist(functionLibrary.getEntryById("n1"));
+        });
+        it("records an error and flips state to error", function() {
+            var node = makeNode({id:"n1", name:"mathlib"});
+            functionLibrary.register(node);
+            functionLibrary.setError(node, new Error("boom"));
+            functionLibrary.getEntryById("n1").state.should.equal("error");
+        });
+    });
+
+    describe("#remove", function() {
+        it("removes the id and name index entries", function() {
+            var node = makeNode({id:"n1", name:"mathlib"});
+            functionLibrary.register(node);
+            functionLibrary.remove(node);
+            should.not.exist(functionLibrary.getEntryById("n1"));
+            should.not.exist(functionLibrary.getEntry("mathlib"));
+        });
+        it("is a no-op for a node that was never registered", function() {
+            should(function() { functionLibrary.remove(makeNode({id:"never"})); }).not.throw();
+        });
+    });
+
+    function ready(node, exportsObject) {
+        functionLibrary.register(node);
+        functionLibrary.setExports(node, exportsObject || {fn: function(){return 42;}});
+        return node;
+    }
+
+    describe("#resolve", function() {
+        it("throws for an invalid target", function() {
+            var caller = makeNode({id:"caller"});
+            (function() { functionLibrary.resolve(caller, ""); }).should.throw();
+            (function() { functionLibrary.resolve(caller, null); }).should.throw();
+        });
+
+        it("resolves by direct node id", function() {
+            var lib = ready(makeNode({id:"lib1", name:"mathlib"}));
+            var caller = makeNode({id:"caller"});
+            var exp = functionLibrary.resolve(caller, "lib1");
+            exp.fn().should.equal(42);
+        });
+
+        it("resolves by name, scoped to the caller's flow first", function() {
+            ready(makeNode({id:"lib1", name:"mathlib", _flow:{TYPE:"flow", flow:{id:"flowA"}}}));
+            var caller = makeNode({id:"caller", _flow:{TYPE:"flow", flow:{id:"flowA"}}});
+            var exp = functionLibrary.resolve(caller, "mathlib");
+            exp.fn().should.equal(42);
+        });
+
+        it("resolves by name flow-wide when unique", function() {
+            ready(makeNode({id:"lib1", name:"mathlib", _flow:{TYPE:"flow", flow:{id:"flowA"}}}));
+            var caller = makeNode({id:"caller", _flow:{TYPE:"flow", flow:{id:"flowB"}}});
+            var exp = functionLibrary.resolve(caller, "mathlib");
+            exp.fn().should.equal(42);
+        });
+
+        it("throws when a name is ambiguous across flows", function() {
+            ready(makeNode({id:"lib1", name:"mathlib", _flow:{TYPE:"flow", flow:{id:"flowA"}}}));
+            ready(makeNode({id:"lib2", name:"mathlib", _flow:{TYPE:"flow", flow:{id:"flowB"}}}));
+            var caller = makeNode({id:"caller", _flow:{TYPE:"flow", flow:{id:"flowC"}}});
+            (function() { functionLibrary.resolve(caller, "mathlib"); }).should.throw();
+        });
+
+        it("throws when the target is not found", function() {
+            var caller = makeNode({id:"caller"});
+            (function() { functionLibrary.resolve(caller, "nope"); }).should.throw();
+        });
+
+        it("resolves a subflow-local design-time id via the caller's z", function() {
+            // simulates a node inside a subflow instance "inst1", whose sibling
+            // library node's design-time id is "designLib" -> runtime id "inst1-designLib"
+            ready(makeNode({
+                id:"inst1-designLib", name:"", z:"inst1",
+                _flow:{TYPE:"subflow", flow:{id:"inst1"}, subflowDef:{name:"My Subflow"}}
+            }));
+            var caller = makeNode({
+                id:"inst1-designCaller", z:"inst1",
+                _flow:{TYPE:"subflow", flow:{id:"inst1"}, subflowDef:{name:"My Subflow"}}
+            });
+            var exp = functionLibrary.resolve(caller, "designLib");
+            exp.fn().should.equal(42);
+        });
+
+        it("throws not-ready while the target is still initialising", function() {
+            var node = makeNode({id:"lib1", name:"mathlib"});
+            functionLibrary.register(node);
+            var caller = makeNode({id:"caller"});
+            (function() { functionLibrary.resolve(caller, "lib1"); }).should.throw();
+        });
+
+        it("throws init-failed if the target's setup errored", function() {
+            var node = makeNode({id:"lib1", name:"mathlib"});
+            functionLibrary.register(node);
+            functionLibrary.setError(node, new Error("boom"));
+            var caller = makeNode({id:"caller"});
+            (function() { functionLibrary.resolve(caller, "lib1"); }).should.throw();
+        });
+
+        it("throws no-exports if the target exported nothing", function() {
+            var node = makeNode({id:"lib1", name:"mathlib"});
+            functionLibrary.register(node);
+            functionLibrary.setExports(node, {});
+            var caller = makeNode({id:"caller"});
+            (function() { functionLibrary.resolve(caller, "lib1"); }).should.throw();
+        });
+
+        it("self-heals and throws not-available for a stale entry", function() {
+            var node = ready(makeNode({id:"lib1", name:"mathlib"}));
+            // simulate the node having been stopped/replaced without `remove()` firing
+            flowsGetStub.callsFake(function(id) { return id === "lib1" ? undefined : node; });
+            var caller = makeNode({id:"caller"});
+            (function() { functionLibrary.resolve(caller, "lib1"); }).should.throw();
+            should.not.exist(functionLibrary.getEntryById("lib1"));
+        });
+    });
+
+    describe("#list / #clear", function() {
+        it("lists registered entries without exposing internal node references", function() {
+            ready(makeNode({id:"lib1", name:"mathlib"}));
+            var list = functionLibrary.list();
+            list.should.have.length(1);
+            list[0].should.have.property("id","lib1");
+            list[0].should.have.property("name","mathlib");
+            list[0].should.have.property("exportNames").which.is.an.Array();
+            list[0].should.not.have.property("node");
+        });
+        it("clear empties the registry", function() {
+            ready(makeNode({id:"lib1", name:"mathlib"}));
+            functionLibrary.clear();
+            functionLibrary.list().should.have.length(0);
+        });
+    });
+
+});


### PR DESCRIPTION
## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

As discussed on Forum: https://discourse.nodered.org/t/formalising-reusable-functions-with-autocompletion-parameter-hints-click-through-navigation/101645

## Proposed changes


### TLDR

Formalises the common but ad-hoc practice of stashing reusable JavaScript in global/flow context by giving the Function node a proper "Module" mode: define a function once, `node.import()` it from anywhere, and get real IDE support for it, autocompletion, parameter hints from JSDoc, and click-through navigation to the source, rather than an untyped blob in context storage. Also adds a `node.onClose()` hook so module code can clean up after itself on delete/redeploy.

### Key points

- New **Mode** setting on the Function node: `Function` (default, unchanged) or `Module` (internal value `library`). A Module node has no inputs/outputs and runs its code once at startup via the existing Setup tab, ending with `module.exports = { ... }`.
- The Module node's `name` doubles as its import key: it is validated live in the editor, required (a nameless Module node can only ever be imported by id) and flagged as an error if it duplicates another Module node's name, so clashes are caught before deploy rather than surfacing as an ambiguous `node.import()` failure at runtime.
- Switching a node to Module mode swaps in ready-to-edit boilerplate for its code tab (a `module.exports = { ... }` skeleton with a short comment pointing at `node.import()` and `node.onClose()`), rather than leaving a blank editor.
- `node.import(idOrName)` resolves another Module node's exports, id first then name, flow scoped then global, mirroring the existing Link Call resolution pattern. Returns a live reference, so a target redeploy is picked up on the next call.
- Full editor tooling for `node.import()`: real TypeScript inference off each Module node's actual source (not a hand rolled type scrape), so `node.import("mathlib").add(1, 2)` gets genuine autocompletion and parameter hints straight from JSDoc. Ctrl+click (or Alt+F12 for peek) on an import call jumps straight to the source node's editor, no more hunting through flows to find where a helper lives.
- `node.onClose(fn)` (Module mode only): since Module nodes have no "On Stop" tab, this is how module code registers cleanup for anything it creates (connections, timers, watchers) on delete or redeploy. `fn` can take 0, 1 or 2 parameters, matching Node-RED's standard node `close` event exactly (sync, `done` only, or `removed` + `done`), and can be called more than once to register independent cleanup functions.
- `node.import` and `node.onClose` are typed as `readonly` in the editor's type definitions, so accidentally writing `node.onClose = fn` instead of `node.onClose(fn)` is flagged as a type error in the editor rather than silently discarding the callback.
- Updated built in help text and the Module mode scaffolding/placeholder code to document `node.onClose`.

### Unit Tests

- `functionLibrary_spec.js` (new): 21 tests covering the module registry, register/resolve/remove and name/id resolution rules.
- `10-function_spec.js`: extended with tests for exporting and importing by name and by id, ambiguous name errors across flows, flow scoped resolution, warnings when a module receives a message directly or exports nothing, deregistration on unload, and `node.onClose` behaviour (synchronous callbacks, asynchronous callbacks awaited before the node is considered closed, and confirming it is not exposed outside Module mode).
- All 123 tests in `10-function_spec.js` and 21 in `functionLibrary_spec.js` passing.
- Manually verified end to end against a running dev instance: export/import across nodes, ctrl+click navigation, class based exports with private fields and getters/setters, and `node.onClose` firing correctly on both redeploy and node deletion (confirmed `removed=true`/`false` in each case, and that multiple registered callbacks all run).

<details>
<summary>Implementation notes and known limitations</summary>

**Runtime**

- `functionLibrary.js` (new) is the module registry: register/setExports/setError/remove/resolve, modelled on the existing `linkcallTargets` registry.
- A Module node's close handling had to be reordered: the existing "clear any outstanding sandboxed timers/intervals" cleanup now runs immediately when the node is constructed rather than after the Setup script runs, so it always fires *before* any user registered `node.onClose` callback. Previously, an async `onClose` that scheduled its own `setTimeout` to defer calling `done()` could have that timer cancelled by the same close pass before it ever fired, causing the node to hang until Node-RED's 15s "Close timed out" fallback.

**Editor / Monaco**

- Each Module node's source is mirrored into a real hidden Monaco model at `file:///node/function/<nodeId>.js`. Other editors reference it via `typeof import("./<id>.js")`, so autocompletion comes from TypeScript's own module resolution rather than a custom type scraper.
- A context stack (not a single value) tracks which Function node dialog is "active" for type purposes, so stacked dialogs (e.g. opened via ctrl+click) don't clobber each other's typing.
- External npm module types (Setup tab imports, e.g. a crypto library) still resolve to `any`. This is a separate, pre-existing gap in how Node-RED handles external module typing generally, not something introduced or fixed by this change.

**Known limitations**

- Ctrl+click /hover does not resolve a Module node that only exists inside a subflow instance; it degrades to a "not found".

</details>

### Demo 
<img width="836" height="611" alt="image" src="https://github.com/user-attachments/assets/48041bbc-db6d-43ff-a2df-f67977e9ad2f" />

```json
[{"id":"d5d507751a25f62f","type":"inject","z":"806d4eb568dca907","name":"x=2, y=44, z=4","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"{\"x\":2, \"y\":44, \"z\":4}","payloadType":"json","x":180,"y":140,"wires":[["1008986f7475754a"]]},{"id":"1008986f7475754a","type":"function","z":"806d4eb568dca907","name":"do maths","mode":"default","inputs":1,"func":"// CTRL+click on \"math-lib\" to navigate\nconst mathlib = node.import(\"math-lib\")\nconst x = msg.payload.x\nconst y = msg.payload.y\nconst z = msg.payload.z\n\n// CTRL+click methods to navigate\n// ALT+F12 to peek definition\nlet result = mathlib.add(x, y)\nresult = mathlib.subtract(result, z)\n\n// return it\nmsg.payload = result\nreturn msg;","outputs":1,"timeout":0,"noerr":0,"initialize":"","finalize":"","libs":[],"x":380,"y":140,"wires":[["c86aa7313bde73ad"]]},{"id":"c86aa7313bde73ad","type":"debug","z":"806d4eb568dca907","name":"debug 1","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","statusVal":"","statusType":"auto","x":700,"y":140,"wires":[]},{"id":"2e5e7ffa55869779","type":"function","z":"806d4eb568dca907","name":"modbus CRC of payload","mode":"default","inputs":1,"func":"// Destructuing supported\nconst { calculateModbusCrc } = node.import('crc-lib')\n\n// Hover to see function signature\n// CTRL+SHIFT+SPACE inside brackets for hint\n// CTRL+click on method or peek it with ALT+F12\nmsg.payload = calculateModbusCrc(msg.payload+'')\n\nreturn msg;\n","outputs":1,"timeout":0,"noerr":0,"initialize":"","finalize":"","libs":[],"x":430,"y":360,"wires":[["a4cc6624e1cf045a"]]},{"id":"5941a8b51f319f48","type":"inject","z":"806d4eb568dca907","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"","payloadType":"date","x":160,"y":360,"wires":[["2e5e7ffa55869779"]]},{"id":"a4cc6624e1cf045a","type":"debug","z":"806d4eb568dca907","name":"debug 2","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","statusVal":"","statusType":"auto","x":700,"y":360,"wires":[]},{"id":"f61b43872a8d48cf","type":"function","z":"806d4eb568dca907","name":"crc-lib","mode":"library","inputs":0,"func":"\nreturn msg;","outputs":0,"timeout":0,"noerr":0,"initialize":"// Define reusable functions here and export them.\n// Other Function nodes can call them via node.import().\n\n\nconst { crc16 } = easyCrc\n\n/**\n * Computes a modbus CRC on the provided data\n * @param {string|Buffer} data - Data to compute modbus CRC for\n */\nconst calculateModbusCrc = (data) => crc16('MODBUS', data)\n\nmodule.exports = {\n    calculateModbusCrc\n}\n","finalize":"","libs":[{"var":"easyCrc","module":"easy-crc"}],"x":410,"y":300,"wires":[]},{"id":"6857c2d2f82d6078","type":"function","z":"806d4eb568dca907","name":"RunningStatsLib","mode":"library","inputs":0,"func":"\nreturn msg;","outputs":0,"timeout":0,"noerr":0,"initialize":"// Define reusable functions here and export them.\n// Other Function nodes can call them via node.import().\n\n// When needed, node.onClose(fn) can be used to register cleanup logic.\n// See built-in help for details.\n\n/**\n * Tracks running statistics over a stream of numeric samples.\n */\nclass RunningStats {\n    #count = 0;\n    #sum = 0;\n    #min = Infinity;\n    #max = -Infinity;\n    #label;\n\n    /** @param {string} [label] - optional label for this instance */\n    constructor(label) {\n        this.#label = label || 'stats';\n    }\n\n    /** Number of samples added so far */\n    get count() { return this.#count; }\n\n    /** Mean of all samples added so far (NaN if none yet) */\n    get average() { return this.#count === 0 ? NaN : this.#sum / this.#count; }\n\n    get min() { return this.#min; }\n    get max() { return this.#max; }\n\n    get label() { return this.#label; }\n    /** @param {string} value */\n    set label(value) { this.#label = String(value); }\n\n    /**\n     * Add a sample.\n     * @param {number} value\n     * @returns {this} for chaining, eg stats.add(1).add(2).add(3)\n     */\n    add(value) {\n        this.#count++;\n        this.#sum += value;\n        if (value < this.#min) this.#min = value;\n        if (value > this.#max) this.#max = value;\n        return this;\n    }\n\n    /** Reset all accumulated statistics */\n    reset() {\n        this.#count = 0;\n        this.#sum = 0;\n        this.#min = Infinity;\n        this.#max = -Infinity;\n        return this;\n    }\n\n    /** Plain-object snapshot - safe to put on msg (crosses the vm realm boundary) */\n    toSummary() {\n        return { label: this.#label, count: this.#count, average: this.average, min: this.#min, max: this.#max };\n    }\n}\n\nnode.onClose(function () {\n    node.log('RunningStats module closing');\n});\n\nmodule.exports = { RunningStats };\n","finalize":"","libs":[],"x":440,"y":500,"wires":[]},{"id":"b5f1e136d3d04494","type":"function","z":"806d4eb568dca907","name":"importing a class RunningStats","mode":"default","inputs":1,"func":"// CTRL+click import to navigate, CTRL+click RunningStats to peek the class\nconst { RunningStats } = node.import(\"RunningStatsLib\");\n\n/** @type {InstanceType<typeof RunningStats>}} */\nlet stats = flow.get('myStats');\nif (!stats) {\n    stats = new RunningStats('sensor-A');\n    flow.set('myStats', stats);\n}\n\nif (msg.label && msg.label !== stats.label) {\n    stats.label = msg.label\n}\n\nif (msg.topic === 'reset') {\n    stats.reset()\n} else {\n    stats.add(msg.payload);\n}\nmsg.payload = stats.toSummary();\nreturn msg;\n","outputs":1,"timeout":0,"noerr":0,"initialize":"","finalize":"","libs":[],"x":450,"y":560,"wires":[["307d776bb1323d91"]]},{"id":"b7c36bbfea35cf05","type":"inject","z":"806d4eb568dca907","name":"random 1 ~ 10","props":[{"p":"payload"},{"p":"label","v":"test-1","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"(\t    $minimum := 1;\t    $maximum := 10;\t    $round(($random() * ($maximum-$minimum)) + $minimum, 0)\t)","payloadType":"jsonata","x":180,"y":560,"wires":[["b5f1e136d3d04494"]]},{"id":"307d776bb1323d91","type":"debug","z":"806d4eb568dca907","name":"debug 3","active":true,"tosidebar":true,"console":false,"tostatus":true,"complete":"payload","targetType":"msg","statusVal":"payload","statusType":"auto","x":700,"y":560,"wires":[]},{"id":"a22c47b270719df2","type":"inject","z":"806d4eb568dca907","name":"","props":[{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"reset","x":150,"y":600,"wires":[["b5f1e136d3d04494"]]},{"id":"c1a732f3c492d1ae","type":"function","z":"806d4eb568dca907","name":"math-lib","mode":"library","inputs":0,"func":"\nreturn msg;","outputs":0,"timeout":0,"noerr":0,"initialize":"node.onClose(function () {\n    node.log('cleanup A ran (sync)');\n});\n\nnode.onClose(function (removed, done) {\n    node.log('cleanup B ran (async), removed=' + removed);\n    done();\n});\n\n/**\n * Adds 2 numbers then returns the computed result\n * @param {number} x - x parameter\n * @param {number} y - y parameter\n */\nfunction add(x, y) {\n    return x + y\n}\n\n/**\n * subtracts y from x and returns result\n * @param {number} x - x parameter\n * @param {number} y - y parameter\n */\nfunction subtract(x, y) {\n    return x - y\n}\n\n/**\n * Maths Library with common used functions\n */\nmodule.exports = {\n    add,\n    subtract\n}\n","finalize":"","libs":[],"x":420,"y":80,"wires":[]},{"id":"f665c8fefcf8081c","type":"comment","z":"806d4eb568dca907","name":"class demo","info":"","x":150,"y":500,"wires":[]},{"id":"a80a543b94d95eb4","type":"comment","z":"806d4eb568dca907","name":"basic function export demo","info":"","x":190,"y":80,"wires":[]},{"id":"2ad5f5bfd72bf441","type":"comment","z":"806d4eb568dca907","name":"re-export setup module easy-crc","info":"","x":210,"y":300,"wires":[]}]
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
