### PR TITLE
Exclude empty scope for Catch and Status nodes

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/common/25-catch.html
+++ b/packages/node_modules/@node-red/nodes/core/common/25-catch.html
@@ -31,7 +31,19 @@
         color:"#e49191",
         defaults: {
             name: {value:""},
-            scope: {value:null, type:"*[]"},
+            scope: {
+                value: null,
+                type: "*[]",
+                validate: function (v, opt) {
+                    if (Array.isArray(v)) {
+                        if (v.length > 0) {
+                            return true;
+                        }
+                        return RED._("node-red:complete.errors.scopeUndefined");
+                    }
+                    return true;
+                },
+            },
             uncaught: {value:false}
         },
         inputs:0,

--- a/packages/node_modules/@node-red/nodes/core/common/25-status.html
+++ b/packages/node_modules/@node-red/nodes/core/common/25-status.html
@@ -27,7 +27,19 @@
         color:"#94c1d0",
         defaults: {
             name: {value:""},
-            scope: {value:null, type:"*[]"}
+            scope: {
+                value: null,
+                type: "*[]",
+                validate: function (v, opt) {
+                    if (Array.isArray(v)) {
+                        if (v.length > 0) {
+                            return true;
+                        }
+                        return RED._("node-red:complete.errors.scopeUndefined");
+                    }
+                    return true;
+                },
+            },
         },
         inputs:0,
         outputs:1,


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Part of #5875 and follows #5946.

The scope of Catch and Status nodes includes a validation that excludes an empty selection list.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
