### PR TITLE
Add optgroup and simple separator to typedInput

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -699,6 +699,9 @@
         if (!opt.multiple) {
             for (var i=0;i<_options.length;i++) {
                 op = _options[i];
+                if (op === null) {
+                    continue; // Separator
+                }
                 if (typeof op === "string" && op === currentVal) {
                     return {value:currentVal}
                 } else if (op.value === currentVal) {
@@ -717,6 +720,9 @@
             });
             for (var i=0;i<_options.length;i++) {
                 op = _options[i];
+                if (op === null) {
+                    continue; // Separator
+                }
                 var val = typeof op === "string" ? op : op.value;
                 if (currentValues.hasOwnProperty(val)) {
                     delete currentValues[val];
@@ -971,9 +977,34 @@
             var menu = $("<div>").addClass("red-ui-typedInput-options red-ui-editor-dialog");
             menu.opts = opts;
             menu.callback = callback;
+
+            const optGroup = {};
+            menuOptions = menuOptions.reduce((options, option) => {
+                if (typeof option?.group === "string") {
+                    const groupName = option.group;
+                    if (!optGroup[groupName]) {
+                        options.push({ value: "", label: groupName });
+                        optGroup[groupName] = true;
+                    }
+                } else if (typeof option?.group === "object") {
+                    const groupName = option.group.label;
+                    if (!optGroup[groupName]) {
+                        options.push({ ...option.group, value: "" });
+                        optGroup[groupName] = true;
+                    }
+                }
+                options.push(option);
+                return options;
+            }, []);
+
             menuOptions.forEach(function(opt) {
                 if (typeof opt === 'string') {
                     opt = {value:opt,label:opt};
+                }
+                if (opt === null) {
+                    // Simple separator
+                    $('<a href="#"></a>').css({ padding: "5px" }).css("pointer-events", "none").appendTo(menu);
+                    return;
                 }
                 var op = $('<a href="#"></a>').attr("value",opt.value).appendTo(menu);
                 if (opt.label) {
@@ -992,6 +1023,11 @@
                     }
                 } else {
                     op.css({paddingLeft: "18px"});
+                }
+                if (optGroup[opt.label]) {
+                    // Opt group separator - no event
+                    op.css("pointer-events", "none");
+                    return;
                 }
                 if (!opt.icon && !opt.label) {
                     op.text(opt.value);
@@ -1397,7 +1433,7 @@
                             _options.forEach(function(o) {
                                 if (typeof o === 'string') {
                                     that.activeOptions[o] = {label:o,value:o};
-                                } else {
+                                } else if (o !== null) {
                                     that.activeOptions[o.value] = o;
                                 }
                             });

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -1003,7 +1003,7 @@
                 }
                 if (opt === null) {
                     // Simple separator
-                    $('<a href="#"></a>').css({ padding: "5px" }).css("pointer-events", "none").appendTo(menu);
+                    $('<a href="#"></a>').css({ padding: "5px", "pointer-events": "none" }).appendTo(menu);
                     return;
                 }
                 var op = $('<a href="#"></a>').attr("value",opt.value).appendTo(menu);
@@ -1025,8 +1025,8 @@
                     op.css({paddingLeft: "18px"});
                 }
                 if (optGroup[opt.label]) {
-                    // Opt group separator - no event
-                    op.css("pointer-events", "none");
+                    // Opt group separator - not selectable
+                    op.removeAttr("value").css("pointer-events", "none");
                     return;
                 }
                 if (!opt.icon && !opt.label) {

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -1021,6 +1021,8 @@
                     } else {
                         $('<i>',{class:"red-ui-typedInput-icon "+opt.icon}).prependTo(op);
                     }
+                } else if (opt.group) {
+                    op.css({paddingLeft: "36px"});
                 } else {
                     op.css({paddingLeft: "18px"});
                 }


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

Ref: https://discourse.nodered.org/t/typedinput-with-optgroup/101743

Allow `typedInput` to offer opt group and simple separator.

### Definition

#### Separator

To add a separator, simply use the `null` value.

#### Opt Group

Each option can define a group to which it belongs. TypedInput will create these separators in the list.
The separator for a group can be customized with the `icon` property.

```ts
// options
{
  value: string;
  label?: string;
  icon?: string;
  group?: string | { label: string; icon?: string }
}[]
```

### Example

<img width="318" height="315" alt="Capture d’écran 2026-09-08 à 11 20 06" src="https://github.com/user-attachments/assets/50ddd8cf-f75a-46a6-bbd8-a6133786d036" />

```js
$("#node-input-example").typedInput({type:"foods", types:[{
    value: "foods",
    multiple: true,
    options: [
        { value: "none", label: "None" },

        null,

        { value: "apple", label: "Apple", group: "Fruit"},
        { value: "banana", label: "Banana", group: "Fruit"},
        { value: "cherry", label: "Cherry", group: "Fruit"},

        { value: "twix", label: "Apple", group: "Chocolate"},
        { value: "chomp", label: "Banana", group: "Chocolate"},
        { value: "Curley-wirly", label: "Cherry", group: "Chocolate"},
    ]
}]})
```

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
