### PR TITLE
Fix file in completion after filename evaluation error

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/storage/10-file.js
+++ b/packages/node_modules/@node-red/nodes/core/storage/10-file.js
@@ -314,7 +314,7 @@ module.exports = function(RED) {
             RED.util.evaluateNodeProperty(node.filename,node.filenameType,node,msg,(err,value) => {
                 if (err) {
                     node.error(err,msg);
-                    return done();
+                    return nodeDone();
                 } else {
                     if (typeof value !== 'string' && value !== null && value !== undefined) {
                         value = value.toString();

--- a/test/nodes/core/storage/10-file_spec.js
+++ b/test/nodes/core/storage/10-file_spec.js
@@ -1308,6 +1308,30 @@ describe('file Nodes', function() {
             });
         });
 
+        it('should handle a filename JSONata evaluation error and call done', function(done) {
+            const completeNode = require("nr-test-utils").require("@node-red/nodes/core/common/24-complete.js");
+            var flow = [{id:"fileInNode1", type:"file in", name: "fileInNode", "filename":"$nonExistentFunction()", "filenameType":"jsonata", "format":"utf8", wires:[[]]},
+                        {id:"completeNode1", type:"complete", scope:["fileInNode1"], uncaught:false, wires:[["helperNode1"]]},
+                        {id:"helperNode1", type:"helper", wires:[[]]}];
+            helper.load([fileNode, completeNode], flow, function() {
+                var n1 = helper.getNode("fileInNode1");
+                var helperNode1 = helper.getNode("helperNode1");
+                helperNode1.on("input", function(msg) {
+                    try {
+                        n1.error.called.should.be.true();
+                        n1.error.lastCall.args[0].should.have.property("code", "T1006");
+                        n1.error.lastCall.args[0].should.have.property("message", "Attempted to invoke a non-function");
+                        n1.error.lastCall.args[1].should.have.property("payload", "trigger");
+                        msg.should.have.property("payload", "trigger");
+                        done();
+                    } catch(err) {
+                        done(err);
+                    }
+                });
+                n1.receive({payload:"trigger"});
+            });
+        });
+
         it('should read in a file using fileWorkingDirectory to set cwd', function(done) {
             var flow = [{id:"fileInNode1", type:"file in", name: "fileInNode", "filename":relativePathToFile, "format":"utf8", wires:[["n2"]]},
                         {id:"n2", type:"helper"}];


### PR DESCRIPTION
## Proposed changes

- Use the `nodeDone` callback when a **file in** node cannot evaluate its filename.
- Add coverage for a JSONata filename evaluation error, including error reporting and message completion.

Fixes #5928

## Checklist

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] I have read the contribution guidelines.
- [x] I have added suitable unit tests to cover the changed functionality.
- [x] I have run `npm run test:no-coverage`.