### PR TITLE
Iterate through Catch, Complete and Status nodes to remove deleted nodes

### DIFF
--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1073,22 +1073,21 @@ RED.editor = (function() {
                             const activeFlowNodes = RED.nodes.filterNodes({ z: node.z });
                             // Iterate through the Catch, Complete, and Status nodes to remove the deleted node
                             activeFlowNodes.forEach((candidateNode) => {
-                                if (types.includes(candidateNode.type)) {
-                                    if (Array.isArray(candidateNode.scope)) {
-                                        if (candidateNode.scope.includes(node.id)) {
-                                            changedNodes.push({
-                                                t: "edit",
-                                                changes: { scope: candidateNode.scope.slice() },
-                                                changed: candidateNode.changed,
-                                                dirty: RED.nodes.dirty(),
-                                                node: candidateNode,
-                                            });
-                                            candidateNode.scope.splice(candidateNode.scope.indexOf(node.id), 1);
-                                            candidateNode.changed = true;
-                                            candidateNode.dirty = true;
-                                            RED.editor.validateNode(candidateNode);
-                                        }
-                                    }
+                                const isMatchingType = types.includes(candidateNode.type);
+                                const hasNodeSelectionScope = isMatchingType && Array.isArray(candidateNode.scope);
+                                const isInScope = hasNodeSelectionScope && candidateNode.scope.includes(node.id);
+                                if (isInScope) {
+                                    changedNodes.push({
+                                        t: "edit",
+                                        changes: { scope: candidateNode.scope.slice() },
+                                        changed: candidateNode.changed,
+                                        dirty: RED.nodes.dirty(),
+                                        node: candidateNode,
+                                    });
+                                    candidateNode.scope.splice(candidateNode.scope.indexOf(node.id), 1);
+                                    candidateNode.changed = true;
+                                    candidateNode.dirty = true;
+                                    RED.editor.validateNode(candidateNode);
                                 }
                             });
 

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/editor.js
@@ -1068,6 +1068,37 @@ RED.editor = (function() {
                                 }
                             }
 
+                            const changedNodes = [];
+                            const types = ["catch", "complete", "status"];
+                            const activeFlowNodes = RED.nodes.filterNodes({ z: node.z });
+                            // Iterate through the Catch, Complete, and Status nodes to remove the deleted node
+                            activeFlowNodes.forEach((candidateNode) => {
+                                if (types.includes(candidateNode.type)) {
+                                    if (Array.isArray(candidateNode.scope)) {
+                                        if (candidateNode.scope.includes(node.id)) {
+                                            changedNodes.push({
+                                                t: "edit",
+                                                changes: { scope: candidateNode.scope.slice() },
+                                                changed: candidateNode.changed,
+                                                dirty: RED.nodes.dirty(),
+                                                node: candidateNode,
+                                            });
+                                            candidateNode.scope.splice(candidateNode.scope.indexOf(node.id), 1);
+                                            candidateNode.changed = true;
+                                            candidateNode.dirty = true;
+                                            RED.editor.validateNode(candidateNode);
+                                        }
+                                    }
+                                }
+                            });
+
+                            if (changedNodes.length) {
+                                historyEvent = {
+                                    t: "multi",
+                                    events: [historyEvent, ...changedNodes],
+                                };
+                            }
+
                             RED.nodes.dirty(true);
                             RED.view.redraw(true);
                             RED.history.push(historyEvent);

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -3740,7 +3740,7 @@ RED.view = (function() {
                 const changedNodeMap = {};
                 const types = ["catch", "complete", "status"];
                 const activeFlowNodes = RED.nodes.filterNodes({ z: node.z });
-                // Do a list of Catch, Complete, and Status nodes that have a scope
+                // Do a list of Catch, Complete, and Status nodes that have a node selection scope
                 const candidateNodes = activeFlowNodes.filter((node) => types.includes(node.type) && Array.isArray(node.scope));
                 for (var i=0;i<movingSet.length();i++) {
                     node = movingSet.get(i).n;

--- a/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
+++ b/packages/node_modules/@node-red/editor-client/src/js/ui/view.js
@@ -3736,6 +3736,12 @@ RED.view = (function() {
                         }
                     })
                 }
+
+                const changedNodeMap = {};
+                const types = ["catch", "complete", "status"];
+                const activeFlowNodes = RED.nodes.filterNodes({ z: node.z });
+                // Do a list of Catch, Complete, and Status nodes that have a scope
+                const candidateNodes = activeFlowNodes.filter((node) => types.includes(node.type) && Array.isArray(node.scope));
                 for (var i=0;i<movingSet.length();i++) {
                     node = movingSet.get(i).n;
                     node.selected = false;
@@ -3757,6 +3763,25 @@ RED.view = (function() {
                                 RED.group.markDirty(group);
                             }
                         }
+
+                        // Iterate through the Catch, Complete, and Status nodes to remove the deleted node
+                        candidateNodes.forEach((candidateNode) => {
+                            if (candidateNode.scope.includes(node.id)) {
+                                if (!changedNodeMap[candidateNode.id]) {
+                                    changedNodeMap[candidateNode.id] = {
+                                        t: "edit",
+                                        changes: { scope: candidateNode.scope.slice() },
+                                        changed: candidateNode.changed,
+                                        dirty: RED.nodes.dirty(),
+                                        node: candidateNode,
+                                    };
+                                    candidateNode.changed = true;
+                                    candidateNode.dirty = true;
+                                }
+                                candidateNode.scope.splice(candidateNode.scope.indexOf(node.id), 1);
+                                RED.editor.validateNode(candidateNode);
+                            }
+                        });
                     } else if (node.type === 'junction') {
                         var result = RED.nodes.removeJunction(node)
                         removedJunctions.push(node);
@@ -3781,6 +3806,11 @@ RED.view = (function() {
                         }
                         node.dirty = true;
                     }
+                }
+
+                const changedNodes = Object.values(changedNodeMap)
+                if (changedNodes.length) {
+                    historyEvents.push(...changedNodes);
                 }
 
                 // Groups must be removed in the right order - from inner-most


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Closes #5875.

When a node is deleted, a loop iterates over every Catch, Complete, and Status node (active flow) to remove the deleted node from the scope. This keeps the scope up to date, thereby sparing the user from having to search for incorrect scopes.

Once all scopes are updated, each modified node is validated and saved to the history.

In a future PR, the scope of Catch and Status nodes will include node validation that excludes an empty selection list.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
