### PR TITLE
fix(editor): make disabled wires visible in dark theme

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/dark-colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/dark-colors.scss
@@ -238,7 +238,7 @@ $node-status-colors: (
 // ── Wires / links ──
 $link-color:             $neutral-mid;
 $link-link-color:        $neutral-mid;
-$link-disabled-color:    $border-2;
+$link-disabled-color:    #444444;
 $link-link-active-color: $accent;
 $link-unknown-color:     #ff6369;
 


### PR DESCRIPTION
## Summary
Fixes #5879 — in the dark theme, disabled flow's wires were almost invisible.

## Root cause
`$link-disabled-color` in `dark-colors.scss` was set to `$border-2` (`#2a2a2c`), a divider/border tone that is nearly identical to the dark theme's canvas background (`$canvas-bg: #0e0e12`). Since disabled-wire strokes use this variable (`flow.scss`, `.red-ui-workspace-disabled` / `.red-ui-flow-node-disabled`), the wires blended into the background instead of reading as "dimmed."

## Fix
Use `#444444` — the value this same file already uses elsewhere for "disabled but still visible" UI (e.g. `$node-config-icon-container-disabled`). This mirrors the relationship the light theme already has between its active and disabled link colors (`$link-color: #999` vs `$link-disabled-color: #ccc` — the disabled one is dimmed relative to active, not indistinguishable from the page background).

## Verification
Compiled the editor's sass (`sass packages/node_modules/@node-red/editor-client/src/sass/style.scss`) before and after the change and confirmed:
- Build succeeds with no errors/warnings introduced.
- The compiled dark-theme rule now emits `--red-ui-link-disabled-color: #444444;` instead of `#2a2a2c`.
- Light theme's `--red-ui-link-disabled-color: #ccc` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)