### PR TITLE
Fix setObjectProperty with invalid array paths

### DIFF
--- a/packages/node_modules/@node-red/util/lib/util.js
+++ b/packages/node_modules/@node-red/util/lib/util.js
@@ -470,6 +470,10 @@ function setObjectProperty(msg,prop,value,createMissing) {
     var obj = msg;
     var key;
     for (var i=0;i<length-1;i++) {
+        if (obj === null || (typeof obj !== "object" && typeof obj !== "function")) {
+            // Cannot traverse a property beneath a non-object/array
+            return false;
+        }
         key = msgPropParts[i];
         if (typeof key === 'string' || (typeof key === 'number' && !Array.isArray(obj))) {
             if (Object.hasOwn(obj, key)) {
@@ -506,6 +510,10 @@ function setObjectProperty(msg,prop,value,createMissing) {
                 obj = obj[key];
             }
         }
+    }
+    if (obj === null || (typeof obj !== "object" && typeof obj !== "function")) {
+        // Cannot set or delete a property beneath a non-object/array
+        return false;
     }
     key = msgPropParts[length-1];
     if (typeof value === "undefined") {

--- a/test/unit/@node-red/util/lib/util_spec.js
+++ b/test/unit/@node-red/util/lib/util_spec.js
@@ -200,7 +200,25 @@ describe("@node-red/util/util", function() {
             result.should.be.true();
             obj.should.have.property("msg");
             obj.msg.should.have.property("a","bar");
-        })
+        });
+        it('does not set a property beneath a null array element', function() {
+            var obj = {a:[null]};
+            var result = util.setObjectProperty(obj,"a[0].b.c","bar");
+            result.should.be.false();
+            obj.should.eql({a:[null]});
+        });
+        it('does not set a property beneath a primitive array element', function() {
+            var obj = {a:[123]};
+            var result = util.setObjectProperty(obj,"a[0].b.c","bar");
+            result.should.be.false();
+            obj.should.eql({a:[123]});
+        });
+        it('does not delete a property beneath a null array element', function() {
+            var obj = {a:[null]};
+            var result = util.setObjectProperty(obj,"a[0].b",undefined);
+            result.should.be.false();
+            obj.should.eql({a:[null]});
+        });
     });
     describe('setMessageProperty', function() {
         it('sets a property', function() {


### PR DESCRIPTION
## Summary
- Return false instead of throwing when an array path contains a null or primitive intermediate value.
- Add regression coverage for deep set and delete operations through invalid array elements.

## Testing
- npx mocha test/unit/@node-red/util/lib/util_spec.js
- npm run mocha:core

Fixes #5927