### PR TITLE
Fix incorrect rendering of `typedInput` with a single type

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/common/typedInput.js
@@ -1279,6 +1279,11 @@
                 if (this.options.debug) { console.log(this.identifier,"----- SET TYPE -----",type) }
                 var previousValue = null;
                 var opt = this.typeMap[type];
+                if (!opt && this.propertyType === null) {
+                    // Initialization may fail if the initial value of the type is not included in the list of types
+                    type = this.options.default || this.typeList[0].value;
+                    opt = this.typeMap[type];
+                }
                 if (opt && this.propertyType !== type) {
                     // If previousType is !null, then this is a change of the type, rather than the initialisation
                     var previousType = this.typeMap[this.propertyType];


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Fixes #5698.

The *FINS Write* node has a rendering issue with one of the `typedInput` inputs. After analysis, the cause is the default value of the type given by the node definition.

This input has a list of types (`["msg"]`) but the initialized type is `str` due to `this.typeField.val()`.

To avoid this behavior, I propose overwriting the incorrect type with the default type or the first type in the list. `typedInput` should initialize correctly even if the requested type is incorrect.

The linked issue opened by Allan is most likely related to this behavior.

CC @Steve-Mcl 😉 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
