### PR TITLE
Add `data-sync` support for sequential script loading

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/red.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/red.js
@@ -64,37 +64,80 @@ var RED = (function() {
     }
 
     function appendConfig(config, moduleIdMatch, targetContainer, done) {
-        done = done || function(){};
-        var moduleId;
+        done = done || function () { };
+
+        let moduleId;
         if (moduleIdMatch) {
             moduleId = moduleIdMatch[1];
             RED._loadingModule = moduleId;
         } else {
             moduleId = "unknown";
         }
+
         try {
-            var hasDeferred = false;
-            var nodeConfigEls = $("<div>"+config+"</div>");
-            var scripts = nodeConfigEls.find("script");
-            var scriptCount = scripts.length;
-            scripts.each(function(i,el) {
-                var srcUrl = $(el).attr('src');
+            const nodeConfigEls = $("<div>" + config + "</div>");
+            const scripts = nodeConfigEls.find("script");
+            let scriptCount = scripts.length;
+            function finishScript() {
+                scriptCount--;
+
+                if (scriptCount === 0) {
+                    $(targetContainer).append(nodeConfigEls);
+                    delete RED._loadingModule;
+                    done();
+                }
+            }
+
+            const syncQueue = [];
+            let syncLoading = false;
+            function loadNextSyncScript() {
+                if (syncLoading || syncQueue.length === 0) {
+                    return;
+                }
+
+                syncLoading = true;
+
+                const el = syncQueue.shift();
+                const newScript = document.createElement("script");
+                if ($(el).attr("type") === "module") {
+                    newScript.type = "module";
+                }
+
+                newScript.onload = function () {
+                    syncLoading = false;
+                    finishScript();
+                    loadNextSyncScript();
+                };
+
+                $(targetContainer).append(newScript);
+                newScript.src = RED.settings.apiRootUrl + $(el).attr("src");
+            }
+
+            let hasDeferred = false;
+            scripts.each(function (i, el) {
+                const srcUrl = $(el).attr("src");
                 if (srcUrl && !/^\s*(https?:|\/|\.)/.test(srcUrl)) {
                     $(el).remove();
-                    var newScript = document.createElement("script");
-                    newScript.onload = function() {
-                        scriptCount--;
-                        if (scriptCount === 0) {
-                            $(targetContainer).append(nodeConfigEls);
-                            delete RED._loadingModule;
-                            done()
+
+                    if ($(el).attr("data-sync") === "true") {
+                        // Flag to force the script to be loaded and executed sequentially,
+                        // preserving its order relative to other synchronous scripts.
+                        syncQueue.push(el);
+                    } else {
+                        const newScript = document.createElement("script");
+
+                        newScript.onload = function () {
+                            finishScript();
+                        };
+
+                        if ($(el).attr("type") === "module") {
+                            newScript.type = "module";
                         }
+
+                        $(targetContainer).append(newScript);
+                        newScript.src = RED.settings.apiRootUrl + srcUrl;
                     }
-                    if ($(el).attr('type') === "module") {
-                        newScript.type = "module";
-                    }
-                    $(targetContainer).append(newScript);
-                    newScript.src = RED.settings.apiRootUrl+srcUrl;
+
                     hasDeferred = true;
                 } else {
                     if (/\/ace.js$/.test(srcUrl) || /\/ext-language_tools.js$/.test(srcUrl)) {
@@ -102,27 +145,32 @@ var RED = (function() {
                         // break the version of ace included in the editor.
                         // At the time of commit, the contrib-python nodes did this.
                         // This is a crude fix until the python nodes are fixed.
-                        console.warn("Blocked attempt to load",srcUrl,"by",moduleId)
+                        console.warn("Blocked attempt to load", srcUrl, "by", moduleId)
                         $(el).remove();
                     }
+
                     scriptCount--;
                 }
-            })
+            });
+
+            loadNextSyncScript();
+
             if (!hasDeferred) {
                 $(targetContainer).append(nodeConfigEls);
                 delete RED._loadingModule;
                 done();
             }
-        } catch(err) {
-            RED.notify(RED._("notification.errors.failedToAppendNode",{module:moduleId, error:err.toString()}),{
+        } catch (err) {
+            RED.notify(RED._("notification.errors.failedToAppendNode", { module: moduleId, error: err.toString() }), {
                 type: "error",
                 timeout: 10000
             });
-            console.log("["+moduleId+"] "+err.toString());
+            console.log("[" + moduleId + "] " + err.toString());
             delete RED._loadingModule;
             done();
         }
     }
+
     function appendPluginConfig(pluginConfig,done) {
         appendConfig(
             pluginConfig,


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

By default, node and plugin scripts are loaded asynchronously. This can cause major initialization issues if a list of scripts is supposed to be loaded and executed synchronously.

Scripts marked with `data-sync="true"` are added to *force* a sequential loading queue.

For example:
```html
<script src="foo.js" data-sync="true"></script>
<script src="bar.js" data-sync="true"></script>
<script src="baz.js" data-sync="true"></script>
```

The scripts will be loaded and executed sequentially: foo.js -> bar.js -> baz.js.

The next script is not started until the previous script has finished loading.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
