### PR TITLE
fix: catch-all-in-group scope depends on node add order

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
+++ b/packages/node_modules/@node-red/runtime/lib/flows/Flow.js
@@ -648,7 +648,8 @@ class Flow {
                 candidateNodes.push({ d: distance, n: targetCatchNode })
             })
             candidateNodes.sort((A,B) => {
-                return A.d - B.d
+                return (A.d - B.d) ||
+                       ((A.n.uncaught ? 1 : 0) - (B.n.uncaught ? 1 : 0))
             })
             let handledByUncaught = false
             candidateNodes.forEach(candidate => {

--- a/test/unit/@node-red/runtime/lib/flows/Flow_spec.js
+++ b/test/unit/@node-red/runtime/lib/flows/Flow_spec.js
@@ -792,6 +792,43 @@ describe('Flow', function() {
             await flow.stop()
         });
 
+        it("group catch-all ignores handled errors regardless of catch node order", async function() {
+            // receive an error that the node-scoped catch already handled.
+            var config = flowUtils.parseConfig([
+                {id:"t1",type:"tab"},
+                {id:"g1", type:"group", z:"t1"},
+                {id:"g2", type:"group", z:"t1"},
+                {id:"1",x:10,y:10,z:"t1",g:"g1",type:"test",name:"a",wires:[]},
+                {id:"3",x:10,y:10,z:"t1",g:"g1",type:"test",name:"c",wires:[]},
+                {id:"c1-scoped",x:10,y:10,z:"t1",g:"g1",type:"catch",scope:["1"],wires:[]},
+                {id:"c1-all",x:10,y:10,z:"t1",g:"g1",type:"catch",scope:"group",uncaught:true,wires:[]},
+                {id:"2",x:10,y:10,z:"t1",g:"g2",type:"test",name:"b",wires:[]},
+                {id:"c2-all",x:10,y:10,z:"t1",g:"g2",type:"catch",scope:"group",uncaught:true,wires:[]},
+                {id:"c2-scoped",x:10,y:10,z:"t1",g:"g2",type:"catch",scope:["2"],wires:[]}
+            ]);
+            var flow = Flow.create({},config,config.flows["t1"]);
+            await flow.start();
+
+            flow.handleError(config.flows["t1"].nodes["1"],"my-error",{a:"foo"});
+            flow.handleError(config.flows["t1"].nodes["2"],"my-error",{a:"foo"});
+            await NR_TEST_UTILS.sleep(50)
+
+            // node-scoped catch handles the error in both groups
+            currentNodes["c1-scoped"].should.have.a.property("handled",1);
+            currentNodes["c2-scoped"].should.have.a.property("handled",1);
+            // catch-all must ignore it in both groups, order notwithstanding
+            currentNodes["c1-all"].should.have.a.property("handled",0);
+            currentNodes["c2-all"].should.have.a.property("handled",0);
+
+            // regression guard: catch-all still fires when nothing else handles it
+            flow.handleError(config.flows["t1"].nodes["3"],"unhandled-error",{a:"bar"});
+            await NR_TEST_UTILS.sleep(50)
+            currentNodes["c1-all"].should.have.a.property("handled",1);
+            currentNodes["c1-scoped"].should.have.a.property("handled",1);
+
+            await flow.stop()
+        });
+
         it("moves any existing error object sideways", async function() {
             var config = flowUtils.parseConfig([
                 {id:"t1",type:"tab"},


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
Proposed change is a one-line tiebreak added to the sort comparator in `Flow.handleError()`, so that when two catch nodes are at the same group distance, non-uncaught (specifically scoped) catch nodes always sort before uncaught (catch-all) ones regardless of the order they were added to the group.

Fixes #5811 
<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
