### PR TITLE
Support .mjs node files in template derivation

### DIFF
--- a/packages/node_modules/@node-red/registry/lib/loader.js
+++ b/packages/node_modules/@node-red/registry/lib/loader.js
@@ -272,7 +272,7 @@ async function loadNodeConfig(fileInfo) {
         module: module,
         name: name,
         file: file,
-        template: file.replace(/\.c?js$/,".html"),
+        template: file.replace(/\.[cm]?js$/,".html"),
         enabled: isEnabled,
         loaded:false,
         version: version,

--- a/packages/node_modules/@node-red/registry/lib/localfilesystem.js
+++ b/packages/node_modules/@node-red/registry/lib/localfilesystem.js
@@ -72,11 +72,11 @@ function getLocalFile(file) {
         return null;
     }
     try {
-        fs.statSync(file.replace(/\.c?js$/,".html"));
+        fs.statSync(file.replace(/\.[cm]?js$/,".html"));
         return {
             file:    file,
             module:  "node-red",
-            name:    path.basename(file).replace(/^\d+-/,"").replace(/\.c?js$/,""),
+            name:    path.basename(file).replace(/^\d+-/,"").replace(/\.[cm]?js$/,""),
             version: settings.version
         };
     } catch(err) {
@@ -114,7 +114,7 @@ function getLocalNodeFiles(dir, skipValidNodeRedModules) {
     files.forEach(function(fn) {
         var stats = fs.statSync(path.join(dir,fn));
         if (stats.isFile()) {
-            if (/\.c?js$/.test(fn)) {
+            if (/\.[cm]?js$/.test(fn)) {
                 var info = getLocalFile(path.join(dir,fn));
                 if (info) {
                     result.push(info);

--- a/test/unit/@node-red/registry/lib/loader_spec.js
+++ b/test/unit/@node-red/registry/lib/loader_spec.js
@@ -125,6 +125,56 @@ describe("red/nodes/registry/loader",function() {
             });
         });
 
+        it("derives html template for .mjs node files", function(done) {
+            stubs.push(sinon.stub(localfilesystem,"getNodeFiles").callsFake(function(){
+                var result = {};
+                result["node-red"] = {
+                    "name": "node-red",
+                    "version": "1.2.3",
+                    "nodes": {
+                        "TestNodeMjs": {
+                            "file": path.join(resourcesDir,"TestNodeMjs","TestNodeMjs.mjs"),
+                            "module": "node-red",
+                            "name": "TestNodeMjs"
+                        }
+                    }
+                };
+                return result;
+            }));
+
+            stubs.push(sinon.stub(registry,"saveNodeList").callsFake(function(){ return }));
+            stubs.push(sinon.stub(registry,"addModule").callsFake(function(){ return }));
+            stubs.push(sinon.stub(registry,"getNodeInfo").callsFake(function(){ return null; }));
+
+            stubs.push(sinon.stub(nodes,"registerType"));
+            loader.init({nodes:nodes,log:{info:function(){},_:function(){}},settings:{available:function(){return true;}}});
+            loader.load().then(function(result) {
+                registry.addModule.called.should.be.true();
+                var module = registry.addModule.lastCall.args[0];
+                module.nodes.should.have.property("TestNodeMjs");
+                module.nodes.TestNodeMjs.should.have.property("file");
+                module.nodes.TestNodeMjs.file.should.eql(path.join(resourcesDir,"TestNodeMjs","TestNodeMjs.mjs"));
+                module.nodes.TestNodeMjs.should.have.property("template");
+                module.nodes.TestNodeMjs.template.should.eql(path.join(resourcesDir,"TestNodeMjs","TestNodeMjs.html"));
+                module.nodes.TestNodeMjs.should.have.property("loaded",true);
+                module.nodes.TestNodeMjs.should.have.property("types");
+                module.nodes.TestNodeMjs.types.should.have.a.length(1);
+                module.nodes.TestNodeMjs.types[0].should.eql('test-node-mjs');
+                module.nodes.TestNodeMjs.should.have.property("config");
+                module.nodes.TestNodeMjs.config.should.not.eql("");
+                module.nodes.TestNodeMjs.should.have.property("help");
+                module.nodes.TestNodeMjs.help.should.have.property("en-US");
+
+                nodes.registerType.calledOnce.should.be.true();
+                nodes.registerType.lastCall.args[0].should.eql('node-red/TestNodeMjs');
+                nodes.registerType.lastCall.args[1].should.eql('test-node-mjs');
+
+                done();
+            }).catch(function(err) {
+                done(err);
+            });
+        });
+
         it("load core node files scanned by lfs - ignore html if disableEditor true", function(done) {
             stubs.push(sinon.stub(localfilesystem,"getNodeFiles").callsFake(function(){
                 var result = {};

--- a/test/unit/@node-red/registry/lib/localfilesystem_spec.js
+++ b/test/unit/@node-red/registry/lib/localfilesystem_spec.js
@@ -75,7 +75,8 @@ describe("red/nodes/registry/localfilesystem",function() {
             nm.should.have.a.property('name','node-red');
             nm.should.have.a.property("nodes");
             var nodes = nm.nodes;
-            checkNodes(nm.nodes,['TestNode1','MultipleNodes1','NestedNode','TestNode2','TestNode3','TestNode4'],['TestNodeModule']);
+            checkNodes(nm.nodes,['TestNode1','MultipleNodes1','NestedNode','TestNode2','TestNode3','TestNode4','TestNodeMjs'],['TestNodeModule']);
+            nm.nodes.TestNodeMjs.file.should.match(/TestNodeMjs\.mjs$/);
             i18n.registerMessageCatalog.called.should.be.true();
             i18n.registerMessageCatalog.lastCall.args[0].should.eql('node-red');
             i18n.registerMessageCatalog.lastCall.args[1].should.eql(path.resolve(path.join(resourcesDir,"locales")));

--- a/test/unit/@node-red/registry/lib/resources/local/TestNodeMjs/TestNodeMjs.html
+++ b/test/unit/@node-red/registry/lib/resources/local/TestNodeMjs/TestNodeMjs.html
@@ -1,0 +1,5 @@
+<script type="text/x-red" data-template-name="test-node-mjs"></script>
+<script type="text/x-red" data-help-name="test-node-mjs"></script>
+<script type="text/javascript">RED.nodes.registerType('test-node-mjs',{});</script>
+<style></style>
+<p>this should be filtered out</p>

--- a/test/unit/@node-red/registry/lib/resources/local/TestNodeMjs/TestNodeMjs.mjs
+++ b/test/unit/@node-red/registry/lib/resources/local/TestNodeMjs/TestNodeMjs.mjs
@@ -1,0 +1,5 @@
+// A test node that exports an ESM default function
+export default function(RED) {
+    function TestNode(n) {}
+    RED.nodes.registerType("test-node-mjs",TestNode);
+}


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

`loadNodeConfig` still derived the editor template with `/\.c?js$/`, so a `*.mjs` entry point left `node.template` pointing at the JavaScript file. The editor then never saw `data-template-name`, and the node was missing from the palette.

This extends that substitution (and the matching local filesystem scan/name derivation) to `/\.[cm]?js$/`, so `.mjs` is handled like `.js` and `.cjs`.

Fixes https://github.com/node-red/node-red/issues/5897.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality

## Validation

[`npm run test` on the fork](https://github.com/sankalpsthakur/node-red/actions/runs/34684189675) passes on Node 22 and 24 at `6ce127cc`: 2,847 passing and 60 pending tests on each, including the new `.mjs` regression. The command includes build, dependency verification, lint and coverage tests. EasyCLA passes.

Codex assisted with this description and the isolated validation workflow.
