### PR TITLE
docs: clarify settings.js nodesDir accepts an array of paths

### DIFF
--- a/packages/node_modules/node-red/settings.js
+++ b/packages/node_modules/node-red/settings.js
@@ -56,9 +56,11 @@ module.exports = {
     //userDir: '/home/nol/.node-red/',
 
     /** Node-RED scans the `nodes` directory in the userDir to find local node files.
-     * The following property can be used to specify an additional directory to scan.
+     * The following property can be used to specify one or more additional directories
+     * to scan, as either a single string or an array of strings.
      */
     //nodesDir: '/home/nol/.node-red/nodes',
+    //nodesDir: ['/home/nol/.node-red/nodes', '/home/nol/my-project/nodes'],
 
 /*******************************************************************************
  * Security


### PR DESCRIPTION
## Related issue
Fixes #1131

## What changed
The `nodesDir` comment in `settings.js` only said "an additional directory", but the runtime has accepted an array of paths since `0b8e8de2` (0.7.0, April 2014) — confirmed in `localfilesystem.js`:

```js
nodesDir = Array.isArray(settings.nodesDir) ? settings.nodesDir : [settings.nodesDir]
```

This was never reflected in the comment, so the array support could only be discovered by reading the source (as the issue reporter did). Updated the comment to mention both forms and added a commented-out array example, matching the existing single-path example style.

A follow-up PR will update the matching entry in `docs/user-guide/runtime/configuration.md` on node-red.github.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)