### PR TITLE
Update jsonata 2.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
                 "is-utf8": "0.2.1",
                 "js-yaml": "4.3.0",
                 "json-stringify-safe": "5.0.1",
-                "jsonata": "2.0.6",
+                "jsonata": "2.2.2",
                 "lodash.clonedeep": "^4.5.0",
                 "media-typer": "1.1.0",
                 "memorystore": "1.6.8",
@@ -6658,9 +6658,9 @@
             "license": "ISC"
         },
         "node_modules/jsonata": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.0.6.tgz",
-            "integrity": "sha512-WhQB5tXQ32qjkx2GYHFw2XbL90u+LLzjofAYwi+86g6SyZeXHz9F1Q0amy3dWRYczshOC3Haok9J4pOCgHtwyQ==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.2.2.tgz",
+            "integrity": "sha512-XDFH2PuaAXv0AXJEWwElXbqADmKFGKMLMkFb+qOz0EhjQW2EIJ6pgtordLU+4u3IVERyBfqy6bi6kZKEncvRqA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 8"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "is-utf8": "0.2.1",
         "js-yaml": "4.3.0",
         "json-stringify-safe": "5.0.1",
-        "jsonata": "2.0.6",
+        "jsonata": "2.2.2",
         "lodash.clonedeep": "^4.5.0",
         "media-typer": "1.1.0",
         "memorystore": "1.6.8",

--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -24,7 +24,6 @@ const jsonata = require("jsonata");
 const moment = require("moment-timezone");
 const safeJSONStringify = require("json-stringify-safe");
 const util = require("util");
-const { hasOwnProperty } = Object.prototype;
 const log = require("./log")
 /**
  * Safely returns the object constructor name.
@@ -182,7 +181,7 @@ function compareObjects(obj1,obj2) {
     }
     for (var k in obj1) {
         /* istanbul ignore else */
-        if (hasOwnProperty.call(obj1, k)) {
+        if (Object.hasOwn(obj1, k)) {
             if (!compareObjects(obj1[k],obj2[k])) {
                 return false;
             }
@@ -473,7 +472,7 @@ function setObjectProperty(msg,prop,value,createMissing) {
     for (var i=0;i<length-1;i++) {
         key = msgPropParts[i];
         if (typeof key === 'string' || (typeof key === 'number' && !Array.isArray(obj))) {
-            if (hasOwnProperty.call(obj, key)) {
+            if (Object.hasOwn(obj, key)) {
                 if (length > 1 && ((typeof obj[key] !== "object" && typeof obj[key] !== "function") || obj[key] === null)) {
                     // Break out early as we cannot create a property beneath
                     // this type of value
@@ -570,7 +569,7 @@ function getSetting(node, name, flow_) {
  * @memberof @node-red/util_util
  */
 function evaluateEnvProperty(value, node) {
-    var flow = (node && hasOwnProperty.call(node, "_flow")) ? node._flow : null;
+    var flow = (node && Object.hasOwn(node, "_flow")) ? node._flow : null;
     var result;
     if (/^\${[^}]+}$/.test(value)) {
         // ${ENV_VAR}
@@ -782,10 +781,57 @@ function evaluateJSONataExpression(expr,msg,callback) {
     }
 
     expr.evaluate(context, bindings).then(result => {
-        callback(null, result)
+        callback(null, normaliseJSONataResult(result, new WeakSet()))
     }).catch(err => {
         callback(err)
     })
+}
+
+/**
+ * Restore the standard Object prototype on any object created by JSONata.
+ *
+ * JSONata 2.2.1 hardened itself against prototype pollution by building its
+ * internal objects with `Object.create(null)`. Those objects surface in the
+ * expression result, so anything downstream calling `obj.hasOwnProperty(...)` -
+ * or relying on `toString` - will throw. We cannot assume code outside our
+ * control avoids that, so the prototype is restored before the result is
+ * handed back.
+ *
+ * The result must be walked, not just checked at the top level: JSONata leaves
+ * null-prototype objects nested inside plain objects and, commonly, as the
+ * members of a returned array (`items.{...}`, `$map(...)`, `$append(...)`).
+ *
+ * Only plain objects and arrays are traversed. Buffers, Dates and class
+ * instances are passed through untouched: JSONata never places a constructed
+ * object inside one, and walking them would be expensive (a Buffer has one own
+ * key per byte) and unsafe (property getters on msg.req/msg.res may have side
+ * effects).
+ *
+ * @param  {any}     value - the JSONata result to normalise, modified in place
+ * @param  {WeakSet} seen  - objects already visited, to survive circular references
+ * @return {any} the value that was passed in
+ */
+function normaliseJSONataResult(value, seen) {
+    if (value === null || typeof value !== 'object') { return value }
+    if (seen.has(value)) { return value }
+    seen.add(value)
+    if (Array.isArray(value)) {
+        for (var i = 0; i < value.length; i++) {
+            normaliseJSONataResult(value[i], seen)
+        }
+        return value
+    }
+    var proto = Object.getPrototypeOf(value)
+    if (proto === null) {
+        Object.setPrototypeOf(value, Object.prototype)
+    } else if (proto !== Object.prototype) {
+        return value
+    }
+    var keys = Object.keys(value)
+    for (var k = 0; k < keys.length; k++) {
+        normaliseJSONataResult(value[keys[k]], seen)
+    }
+    return value
 }
 
 /**
@@ -824,7 +870,7 @@ function normaliseNodeTypeName(name) {
 function encodeObject(msg,opts) {
     try {
         var debuglength = 1000;
-        if (opts && hasOwnProperty.call(opts, 'maxLength')) {
+        if (opts && Object.hasOwn(opts, 'maxLength')) {
             debuglength = opts.maxLength;
         }
         var msgType = typeof msg.msg;
@@ -837,7 +883,7 @@ function encodeObject(msg,opts) {
                 type: 'error',
                 data: {
                     name: msg.msg.name,
-                    message: hasOwnProperty.call(msg.msg, 'message') ? msg.msg.message : msg.msg.toString(),
+                    message: Object.hasOwn(msg.msg, 'message') ? msg.msg.message : msg.msg.toString(),
                     code: msg.msg.code,
                     cause: cause + "",
                     stack: msg.msg.stack,
@@ -928,7 +974,7 @@ function encodeObject(msg,opts) {
                                 type: 'error',
                                 data: {
                                     name: value.name,
-                                    message: hasOwnProperty.call(value, 'message') ? value.message : value.toString(),
+                                    message: Object.hasOwn(value, 'message') ? value.message : value.toString(),
                                     code,
                                     cause: cause + "",
                                     stack: value.stack,
@@ -1079,7 +1125,7 @@ function encodeObject(msg,opts) {
             type: 'error',
             data: {
                 name: e.name,
-                message: 'encodeObject Error: ' + (hasOwnProperty.call(e, 'message') ? e.message : e.toString()),
+                message: 'encodeObject Error: ' + (Object.hasOwn(e, 'message') ? e.message : e.toString()),
                 stack: e.stack,
             }
         }

--- a/packages/node_modules/@node-red/util/package.json
+++ b/packages/node_modules/@node-red/util/package.json
@@ -19,7 +19,7 @@
         "fs-extra": "11.4.0",
         "i18next": "25.8.14",
         "json-stringify-safe": "5.0.1",
-        "jsonata": "2.0.6",
+        "jsonata": "2.2.2",
         "lodash.clonedeep": "^4.5.0",
         "moment": "2.30.1",
         "moment-timezone": "0.5.48"

--- a/test/unit/@node-red/util/lib/util_spec.js
+++ b/test/unit/@node-red/util/lib/util_spec.js
@@ -774,6 +774,134 @@ describe("@node-red/util/util", function() {
                   done();
               });
           });
+
+          describe('null prototype results', function() {
+              // JSONata 2.2.1 builds its internal objects with Object.create(null) to
+              // harden against prototype pollution. Those objects reach the expression
+              // result, where anything calling `obj.hasOwnProperty(...)` or relying on
+              // `toString` throws. evaluateJSONataExpression must restore the standard
+              // prototype throughout the result before handing it back.
+
+              // Collect the path of every null-prototype object reachable in the result,
+              // so a failure reports where the prototype was missed rather than just
+              // that one was.
+              function findNullPrototypes(value, path, found, seen) {
+                  if (value === null || typeof value !== 'object' || seen.has(value)) {
+                      return found;
+                  }
+                  seen.add(value);
+                  if (Object.getPrototypeOf(value) === null) {
+                      found.push(path || '<result>');
+                  }
+                  if (Array.isArray(value)) {
+                      value.forEach(function(entry, i) {
+                          findNullPrototypes(entry, path + '[' + i + ']', found, seen);
+                      });
+                      return found;
+                  }
+                  Object.keys(value).forEach(function(key) {
+                      findNullPrototypes(value[key], path + '.' + key, found, seen);
+                  });
+                  return found;
+              }
+
+              var msg = {
+                  payload: { a: 1, b: 2 },
+                  items: [ { n: 1 }, { n: 2 } ]
+              };
+
+              // Each expression returns objects built by JSONata in a different shape.
+              // The array cases matter most: the result itself is an Array, so checking
+              // only the top-level prototype misses the null-prototype members.
+              [
+                  { name: 'an object', expr: '{"x": payload.a}' },
+                  { name: 'a nested object', expr: '{"outer": {"inner": payload.a}}' },
+                  { name: 'a deeply nested object', expr: '{"a":{"b":{"c":{"d":1}}}}' },
+                  { name: 'an array of objects', expr: 'items.{"v": n}' },
+                  { name: 'an array literal of objects', expr: '[{"a":1}]' },
+                  { name: 'objects from $map', expr: '$map(items, function($i) { {"v": $i.n} })' },
+                  { name: 'objects from $each', expr: '$each(payload, function($v,$k) { {$k: $v} })' },
+                  { name: 'an object from $merge', expr: '$merge([{"a":1},{"b":2}])' },
+                  { name: 'objects appended to an array', expr: '$append(items, [{"z":1}])' },
+                  { name: 'an array of objects inside an object', expr: '{"list": items.{"v": n}}' },
+                  { name: 'an object merged by the transform operator', expr: 'payload ~> |$|{"added": {"x": 1}}|' }
+              ].forEach(function(testCase) {
+                  it('restores the Object prototype on ' + testCase.name, function(done) {
+                      var expr = util.prepareJSONataExpression(testCase.expr, {});
+                      util.evaluateJSONataExpression(expr, msg, function(err, result) {
+                          try {
+                              should.not.exist(err);
+                              var missed = findNullPrototypes(result, '', [], new WeakSet());
+                              missed.should.eql([], 'null prototype left at: ' + missed.join(', '));
+                              done();
+                          } catch (error) {
+                              done(error);
+                          }
+                      });
+                  });
+              });
+
+              it('returns a result that downstream code can call hasOwnProperty on', function(done) {
+                  var expr = util.prepareJSONataExpression('{"list": items.{"v": n}}', {});
+                  util.evaluateJSONataExpression(expr, msg, function(err, result) {
+                      try {
+                          should.not.exist(err);
+                          // These are the calls that throw on a null-prototype object.
+                          result.hasOwnProperty('list').should.be.true();
+                          result.list[0].hasOwnProperty('v').should.be.true();
+                          String(result.list[0]).should.equal('[object Object]');
+                          done();
+                      } catch (error) {
+                          done(error);
+                      }
+                  });
+              });
+
+              it('leaves a Buffer in the result untouched', function(done) {
+                  var expr = util.prepareJSONataExpression('{"b": payload}', {});
+                  var buffer = Buffer.from('hello');
+                  util.evaluateJSONataExpression(expr, { payload: buffer }, function(err, result) {
+                      try {
+                          should.not.exist(err);
+                          Buffer.isBuffer(result.b).should.be.true();
+                          result.b.toString().should.equal('hello');
+                          done();
+                      } catch (error) {
+                          done(error);
+                      }
+                  });
+              });
+
+              it('handles a circular reference in the result', function(done) {
+                  // `$` returns the message itself, so a cycle in the message ends up in
+                  // the result and the prototype walk must not recurse forever.
+                  var circular = { payload: { a: 1 } };
+                  circular.payload.self = circular;
+                  var expr = util.prepareJSONataExpression('$', {});
+                  util.evaluateJSONataExpression(expr, circular, function(err, result) {
+                      try {
+                          should.not.exist(err);
+                          findNullPrototypes(result, '', [], new WeakSet()).should.eql([]);
+                          done();
+                      } catch (error) {
+                          done(error);
+                      }
+                  });
+              });
+
+              it('passes a primitive result through unchanged', function(done) {
+                  var expr = util.prepareJSONataExpression('payload.a', {});
+                  util.evaluateJSONataExpression(expr, msg, function(err, result) {
+                      try {
+                          should.not.exist(err);
+                          result.should.equal(1);
+                          done();
+                      } catch (error) {
+                          done(error);
+                      }
+                  });
+              });
+          });
       });
 
     describe('encodeObject', function () {


### PR DESCRIPTION
Updates to JSONata 2.2.2.

Due to the changes in JSONata to emit a null prototype object, this updates the utility functions we wrap around JSONata to safely restore the object prototypes where necessary.

I originally also prepare a change to migrate from `x.hasOwnProperty('foo')` to `Object.hasOwn(x, 'foo')` - as a safer idiom. But to keep this change small and focussed, I'm going to leave that out for now. Those changes still appear in `util.js`, but not the 100s of other files that touches.