### PR TITLE
Exclude a URL already used by `http in` nodes

### DIFF
--- a/packages/node_modules/@node-red/nodes/core/network/21-httpin.html
+++ b/packages/node_modules/@node-red/nodes/core/network/21-httpin.html
@@ -81,8 +81,25 @@
         color:"rgb(231, 231, 174)",
         defaults: {
             name: {value:""},
-            url: {value:"", required:true,
-                  label:RED._("node-red:httpin.label.url")},
+            url: {
+                value: "",
+                required: true,
+                label: RED._("node-red:httpin.label.url"),
+                validate: function (v, _opt) {
+                    const httpInNodes = RED.nodes.filterNodes({ type: "http in" });
+                    for (const node of httpInNodes) {
+                        if (node.id === this.id) {
+                            continue;
+                        }
+                        if (node.url === v) {
+                            RED.editor.validateNode(node);
+                            // No need for full look up
+                            return RED._("node-red:httpin.errors.url-already-used");
+                        }
+                    }
+                    return true;
+                }
+            },
             method: {value:"get",required:true},
             upload: {value:false},
             skipBodyParsing: {value:false},

--- a/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/en-US/messages.json
@@ -585,7 +585,8 @@
             "timeout-isnegative": "Timeout value is negative, ignoring",
             "invalid-payload": "Invalid payload",
             "invalid-url": "Invalid url",
-            "rejectunauthorized-invalid": "msg.rejectUnauthorized should be a boolean"
+            "rejectunauthorized-invalid": "msg.rejectUnauthorized should be a boolean",
+            "url-already-used": "URL already used by another http-in node"
         },
         "status": {
             "requesting": "requesting"

--- a/packages/node_modules/@node-red/nodes/locales/fr/messages.json
+++ b/packages/node_modules/@node-red/nodes/locales/fr/messages.json
@@ -585,7 +585,8 @@
             "timeout-isnegative": "La valeur du délai d'attente est négative, ignorée",
             "invalid-payload": "Charge utile invalide",
             "invalid-url": "URL invalide",
-            "rejectunauthorized-invalid": "msg.rejectUnauthorized devrait être un booléen"
+            "rejectunauthorized-invalid": "msg.rejectUnauthorized devrait être un booléen",
+            "url-already-used": "Le chemin d'URL est déjà utilisé par un autre noeud http-in"
         },
         "status": {
             "requesting": "en cours de demande"


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Closes #5643.

Exclude a URL already used by any `http in` node.

Test flow:
```json
[{"id":"a7397f05ee049730","type":"http in","z":"15cdbf1d258ebb57","name":"","url":"used","method":"get","upload":false,"skipBodyParsing":false,"swaggerDoc":"","x":220,"y":460,"wires":[[]]},{"id":"a2e2892cd4f7e818","type":"http in","z":"15cdbf1d258ebb57","name":"","url":"ok","method":"get","upload":false,"skipBodyParsing":false,"swaggerDoc":"","x":440,"y":460,"wires":[[]]},{"id":"577ee8823ae8201b","type":"http in","z":"15cdbf1d258ebb57","name":"","url":"used","method":"get","upload":false,"skipBodyParsing":false,"swaggerDoc":"","x":340,"y":540,"wires":[[]]}]
```

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/main/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the forum/slack team.
- [x] I have run `npm run test` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
