### PR TITLE
Fix group default fill colors

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/sass/dark-colors.scss
+++ b/packages/node_modules/@node-red/editor-client/src/sass/dark-colors.scss
@@ -289,8 +289,8 @@ $diff-merge-header-background:          #0c1428;
 $diff-merge-header-border-color:        $border-1;
 
 // ── Node groups ──
-$group-default-fill:           #ffffff;
-$group-default-fill-opacity:   0.03;
+$group-default-fill:           none;
+$group-default-fill-opacity:   1;
 $group-default-stroke:         #555555;
 $group-default-stroke-opacity: 1;
 $group-default-label-color:    $text-primary;


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

The main focus of #5878 was fixing an issue I noticed with the color picker. Sometimes, it would incorrectly display the value `none` as the fill color even though a color value was set.

Unfortunately, that fix surfaced the issue @VisualReversal reported.

The main issue is that the values ​​set in `$group-default-fill*` variables are used when no customization is applied.

Currently, these variables have the following values ​​in the dark theme:

```css
$group-default-fill: #ffffff;
$group-default-fill-opacity: 0.03;
```

With `$group-default-fill-opacity: 0.03;` being the main culprit here. Since it's almost transparent, it makes it seem like any custom colors we set get removed.

Speaking from experience, I rarely remember to change the opacity when customizing a group's color. I believe this is likely the case for other Node-RED users as well.

This PR fixes the issue by setting the same default values ​used in the light theme:

```css
$group-default-fill: none;
$group-default-fill-opacity: 1;
```


Fixes #5922

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [ ] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
